### PR TITLE
fix(runtime): land permission switches before the next turn's first tool call (#3349)

### DIFF
--- a/packages/core/src/__tests__/permission-profile.test.ts
+++ b/packages/core/src/__tests__/permission-profile.test.ts
@@ -26,6 +26,7 @@ import {
   createDangerFullAccessPermissionProfile,
   createReadOnlyPermissionProfile,
   createWorkspaceWritePermissionProfile,
+  isCanonicalReadOnlyPermissionProfile,
   isDeniedPath,
   isProtectedMetadataPath,
   isReadOnlyPermissionProfile,
@@ -190,6 +191,62 @@ describe('isReadOnlyPermissionProfile', () => {
       name: 'custom',
     };
     assert.strictEqual(isReadOnlyPermissionProfile(renamedButStillReadOnly), true);
+  });
+});
+
+describe('isCanonicalReadOnlyPermissionProfile', () => {
+  test('matches the canonical policy without relying on its display name', () => {
+    const { name: _name, ...policy } = createReadOnlyPermissionProfile();
+    for (const profile of [
+      policy,
+      { ...policy, name: 'custom' },
+      { ...policy, name: 'read-only' },
+    ]) {
+      assert.strictEqual(isCanonicalReadOnlyPermissionProfile(profile), true);
+    }
+  });
+
+  test('distinguishes extra read authority from the canonical Explore policy', () => {
+    const profile = createReadOnlyPermissionProfile();
+    const extraRead: PermissionProfileManaged = {
+      ...profile,
+      fileSystem: {
+        ...profile.fileSystem,
+        entries: [
+          ...profile.fileSystem.entries,
+          { kind: 'path', access: 'read', path: '/outside' },
+        ],
+      },
+    };
+    assert.strictEqual(isReadOnlyPermissionProfile(extraRead), true);
+    assert.strictEqual(isCanonicalReadOnlyPermissionProfile(extraRead), false);
+  });
+
+  test('does not certify other managed policies as canonical Explore', () => {
+    const profile = createReadOnlyPermissionProfile();
+    const nonCanonical: PermissionProfileManaged[] = [
+      createWorkspaceWritePermissionProfile(),
+      createDangerFullAccessPermissionProfile(),
+      { ...profile, network: { kind: 'enabled' } },
+      { ...profile, fileSystem: { kind: 'restricted', entries: [] } },
+      {
+        ...profile,
+        fileSystem: {
+          ...profile.fileSystem,
+          entries: [{ kind: 'special', access: 'read', special: ':root' }],
+        },
+      },
+      {
+        ...profile,
+        fileSystem: {
+          ...profile.fileSystem,
+          protectedMetadata: { access: 'deny_write', names: ['.git'] },
+        },
+      },
+    ];
+    for (const candidate of nonCanonical) {
+      assert.strictEqual(isCanonicalReadOnlyPermissionProfile(candidate), false);
+    }
   });
 });
 

--- a/packages/core/src/collaboration.ts
+++ b/packages/core/src/collaboration.ts
@@ -17,10 +17,28 @@
  * under the License.
  */
 
+import type { PermissionMode } from './permission.js';
+
 export const COLLABORATION_MODES = ['agent', 'plan'] as const;
 
 export type CollaborationMode = (typeof COLLABORATION_MODES)[number];
 
 export function isCollaborationMode(value: unknown): value is CollaborationMode {
   return typeof value === 'string' && (COLLABORATION_MODES as readonly string[]).includes(value);
+}
+
+/**
+ * The permission mode a session runs under once its collaboration mode is
+ * applied: Plan mode holds the session to read-only unless it is on Bypass.
+ *
+ * Lives here because both the model composer and tool dispatch have to reach
+ * the same answer; a second copy of the rule is a second authority.
+ */
+export function resolveCollaborationPermissionMode(input: {
+  readonly collaborationMode: CollaborationMode;
+  readonly permissionMode: PermissionMode;
+}): PermissionMode {
+  return input.collaborationMode === 'plan' && input.permissionMode !== 'bypass'
+    ? 'explore'
+    : input.permissionMode;
 }

--- a/packages/core/src/permission-profile.ts
+++ b/packages/core/src/permission-profile.ts
@@ -153,6 +153,26 @@ export function isReadOnlyPermissionProfile(profile: PermissionProfileManaged): 
   );
 }
 
+/**
+ * True only for the canonical Explore policy, independently of its display name.
+ * A read-only profile may still grant extra read paths that restoring Explore
+ * would revoke. Treat every other policy conservatively as a possible narrowing.
+ * Storage and Runtime must agree on which policy an Explore reset preserves.
+ */
+export function isCanonicalReadOnlyPermissionProfile(profile: PermissionProfileManaged): boolean {
+  const { fileSystem, network } = profile;
+  const entry = fileSystem.entries[0];
+  return (
+    fileSystem.kind === 'restricted' &&
+    fileSystem.protectedMetadata === undefined &&
+    fileSystem.entries.length === 1 &&
+    entry?.kind === 'special' &&
+    entry.access === 'read' &&
+    entry.special === ':workspace_roots' &&
+    network.kind === 'restricted'
+  );
+}
+
 export function createWorkspaceWritePermissionProfile(): PermissionProfileManaged {
   return {
     type: 'managed',

--- a/packages/runtime-host/src/__tests__/client-capability-admission-integration.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-admission-integration.test.ts
@@ -152,6 +152,7 @@ test('cancels managed approval owners and joiners with the canonical provider id
         modelId: 'model-1',
         readExecutionBoundary: async () =>
           createManagedExecutionBoundary(createWorkspaceWritePermissionProfile(), 0),
+        readPermissionMode: async () => 'ask',
         newId: nextId(),
         now: nextNow(),
         getPermissionPauseTarget: () => null,

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { deferred, waitFor } from '@maka/core/test-only/async-primitives';
+import { deferred, type Deferred, waitFor } from '@maka/core/test-only/async-primitives';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
@@ -521,6 +521,337 @@ test('production Host executes Bash against the current live sandbox boundary', 
     }
   }
 });
+
+test('permission widening through the Host reaches the next ordinary Turn tool call', async () => {
+  await runPermissionUpdateHostRegression('ordinary_session');
+});
+
+test('permission widening through the Host reaches a tool call in an active Goal continuation', async () => {
+  await runPermissionUpdateHostRegression('active_goal');
+});
+
+async function runPermissionUpdateHostRegression(
+  scenario: 'ordinary_session' | 'active_goal',
+): Promise<void> {
+  const scenarioSlug = scenario.replace('_', '-');
+  const base = await mkdtemp(join(tmpdir(), `maka-host-permission-${scenario}-`));
+  const root = join(base, 'interactive');
+  const project = join(base, 'project');
+  const provider = await startProvider();
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  const context: ConnectionContext = {
+    hostEpoch: `permission-${scenario}-epoch`,
+    connectionId: `permission-${scenario}-client`,
+    principal: 'local_os_user',
+    acquireResidency: () => ({ release() {} }),
+  };
+  const capabilityConnectionId = `permission-${scenario}-capability`;
+  const capabilityContext: ConnectionContext = {
+    ...context,
+    connectionId: capabilityConnectionId,
+  };
+  const calls: Array<Extract<ClientCapabilityHostFrame, { kind: 'client.capability.call' }>> = [];
+  let admitted = 0;
+  let composition: Awaited<ReturnType<typeof createExecutionRuntimeHostComposition>> | undefined;
+  let capabilityConnection:
+    | ReturnType<HostClientCapabilityCoordinator['attachConnection']>
+    | undefined;
+  let releaseActiveRequest: (() => void) | undefined;
+  try {
+    await mkdir(project);
+    const policy = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    const created = await policy.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: `permission-${scenarioSlug}-provider`,
+        name: `Permission ${scenario} provider`,
+        providerType: 'moonshot',
+        baseUrl: provider.baseUrl,
+        enabled: true,
+        enabledModelIds: [MODEL_ID],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const modelConnection = created.snapshot.connections[0];
+    assert.ok(modelConnection);
+    if (!modelConnection) return;
+    assert.equal(
+      (
+        await policy.credentialVault.set({
+          locator: {
+            scope: 'connection',
+            connectionId: modelConnection.connectionId,
+            kind: 'api_key',
+          },
+          expected: null,
+          secret: API_KEY,
+        })
+      ).kind,
+      'committed',
+    );
+    await publishConnectionModel(policy, modelConnection.connectionId, MODEL_ID, 32_768);
+
+    const execution = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const session = await execution.sessionStore.create({
+      cwd: project,
+      llmConnectionId: modelConnection.connectionId,
+      llmConnectionSlug: `permission-${scenarioSlug}-provider`,
+      model: MODEL_ID,
+      permissionMode: 'explore',
+    });
+    composition = await createExecutionRuntimeHostComposition({
+      owner,
+      hostEpoch: context.hostEpoch,
+      acquireResidency: context.acquireResidency,
+      retainUntilProcessExit: () => undefined,
+      requestDrain: () => undefined,
+    });
+    await composition.recover();
+    const clientCapabilities = composition.clientCapabilities as
+      | HostClientCapabilityCoordinator
+      | undefined;
+    assert.ok(clientCapabilities);
+    if (!clientCapabilities) return;
+
+    capabilityConnection = clientCapabilities.attachConnection(
+      clientCapabilityConnectionIdentity(capabilityConnectionId),
+      {
+        send: async (frame) => {
+          if (frame.kind === 'client.capability.call') {
+            calls.push(frame);
+            queueMicrotask(() => {
+              capabilityConnection?.accept({
+                kind: 'client.capability.accepted',
+                invocationId: frame.invocationId,
+                admissionEvidence: { kind: 'none' },
+              });
+            });
+          } else if (frame.kind === 'client.capability.admitted') {
+            admitted += 1;
+            queueMicrotask(() => {
+              capabilityConnection?.accept({
+                kind: 'client.capability.result',
+                invocationId: frame.invocationId,
+                result: {
+                  content: [{ type: 'text', text: CLIENT_CAPABILITY_RESULT_TEXT }],
+                },
+              });
+            });
+          }
+        },
+      },
+    );
+    const registered = await composition.handlers['client.capability.replace'](
+      {
+        registrationId: `permission-${scenario}-registration`,
+        offers: [
+          {
+            offerId: 'hosted-browser',
+            version: '0',
+            affinity: 'session',
+            hostPathAccess: 'cwd',
+            label: 'Hosted Browser',
+            tools: [
+              {
+                serverId: 'hosted_browser',
+                name: 'navigate',
+                description: 'Navigate the hosted browser.',
+                inputSchema: {
+                  type: 'object',
+                  properties: { url: { type: 'string' } },
+                  required: ['url'],
+                  additionalProperties: false,
+                },
+              },
+            ],
+          },
+        ],
+      },
+      capabilityContext,
+    );
+    assert.equal(registered.ok, true);
+    assert.deepEqual(await clientCapabilities.bindSession(session.id, capabilityConnectionId), {
+      ok: true,
+    });
+    const snapshot = clientCapabilities.snapshotForSession(session.id);
+    assert.ok(snapshot);
+    if (!snapshot) return;
+    const group = snapshot.groups[0];
+    const tool = snapshot.tools[0];
+    snapshot.release();
+    assert.ok(group);
+    assert.ok(tool);
+    if (!group || !tool) return;
+    const providerControl = provider.configurePermissionUpdateFlow({
+      scenario,
+      groupId: group.id,
+      toolName: tool.name,
+    });
+    releaseActiveRequest = providerControl.releaseActiveRequest;
+
+    let exercisedRunId: string;
+    if (scenario === 'ordinary_session') {
+      const firstTurnId = 'permission-ordinary-running-turn';
+      const firstStarted = await startTurn(
+        composition,
+        session.id,
+        firstTurnId,
+        'Keep this Turn active while permission changes.',
+        context,
+      );
+      await settleWithin(providerControl.activeRequestStarted);
+      await commitBypassPermissionUpdate(composition, execution, session.id, context);
+      providerControl.releaseActiveRequest();
+      const firstTerminal = await waitForTerminal(
+        composition,
+        session.id,
+        firstTurnId,
+        firstStarted,
+        context,
+      );
+      assert.equal(firstTerminal.status, 'completed');
+
+      const nextTurnId = 'permission-ordinary-next-turn';
+      const nextTerminal = await waitForTerminal(
+        composition,
+        session.id,
+        nextTurnId,
+        await startTurn(
+          composition,
+          session.id,
+          nextTurnId,
+          'Use the connected browser capability.',
+          context,
+        ),
+        context,
+      );
+      assert.equal(nextTerminal.status, 'completed');
+      exercisedRunId = nextTerminal.runId;
+    } else {
+      const armed = await composition.handlers['goal.arm'](
+        {
+          sessionId: session.id,
+          condition: 'Use the connected browser capability once.',
+          maxIterations: 3,
+          tokenBudget: null,
+        },
+        context,
+      );
+      assert.equal(armed.ok, true);
+      if (!armed.ok) return;
+      const carryingTurnId = 'permission-goal-carrying-turn';
+      const carryingStarted = await startTurn(
+        composition,
+        session.id,
+        carryingTurnId,
+        'Begin the active Goal.',
+        context,
+      );
+      const carryingTerminal = waitForTerminal(
+        composition,
+        session.id,
+        carryingTurnId,
+        carryingStarted,
+        context,
+      );
+      await settleWithin(providerControl.activeRequestStarted);
+      assert.equal((await carryingTerminal).status, 'completed');
+      const activeGoalRun = (
+        await execution.runtimeEventStore.listSessionInvocations(session.id)
+      ).find(
+        (run) =>
+          run.terminalEvent === undefined &&
+          run.opening.root.kind === 'goal' &&
+          run.opening.root.goalId === armed.result.goal.goalId,
+      );
+      assert.ok(activeGoalRun, 'Goal continuation did not hold an active Run');
+      if (!activeGoalRun) return;
+      assert.equal(activeGoalRun.opening.configuration.permissionMode, 'explore');
+      exercisedRunId = activeGoalRun.runId;
+
+      await commitBypassPermissionUpdate(composition, execution, session.id, context);
+      providerControl.releaseActiveRequest();
+      await waitForGoalStatus(composition, session.id, 'achieved', context);
+    }
+
+    assert.equal((await execution.sessionStore.readHeader(session.id)).permissionMode, 'bypass');
+    assert.equal((await execution.sessionStore.readExecutionBoundary(session.id)).kind, 'bypass');
+    assert.equal(admitted, 1);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0]?.arguments, {
+      url: 'https://example.test/permission-update',
+    });
+    const events = await execution.runtimeEventStore.readRuntimeEvents(session.id, exercisedRunId);
+    assert.ok(
+      events.some(
+        (event) =>
+          event.content?.kind === 'function_response' &&
+          event.content.name === tool.name &&
+          JSON.stringify(event.content.result).includes(CLIENT_CAPABILITY_RESULT_TEXT),
+      ),
+    );
+  } finally {
+    releaseActiveRequest?.();
+    try {
+      await capabilityConnection?.close();
+    } finally {
+      try {
+        await composition?.close();
+      } finally {
+        try {
+          await owner.close();
+        } finally {
+          try {
+            await provider.close();
+          } finally {
+            await rm(base, { recursive: true, force: true });
+          }
+        }
+      }
+    }
+  }
+}
+
+async function commitBypassPermissionUpdate(
+  composition: Awaited<ReturnType<typeof createExecutionRuntimeHostComposition>>,
+  execution: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>>,
+  sessionId: string,
+  context: ConnectionContext,
+): Promise<void> {
+  const current = await execution.sessionStore.readHeaderRecordSnapshot(sessionId);
+  const updated = await composition.handlers['session.configuration.update'](
+    {
+      sessionId,
+      expectedRevision: current.revision,
+      patch: { permissionMode: 'bypass' },
+    },
+    context,
+  );
+  assert.equal(updated.ok, true, JSON.stringify(updated));
+  if (!updated.ok) return;
+  assert.equal(updated.result.kind, 'committed');
+  if (updated.result.kind !== 'committed' || 'kind' in updated.result.session) return;
+  assert.equal(updated.result.session.permissionMode, 'bypass');
+}
+
+async function waitForGoalStatus(
+  composition: Awaited<ReturnType<typeof createExecutionRuntimeHostComposition>>,
+  sessionId: string,
+  status: 'achieved',
+  context: ConnectionContext,
+): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const queried = await composition.handlers['goal.query']({ sessionId }, context);
+    assert.equal(queried.ok, true);
+    if (queried.ok && queried.result.goal?.status === status) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Hosted Goal did not reach ${status}`);
+}
 
 test('backend creation admits the enabled bootstrap DeepSeek model before discovery', async () => {
   const modelId = 'deepseek-v4-flash';
@@ -5083,6 +5414,15 @@ interface ManagedSandboxPaths {
 type ProviderFlow =
   | { readonly kind: 'default' }
   | {
+      readonly kind: 'permission_update';
+      readonly scenario: 'ordinary_session' | 'active_goal';
+      readonly groupId: string;
+      readonly toolName: string;
+      readonly activeRequestStarted: Deferred<void>;
+      readonly activeRequestRelease: Deferred<void>;
+      goalEvaluationCount: number;
+    }
+  | {
       readonly kind: 'managed_bash';
       readonly sandboxPaths?: ManagedSandboxPaths;
     }
@@ -5103,6 +5443,14 @@ type ProviderFlow =
 async function startProvider(): Promise<{
   readonly baseUrl: string;
   readonly requests: ProviderRequest[];
+  configurePermissionUpdateFlow(input: {
+    scenario: 'ordinary_session' | 'active_goal';
+    groupId: string;
+    toolName: string;
+  }): {
+    readonly activeRequestStarted: Promise<void>;
+    releaseActiveRequest(): void;
+  };
   configureManagedBashFlow(sandboxPaths?: ManagedSandboxPaths): void;
   configureClientCapability(input: { groupId: string; toolName: string }): void;
   configureProjectionImageFlow(toolName: string): void;
@@ -5132,6 +5480,22 @@ async function startProvider(): Promise<{
   return {
     baseUrl: `http://127.0.0.1:${address.port}/v1`,
     requests,
+    configurePermissionUpdateFlow: (input) => {
+      if (flow.kind !== 'default') throw new Error('Provider flow is already configured');
+      const activeRequestStarted = deferred<void>();
+      const activeRequestRelease = deferred<void>();
+      flow = {
+        kind: 'permission_update',
+        ...input,
+        activeRequestStarted,
+        activeRequestRelease,
+        goalEvaluationCount: 0,
+      };
+      return {
+        activeRequestStarted: activeRequestStarted.promise,
+        releaseActiveRequest: () => activeRequestRelease.resolve(),
+      };
+    },
     configureManagedBashFlow: (sandboxPaths) => {
       if (flow.kind !== 'default') throw new Error('Provider flow is already configured');
       flow = {
@@ -5208,6 +5572,11 @@ async function handleProviderRequest(
       serialized,
     );
     const isHistoryCompaction = /context summarization assistant/.test(serialized);
+    const isGoalEvaluation = /goal evaluation judge/.test(serialized);
+    const goalEvaluation =
+      flow.kind === 'permission_update' && flow.scenario === 'active_goal' && isGoalEvaluation
+        ? ++flow.goalEvaluationCount
+        : 0;
     response.writeHead(200, { 'content-type': 'application/json' });
     response.end(
       JSON.stringify({
@@ -5228,9 +5597,20 @@ async function handleProviderRequest(
                     requestedItems: [],
                     incidentalItems: [],
                   })
-                : isHistoryCompaction
-                  ? COMPACT_SUMMARY_TEXT
-                  : SUMMARY_TEXT,
+                : goalEvaluation > 0
+                  ? JSON.stringify({
+                      met: goalEvaluation > 1,
+                      impossible: false,
+                      progress: true,
+                      waiting: false,
+                      reason:
+                        goalEvaluation > 1
+                          ? 'The permission update reached the continuation tool.'
+                          : 'Continue with the permission-sensitive tool call.',
+                    })
+                  : isHistoryCompaction
+                    ? COMPACT_SUMMARY_TEXT
+                    : SUMMARY_TEXT,
             },
             finish_reason: 'stop',
           },
@@ -5241,6 +5621,36 @@ async function handleProviderRequest(
     return;
   }
   const streamRequestIndex = requests.filter((candidate) => candidate.body.stream === true).length;
+  if (flow.kind === 'permission_update' && streamRequestIndex === 1) {
+    if (flow.scenario === 'ordinary_session') {
+      flow.activeRequestStarted.resolve();
+      await flow.activeRequestRelease.promise;
+    }
+    respondProviderText(response, RESPONSE_TEXT);
+    return;
+  }
+  if (flow.kind === 'permission_update' && streamRequestIndex === 2) {
+    if (flow.scenario === 'active_goal') {
+      flow.activeRequestStarted.resolve();
+      await flow.activeRequestRelease.promise;
+    }
+    assert.ok(toolNames(body).includes('tool_search'));
+    respondProviderToolCall(response, streamRequestIndex, 'tool_search', {
+      query: flow.toolName,
+    });
+    return;
+  }
+  if (flow.kind === 'permission_update' && streamRequestIndex === 3) {
+    assert.ok(toolNames(body).includes(flow.toolName));
+    respondProviderToolCall(response, streamRequestIndex, flow.toolName, {
+      url: 'https://example.test/permission-update',
+    });
+    return;
+  }
+  if (flow.kind === 'permission_update') {
+    respondProviderText(response, RESPONSE_TEXT);
+    return;
+  }
   if (flow.kind === 'projection_image' && streamRequestIndex === 1) {
     assert.ok(toolNames(body).includes(flow.toolName));
     respondProviderToolCall(response, streamRequestIndex, flow.toolName, {});

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -104,7 +104,6 @@ import {
 import {
   createHostAiSdkBackend,
   prepareHostAiSdkBackend,
-  resolveCollaborationPermissionMode,
   type HostAiSdkBackendInput,
 } from '../server/execution-model-composition.js';
 import {

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -1119,6 +1119,55 @@ test('configuration update admits Plan mode through Runtime authority', async ()
   assert.equal(fixture.drainRequests(), 0);
 });
 
+test('permission-only Host updates select the live boundary transition path', async () => {
+  const observed: boolean[] = [];
+  const fixture = createFixture({
+    manager: {
+      transitionSessionConfiguration: async (_sessionId, input) => {
+        observed.push(input.permissionModeOnly);
+        if (!input.permissionModeOnly) {
+          throw new SessionConfigurationTransitionError(
+            'session_busy',
+            'Session configuration cannot change while a linked Turn is active',
+          );
+        }
+        return headerSnapshot(
+          { ...fixture.header(), permissionMode: input.configuration.permissionMode },
+          fixture.revision() + 1,
+        );
+      },
+    },
+  });
+
+  const widening = await fixture.coordinator.handlers['session.configuration.update'](
+    {
+      sessionId: fixture.sessionId,
+      expectedRevision: fixture.revision(),
+      patch: { permissionMode: 'bypass' },
+    },
+    context,
+  );
+  const mixed = await fixture.coordinator.handlers['session.configuration.update'](
+    {
+      sessionId: fixture.sessionId,
+      expectedRevision: fixture.revision(),
+      patch: { permissionMode: 'bypass', collaborationMode: 'plan' },
+    },
+    context,
+  );
+
+  assert.equal(widening.ok, true);
+  assert.deepEqual(mixed, {
+    ok: false,
+    error: {
+      code: 'session_busy',
+      message: 'Session configuration cannot change while a linked Turn is active',
+    },
+  });
+  assert.deepEqual(observed, [true, false]);
+  assert.equal(fixture.drainRequests(), 0);
+});
+
 test('configuration update never rebinds a bound Session through a reused slug', async () => {
   let observedRef: unknown;
   const fixture = createFixture({

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -24,6 +24,7 @@ import { relayModelProfile } from '@maka/core/model-thinking';
 import type { ModelCallAttempt } from '@maka/core/model-call-attempt';
 import type { ModelCallCommit } from '@maka/core/agent-run';
 import type { PermissionMode } from '@maka/core/permission';
+import { resolveCollaborationPermissionMode } from '@maka/core/collaboration';
 import { AiSdkBackend } from '@maka/runtime/ai-sdk-backend';
 import {
   buildDefaultContextBudgetPolicy,
@@ -544,11 +545,4 @@ class HostAiSdkBackend extends AiSdkBackend {
   }
 }
 
-export function resolveCollaborationPermissionMode(input: {
-  readonly collaborationMode: 'agent' | 'plan';
-  readonly permissionMode: PermissionMode;
-}): PermissionMode {
-  return input.collaborationMode === 'plan' && input.permissionMode !== 'bypass'
-    ? 'explore'
-    : input.permissionMode;
-}
+export { resolveCollaborationPermissionMode };

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -372,6 +372,8 @@ async function buildHostAiSdkBackend(
           : {}),
         readExecutionBoundary: () =>
           input.context.store.readExecutionBoundary(input.context.sessionId),
+        readPermissionMode: async () =>
+          (await input.context.store.readHeader(input.context.sessionId)).permissionMode,
         ...(input.context.store.createSandboxBoundaryRequest
           ? {
               createSandboxBoundaryRequest: (request) =>

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -546,5 +546,3 @@ class HostAiSdkBackend extends AiSdkBackend {
     }
   }
 }
-
-export { resolveCollaborationPermissionMode };

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -763,6 +763,7 @@ export class HostSessionCatalogCoordinator {
         await this.#manager.transitionSessionConfiguration(input.sessionId, {
           expectedRevision: input.expectedRevision,
           clearConnectionBlock: input.patch.modelTarget !== undefined,
+          permissionModeOnly: isPermissionModeOnlyPatch(input.patch),
           configuration,
         });
         return configurationSuccess(
@@ -1271,6 +1272,16 @@ function sessionConfigurationMatches(
     header.permissionMode === configuration.permissionMode &&
     (header.collaborationMode ?? 'agent') === configuration.collaborationMode &&
     (header.orchestrationMode ?? 'default') === configuration.orchestrationMode
+  );
+}
+
+function isPermissionModeOnlyPatch(patch: SessionConfigurationUpdateInput['patch']): boolean {
+  return (
+    patch.permissionMode !== undefined &&
+    patch.modelTarget === undefined &&
+    patch.thinkingLevel === undefined &&
+    patch.collaborationMode === undefined &&
+    patch.orchestrationMode === undefined
   );
 }
 

--- a/packages/runtime-host/src/server/workhub-coordination-coordinator.ts
+++ b/packages/runtime-host/src/server/workhub-coordination-coordinator.ts
@@ -880,6 +880,7 @@ export class HostWorkHubCoordinationCoordinator {
       const configured = await this.#transitionConfiguration({
         expectedRevision: record.revision,
         clearConnectionBlock: false,
+        permissionModeOnly: false,
         configuration: {
           backend: record.header.backend,
           llmConnectionId: record.header.llmConnectionId,

--- a/packages/runtime-host/src/test-only/client-capability-form-host.ts
+++ b/packages/runtime-host/src/test-only/client-capability-form-host.ts
@@ -114,13 +114,15 @@ async function createFormHost(
   assert.ok(offer);
   const descriptor = offer.tools[0];
   assert.ok(descriptor);
+  const header = sessionHeader();
   const runtime = new ToolRuntime({
     sessionId: RUN.sessionId,
-    header: sessionHeader(),
+    header,
     connection: llmConnection(),
     modelId: 'model-1',
     readExecutionBoundary: async () =>
       createManagedExecutionBoundary(createWorkspaceWritePermissionProfile(), 0),
+    readPermissionMode: async () => header.permissionMode,
     newId: nextId(),
     now: nextNow(),
     getPermissionPauseTarget: () => null,

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -5164,6 +5164,7 @@ describe('AiSdkBackend model history', () => {
           newId: idGenerator(),
           now: monotonicClock(),
           readExecutionBoundary: readExternalExecutionBoundary,
+          readPermissionMode: async () => 'ask',
           contextBudget: {
             name: 'malformed-summary-config-circuit-test',
             charsPerToken: 1,

--- a/packages/runtime/src/__tests__/execution-boundary-test-helpers.ts
+++ b/packages/runtime/src/__tests__/execution-boundary-test-helpers.ts
@@ -45,8 +45,11 @@ import type { ModelProjectionTransition } from '@maka/core/model-projection-tran
 export const readExternalExecutionBoundary: AiSdkBackendInput['readExecutionBoundary'] = async () =>
   createExternalExecutionBoundary();
 
-type TestAiSdkBackendInput = Omit<AiSdkBackendInput, 'readExecutionBoundary'> &
-  Partial<Pick<AiSdkBackendInput, 'readExecutionBoundary'>> & {
+type TestAiSdkBackendInput = Omit<
+  AiSdkBackendInput,
+  'readExecutionBoundary' | 'readPermissionMode'
+> &
+  Partial<Pick<AiSdkBackendInput, 'readExecutionBoundary' | 'readPermissionMode'>> & {
     testProjectionArtifacts?: boolean;
     /**
      * The transcript this backend's turn produces, row by row as it appears.
@@ -100,6 +103,7 @@ export function createTestAiSdkBackend(input: TestAiSdkBackendInput): AiSdkBacke
   const transitions: ModelProjectionTransition[] = [];
   const backend = new AiSdkBackend({
     readExecutionBoundary: readExternalExecutionBoundary,
+    readPermissionMode: async () => input.header.permissionMode,
     loadModelProjectionTransitions: async () => ({
       transitions: [...transitions],
       unreadableTargets: new Set<string>(),
@@ -158,8 +162,11 @@ export function testToolResultArchive(
   });
 }
 
-type TestToolRuntimeInput = Omit<ToolRuntimeInput, 'readExecutionBoundary' | 'turnId'> &
-  Partial<Pick<ToolRuntimeInput, 'readExecutionBoundary' | 'turnId'>> & {
+type TestToolRuntimeInput = Omit<
+  ToolRuntimeInput,
+  'readExecutionBoundary' | 'readPermissionMode' | 'turnId'
+> &
+  Partial<Pick<ToolRuntimeInput, 'readExecutionBoundary' | 'readPermissionMode' | 'turnId'>> & {
     /** The transcript rows this runtime's calls produce; see the backend helper. */
     appendMessage?: (message: StoredMessage) => Promise<void>;
   };
@@ -169,6 +176,7 @@ export function createTestToolRuntime(input: TestToolRuntimeInput): ToolRuntime 
   const { appendMessage, ...runtimeInput } = input;
   const runtime = new ToolRuntime({
     readExecutionBoundary: readExternalExecutionBoundary,
+    readPermissionMode: async () => input.header.permissionMode,
     turnId: 'turn-1',
     ...runtimeInput,
   });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -46,7 +46,10 @@ import {
   createGenesisExecutionBoundary,
   isSandboxBoundaryRestartClosure,
 } from '@maka/core/sandbox-boundary';
-import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
+import {
+  createReadOnlyPermissionProfile,
+  createWorkspaceWritePermissionProfile,
+} from '@maka/core/permission-profile';
 import { DEEP_RESEARCH_SESSION_LABEL } from '@maka/core/deep-research';
 import { RUNTIME_CONTINUATION_AUTHORITY_V1 } from '@maka/core/runtime-event-store';
 import { deriveTurnRecords } from '@maka/core/session';
@@ -103,6 +106,7 @@ import {
   SessionManager,
   headerToSummary,
   type BackendFactoryContext,
+  type SessionConfigurationTransitionRequest,
   type SessionConfigurationStoreUpdate,
   type SessionStore,
   type VersionedSessionHeader,
@@ -485,6 +489,7 @@ describe('SessionManager Plan control boundaries', () => {
       manager.transitionSessionConfiguration(child.id, {
         expectedRevision: 1,
         clearConnectionBlock: false,
+        permissionModeOnly: false,
         configuration: {
           backend: child.backend,
           llmConnectionId: 'test-connection-id',
@@ -636,6 +641,7 @@ describe('SessionManager graph operator provisioning', () => {
       .transitionSessionConfiguration(parent.id, {
         expectedRevision: 1,
         clearConnectionBlock: false,
+        permissionModeOnly: false,
         configuration: {
           backend: parent.backend,
           llmConnectionId: 'test-connection-id',
@@ -2408,8 +2414,6 @@ describe('SessionManager child-session runtime primitive', () => {
       ),
       true,
     );
-    await manager.setPermissionMode(result.childSessionId, 'bypass');
-    assert.strictEqual((await store.readHeader(result.childSessionId)).permissionMode, 'bypass');
     const projection = await manager.listChildAgents(parent.id);
     assert.deepStrictEqual(projection.runs, []);
     assert.strictEqual(projection.executions.length, 1);
@@ -4086,6 +4090,7 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
       manager.transitionSessionConfiguration(session.id, {
         expectedRevision: 1,
         clearConnectionBlock: false,
+        permissionModeOnly: false,
         configuration: baseConfiguration,
       }),
       (error: unknown) => {
@@ -4100,6 +4105,7 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
     const committed = await manager.transitionSessionConfiguration(session.id, {
       expectedRevision: 1,
       clearConnectionBlock: false,
+      permissionModeOnly: false,
       configuration: baseConfiguration,
     });
     assert.equal(committed.revision, 2);
@@ -4108,8 +4114,24 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
 
     await assert.rejects(
       manager.transitionSessionConfiguration(session.id, {
+        expectedRevision: 1,
+        clearConnectionBlock: false,
+        permissionModeOnly: false,
+        configuration: baseConfiguration,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof SessionConfigurationRevisionConflictError);
+        assert.equal(error.expectedRevision, 1);
+        assert.equal(error.actualRevision, 2);
+        return true;
+      },
+    );
+
+    await assert.rejects(
+      manager.transitionSessionConfiguration(session.id, {
         expectedRevision: 2,
         clearConnectionBlock: false,
+        permissionModeOnly: true,
         configuration: {
           ...baseConfiguration,
           permissionMode: 'explore',
@@ -4152,6 +4174,7 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
     const preserved = await manager.transitionSessionConfiguration(session.id, {
       expectedRevision: 1,
       clearConnectionBlock: false,
+      permissionModeOnly: false,
       configuration,
     });
     assert.equal(preserved.header.blockedReason, 'NO_REAL_CONNECTION');
@@ -4160,6 +4183,7 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
     const recovered = await manager.transitionSessionConfiguration(session.id, {
       expectedRevision: 2,
       clearConnectionBlock: true,
+      permissionModeOnly: false,
       configuration,
     });
     assert.equal(recovered.header.blockedReason, undefined);
@@ -4254,6 +4278,7 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
       .transitionSessionConfiguration(session.id, {
         expectedRevision: 1,
         clearConnectionBlock: false,
+        permissionModeOnly: false,
         configuration: {
           backend: session.backend,
           llmConnectionId: 'test-connection-id',
@@ -4307,6 +4332,7 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
     const transition = manager.transitionSessionConfiguration(session.id, {
       expectedRevision: 1,
       clearConnectionBlock: false,
+      permissionModeOnly: false,
       configuration: {
         backend: session.backend,
         llmConnectionId: 'test-connection-id',
@@ -4532,7 +4558,7 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
 
 describe('SessionManager permission mode updates', () => {
   test('revokes background shell authority before narrowing Auto to Explore', async () => {
-    const store = new AtomicBoundaryMemorySessionStore();
+    const store = new VersionedConfigurationMemorySessionStore();
     const calls: string[] = [];
     const manager = new SessionManager({
       store,
@@ -4556,13 +4582,86 @@ describe('SessionManager permission mode updates', () => {
       } as never,
     });
     const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    const current = await store.readHeaderRecordSnapshot(session.id);
 
-    await manager.setPermissionMode(session.id, 'explore');
+    await manager.transitionSessionConfiguration(session.id, {
+      expectedRevision: current.revision,
+      clearConnectionBlock: false,
+      permissionModeOnly: true,
+      configuration: configurationForHeader(current.header, { permissionMode: 'explore' }),
+    });
 
     assert.deepStrictEqual(calls, [`terminate:${session.id}`, 'commit', `resume:${session.id}`]);
     const boundary = await store.readExecutionBoundary(session.id);
     assert.strictEqual(boundary.kind, 'managed');
     if (boundary.kind === 'managed') assert.strictEqual(boundary.profile.name, 'read-only');
+  });
+
+  test('treats an expanded Explore profile as narrowing before restoring Explore', async () => {
+    const store = new VersionedConfigurationMemorySessionStore();
+    const gate = makeGate();
+    const calls: string[] = [];
+    const backends = new BackendRegistry();
+    const runStore = new MemoryAgentRunStore();
+    backends.register('ai-sdk', (ctx) => new TestBackend(ctx, gate));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(987),
+      shellRuns: {
+        async terminateSession(sessionId: string) {
+          calls.push(`terminate:${sessionId}`);
+          return { sessionId, token: Symbol('test') };
+        },
+        async commitSessionClose() {
+          calls.push('commit');
+        },
+        rollbackSessionClose() {
+          calls.push('rollback');
+        },
+        resumeSession(sessionId: string) {
+          calls.push(`resume:${sessionId}`);
+        },
+      } as never,
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    store.forceBoundary(session.id, {
+      kind: 'managed',
+      profile: applySandboxBoundaryExpansion(createReadOnlyPermissionProfile(), {
+        filesystem: {
+          entries: [{ path: '/approved/output', access: 'write', scope: 'subtree' }],
+        },
+      }),
+      revision: 1,
+    });
+    const activeTurn = manager
+      .sendMessage(session.id, { turnId: 'turn-expanded-explore', text: 'keep running' })
+      [Symbol.asyncIterator]();
+    await activeTurn.next();
+
+    const current = await store.readHeaderRecordSnapshot(session.id);
+    const narrowing = {
+      expectedRevision: current.revision,
+      clearConnectionBlock: false,
+      permissionModeOnly: true,
+      configuration: configurationForHeader(current.header, { permissionMode: 'explore' }),
+    } as const;
+    await expectRejects(
+      manager.transitionSessionConfiguration(session.id, narrowing),
+      /linked Turn is active/,
+    );
+    assert.deepStrictEqual(calls, []);
+    assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'ask');
+
+    gate.release();
+    while (!(await activeTurn.next()).done) {}
+
+    await manager.transitionSessionConfiguration(session.id, narrowing);
+    assert.deepStrictEqual(calls, [`terminate:${session.id}`, 'commit', `resume:${session.id}`]);
+    assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'explore');
   });
 
   test('revokes descendant background shell authority through the direct boundary API', async () => {
@@ -4677,7 +4776,7 @@ describe('SessionManager permission mode updates', () => {
   });
 
   test('keeps narrowing blocked until all overlapping turns finish', async () => {
-    const store = new MemorySessionStore();
+    const store = new VersionedConfigurationMemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     const firstGate = makeGate();
@@ -4718,12 +4817,26 @@ describe('SessionManager permission mode updates', () => {
 
     // Widening is a grant, so it commits against the live Turn instead of
     // making the user wait for it out (#3349).
-    const widened = await manager.setPermissionMode(session.id, 'bypass');
-    assert.strictEqual(widened.permissionMode, 'bypass');
+    const current = await store.readHeaderRecordSnapshot(session.id);
+    const widened = await manager.transitionSessionConfiguration(session.id, {
+      expectedRevision: current.revision,
+      clearConnectionBlock: false,
+      permissionModeOnly: true,
+      configuration: configurationForHeader(current.header, { permissionMode: 'bypass' }),
+    });
+    assert.strictEqual(widened.header.permissionMode, 'bypass');
     assert.strictEqual((await manager.readExecutionBoundary(session.id)).kind, 'bypass');
     // Narrowing still requires quiescence: that is what lets it terminate the
     // lineage's shells safely.
-    await expectRejects(manager.setPermissionMode(session.id, 'explore'), /当前任务正在运行/);
+    await expectRejects(
+      manager.transitionSessionConfiguration(session.id, {
+        expectedRevision: widened.revision,
+        clearConnectionBlock: false,
+        permissionModeOnly: true,
+        configuration: configurationForHeader(widened.header, { permissionMode: 'explore' }),
+      }),
+      /linked Turn is active/,
+    );
 
     secondGate.release();
     await second.next();
@@ -4737,13 +4850,12 @@ describe('SessionManager permission mode updates', () => {
         ['turn-2', 'completed'],
       ],
     );
-
     const summary = await manager.setPermissionMode(session.id, 'bypass');
     assert.strictEqual(summary.permissionMode, 'bypass');
   });
 
-  test('leaving explore clears the deep research label so visible read-only copy stays truthful', async () => {
-    const store = new MemorySessionStore();
+  test('the setPermissionMode wrapper delegates deep research cleanup to configuration authority', async () => {
+    const store = new VersionedConfigurationMemorySessionStore();
     const backends = new BackendRegistry();
     backends.register('ai-sdk', (ctx) => new TestBackend(ctx));
     const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(6_000) });
@@ -10504,7 +10616,7 @@ describe('SessionManager permission mode updates', () => {
   });
 
   test('marks a sandbox boundary request waiting and blocks boundary mode changes', async () => {
-    const store = new MemorySessionStore();
+    const store = new VersionedConfigurationMemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     let backend: SandboxBoundaryWaitBackend | undefined;
@@ -10537,7 +10649,7 @@ describe('SessionManager permission mode updates', () => {
     assert.strictEqual((await store.readHeader(session.id)).status, 'waiting_for_user');
     const [run] = await runStore.listSessionInvocations(session.id);
     assert.strictEqual(run?.terminalEvent, undefined);
-    await expectRejects(manager.setPermissionMode(session.id, 'bypass'), /等待确认/);
+    await expectRejects(manager.setPermissionMode(session.id, 'bypass'), /pending Interaction/);
     assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'ask');
 
     await manager.respondToSandboxBoundary(session.id, {
@@ -13290,7 +13402,16 @@ class MemorySessionStore implements SessionStore {
 
 class VersionedConfigurationMemorySessionStore extends MemorySessionStore {
   private readonly revisions = new Map<string, number>();
+  private readonly forcedBoundaries = new Map<string, ExecutionBoundary>();
   nextConfigurationUpdateGate: { started: Gate; release: Gate } | undefined;
+
+  forceBoundary(sessionId: string, boundary: ExecutionBoundary): void {
+    this.forcedBoundaries.set(sessionId, boundary);
+  }
+
+  override async readExecutionBoundary(sessionId: string): Promise<ExecutionBoundary> {
+    return this.forcedBoundaries.get(sessionId) ?? super.readExecutionBoundary(sessionId);
+  }
 
   override async create(
     input: CreateSessionInput,
@@ -13342,6 +13463,7 @@ class VersionedConfigurationMemorySessionStore extends MemorySessionStore {
           }
         : {}),
     });
+    this.forcedBoundaries.delete(sessionId);
     this.revisions.set(sessionId, revision + 1);
     return { header, revision: revision + 1, committedAt: revision + 1 };
   }
@@ -14067,6 +14189,24 @@ function makeInput(overrides: Partial<CreateSessionInput> = {}): CreateSessionIn
     permissionMode: 'ask',
     name: 'Session',
     labels: [],
+    ...overrides,
+  };
+}
+
+function configurationForHeader(
+  header: SessionHeader,
+  overrides: Partial<SessionConfigurationTransitionRequest['configuration']> = {},
+): SessionConfigurationTransitionRequest['configuration'] {
+  return {
+    backend: header.backend,
+    ...(header.llmConnectionId === undefined ? {} : { llmConnectionId: header.llmConnectionId }),
+    llmConnectionSlug: header.llmConnectionSlug,
+    connectionLocked: header.connectionLocked,
+    model: header.model,
+    thinkingLevel: header.thinkingLevel,
+    permissionMode: header.permissionMode,
+    collaborationMode: header.collaborationMode ?? 'agent',
+    orchestrationMode: header.orchestrationMode ?? 'default',
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4676,7 +4676,7 @@ describe('SessionManager permission mode updates', () => {
     assert.strictEqual(store.disposeCount, 3);
   });
 
-  test('keeps mode changes blocked until all overlapping turns finish', async () => {
+  test('keeps narrowing blocked until all overlapping turns finish', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -4716,7 +4716,14 @@ describe('SessionManager permission mode updates', () => {
       ],
     );
 
-    await expectRejects(manager.setPermissionMode(session.id, 'bypass'), /当前任务正在运行/);
+    // Widening is a grant, so it commits against the live Turn instead of
+    // making the user wait for it out (#3349).
+    const widened = await manager.setPermissionMode(session.id, 'bypass');
+    assert.strictEqual(widened.permissionMode, 'bypass');
+    assert.strictEqual((await manager.readExecutionBoundary(session.id)).kind, 'bypass');
+    // Narrowing still requires quiescence: that is what lets it terminate the
+    // lineage's shells safely.
+    await expectRejects(manager.setPermissionMode(session.id, 'explore'), /当前任务正在运行/);
 
     secondGate.release();
     await second.next();
@@ -10530,7 +10537,7 @@ describe('SessionManager permission mode updates', () => {
     assert.strictEqual((await store.readHeader(session.id)).status, 'waiting_for_user');
     const [run] = await runStore.listSessionInvocations(session.id);
     assert.strictEqual(run?.terminalEvent, undefined);
-    await expectRejects(manager.setPermissionMode(session.id, 'bypass'), /当前任务正在运行/);
+    await expectRejects(manager.setPermissionMode(session.id, 'bypass'), /等待确认/);
     assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'ask');
 
     await manager.respondToSandboxBoundary(session.id, {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4954,113 +4954,140 @@ describe('SessionManager permission mode updates', () => {
     assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'explore');
   });
 
-  test('restoring Explore revokes an approved outside read through the durable configuration path', async (t) => {
-    const root = await mkdtemp(join(tmpdir(), 'maka-explore-read-revocation-'));
-    const store = createSessionStore(root);
-    t.after(async () => {
-      await store.close?.();
-      await rm(root, { recursive: true, force: true });
-    });
-    const gate = makeGate();
-    const calls: string[] = [];
-    const backends = new BackendRegistry();
-    const runStore = new MemoryAgentRunStore();
-    backends.register('ai-sdk', (ctx) => new TestBackend(ctx, gate));
-    const manager = new SessionManager({
-      store,
-      runStore,
-      runtimeEventStore: runStore,
-      backends,
-      newId: nextId(),
-      now: nextNow(988),
-      shellRuns: {
-        async terminateSession(sessionId: string) {
-          calls.push(`terminate:${sessionId}`);
-          return { sessionId, token: Symbol('test') };
-        },
-        async commitSessionClose() {
-          calls.push('commit');
-        },
-        rollbackSessionClose() {
-          calls.push('rollback');
-        },
-        resumeSession(sessionId: string) {
-          calls.push(`resume:${sessionId}`);
-        },
-      } as never,
-    });
-    const workspaceRoot = join(root, 'workspace');
-    const outsidePath = join(root, 'approved', 'input.txt');
-    const session = await manager.createSession(
-      makeInput({ permissionMode: 'explore', cwd: workspaceRoot }),
-    );
-    const updatePermissionMode = async (permissionMode: PermissionMode) => {
-      const current = await store.readHeaderRecordSnapshot(session.id);
-      return manager.transitionSessionConfiguration(session.id, {
-        expectedRevision: current.revision,
-        clearConnectionBlock: false,
-        permissionModeOnly: true,
-        configuration: configurationForHeader(current.header, { permissionMode }),
-      });
-    };
-    await store.createSandboxBoundaryRequest({
-      sessionId: session.id,
-      requestId: 'outside-read',
-      turnId: 'turn-approval',
-      runId: 'run-approval',
-      expansion: {
-        filesystem: { entries: [{ path: outsidePath, access: 'read', scope: 'exact' }] },
-      },
-      justification: 'Read the approved input outside the workspace.',
-    });
-    const settlement = await store.settleSandboxBoundaryRequest({
-      sessionId: session.id,
-      requestId: 'outside-read',
-      decision: 'allow',
-    });
-    assert.strictEqual(settlement.request.status, 'approved');
-    await updatePermissionMode('ask');
-    const expanded = await store.readExecutionBoundary(session.id);
-    assert.strictEqual(expanded.kind, 'managed');
-    if (expanded.kind !== 'managed') throw new Error('Expected a managed boundary');
-    assert.strictEqual(expanded.profile.name, 'read-only');
-    assert.strictEqual(isReadOnlyPermissionProfile(expanded.profile), true);
-    assert.strictEqual(
-      canReadPath(expanded.profile, outsidePath, { workspaceRoots: [workspaceRoot] }),
-      true,
-    );
-    assert.deepStrictEqual(calls, []);
+  for (const route of ['configuration', 'boundary'] as const) {
+    for (const grant of ['read', 'write', 'network'] as const) {
+      test(`restoring Explore revokes an approved ${grant} through the durable ${route} path`, async (t) => {
+        const root = await mkdtemp(join(tmpdir(), 'maka-explore-read-revocation-'));
+        const store = createSessionStore(root);
+        t.after(async () => {
+          await store.close?.();
+          await rm(root, { recursive: true, force: true });
+        });
+        const gate = makeGate();
+        const calls: string[] = [];
+        const backends = new BackendRegistry();
+        const runStore = new MemoryAgentRunStore();
+        backends.register('ai-sdk', (ctx) => new TestBackend(ctx, gate));
+        const manager = new SessionManager({
+          store,
+          runStore,
+          runtimeEventStore: runStore,
+          backends,
+          newId: nextId(),
+          now: nextNow(988),
+          shellRuns: {
+            async terminateSession(sessionId: string) {
+              calls.push(`terminate:${sessionId}`);
+              return { sessionId, token: Symbol('test') };
+            },
+            async commitSessionClose() {
+              calls.push('commit');
+            },
+            rollbackSessionClose() {
+              calls.push('rollback');
+            },
+            resumeSession(sessionId: string) {
+              calls.push(`resume:${sessionId}`);
+            },
+          } as never,
+        });
+        const workspaceRoot = join(root, 'workspace');
+        const outsidePath = join(root, 'approved', 'input.txt');
+        const session = await manager.createSession(
+          makeInput({ permissionMode: 'explore', cwd: workspaceRoot }),
+        );
+        const updatePermissionMode = async (permissionMode: PermissionMode) => {
+          const current = await store.readHeaderRecordSnapshot(session.id);
+          return manager.transitionSessionConfiguration(session.id, {
+            expectedRevision: current.revision,
+            clearConnectionBlock: false,
+            permissionModeOnly: true,
+            configuration: configurationForHeader(current.header, { permissionMode }),
+          });
+        };
+        await store.createSandboxBoundaryRequest({
+          sessionId: session.id,
+          requestId: 'approved-expansion',
+          turnId: 'turn-approval',
+          runId: 'run-approval',
+          expansion:
+            grant === 'network'
+              ? { network: { enabled: true } }
+              : {
+                  filesystem: { entries: [{ path: outsidePath, access: grant, scope: 'exact' }] },
+                },
+          justification: 'Approve one specific sandbox expansion.',
+        });
+        const settlement = await store.settleSandboxBoundaryRequest({
+          sessionId: session.id,
+          requestId: 'approved-expansion',
+          decision: 'allow',
+        });
+        assert.strictEqual(settlement.request.status, 'approved');
+        if (route === 'configuration') await updatePermissionMode('ask');
+        const restoreExplore = () =>
+          route === 'configuration'
+            ? updatePermissionMode('explore')
+            : manager.setExecutionBoundaryKind(session.id, 'managed');
+        const expanded = await store.readExecutionBoundary(session.id);
+        assert.strictEqual(expanded.kind, 'managed');
+        if (expanded.kind !== 'managed') throw new Error('Expected a managed boundary');
+        assert.strictEqual(expanded.profile.name, 'read-only');
+        assert.strictEqual(isReadOnlyPermissionProfile(expanded.profile), grant === 'read');
+        assert.strictEqual(
+          expanded.profile.network.kind,
+          grant === 'network' ? 'enabled' : 'restricted',
+        );
+        assert.strictEqual(
+          canReadPath(expanded.profile, outsidePath, { workspaceRoots: [workspaceRoot] }),
+          grant !== 'network',
+        );
+        assert.deepStrictEqual(calls, []);
 
-    const activeTurn = manager
-      .sendMessage(session.id, { turnId: 'turn-expanded-read', text: 'keep reading' })
-      [Symbol.asyncIterator]();
-    try {
-      await activeTurn.next();
-      await assert.rejects(updatePermissionMode('explore'), (error: unknown) => {
-        assert.ok(error instanceof SessionConfigurationTransitionError);
-        assert.strictEqual(error.code, 'session_busy');
-        return true;
+        const activeTurn = manager
+          .sendMessage(session.id, { turnId: 'turn-expanded-read', text: 'keep reading' })
+          [Symbol.asyncIterator]();
+        try {
+          await activeTurn.next();
+          await assert.rejects(restoreExplore(), (error: unknown) => {
+            if (route === 'boundary') {
+              assert.ok(error instanceof Error);
+              assert.match(error.message, /当前任务正在运行/);
+              return true;
+            }
+            assert.ok(error instanceof SessionConfigurationTransitionError);
+            assert.strictEqual(error.code, 'session_busy');
+            return true;
+          });
+          assert.deepStrictEqual(await store.readExecutionBoundary(session.id), expanded);
+          assert.strictEqual(
+            (await store.readHeader(session.id)).permissionMode,
+            route === 'configuration' ? 'ask' : 'explore',
+          );
+          assert.deepStrictEqual(calls, []);
+        } finally {
+          gate.release();
+          while (!(await activeTurn.next()).done) {}
+        }
+
+        await restoreExplore();
+        assert.deepStrictEqual(calls, [
+          `terminate:${session.id}`,
+          'commit',
+          `resume:${session.id}`,
+        ]);
+        const narrowed = await store.readExecutionBoundary(session.id);
+        assert.strictEqual(narrowed.kind, 'managed');
+        if (narrowed.kind !== 'managed') throw new Error('Expected a managed boundary');
+        assert.deepStrictEqual(narrowed.profile, createReadOnlyPermissionProfile());
+        assert.strictEqual(
+          canReadPath(narrowed.profile, outsidePath, { workspaceRoots: [workspaceRoot] }),
+          false,
+        );
+        assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'explore');
       });
-      assert.deepStrictEqual(await store.readExecutionBoundary(session.id), expanded);
-      assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'ask');
-      assert.deepStrictEqual(calls, []);
-    } finally {
-      gate.release();
-      while (!(await activeTurn.next()).done) {}
     }
-
-    await updatePermissionMode('explore');
-    assert.deepStrictEqual(calls, [`terminate:${session.id}`, 'commit', `resume:${session.id}`]);
-    const narrowed = await store.readExecutionBoundary(session.id);
-    assert.strictEqual(narrowed.kind, 'managed');
-    if (narrowed.kind !== 'managed') throw new Error('Expected a managed boundary');
-    assert.deepStrictEqual(narrowed.profile, createReadOnlyPermissionProfile());
-    assert.strictEqual(
-      canReadPath(narrowed.profile, outsidePath, { workspaceRoots: [workspaceRoot] }),
-      false,
-    );
-    assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'explore');
-  });
+  }
 
   test('revokes descendant background shell authority through the direct boundary API', async () => {
     const store = new AtomicBoundaryMemorySessionStore();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -99,6 +99,7 @@ import { assertDoubleRunNotSealed } from './runtime-event-store-seal.js';
 import type { LanguageModelV4StreamPart } from '@ai-sdk/provider';
 import { z } from 'zod';
 import { AiSdkBackend } from '../ai-sdk-backend.js';
+import { renderPlanModePrompt, selectCollaborationTools } from '../plan-mode.js';
 import {
   BackendRegistry,
   SessionConfigurationRevisionConflictError,
@@ -4557,6 +4558,139 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
 });
 
 describe('SessionManager permission mode updates', () => {
+  for (const checkpoint of ['prepare', 'build'] as const) {
+    test(`retains a permission refresh during backend ${checkpoint} until the admitted turn exits`, async () => {
+      const store = new VersionedConfigurationMemorySessionStore();
+      const activationStarted = makeGate();
+      const releaseActivation = makeGate();
+      const sendGate = makeGate();
+      const builds: PermissionMode[] = [];
+      const dispatched: Array<{ tools: string[]; prompt: string }> = [];
+      const instances: TestBackend[] = [];
+      const backends = new BackendRegistry();
+      backends.register('ai-sdk', {
+        async prepare() {
+          if (checkpoint === 'prepare' && builds.length === 0) {
+            activationStarted.release();
+            await releaseActivation.promise;
+          }
+          return {
+            async build(ctx) {
+              builds.push(ctx.header.permissionMode);
+              if (checkpoint === 'build' && builds.length === 1) {
+                activationStarted.release();
+                await releaseActivation.promise;
+              }
+              const fullAccess = ctx.header.permissionMode === 'bypass';
+              const composition = {
+                tools: selectCollaborationTools({
+                  mode: 'plan',
+                  tools: [testTool('Read'), testTool('Write')],
+                  hasActiveExecution: false,
+                  fullAccess,
+                }).map((tool) => tool.name),
+                prompt: renderPlanModePrompt({ fullAccess }),
+              };
+              const backend = new (class extends TestBackend {
+                override async *send(input: BackendSendInput) {
+                  dispatched.push(composition);
+                  yield* super.send(input);
+                }
+              })(ctx, sendGate);
+              instances.push(backend);
+              return backend;
+            },
+          };
+        },
+      });
+      const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(980) });
+      const session = await manager.createSession(
+        makeInput({ permissionMode: 'ask', collaborationMode: 'plan' }),
+      );
+      const firstTurn = manager
+        .sendMessage(session.id, { turnId: 'turn-building', text: 'plan' })
+        [Symbol.asyncIterator]();
+      const firstEvent = firstTurn.next();
+      await activationStarted.promise;
+      try {
+        const current = await store.readHeaderRecordSnapshot(session.id);
+        await manager.transitionSessionConfiguration(session.id, {
+          expectedRevision: current.revision,
+          clearConnectionBlock: false,
+          permissionModeOnly: true,
+          configuration: configurationForHeader(current.header, { permissionMode: 'bypass' }),
+        });
+        assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'bypass');
+        assert.strictEqual(store.disposeCount, 0);
+      } finally {
+        releaseActivation.release();
+      }
+      try {
+        await firstEvent;
+        assert.strictEqual(store.disposeCount, 0);
+        assert.strictEqual(instances[0]?.stopCalls, 0);
+      } finally {
+        sendGate.release();
+        while (!(await firstTurn.next()).done) {}
+      }
+      assert.strictEqual(store.disposeCount, 1);
+
+      await drain(manager.sendMessage(session.id, { turnId: 'turn-fresh', text: 'write now' }));
+      assert.deepStrictEqual(builds, ['ask', 'bypass']);
+      assert.deepStrictEqual(
+        dispatched.map((input) => input.tools),
+        [['Read'], ['Read', 'Write']],
+      );
+      assert.strictEqual(dispatched[0]?.prompt, renderPlanModePrompt());
+      assert.strictEqual(dispatched[1]?.prompt, renderPlanModePrompt({ fullAccess: true }));
+    });
+  }
+
+  test('settles a backend refresh when an in-flight build fails', async () => {
+    const store = new VersionedConfigurationMemorySessionStore();
+    const buildStarted = makeGate();
+    const releaseBuild = makeGate();
+    const builds: PermissionMode[] = [];
+    const backends = new BackendRegistry();
+    backends.register('ai-sdk', async (ctx) => {
+      builds.push(ctx.header.permissionMode);
+      if (builds.length === 1) {
+        buildStarted.release();
+        await releaseBuild.promise;
+        throw new Error('injected activation failure');
+      }
+      return new TestBackend(ctx);
+    });
+    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(982) });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    const firstTurn = assert.rejects(
+      drain(manager.sendMessage(session.id, { turnId: 'turn-failing', text: 'start' })),
+      /injected activation failure/,
+    );
+    await buildStarted.promise;
+    const current = await store.readHeaderRecordSnapshot(session.id);
+    await manager.transitionSessionConfiguration(session.id, {
+      expectedRevision: current.revision,
+      clearConnectionBlock: false,
+      permissionModeOnly: true,
+      configuration: configurationForHeader(current.header, { permissionMode: 'bypass' }),
+    });
+    let refreshed = false;
+    const refresh = manager.refreshIdleBackends().then(() => {
+      refreshed = true;
+    });
+    try {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.strictEqual(refreshed, false);
+    } finally {
+      releaseBuild.release();
+    }
+    await firstTurn;
+    await refresh;
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-retry', text: 'retry' }));
+    assert.deepStrictEqual(builds, ['ask', 'bypass']);
+  });
+
   test('revokes background shell authority before narrowing Auto to Explore', async () => {
     const store = new VersionedConfigurationMemorySessionStore();
     const calls: string[] = [];

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4564,6 +4564,123 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
 });
 
 describe('SessionManager permission mode updates', () => {
+  for (const route of ['direct', 'legacy'] as const) {
+    test(`serializes concurrent ${route} boundary commits before they can become narrowing`, {
+      timeout: 10_000,
+    }, async (t) => {
+      const root = await mkdtemp(join(tmpdir(), 'maka-boundary-commit-race-'));
+      const store = createSessionStore(root);
+      // Hide optional capabilities from Runtime, without changing SQLite's own
+      // internal method calls, to exercise the legacy SessionStore contract.
+      const runtimeStore =
+        route === 'legacy'
+          ? new Proxy(store, {
+              get(target, key) {
+                if (key === 'readHeaderRecordSnapshot' || key === 'updateSessionConfiguration')
+                  return undefined;
+                const value = Reflect.get(target, key, target);
+                return typeof value === 'function' ? value.bind(target) : value;
+              },
+            })
+          : store;
+      const gate = makeGate();
+      t.after(async () => {
+        gate.release();
+        await store.close?.();
+        await rm(root, { recursive: true, force: true });
+      });
+      const calls: string[] = [];
+      const backends = new BackendRegistry();
+      let backend: TestBackend | undefined;
+      backends.register('ai-sdk', (ctx) => (backend = new TestBackend(ctx, gate)));
+      const manager = new SessionManager({
+        store: runtimeStore,
+        backends,
+        newId: nextId(),
+        now: nextNow(979),
+        shellRuns: {
+          async terminateSession(sessionId: string) {
+            calls.push(`terminate:${sessionId}`);
+            return { sessionId, token: Symbol('test') };
+          },
+          async commitSessionClose() {
+            calls.push('commit');
+          },
+          rollbackSessionClose() {
+            calls.push('rollback');
+          },
+          resumeSession(sessionId: string) {
+            calls.push(`resume:${sessionId}`);
+          },
+        } as never,
+      });
+      const session = await manager.createSession(makeInput({ permissionMode: 'explore' }));
+      const update = (bypass: boolean) =>
+        route === 'direct'
+          ? manager.setExecutionBoundaryKind(session.id, bypass ? 'bypass' : 'managed')
+          : manager.setPermissionMode(session.id, bypass ? 'bypass' : 'ask');
+      const turn = manager
+        .sendMessage(session.id, { turnId: 'turn-racing', text: 'keep running' })
+        [Symbol.asyncIterator]();
+      try {
+        await turn.next();
+        // Both requests initially observe Explore. The second must not reuse
+        // that classification after the first has committed Bypass.
+        const results = await Promise.allSettled([update(true), update(false)]);
+        assert.deepStrictEqual(
+          results.map((result) => result.status),
+          ['fulfilled', 'rejected'],
+        );
+        const conflict = results[1];
+        assert.ok(conflict?.status === 'rejected');
+        assert.ok(conflict.reason instanceof SessionConfigurationTransitionError);
+        assert.strictEqual(conflict.reason.code, 'operation_conflict');
+        assert.deepStrictEqual(await store.readExecutionBoundary(session.id), {
+          kind: 'bypass',
+          revision: 1,
+        });
+        assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'bypass');
+        assert.deepStrictEqual(manager.runningTurnIds(session.id), ['turn-racing']);
+        assert.strictEqual(backend?.stopCalls, 0);
+        assert.deepStrictEqual(calls, []);
+        // A fresh retry is now correctly classified as narrowing.
+        await assert.rejects(update(false), /当前任务正在运行|linked Turn is active/);
+      } finally {
+        gate.release();
+        while (!(await turn.next()).done) {}
+      }
+      // The conflict released the mutation lane; idle narrowing still revokes shells.
+      await update(false);
+      assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'ask');
+      assert.deepStrictEqual(calls, [`terminate:${session.id}`, 'commit', `resume:${session.id}`]);
+    });
+  }
+
+  test('rejects unprotected boundary commits when admission mutation authority is unavailable', async () => {
+    const store = new MemorySessionStore();
+    const kernel = new DelegatingRuntimeKernel();
+    Object.defineProperty(kernel, 'runSessionAdmissionMutation', { value: undefined });
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      runtimeKernel: kernel,
+      newId: nextId(),
+      now: nextNow(979),
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'explore' }));
+    await assert.rejects(
+      manager.setExecutionBoundaryKind(session.id, 'bypass'),
+      (error: unknown) => {
+        assert.ok(error instanceof SessionConfigurationTransitionError);
+        assert.strictEqual(error.code, 'operation_unavailable');
+        return true;
+      },
+    );
+    assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'explore');
+    assert.strictEqual((await store.readExecutionBoundary(session.id)).kind, 'managed');
+    assert.deepStrictEqual(kernel.disposed, []);
+  });
+
   for (const checkpoint of [
     'header',
     'safety',

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -22,6 +22,10 @@ import { sectionedSummary } from './history-compact-test-fixtures.js';
 import { runtimeInvocationFailureClass } from '../runtime-event-read-model.js';
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createSessionStore } from '@maka/storage/session-store';
 import { DEFAULT_TOOL_MODE } from '@maka/core/tool-mode';
 import {
   buildInvocationOpenedEvent,
@@ -47,8 +51,10 @@ import {
   isSandboxBoundaryRestartClosure,
 } from '@maka/core/sandbox-boundary';
 import {
+  canReadPath,
   createReadOnlyPermissionProfile,
   createWorkspaceWritePermissionProfile,
+  isReadOnlyPermissionProfile,
 } from '@maka/core/permission-profile';
 import { DEEP_RESEARCH_SESSION_LABEL } from '@maka/core/deep-research';
 import { RUNTIME_CONTINUATION_AUTHORITY_V1 } from '@maka/core/runtime-event-store';
@@ -4795,6 +4801,114 @@ describe('SessionManager permission mode updates', () => {
 
     await manager.transitionSessionConfiguration(session.id, narrowing);
     assert.deepStrictEqual(calls, [`terminate:${session.id}`, 'commit', `resume:${session.id}`]);
+    assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'explore');
+  });
+
+  test('restoring Explore revokes an approved outside read through the durable configuration path', async (t) => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-explore-read-revocation-'));
+    const store = createSessionStore(root);
+    t.after(async () => {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    });
+    const gate = makeGate();
+    const calls: string[] = [];
+    const backends = new BackendRegistry();
+    const runStore = new MemoryAgentRunStore();
+    backends.register('ai-sdk', (ctx) => new TestBackend(ctx, gate));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(988),
+      shellRuns: {
+        async terminateSession(sessionId: string) {
+          calls.push(`terminate:${sessionId}`);
+          return { sessionId, token: Symbol('test') };
+        },
+        async commitSessionClose() {
+          calls.push('commit');
+        },
+        rollbackSessionClose() {
+          calls.push('rollback');
+        },
+        resumeSession(sessionId: string) {
+          calls.push(`resume:${sessionId}`);
+        },
+      } as never,
+    });
+    const workspaceRoot = join(root, 'workspace');
+    const outsidePath = join(root, 'approved', 'input.txt');
+    const session = await manager.createSession(
+      makeInput({ permissionMode: 'explore', cwd: workspaceRoot }),
+    );
+    const updatePermissionMode = async (permissionMode: PermissionMode) => {
+      const current = await store.readHeaderRecordSnapshot(session.id);
+      return manager.transitionSessionConfiguration(session.id, {
+        expectedRevision: current.revision,
+        clearConnectionBlock: false,
+        permissionModeOnly: true,
+        configuration: configurationForHeader(current.header, { permissionMode }),
+      });
+    };
+    await store.createSandboxBoundaryRequest({
+      sessionId: session.id,
+      requestId: 'outside-read',
+      turnId: 'turn-approval',
+      runId: 'run-approval',
+      expansion: {
+        filesystem: { entries: [{ path: outsidePath, access: 'read', scope: 'exact' }] },
+      },
+      justification: 'Read the approved input outside the workspace.',
+    });
+    const settlement = await store.settleSandboxBoundaryRequest({
+      sessionId: session.id,
+      requestId: 'outside-read',
+      decision: 'allow',
+    });
+    assert.strictEqual(settlement.request.status, 'approved');
+    await updatePermissionMode('ask');
+    const expanded = await store.readExecutionBoundary(session.id);
+    assert.strictEqual(expanded.kind, 'managed');
+    if (expanded.kind !== 'managed') throw new Error('Expected a managed boundary');
+    assert.strictEqual(expanded.profile.name, 'read-only');
+    assert.strictEqual(isReadOnlyPermissionProfile(expanded.profile), true);
+    assert.strictEqual(
+      canReadPath(expanded.profile, outsidePath, { workspaceRoots: [workspaceRoot] }),
+      true,
+    );
+    assert.deepStrictEqual(calls, []);
+
+    const activeTurn = manager
+      .sendMessage(session.id, { turnId: 'turn-expanded-read', text: 'keep reading' })
+      [Symbol.asyncIterator]();
+    try {
+      await activeTurn.next();
+      await assert.rejects(updatePermissionMode('explore'), (error: unknown) => {
+        assert.ok(error instanceof SessionConfigurationTransitionError);
+        assert.strictEqual(error.code, 'session_busy');
+        return true;
+      });
+      assert.deepStrictEqual(await store.readExecutionBoundary(session.id), expanded);
+      assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'ask');
+      assert.deepStrictEqual(calls, []);
+    } finally {
+      gate.release();
+      while (!(await activeTurn.next()).done) {}
+    }
+
+    await updatePermissionMode('explore');
+    assert.deepStrictEqual(calls, [`terminate:${session.id}`, 'commit', `resume:${session.id}`]);
+    const narrowed = await store.readExecutionBoundary(session.id);
+    assert.strictEqual(narrowed.kind, 'managed');
+    if (narrowed.kind !== 'managed') throw new Error('Expected a managed boundary');
+    assert.deepStrictEqual(narrowed.profile, createReadOnlyPermissionProfile());
+    assert.strictEqual(
+      canReadPath(narrowed.profile, outsidePath, { workspaceRoots: [workspaceRoot] }),
+      false,
+    );
     assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'explore');
   });
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4873,6 +4873,23 @@ describe('SessionManager permission mode updates', () => {
     assert.deepStrictEqual((await store.readHeader(session.id)).labels, ['kept']);
   });
 
+  test('temporarily preserves setPermissionMode for legacy SessionStore implementations', async () => {
+    const store = new MemorySessionStore();
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: nextId(),
+      now: nextNow(6_100),
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+
+    const summary = await manager.setPermissionMode(session.id, 'bypass');
+
+    assert.strictEqual(summary.permissionMode, 'bypass');
+    assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'bypass');
+    assert.strictEqual((await store.readExecutionBoundary(session.id)).kind, 'bypass');
+  });
+
   test('starts a new turn without workspace identity when safety inspection fails', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4564,12 +4564,29 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
 });
 
 describe('SessionManager permission mode updates', () => {
-  for (const checkpoint of ['prepare', 'build'] as const) {
-    test(`retains a permission refresh during backend ${checkpoint} until the admitted turn exits`, async () => {
+  for (const checkpoint of [
+    'header',
+    'safety',
+    'admission',
+    'activation_gate',
+    'prepare',
+    'build',
+  ] as const) {
+    test(`retains a permission refresh during backend ${checkpoint} until the admitted turn exits`, {
+      timeout: 10_000,
+    }, async (t) => {
       const store = new VersionedConfigurationMemorySessionStore();
       const activationStarted = makeGate();
       const releaseActivation = makeGate();
       const sendGate = makeGate();
+      t.after(() => {
+        releaseActivation.release();
+        sendGate.release();
+      });
+      const pause = async () => {
+        activationStarted.release();
+        await releaseActivation.promise;
+      };
       const builds: PermissionMode[] = [];
       const dispatched: Array<{ tools: string[]; prompt: string }> = [];
       const instances: TestBackend[] = [];
@@ -4609,12 +4626,51 @@ describe('SessionManager permission mode updates', () => {
           };
         },
       });
-      const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(980) });
+      const manager = new SessionManager({
+        store,
+        backends,
+        newId: nextId(),
+        now: nextNow(980),
+        inspectContinuationSafety: async () => {
+          if (checkpoint === 'safety' && builds.length === 0) await pause();
+          return {
+            workspaceIdentity: 'workspace',
+            workspacePath: '/tmp/cwd',
+            backgroundOperationsSettled: true,
+            availableToolNames: [],
+          };
+        },
+        runBackendActivation: async (operation) => {
+          if (checkpoint === 'activation_gate' && builds.length === 0) await pause();
+          return operation();
+        },
+      });
       const session = await manager.createSession(
         makeInput({ permissionMode: 'ask', collaborationMode: 'plan' }),
       );
+      if (checkpoint === 'header') {
+        const readHeader = store.readHeader.bind(store);
+        let firstRead = true;
+        store.readHeader = async (id) => {
+          const header = await readHeader(id);
+          if (firstRead) {
+            firstRead = false;
+            await pause();
+          }
+          return header;
+        };
+      }
       const firstTurn = manager
-        .sendMessage(session.id, { turnId: 'turn-building', text: 'plan' })
+        .sendMessage(
+          session.id,
+          { turnId: 'turn-building', text: 'plan' },
+          {
+            admitTurn: async () => {
+              if (checkpoint === 'admission') await pause();
+              return 'admitted';
+            },
+          },
+        )
         [Symbol.asyncIterator]();
       const firstEvent = firstTurn.next();
       await activationStarted.promise;
@@ -4628,6 +4684,11 @@ describe('SessionManager permission mode updates', () => {
         });
         assert.strictEqual((await store.readHeader(session.id)).permissionMode, 'bypass');
         assert.strictEqual(store.disposeCount, 0);
+        if (checkpoint === 'activation_gate') {
+          // A policy mutation owns the gate and refreshes before releasing it.
+          // Waiting for the queued activation here would deadlock that mutation.
+          await manager.refreshIdleBackends();
+        }
       } finally {
         releaseActivation.release();
       }
@@ -4649,6 +4710,95 @@ describe('SessionManager permission mode updates', () => {
       );
       assert.strictEqual(dispatched[0]?.prompt, renderPlanModePrompt());
       assert.strictEqual(dispatched[1]?.prompt, renderPlanModePrompt({ fullAccess: true }));
+    });
+  }
+
+  test('strict refresh marks cold snapshots without waiting for the policy gate', {
+    timeout: 10_000,
+  }, async (t) => {
+    const store = new MemorySessionStore();
+    const queued = makeGate();
+    const releasePolicyMutation = makeGate();
+    t.after(() => releasePolicyMutation.release());
+    let builds = 0;
+    const backends = new BackendRegistry();
+    backends.register('ai-sdk', (ctx) => {
+      builds += 1;
+      return new TestBackend(ctx);
+    });
+    const manager = new SessionManager({
+      store,
+      backends,
+      newId: nextId(),
+      now: nextNow(981),
+      runBackendActivation: async (operation) => {
+        queued.release();
+        await releasePolicyMutation.promise;
+        return operation();
+      },
+    });
+    const session = await manager.createSession(makeInput());
+    const firstTurn = drain(manager.sendMessage(session.id, { turnId: 'queued', text: 'start' }));
+    await queued.promise;
+    // This is the policy mutation's final step before opening its gate again.
+    // There is no cached generation and no previous per-session invalidation.
+    await manager.refreshIdleBackends();
+    assert.strictEqual(builds, 0);
+    releasePolicyMutation.release();
+    await firstTurn;
+    assert.strictEqual(store.disposeCount, 1);
+    await drain(manager.sendMessage(session.id, { turnId: 'next', text: 'fresh' }));
+    assert.strictEqual(builds, 2);
+  });
+
+  for (const outcome of ['cancelled', 'failed'] as const) {
+    test(`a pre-activation refresh does not retain a ${outcome} admission`, async () => {
+      const store = new VersionedConfigurationMemorySessionStore();
+      const admissionStarted = makeGate();
+      const releaseAdmission = makeGate();
+      const builds: PermissionMode[] = [];
+      const backends = new BackendRegistry();
+      backends.register('ai-sdk', (ctx) => {
+        builds.push(ctx.header.permissionMode);
+        return new TestBackend(ctx);
+      });
+      const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(981) });
+      const session = await manager.createSession(makeInput());
+      const firstTurn = assert.rejects(
+        drain(
+          manager.sendMessage(
+            session.id,
+            { turnId: 'cancelled', text: 'start' },
+            {
+              admitTurn: async () => {
+                admissionStarted.release();
+                await releaseAdmission.promise;
+                if (outcome === 'failed') throw new Error('injected admission failure');
+                return 'cancelled';
+              },
+            },
+          ),
+        ),
+        /cancelled before runtime admission|injected admission failure/,
+      );
+      await admissionStarted.promise;
+      try {
+        const current = await store.readHeaderRecordSnapshot(session.id);
+        await manager.transitionSessionConfiguration(session.id, {
+          expectedRevision: current.revision,
+          clearConnectionBlock: false,
+          permissionModeOnly: true,
+          configuration: configurationForHeader(current.header, { permissionMode: 'bypass' }),
+        });
+      } finally {
+        releaseAdmission.release();
+      }
+      await firstTurn;
+      await manager.refreshIdleBackends();
+      await drain(manager.sendMessage(session.id, { turnId: 'retry', text: 'retry' }));
+      await drain(manager.sendMessage(session.id, { turnId: 'reuse', text: 'reuse' }));
+      assert.deepStrictEqual(builds, ['bypass']);
+      assert.strictEqual(store.disposeCount, 0);
     });
   }
 

--- a/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
@@ -23,8 +23,12 @@ import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promis
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
 import {
+  createReadOnlyPermissionProfile,
+  createWorkspaceWritePermissionProfile,
+} from '@maka/core/permission-profile';
+import {
+  applySandboxBoundaryExpansion,
   type ExecutionBoundary,
   type SandboxBoundaryRequest,
   type SandboxBoundarySettlement,
@@ -56,6 +60,7 @@ describe('ToolRuntime session sandbox boundary', () => {
         header: header(),
         connection: { providerType: 'openai', slug: 'test' } as never,
         modelId: 'test',
+        readPermissionMode: async () => 'ask',
         readExecutionBoundary: async () => {
           reads += 1;
           return {
@@ -113,12 +118,13 @@ describe('ToolRuntime session sandbox boundary', () => {
   test('reads the authoritative boundary for every tool invocation', async () => {
     const observed: ExecutionBoundary[] = [];
     let revision = 0;
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
       connection: { providerType: 'openai', slug: 'test' } as never,
       modelId: 'test',
+      readPermissionMode: async () => 'ask',
       readExecutionBoundary: async () => ({
         kind: 'managed',
         profile: createWorkspaceWritePermissionProfile(),
@@ -148,24 +154,25 @@ describe('ToolRuntime session sandbox boundary', () => {
     );
   });
 
-  // #3349: the header carries the mode the backend was built with. A picker
-  // switch to Bypass between two turns widens the boundary without rebuilding
-  // that header, so a dispatch that trusts the header keeps sandboxing and
-  // keeps prompting while the picker already reads Bypass.
-  test('reads the permission mode off the live boundary, not the header it was built with', async () => {
+  test('reads the selected mode live while letting a Bypass boundary override it', async () => {
+    let selectedMode: 'explore' | 'ask' = 'explore';
     let boundary: ExecutionBoundary = {
       kind: 'managed',
-      profile: createWorkspaceWritePermissionProfile(),
+      profile: applySandboxBoundaryExpansion(createReadOnlyPermissionProfile(), {
+        filesystem: {
+          entries: [{ path: '/approved/output', access: 'write', scope: 'subtree' }],
+        },
+      }),
       revision: 0,
     };
     const observed: Array<{ kind: string; permissionMode: string | undefined }> = [];
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
       connection: { providerType: 'openai', slug: 'test' } as never,
       modelId: 'test',
-      appendMessage: async () => {},
+      readPermissionMode: async () => selectedMode,
       readExecutionBoundary: async () => boundary,
       newId: nextId(),
       now: () => 1,
@@ -186,11 +193,14 @@ describe('ToolRuntime session sandbox boundary', () => {
     };
 
     await settle(runtime, tool, 'tool-1');
-    boundary = { kind: 'bypass', revision: 1 };
+    selectedMode = 'ask';
     await settle(runtime, tool, 'tool-2');
+    boundary = { kind: 'bypass', revision: 1 };
+    await settle(runtime, tool, 'tool-3');
 
     assert.equal(header().permissionMode, 'ask');
     assert.deepEqual(observed, [
+      { kind: 'managed', permissionMode: 'explore' },
       { kind: 'managed', permissionMode: 'ask' },
       { kind: 'bypass', permissionMode: 'bypass' },
     ]);
@@ -198,13 +208,12 @@ describe('ToolRuntime session sandbox boundary', () => {
 
   test('holds Plan mode to read-only even when the live boundary allows writes', async () => {
     let observed: string | undefined;
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: { ...header(), collaborationMode: 'plan' },
       connection: { providerType: 'openai', slug: 'test' } as never,
       modelId: 'test',
-      appendMessage: async () => {},
       readExecutionBoundary: async () => ({
         kind: 'managed',
         profile: createWorkspaceWritePermissionProfile(),
@@ -240,7 +249,7 @@ describe('ToolRuntime session sandbox boundary', () => {
       revision: 0,
     };
     let created: SandboxBoundaryRequest | undefined;
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -360,7 +369,7 @@ describe('ToolRuntime session sandbox boundary', () => {
         await releaseAdmission.promise;
       },
     };
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       hostedInteraction,
       sessionId: 'session-1',
@@ -442,7 +451,7 @@ describe('ToolRuntime session sandbox boundary', () => {
 
   test('rejects an invalid expansion before creating durable pending state', async () => {
     let createCalls = 0;
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -499,7 +508,7 @@ describe('ToolRuntime session sandbox boundary', () => {
     const canonicalFile = await realpath(file);
     let created: SandboxBoundaryRequest | undefined;
     const events: SessionEvent[] = [];
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(root),
@@ -577,7 +586,7 @@ describe('ToolRuntime session sandbox boundary', () => {
   test('rejects exact directory authority before creating durable pending state', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-boundary-directory-'));
     let createCalls = 0;
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(root),
@@ -636,7 +645,7 @@ describe('ToolRuntime session sandbox boundary', () => {
     };
     let created: SandboxBoundaryRequest | undefined;
     const settlements: Array<{ requestId: string; decision: string }> = [];
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -711,7 +720,7 @@ describe('ToolRuntime session sandbox boundary', () => {
       releaseCreate = resolve;
     });
     const settlements: string[] = [];
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -775,7 +784,7 @@ describe('ToolRuntime session sandbox boundary', () => {
   });
 
   test('returns a structured boundary requirement to the agent', async () => {
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -837,7 +846,7 @@ describe('ToolRuntime session sandbox boundary', () => {
   });
 
   test('counts one boundary correction per model step and keeps failure kinds independent', async () => {
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -910,7 +919,7 @@ describe('ToolRuntime session sandbox boundary', () => {
   test('cancels a suspended nested boundary wait when its cell aborts', async () => {
     const events: SessionEvent[] = [];
     const settlements: string[] = [];
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -991,7 +1000,7 @@ describe('ToolRuntime session sandbox boundary', () => {
 
   test('keeps a durable deny failure attached to the aborted nested call', async () => {
     const events: SessionEvent[] = [];
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -1046,7 +1055,7 @@ describe('ToolRuntime session sandbox boundary', () => {
 
   test('returns structured requires_bypass without opening an interaction', async () => {
     const events: SessionEvent[] = [];
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -1114,7 +1123,7 @@ describe('ToolRuntime session sandbox boundary', () => {
     // here: ToolRuntime injects that callback unconditionally. This is the
     // branch a model actually reaches, and it used to say something different
     // from the tool the model called.
-    const runtime = new ToolRuntime({
+    const runtime = createRuntime({
       turnId: 'turn-1',
       sessionId: 'session-1',
       header: header(),
@@ -1157,6 +1166,16 @@ describe('ToolRuntime session sandbox boundary', () => {
     });
   });
 });
+
+type SandboxToolRuntimeInput = Omit<ToolRuntimeInput, 'readPermissionMode'> &
+  Partial<Pick<ToolRuntimeInput, 'readPermissionMode'>>;
+
+function createRuntime(input: SandboxToolRuntimeInput): ToolRuntime {
+  return new ToolRuntime({
+    readPermissionMode: async () => input.header.permissionMode,
+    ...input,
+  });
+}
 
 async function settle(runtime: ToolRuntime, tool: MakaTool, toolCallId: string): Promise<void> {
   const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
@@ -148,6 +148,90 @@ describe('ToolRuntime session sandbox boundary', () => {
     );
   });
 
+  // #3349: the header carries the mode the backend was built with. A picker
+  // switch to Bypass between two turns widens the boundary without rebuilding
+  // that header, so a dispatch that trusts the header keeps sandboxing and
+  // keeps prompting while the picker already reads Bypass.
+  test('reads the permission mode off the live boundary, not the header it was built with', async () => {
+    let boundary: ExecutionBoundary = {
+      kind: 'managed',
+      profile: createWorkspaceWritePermissionProfile(),
+      revision: 0,
+    };
+    const observed: Array<{ kind: string; permissionMode: string | undefined }> = [];
+    const runtime = new ToolRuntime({
+      turnId: 'turn-1',
+      sessionId: 'session-1',
+      header: header(),
+      connection: { providerType: 'openai', slug: 'test' } as never,
+      modelId: 'test',
+      appendMessage: async () => {},
+      readExecutionBoundary: async () => boundary,
+      newId: nextId(),
+      now: () => 1,
+      getPermissionPauseTarget: () => null,
+    });
+    const tool: MakaTool = {
+      name: 'Bash',
+      description: 'test',
+      parameters: {},
+      impl: (_args, context) => {
+        assert.ok(context.executionBoundary);
+        observed.push({
+          kind: context.executionBoundary.kind,
+          permissionMode: context.permissionMode,
+        });
+        return { ok: true };
+      },
+    };
+
+    await settle(runtime, tool, 'tool-1');
+    boundary = { kind: 'bypass', revision: 1 };
+    await settle(runtime, tool, 'tool-2');
+
+    assert.equal(header().permissionMode, 'ask');
+    assert.deepEqual(observed, [
+      { kind: 'managed', permissionMode: 'ask' },
+      { kind: 'bypass', permissionMode: 'bypass' },
+    ]);
+  });
+
+  test('holds Plan mode to read-only even when the live boundary allows writes', async () => {
+    let observed: string | undefined;
+    const runtime = new ToolRuntime({
+      turnId: 'turn-1',
+      sessionId: 'session-1',
+      header: { ...header(), collaborationMode: 'plan' },
+      connection: { providerType: 'openai', slug: 'test' } as never,
+      modelId: 'test',
+      appendMessage: async () => {},
+      readExecutionBoundary: async () => ({
+        kind: 'managed',
+        profile: createWorkspaceWritePermissionProfile(),
+        revision: 0,
+      }),
+      newId: nextId(),
+      now: () => 1,
+      getPermissionPauseTarget: () => null,
+    });
+
+    await settle(
+      runtime,
+      {
+        name: 'Bash',
+        description: 'test',
+        parameters: {},
+        impl: (_args, context) => {
+          observed = context.permissionMode;
+          return { ok: true };
+        },
+      },
+      'tool-1',
+    );
+
+    assert.equal(observed, 'explore');
+  });
+
   test('parks the dedicated tool and admits only one boundary request at a time', async () => {
     const events: SessionEvent[] = [];
     const managed: ExecutionBoundary = {

--- a/packages/runtime/src/__tests__/tool-runtime-settlement.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-settlement.test.ts
@@ -22,9 +22,11 @@ import { createTestToolRuntime } from './execution-boundary-test-helpers.js';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  applySandboxBoundaryExpansion,
   createBypassExecutionBoundary,
   createGenesisExecutionBoundary,
 } from '@maka/core/sandbox-boundary';
+import { createReadOnlyPermissionProfile } from '@maka/core/permission-profile';
 import { type LlmConnection } from '@maka/core/llm-connections';
 import type { SessionEvent } from '@maka/core/events';
 import { type SessionHeader } from '@maka/core/session';
@@ -82,6 +84,56 @@ describe('ToolRuntime settlement', () => {
       String((allowed.result as { error?: unknown }).error),
       /missing its Host admission/u,
     );
+  });
+
+  it('does not promote an expanded Explore boundary into Client Capability admission', async () => {
+    let preparationCalls = 0;
+    let implementationCalls = 0;
+    const clientTool: MakaTool = {
+      name: 'client_browser',
+      description: 'client browser',
+      parameters: {},
+      categoryHint: 'custom_tool',
+      hostAdmission: 'client_capability',
+      prepareExecution: async () => {
+        preparationCalls += 1;
+        return { execute: async () => ({ ok: true }), cancel: () => undefined };
+      },
+      impl: () => {
+        implementationCalls += 1;
+        return { ok: true };
+      },
+    };
+    const expandedProfile = applySandboxBoundaryExpansion(createReadOnlyPermissionProfile(), {
+      filesystem: {
+        entries: [{ path: '/approved/output', access: 'write', scope: 'subtree' }],
+      },
+    });
+    const runtime = makeRuntime({
+      readPermissionMode: async () => 'explore',
+      readExecutionBoundary: async () => ({
+        kind: 'managed',
+        profile: expandedProfile,
+        revision: 1,
+      }),
+    });
+
+    const settlement = await runtime.settleToolCall({
+      tool: clientTool,
+      turnId: 'turn-1',
+      stepId: 'step-1',
+      toolCallId: 'call-expanded-explore',
+      input: {},
+      abortSignal: new AbortController().signal,
+      eventSink: {
+        push: () => undefined,
+        pushAndWaitUntilConsumed: async () => undefined,
+      },
+    });
+
+    assert.equal(preparationCalls, 0);
+    assert.equal(implementationCalls, 0);
+    assert.match(String((settlement.result as { error?: unknown }).error), /require the Bypass/u);
   });
 
   it('prepares Bypass Client Capability work before T1 and admits only after T1', async () => {
@@ -645,7 +697,12 @@ function makeRuntime(
   overrides: Partial<
     Pick<
       ToolRuntimeInput,
-      'readExecutionBoundary' | 'spawnChildSession' | 'runId' | 'invocationId' | 'runtimeCommitSink'
+      | 'readExecutionBoundary'
+      | 'readPermissionMode'
+      | 'spawnChildSession'
+      | 'runId'
+      | 'invocationId'
+      | 'runtimeCommitSink'
     >
   > = {},
 ): ToolRuntime {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -124,6 +124,8 @@ export interface AiSdkBackendInput extends AiSdkCompactionCapabilities {
   providerStateIdentity?: `sha256:${string}`;
   /** Reads the authoritative session boundary immediately before every local tool invocation. */
   readExecutionBoundary: ToolRuntimeInput['readExecutionBoundary'];
+  /** Reads the user's current Session permission selection for each local tool invocation. */
+  readPermissionMode: ToolRuntimeInput['readPermissionMode'];
   createSandboxBoundaryRequest?: ToolRuntimeInput['createSandboxBoundaryRequest'];
   settleSandboxBoundaryRequest?: ToolRuntimeInput['settleSandboxBoundaryRequest'];
 
@@ -499,6 +501,7 @@ export class AiSdkBackend implements AgentBackend {
       connection: input.connection,
       modelId: input.modelId,
       readExecutionBoundary: input.readExecutionBoundary,
+      readPermissionMode: input.readPermissionMode,
       createSandboxBoundaryRequest: input.createSandboxBoundaryRequest,
       settleSandboxBoundaryRequest: input.settleSandboxBoundaryRequest,
       newId: this.newId,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -355,6 +355,7 @@ interface PendingExecutionClaim {
   phase: 'pending' | 'attached' | 'reserved' | 'released' | 'failed';
   run?: AgentRun;
   hostOperation?: true;
+  backendHeaderSnapshot?: { invalidated: boolean };
   backendPreparation?: PreparedBackendActivation;
   stopIntent?: SessionStopIntent;
   finalization?: ExecutionClaimOutcome;
@@ -421,6 +422,19 @@ export class RuntimeKernel implements RuntimeKernelLike {
       }
     };
     return await (this.deps.runBackendActivation?.(activate) ?? activate());
+  }
+
+  private readBackendHeader(execution: PendingExecutionClaim): Promise<SessionHeader> {
+    // Register before the read: even the store may suspend after taking its
+    // snapshot. This covers all preflight work before the policy activation gate.
+    execution.backendHeaderSnapshot = { invalidated: false };
+    return this.deps.store.readHeader(execution.sessionId);
+  }
+
+  private invalidateBackendHeaderSnapshots(sessionId: string): void {
+    for (const execution of this.executionClaims.get(sessionId) ?? []) {
+      if (execution.backendHeaderSnapshot) execution.backendHeaderSnapshot.invalidated = true;
+    }
   }
 
   claimExecution(sessionId: string): RuntimeExecutionClaim {
@@ -656,7 +670,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const execution = this.takeExecutionClaim(sessionId, options.execution);
     try {
       await this.enterExecutionClaim(execution);
-      const header = await this.deps.store.readHeader(sessionId);
+      const header = await this.readBackendHeader(execution);
       let workspaceIdentity: string | undefined;
       if (this.deps.inspectContinuationSafety) {
         try {
@@ -759,7 +773,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       throw new Error('Cannot continue while another run is active');
     }
 
-    const header = await this.deps.store.readHeader(continuation.sessionId);
+    const header = await this.readBackendHeader(execution);
     const sessionRuns = await this.deps.runtimeEventStore.listSessionInvocations(
       continuation.sessionId,
     );
@@ -1114,7 +1128,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           'Cannot compact while a Turn is running',
         );
       }
-      const header = await this.deps.store.readHeader(sessionId);
+      const header = await this.readBackendHeader(execution);
       await this.requireContextCompactionBackend(sessionId, header, execution);
     } finally {
       this.releaseExecutionClaim(execution);
@@ -1140,7 +1154,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       );
     }
 
-    const header = await this.deps.store.readHeader(sessionId);
+    const header = await this.readBackendHeader(execution);
     const turnId = input.turnId ?? this.deps.newId();
     const run = new AgentRun({
       sessionId,
@@ -2247,6 +2261,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   }
 
   async invalidateBackend(sessionId: string): Promise<void> {
+    this.invalidateBackendHeaderSnapshots(sessionId);
     this.ensureBackendInvalidation(sessionId);
     await this.flushBackendInvalidation(sessionId);
   }
@@ -2255,10 +2270,15 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const sessionIds = new Set(
       [...this.backendGenerations.values()].map((generation) => generation.sessionId),
     );
+    for (const [sessionId, claims] of this.executionClaims) {
+      if ([...claims].some((execution) => execution.backendHeaderSnapshot))
+        sessionIds.add(sessionId);
+    }
     for (const execution of this.backendActivations) sessionIds.add(execution.sessionId);
     for (const sessionId of this.backendInvalidations.keys()) sessionIds.add(sessionId);
     await Promise.all(
       [...sessionIds].map(async (sessionId) => {
+        this.invalidateBackendHeaderSnapshots(sessionId);
         const failedGeneration = this.backendGenerationsFor(sessionId).find(
           (generation) => generation.phase === 'failed',
         );
@@ -2872,6 +2892,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
       }
     }
 
+    await this.waitForBackendDisposal(sessionId);
+    if (execution.backendHeaderSnapshot?.invalidated) {
+      // A refresh must not wait for preflight claims that may themselves be
+      // waiting on the policy mutation gate. Remember their stale snapshots,
+      // then re-arm invalidation inside activation, after any old disposal.
+      this.ensureBackendInvalidation(sessionId);
+    }
     const invalidation = this.backendInvalidations.get(sessionId);
     if (!invalidation) return;
     // This activation was already admitted when the refresh arrived. Let it

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -364,6 +364,7 @@ type BackendDisposalOutcome = { ok: true } | { ok: false; error: unknown };
 
 interface BackendInvalidationState {
   readonly outcome: Promise<BackendDisposalOutcome>;
+  readonly activations: Set<PendingExecutionClaim>;
   resolve(outcome: BackendDisposalOutcome): void;
   disposal?: Promise<void>;
   failure?: Error;
@@ -380,6 +381,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private readonly active = new Map<string, BackendGeneration>();
   private readonly backendGenerations = new Map<number, BackendGeneration>();
   private readonly backendActivationBuilds = new Map<string, Promise<BackendGeneration>>();
+  private readonly backendActivations = new Set<PendingExecutionClaim>();
   private readonly stopOperations = new Map<string, StopOperation>();
   private readonly stopAttempts = new Map<string, Promise<void>>();
   private readonly executionClaims = new Map<string, Set<PendingExecutionClaim>>();
@@ -404,8 +406,21 @@ export class RuntimeKernel implements RuntimeKernelLike {
     this.historyCompactCoordinator = new HistoryCompactCheckpointCoordinator(deps);
   }
 
-  private async runBackendActivation<T>(operation: () => Promise<T> | T): Promise<T> {
-    return await (this.deps.runBackendActivation?.(operation) ?? operation());
+  private async runBackendActivation<T>(
+    execution: PendingExecutionClaim,
+    operation: () => Promise<T> | T,
+  ): Promise<T> {
+    const activate = async () => {
+      this.backendActivations.add(execution);
+      try {
+        return await operation();
+      } finally {
+        this.backendActivations.delete(execution);
+        this.backendInvalidations.get(execution.sessionId)?.activations.delete(execution);
+        await this.flushBackendInvalidation(execution.sessionId);
+      }
+    };
+    return await (this.deps.runBackendActivation?.(activate) ?? activate());
   }
 
   claimExecution(sessionId: string): RuntimeExecutionClaim {
@@ -1171,7 +1186,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           runId: run.runId,
         });
       }
-      begin = await this.runBackendActivation(async () => {
+      begin = await this.runBackendActivation(execution, async () => {
         run.bindProviderStateIdentity(
           await this.prepareBackendForExecution(sessionId, header, execution),
         );
@@ -1274,7 +1289,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     header: SessionHeader,
     execution: PendingExecutionClaim,
   ): Promise<BackendGeneration> {
-    const active = await this.runBackendActivation(() =>
+    const active = await this.runBackendActivation(execution, () =>
       this.ensureActive(sessionId, header, execution),
     );
     if (!active.backend.compactHistory) {
@@ -1312,7 +1327,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           runId: run.runId,
         });
       }
-      begin = await this.runBackendActivation(async () => {
+      begin = await this.runBackendActivation(execution, async () => {
         await prepareBackendActivation?.();
         run.bindProviderStateIdentity(
           await this.prepareBackendForExecution(sessionId, run.headerSnapshot(), execution),
@@ -1457,7 +1472,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     let begin: Awaited<ReturnType<AgentRun['beginContinuation']>>;
     try {
       if (messageOwner) owners.bindMessage(this.deps.messageAuthority, messageOwner);
-      begin = await this.runBackendActivation(async () => {
+      begin = await this.runBackendActivation(execution, async () => {
         if (!revalidateSafety) {
           throw new Error('Durable continuation omitted final safety revalidation');
         }
@@ -2240,6 +2255,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const sessionIds = new Set(
       [...this.backendGenerations.values()].map((generation) => generation.sessionId),
     );
+    for (const execution of this.backendActivations) sessionIds.add(execution.sessionId);
     for (const sessionId of this.backendInvalidations.keys()) sessionIds.add(sessionId);
     await Promise.all(
       [...sessionIds].map(async (sessionId) => {
@@ -2811,7 +2827,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
 
   private async flushBackendInvalidation(sessionId: string): Promise<void> {
     const invalidation = this.backendInvalidations.get(sessionId);
-    if (!invalidation || this.hasActiveRuns(sessionId)) return;
+    if (!invalidation || invalidation.activations.size > 0 || this.hasActiveRuns(sessionId)) return;
     await this.startBackendDisposal(sessionId, invalidation);
   }
 
@@ -2858,8 +2874,12 @@ export class RuntimeKernel implements RuntimeKernelLike {
 
     const invalidation = this.backendInvalidations.get(sessionId);
     if (!invalidation) return;
+    // This activation was already admitted when the refresh arrived. Let it
+    // reserve its Run; invalidation must survive until that Run exits (or the
+    // activation fails), rather than disposing a not-yet-reserved generation.
+    if (invalidation.activations.has(execution)) return;
     await this.flushBackendInvalidation(sessionId);
-    if (this.hasActiveRuns(sessionId)) {
+    if (invalidation.activations.size > 0 || this.hasActiveRuns(sessionId)) {
       throw new Error(`Backend generation is quarantined for session ${sessionId}`);
     }
     await this.startBackendDisposal(sessionId, invalidation);
@@ -2896,14 +2916,29 @@ export class RuntimeKernel implements RuntimeKernelLike {
 
   private ensureBackendInvalidation(sessionId: string): BackendInvalidationState {
     const existing = this.backendInvalidations.get(sessionId);
-    if (existing) return existing;
+    if (existing) {
+      if (!existing.disposal) this.retainBackendActivations(sessionId, existing);
+      return existing;
+    }
     let resolve!: (outcome: BackendDisposalOutcome) => void;
     const outcome = new Promise<BackendDisposalOutcome>((resolvePromise) => {
       resolve = resolvePromise;
     });
-    const invalidation = { outcome, resolve };
+    const invalidation: BackendInvalidationState = { outcome, resolve, activations: new Set() };
+    this.retainBackendActivations(sessionId, invalidation);
     this.backendInvalidations.set(sessionId, invalidation);
     return invalidation;
+  }
+
+  private retainBackendActivations(
+    sessionId: string,
+    invalidation: BackendInvalidationState,
+  ): void {
+    // A cold backend has no generation or activeRuns yet. Retain the entire
+    // prepare/build/reservation interval, not just the shared factory promise.
+    for (const execution of this.backendActivations) {
+      if (execution.sessionId === sessionId) invalidation.activations.add(execution);
+    }
   }
 
   private async updateStatus(

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -70,7 +70,7 @@ import type {
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type { UserQuestionResponse } from '@maka/core/user-question';
 import type { PermissionMode } from '@maka/core/permission';
-import { isReadOnlyPermissionProfile } from '@maka/core/permission-profile';
+import { isCanonicalReadOnlyPermissionProfile } from '@maka/core/permission-profile';
 import { DEFAULT_TOOL_MODE } from '@maka/core/tool-mode';
 import type {
   CreateSandboxBoundaryRequest,
@@ -5188,7 +5188,9 @@ function narrowsExecutionAuthority(
 ): boolean {
   if (nextPermissionMode === 'bypass') return false;
   if (boundary.kind !== 'managed') return true;
-  return nextPermissionMode === 'explore' && !isReadOnlyPermissionProfile(boundary.profile);
+  return (
+    nextPermissionMode === 'explore' && !isCanonicalReadOnlyPermissionProfile(boundary.profile)
+  );
 }
 
 function agentRunStatusForSpawnResult(

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1735,8 +1735,19 @@ export class SessionManager {
       // check only gets easier — so the grant is just written. Waiting for the
       // Session to go idle is what let a running Turn, or a Goal's continuation
       // holding a claim near-continuously, keep the user's own grant out.
-      const commit = await prepareBoundaryCommit();
-      const result = await commit();
+      if (!this.runtimeKernel.runSessionAdmissionMutation) {
+        throw new SessionConfigurationTransitionError(
+          'operation_unavailable',
+          'Session boundary changes require Runtime admission mutation authority',
+        );
+      }
+      // Serialize the revision check through commit without requiring an idle
+      // Turn. Otherwise two unversioned writes can both pass the check, then
+      // the later write can narrow the first grant using its stale classification.
+      const result = await this.runtimeKernel.runSessionAdmissionMutation([sessionId], async () => {
+        const commit = await prepareBoundaryCommit();
+        return commit();
+      });
       // Not `disposeBackend`: disposing a live Turn's backend stops that Turn.
       // Invalidation refreshes it now when the Session is idle, and otherwise
       // defers to the next activation, which disposes before it starts.

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1625,8 +1625,16 @@ export class SessionManager {
   }
 
   async setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary> {
-    const store = this.requireSessionConfigurationStore();
-    const current = await store.readHeaderRecordSnapshot(sessionId);
+    const readHeaderRecordSnapshot = this.deps.store.readHeaderRecordSnapshot?.bind(
+      this.deps.store,
+    );
+    if (!readHeaderRecordSnapshot || !this.deps.store.updateSessionConfiguration) {
+      // Temporary compatibility bridge for SessionStore embeddings that predate
+      // versioned configuration authority. A follow-up PR will shortly remove
+      // setPermissionMode and this redundant fallback after callers migrate.
+      return this.setPermissionModeWithLegacyStore(sessionId, mode);
+    }
+    const current = await readHeaderRecordSnapshot(sessionId);
     const next = await this.transitionSessionConfiguration(sessionId, {
       expectedRevision: current.revision,
       clearConnectionBlock: false,
@@ -1634,6 +1642,44 @@ export class SessionManager {
       configuration: sessionConfigurationWithPermissionMode(current.header, mode),
     });
     return headerToSummary(next.header);
+  }
+
+  private async setPermissionModeWithLegacyStore(
+    sessionId: string,
+    mode: PermissionMode,
+  ): Promise<SessionSummary> {
+    const previous = await this.deps.store.readHeader(sessionId);
+    const boundary = await this.deps.store.readExecutionBoundary(sessionId);
+    const leavingDeepResearch = isDeepResearchSession(previous.labels) && mode !== 'explore';
+    if (
+      previous.permissionMode === mode &&
+      executionBoundaryMatchesPermissionMode(boundary, mode) &&
+      !leavingDeepResearch
+    ) {
+      return headerToSummary(previous);
+    }
+
+    const labels = leavingDeepResearch
+      ? previous.labels.filter((label) => label !== DEEP_RESEARCH_SESSION_LABEL)
+      : previous.labels;
+    const kind = mode === 'bypass' ? 'bypass' : 'managed';
+    await this.commitExecutionBoundaryTransition(sessionId, boundary, mode, async () => {
+      const current = await this.deps.store.readHeader(sessionId);
+      if (current.status === 'waiting_for_user') {
+        throw new SessionConfigurationTransitionError(
+          'session_busy',
+          'Session has a pending Interaction',
+        );
+      }
+      return () =>
+        this.deps.store.setExecutionBoundaryKind(sessionId, kind, {
+          permissionMode: mode,
+          labels,
+        });
+    });
+    const next = await this.deps.store.readHeader(sessionId);
+    this.runtimeKernel.updateCachedHeader(sessionId, next);
+    return headerToSummary(next);
   }
 
   async setExecutionBoundaryKind(
@@ -5123,6 +5169,17 @@ function sessionConfigurationMatches(
     header.permissionMode === configuration.permissionMode &&
     sessionConfigurationMatchesExceptPermissionMode(header, configuration)
   );
+}
+
+function executionBoundaryMatchesPermissionMode(
+  boundary: ExecutionBoundary,
+  mode: PermissionMode,
+): boolean {
+  if (mode === 'bypass') return boundary.kind === 'bypass';
+  if (boundary.kind !== 'managed') return false;
+  return mode === 'explore'
+    ? boundary.profile.name === 'read-only'
+    : boundary.profile.name !== 'read-only';
 }
 
 function narrowsExecutionAuthority(

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -70,6 +70,7 @@ import type {
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type { UserQuestionResponse } from '@maka/core/user-question';
 import type { PermissionMode } from '@maka/core/permission';
+import { isReadOnlyPermissionProfile } from '@maka/core/permission-profile';
 import { DEFAULT_TOOL_MODE } from '@maka/core/tool-mode';
 import type {
   CreateSandboxBoundaryRequest,
@@ -541,6 +542,7 @@ export interface SessionConfigurationStoreUpdate {
 export interface SessionConfigurationTransitionRequest {
   readonly expectedRevision: number;
   readonly clearConnectionBlock: boolean;
+  readonly permissionModeOnly: boolean;
   readonly configuration: Omit<SessionConfigurationStoreUpdate['configuration'], 'labels'>;
 }
 
@@ -1144,56 +1146,80 @@ export class SessionManager {
     input: SessionConfigurationTransitionRequest,
   ): Promise<VersionedSessionHeader> {
     const store = this.requireSessionConfigurationStore();
-    const next = await this.commitExecutionResourceTransition(
-      sessionId,
-      input.configuration.permissionMode,
-      async () => {
-        const current = await store.readHeaderRecordSnapshot(sessionId);
-        if (current.revision !== input.expectedRevision) {
-          throw new SessionConfigurationRevisionConflictError(
-            input.expectedRevision,
-            current.revision,
-          );
-        }
-        if (current.header.isArchived) {
-          throw new SessionConfigurationTransitionError(
-            'operation_conflict',
-            'Archived Session configuration cannot be changed',
-          );
-        }
-        if (current.header.status === 'waiting_for_user') {
-          throw new SessionConfigurationTransitionError(
-            'session_busy',
-            'Session has a pending Interaction',
-          );
-        }
-        await this.assertCollaborationTransition(
-          current.header,
-          input.configuration.collaborationMode,
+    const observed = await store.readHeaderRecordSnapshot(sessionId);
+    if (observed.revision !== input.expectedRevision) {
+      throw new SessionConfigurationRevisionConflictError(
+        input.expectedRevision,
+        observed.revision,
+      );
+    }
+    if (
+      !input.clearConnectionBlock &&
+      sessionConfigurationMatches(observed.header, input.configuration)
+    ) {
+      return observed;
+    }
+    const permissionModeOnly =
+      input.permissionModeOnly &&
+      sessionConfigurationMatchesExceptPermissionMode(observed.header, input.configuration);
+    const prepareCommit = async (): Promise<() => Promise<VersionedSessionHeader>> => {
+      const current = await store.readHeaderRecordSnapshot(sessionId);
+      if (current.revision !== input.expectedRevision) {
+        throw new SessionConfigurationRevisionConflictError(
+          input.expectedRevision,
+          current.revision,
         );
-        const leavingDeepResearch =
-          isDeepResearchSession(current.header.labels) &&
-          input.configuration.permissionMode !== 'explore';
-        const labels = leavingDeepResearch
-          ? current.header.labels.filter((label) => label !== DEEP_RESEARCH_SESSION_LABEL)
-          : current.header.labels;
-        return () =>
-          store.updateSessionConfiguration(sessionId, {
-            expectedVersion: input.expectedRevision,
-            configuration: {
-              ...input.configuration,
-              labels,
-            },
-            lifecycle:
-              input.clearConnectionBlock && current.header.blockedReason === 'NO_REAL_CONNECTION'
-                ? {
-                    kind: 'clear_connection_block',
-                    statusUpdatedAt: this.deps.now(),
-                  }
-                : { kind: 'preserve' },
-          });
-      },
-    );
+      }
+      if (current.header.isArchived) {
+        throw new SessionConfigurationTransitionError(
+          'operation_conflict',
+          'Archived Session configuration cannot be changed',
+        );
+      }
+      if (current.header.status === 'waiting_for_user') {
+        throw new SessionConfigurationTransitionError(
+          'session_busy',
+          'Session has a pending Interaction',
+        );
+      }
+      await this.assertCollaborationTransition(
+        current.header,
+        input.configuration.collaborationMode,
+      );
+      const leavingDeepResearch =
+        isDeepResearchSession(current.header.labels) &&
+        input.configuration.permissionMode !== 'explore';
+      const labels = leavingDeepResearch
+        ? current.header.labels.filter((label) => label !== DEEP_RESEARCH_SESSION_LABEL)
+        : current.header.labels;
+      return () =>
+        store.updateSessionConfiguration(sessionId, {
+          expectedVersion: input.expectedRevision,
+          configuration: {
+            ...input.configuration,
+            labels,
+          },
+          lifecycle:
+            input.clearConnectionBlock && current.header.blockedReason === 'NO_REAL_CONNECTION'
+              ? {
+                  kind: 'clear_connection_block',
+                  statusUpdatedAt: this.deps.now(),
+                }
+              : { kind: 'preserve' },
+        });
+    };
+    const next = permissionModeOnly
+      ? await this.commitExecutionBoundaryTransition(
+          sessionId,
+          await this.deps.store.readExecutionBoundary(sessionId),
+          input.configuration.permissionMode,
+          prepareCommit,
+        )
+      : await this.commitExecutionResourceTransition(
+          sessionId,
+          input.configuration.permissionMode,
+          prepareCommit,
+        );
     this.runtimeKernel.updateCachedHeader(sessionId, next.header);
     return next;
   }
@@ -1599,35 +1625,15 @@ export class SessionManager {
   }
 
   async setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary> {
-    const previous = await this.deps.store.readHeader(sessionId);
-    const boundary = await this.deps.store.readExecutionBoundary(sessionId);
-    const leavingDeepResearch = isDeepResearchSession(previous.labels) && mode !== 'explore';
-    if (
-      previous.permissionMode === mode &&
-      executionBoundaryMatchesPermissionMode(boundary, mode) &&
-      !leavingDeepResearch
-    ) {
-      return headerToSummary(previous);
-    }
-
-    if (narrowsExecutionAuthority(boundary, mode) && this.runtimeKernel.hasActiveRuns(sessionId)) {
-      throw new Error('当前任务正在运行，等结束后再切换权限模式。');
-    }
-    if (previous.status === 'waiting_for_user') {
-      throw new Error('当前有工具调用正在等待确认，处理后再切换权限模式。');
-    }
-
-    const labels = leavingDeepResearch
-      ? previous.labels.filter((label) => label !== DEEP_RESEARCH_SESSION_LABEL)
-      : previous.labels;
-    const nextKind = mode === 'bypass' ? 'bypass' : 'managed';
-    await this.commitExecutionBoundaryTransition(sessionId, boundary, nextKind, {
-      permissionMode: mode,
-      labels,
+    const store = this.requireSessionConfigurationStore();
+    const current = await store.readHeaderRecordSnapshot(sessionId);
+    const next = await this.transitionSessionConfiguration(sessionId, {
+      expectedRevision: current.revision,
+      clearConnectionBlock: false,
+      permissionModeOnly: true,
+      configuration: sessionConfigurationWithPermissionMode(current.header, mode),
     });
-    const next = await this.deps.store.readHeader(sessionId);
-    this.runtimeKernel.updateCachedHeader(sessionId, next);
-    return headerToSummary(next);
+    return headerToSummary(next.header);
   }
 
   async setExecutionBoundaryKind(
@@ -1643,21 +1649,22 @@ export class SessionManager {
     if (header.status === 'waiting_for_user') {
       throw new Error('当前有沙箱边界请求正在等待确认，处理后再切换。');
     }
-    const boundary = await this.commitExecutionBoundaryTransition(sessionId, current, kind);
+    const boundary = await this.commitExecutionBoundaryTransition(
+      sessionId,
+      current,
+      kind === 'bypass' ? 'bypass' : 'ask',
+      async () => () => this.deps.store.setExecutionBoundaryKind(sessionId, kind),
+    );
     return boundary;
   }
 
-  private async commitExecutionBoundaryTransition(
+  private async commitExecutionBoundaryTransition<T>(
     sessionId: string,
     current: ExecutionBoundary,
-    kind: 'managed' | 'bypass',
-    projection?: {
-      permissionMode: SessionHeader['permissionMode'];
-      labels?: readonly string[];
-    },
-  ): Promise<ExecutionBoundary> {
-    const nextPermissionMode = projection?.permissionMode ?? (kind === 'bypass' ? 'bypass' : 'ask');
-    const prepareCommit = async (): Promise<() => Promise<ExecutionBoundary>> => {
+    nextPermissionMode: PermissionMode,
+    prepareCommit: () => Promise<() => Promise<T>>,
+  ): Promise<T> {
+    const prepareBoundaryCommit = async (): Promise<() => Promise<T>> => {
       const latest = await this.deps.store.readExecutionBoundary(sessionId);
       if (latest.revision !== current.revision) {
         throw new SessionConfigurationTransitionError(
@@ -1665,7 +1672,7 @@ export class SessionManager {
           'Session execution boundary changed before the transition',
         );
       }
-      return () => this.deps.store.setExecutionBoundaryKind(sessionId, kind, projection);
+      return prepareCommit();
     };
     if (!narrowsExecutionAuthority(current, nextPermissionMode)) {
       // Widening needs no quiescence. Every consumer that froze the old, tighter
@@ -1673,15 +1680,19 @@ export class SessionManager {
       // check only gets easier — so the grant is just written. Waiting for the
       // Session to go idle is what let a running Turn, or a Goal's continuation
       // holding a claim near-continuously, keep the user's own grant out.
-      const commit = await prepareCommit();
-      const boundary = await commit();
+      const commit = await prepareBoundaryCommit();
+      const result = await commit();
       // Not `disposeBackend`: disposing a live Turn's backend stops that Turn.
       // Invalidation refreshes it now when the Session is idle, and otherwise
       // defers to the next activation, which disposes before it starts.
       await this.runtimeKernel.invalidateBackend(sessionId);
-      return boundary;
+      return result;
     }
-    return this.commitExecutionResourceTransition(sessionId, nextPermissionMode, prepareCommit);
+    return this.commitExecutionResourceTransition(
+      sessionId,
+      nextPermissionMode,
+      prepareBoundaryCommit,
+    );
   }
 
   private async commitExecutionResourceTransition<T>(
@@ -5071,15 +5082,47 @@ function claimedAgentGraphIntentResult(
   };
 }
 
-function executionBoundaryMatchesPermissionMode(
-  boundary: ExecutionBoundary,
-  mode: PermissionMode,
+function sessionConfigurationWithPermissionMode(
+  header: SessionHeader,
+  permissionMode: PermissionMode,
+): SessionConfigurationTransitionRequest['configuration'] {
+  return {
+    backend: header.backend,
+    ...(header.llmConnectionId === undefined ? {} : { llmConnectionId: header.llmConnectionId }),
+    llmConnectionSlug: header.llmConnectionSlug,
+    connectionLocked: header.connectionLocked,
+    model: header.model,
+    thinkingLevel: header.thinkingLevel,
+    permissionMode,
+    collaborationMode: header.collaborationMode ?? 'agent',
+    orchestrationMode: header.orchestrationMode ?? 'default',
+  };
+}
+
+function sessionConfigurationMatchesExceptPermissionMode(
+  header: SessionHeader,
+  configuration: SessionConfigurationTransitionRequest['configuration'],
 ): boolean {
-  if (mode === 'bypass') return boundary.kind === 'bypass';
-  if (boundary.kind !== 'managed') return false;
-  return mode === 'explore'
-    ? boundary.profile.name === 'read-only'
-    : boundary.profile.name !== 'read-only';
+  return (
+    header.backend === configuration.backend &&
+    header.llmConnectionId === configuration.llmConnectionId &&
+    header.llmConnectionSlug === configuration.llmConnectionSlug &&
+    header.connectionLocked === configuration.connectionLocked &&
+    header.model === configuration.model &&
+    header.thinkingLevel === configuration.thinkingLevel &&
+    (header.collaborationMode ?? 'agent') === configuration.collaborationMode &&
+    (header.orchestrationMode ?? 'default') === configuration.orchestrationMode
+  );
+}
+
+function sessionConfigurationMatches(
+  header: SessionHeader,
+  configuration: SessionConfigurationTransitionRequest['configuration'],
+): boolean {
+  return (
+    header.permissionMode === configuration.permissionMode &&
+    sessionConfigurationMatchesExceptPermissionMode(header, configuration)
+  );
 }
 
 function narrowsExecutionAuthority(
@@ -5088,7 +5131,7 @@ function narrowsExecutionAuthority(
 ): boolean {
   if (nextPermissionMode === 'bypass') return false;
   if (boundary.kind !== 'managed') return true;
-  return nextPermissionMode === 'explore' && boundary.profile.name !== 'read-only';
+  return nextPermissionMode === 'explore' && !isReadOnlyPermissionProfile(boundary.profile);
 }
 
 function agentRunStatusForSpawnResult(

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1687,19 +1687,28 @@ export class SessionManager {
     kind: 'managed' | 'bypass',
   ): Promise<ExecutionBoundary> {
     const current = await this.deps.store.readExecutionBoundary(sessionId);
-    const narrows = narrowsExecutionAuthority(current, kind === 'bypass' ? 'bypass' : 'ask');
+    const header = await this.deps.store.readHeader(sessionId);
+    // Managed includes Explore. Match Storage's default projection, then pass
+    // it explicitly so classification and commit describe the same transition.
+    const permissionMode =
+      kind === 'bypass'
+        ? 'bypass'
+        : header.permissionMode === 'bypass'
+          ? 'ask'
+          : header.permissionMode;
+    const narrows = narrowsExecutionAuthority(current, permissionMode);
     if (narrows && this.runtimeKernel.hasActiveRuns(sessionId)) {
       throw new Error('当前任务正在运行，等结束后再切换沙箱边界。');
     }
-    const header = await this.deps.store.readHeader(sessionId);
     if (header.status === 'waiting_for_user') {
       throw new Error('当前有沙箱边界请求正在等待确认，处理后再切换。');
     }
     const boundary = await this.commitExecutionBoundaryTransition(
       sessionId,
       current,
-      kind === 'bypass' ? 'bypass' : 'ask',
-      async () => () => this.deps.store.setExecutionBoundaryKind(sessionId, kind),
+      permissionMode,
+      async () => () =>
+        this.deps.store.setExecutionBoundaryKind(sessionId, kind, { permissionMode }),
     );
     return boundary;
   }

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1610,7 +1610,7 @@ export class SessionManager {
       return headerToSummary(previous);
     }
 
-    if (this.runtimeKernel.hasActiveRuns(sessionId)) {
+    if (narrowsExecutionAuthority(boundary, mode) && this.runtimeKernel.hasActiveRuns(sessionId)) {
       throw new Error('当前任务正在运行，等结束后再切换权限模式。');
     }
     if (previous.status === 'waiting_for_user') {
@@ -1634,14 +1634,15 @@ export class SessionManager {
     sessionId: string,
     kind: 'managed' | 'bypass',
   ): Promise<ExecutionBoundary> {
-    if (this.runtimeKernel.hasActiveRuns(sessionId)) {
+    const current = await this.deps.store.readExecutionBoundary(sessionId);
+    const narrows = narrowsExecutionAuthority(current, kind === 'bypass' ? 'bypass' : 'ask');
+    if (narrows && this.runtimeKernel.hasActiveRuns(sessionId)) {
       throw new Error('当前任务正在运行，等结束后再切换沙箱边界。');
     }
     const header = await this.deps.store.readHeader(sessionId);
     if (header.status === 'waiting_for_user') {
       throw new Error('当前有沙箱边界请求正在等待确认，处理后再切换。');
     }
-    const current = await this.deps.store.readExecutionBoundary(sessionId);
     const boundary = await this.commitExecutionBoundaryTransition(sessionId, current, kind);
     return boundary;
   }
@@ -1656,7 +1657,7 @@ export class SessionManager {
     },
   ): Promise<ExecutionBoundary> {
     const nextPermissionMode = projection?.permissionMode ?? (kind === 'bypass' ? 'bypass' : 'ask');
-    return this.commitExecutionResourceTransition(sessionId, nextPermissionMode, async () => {
+    const prepareCommit = async (): Promise<() => Promise<ExecutionBoundary>> => {
       const latest = await this.deps.store.readExecutionBoundary(sessionId);
       if (latest.revision !== current.revision) {
         throw new SessionConfigurationTransitionError(
@@ -1665,7 +1666,22 @@ export class SessionManager {
         );
       }
       return () => this.deps.store.setExecutionBoundaryKind(sessionId, kind, projection);
-    });
+    };
+    if (!narrowsExecutionAuthority(current, nextPermissionMode)) {
+      // Widening needs no quiescence. Every consumer that froze the old, tighter
+      // boundary fails closed against a wider one, and a descendant's admission
+      // check only gets easier — so the grant is just written. Waiting for the
+      // Session to go idle is what let a running Turn, or a Goal's continuation
+      // holding a claim near-continuously, keep the user's own grant out.
+      const commit = await prepareCommit();
+      const boundary = await commit();
+      // Not `disposeBackend`: disposing a live Turn's backend stops that Turn.
+      // Invalidation refreshes it now when the Session is idle, and otherwise
+      // defers to the next activation, which disposes before it starts.
+      await this.runtimeKernel.invalidateBackend(sessionId);
+      return boundary;
+    }
+    return this.commitExecutionResourceTransition(sessionId, nextPermissionMode, prepareCommit);
   }
 
   private async commitExecutionResourceTransition<T>(

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -24,7 +24,6 @@ import { resolveCollaborationPermissionMode } from '@maka/core/collaboration';
 import {
   type CreateSandboxBoundaryRequest,
   type ExecutionBoundary,
-  executionBoundaryDisplayMode,
   type SandboxBoundaryDecision,
   type SandboxBoundaryExpansion,
   type SandboxBoundaryRequest,
@@ -376,6 +375,7 @@ export interface ToolRuntimeInput {
   connection: RuntimeExecutionConnection;
   modelId: string;
   readExecutionBoundary: () => Promise<ExecutionBoundary>;
+  readPermissionMode: () => Promise<PermissionMode>;
   createSandboxBoundaryRequest?: (
     input: CreateSandboxBoundaryRequest,
   ) => Promise<SandboxBoundaryRequest>;
@@ -601,6 +601,7 @@ export class ToolRuntime {
   private readonly durableToolAttempts = new Map<string, DurableToolAttempt>();
   private readonly activeToolSettlements = new Set<Promise<unknown>>();
   private readonly readExecutionBoundary: NonNullable<ToolRuntimeInput['readExecutionBoundary']>;
+  private readonly readPermissionMode: NonNullable<ToolRuntimeInput['readPermissionMode']>;
   private readonly stepAdmissions = new Map<
     string,
     { callCount: number; exclusiveToolName?: string }
@@ -608,6 +609,9 @@ export class ToolRuntime {
   constructor(private readonly input: ToolRuntimeInput) {
     if (!input.readExecutionBoundary) {
       throw new Error('ToolRuntime requires explicit execution boundary authority');
+    }
+    if (!input.readPermissionMode) {
+      throw new Error('ToolRuntime requires explicit permission mode authority');
     }
     const hosted = input.hostedInteraction;
     if (hosted && (hosted.sessionId !== input.sessionId || hosted.turnId !== input.turnId)) {
@@ -619,23 +623,22 @@ export class ToolRuntime {
     this.hostedInteraction = hosted;
     this.readExecutionBoundary = input.readExecutionBoundary;
     this.sandboxBoundaryDenied = input.inheritedSandboxBoundaryDenied === true;
+    this.readPermissionMode = input.readPermissionMode;
   }
 
   /**
    * The permission mode in force for this dispatch.
    *
-   * The header carries the mode this backend was built with, which goes stale
-   * the moment the boundary widens under a live Session. The boundary is the
-   * authority, so read the mode off the boundary we are about to dispatch
-   * against; the header only answers for an externally isolated boundary,
-   * which projects to no local mode at all.
+   * A Bypass boundary is an unambiguous live grant. A managed boundary is not:
+   * an approved path or network expansion changes its structural display mode
+   * without changing the mode the user selected. Keep that selection live in
+   * its own authority, then apply the collaboration overlay for this backend.
    */
-  private livePermissionMode(boundary: ExecutionBoundary): PermissionMode {
-    const displayed = executionBoundaryDisplayMode(boundary);
-    if (displayed === undefined) return this.input.header.permissionMode;
+  private async livePermissionMode(boundary: ExecutionBoundary): Promise<PermissionMode> {
+    const permissionMode = boundary.kind === 'bypass' ? 'bypass' : await this.readPermissionMode();
     return resolveCollaborationPermissionMode({
       collaborationMode: this.input.header.collaborationMode ?? 'agent',
-      permissionMode: displayed,
+      permissionMode,
     });
   }
 
@@ -1477,10 +1480,12 @@ export class ToolRuntime {
     }
 
     let clientCapabilityBoundary: ExecutionBoundary | undefined;
+    let clientCapabilityPermissionMode: PermissionMode | undefined;
     let preparedExecution: PreparedMakaToolExecution | undefined;
     if (tool.hostAdmission === 'client_capability') {
       try {
         clientCapabilityBoundary = await this.readExecutionBoundary();
+        clientCapabilityPermissionMode = await this.livePermissionMode(clientCapabilityBoundary);
       } catch (error) {
         const reason = formatSyntheticToolErrorText(error);
         await refuseBeforeDispatch(reason);
@@ -1495,8 +1500,7 @@ export class ToolRuntime {
       }
       const admissionFailure = !tool.prepareExecution
         ? CLIENT_CAPABILITY_PREPARATION_MESSAGE
-        : clientCapabilityBoundary.kind !== 'bypass' &&
-            this.livePermissionMode(clientCapabilityBoundary) !== 'ask'
+        : clientCapabilityBoundary.kind !== 'bypass' && clientCapabilityPermissionMode !== 'ask'
           ? CLIENT_CAPABILITY_BOUNDARY_MESSAGE
           : undefined;
       if (admissionFailure) {
@@ -1525,7 +1529,7 @@ export class ToolRuntime {
           ...(runId ? { runId } : {}),
           cwd: this.input.header.cwd,
           executionBoundary: clientCapabilityBoundary,
-          permissionMode: this.livePermissionMode(clientCapabilityBoundary),
+          permissionMode: clientCapabilityPermissionMode,
           toolCallId: toolUseId,
           abortSignal: ctx.abortSignal,
         });
@@ -1646,6 +1650,8 @@ export class ToolRuntime {
       try {
         const runId = this.input.runId;
         const executionBoundary = clientCapabilityBoundary ?? (await this.readExecutionBoundary());
+        const permissionMode =
+          clientCapabilityPermissionMode ?? (await this.livePermissionMode(executionBoundary));
         const toolContext: MakaToolContext = {
           sessionId: this.input.sessionId,
           turnId,
@@ -1655,7 +1661,7 @@ export class ToolRuntime {
             : {}),
           cwd: this.input.header.cwd,
           executionBoundary,
-          permissionMode: this.livePermissionMode(executionBoundary),
+          permissionMode,
           toolCallId: toolUseId,
           // The id the call event actually carries, not the candidate: by here
           // `prepareDurableToolAttempt` has pushed it on the dispatch lane.

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -20,9 +20,11 @@
 import { decodeCanonicalToolResultContent } from '@maka/core/tool-result-record-schema';
 import { projectAgentSwarmResult } from '@maka/core/agent-swarm';
 import { projectToolActivityArgs } from '@maka/core/tool-activity-args';
+import { resolveCollaborationPermissionMode } from '@maka/core/collaboration';
 import {
   type CreateSandboxBoundaryRequest,
   type ExecutionBoundary,
+  executionBoundaryDisplayMode,
   type SandboxBoundaryDecision,
   type SandboxBoundaryExpansion,
   type SandboxBoundaryRequest,
@@ -617,6 +619,24 @@ export class ToolRuntime {
     this.hostedInteraction = hosted;
     this.readExecutionBoundary = input.readExecutionBoundary;
     this.sandboxBoundaryDenied = input.inheritedSandboxBoundaryDenied === true;
+  }
+
+  /**
+   * The permission mode in force for this dispatch.
+   *
+   * The header carries the mode this backend was built with, which goes stale
+   * the moment the boundary widens under a live Session. The boundary is the
+   * authority, so read the mode off the boundary we are about to dispatch
+   * against; the header only answers for an externally isolated boundary,
+   * which projects to no local mode at all.
+   */
+  private livePermissionMode(boundary: ExecutionBoundary): PermissionMode {
+    const displayed = executionBoundaryDisplayMode(boundary);
+    if (displayed === undefined) return this.input.header.permissionMode;
+    return resolveCollaborationPermissionMode({
+      collaborationMode: this.input.header.collaborationMode ?? 'agent',
+      permissionMode: displayed,
+    });
   }
 
   async endTurn(reason: 'completed' | 'aborted' = 'completed'): Promise<void> {
@@ -1475,7 +1495,8 @@ export class ToolRuntime {
       }
       const admissionFailure = !tool.prepareExecution
         ? CLIENT_CAPABILITY_PREPARATION_MESSAGE
-        : clientCapabilityBoundary.kind !== 'bypass' && this.input.header.permissionMode !== 'ask'
+        : clientCapabilityBoundary.kind !== 'bypass' &&
+            this.livePermissionMode(clientCapabilityBoundary) !== 'ask'
           ? CLIENT_CAPABILITY_BOUNDARY_MESSAGE
           : undefined;
       if (admissionFailure) {
@@ -1504,7 +1525,7 @@ export class ToolRuntime {
           ...(runId ? { runId } : {}),
           cwd: this.input.header.cwd,
           executionBoundary: clientCapabilityBoundary,
-          permissionMode: this.input.header.permissionMode,
+          permissionMode: this.livePermissionMode(clientCapabilityBoundary),
           toolCallId: toolUseId,
           abortSignal: ctx.abortSignal,
         });
@@ -1634,7 +1655,7 @@ export class ToolRuntime {
             : {}),
           cwd: this.input.header.cwd,
           executionBoundary,
-          permissionMode: this.input.header.permissionMode,
+          permissionMode: this.livePermissionMode(executionBoundary),
           toolCallId: toolUseId,
           // The id the call event actually carries, not the candidate: by here
           // `prepareDurableToolAttempt` has pushed it on the dispatch lane.

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -23,6 +23,7 @@ import { dirname, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { existsSync, mkdirSync } from 'node:fs';
 import { isDeepStrictEqual } from 'node:util';
+import { isCanonicalReadOnlyPermissionProfile } from '@maka/core/permission-profile';
 import type { DatabaseSync } from 'node:sqlite';
 import {
   AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
@@ -4575,7 +4576,7 @@ export class SqliteSessionMetadataStore {
           `Managed sandbox boundary history is invalid: ${sessionId}`,
         );
       }
-      if (!isCanonicalReadOnlySandboxProfile(boundary.profile)) return boundary.profile;
+      if (!isCanonicalReadOnlyPermissionProfile(boundary.profile)) return boundary.profile;
     }
     return requireManagedProfile(createGenesisExecutionBoundary('ask'));
   }
@@ -4838,7 +4839,7 @@ export class SqliteSessionMetadataStore {
       kind === 'managed'
         ? projectedMode === 'explore'
           ? requireManagedProfile(createGenesisExecutionBoundary('explore'))
-          : current.kind === 'managed' && !isCanonicalReadOnlySandboxProfile(current.profile)
+          : current.kind === 'managed' && !isCanonicalReadOnlyPermissionProfile(current.profile)
             ? current.profile
             : this.readLatestAutoSandboxProfileSync(sessionId)
         : undefined;
@@ -6262,16 +6263,6 @@ function requireManagedProfile(
 ): Extract<ExecutionBoundary, { kind: 'managed' }>['profile'] {
   if (boundary.kind !== 'managed') throw new Error('Expected a managed execution boundary');
   return boundary.profile;
-}
-
-function isCanonicalReadOnlySandboxProfile(
-  profile: Extract<ExecutionBoundary, { kind: 'managed' }>['profile'],
-): boolean {
-  const { name: _profileName, ...profilePolicy } = profile;
-  const { name: _canonicalName, ...canonicalPolicy } = requireManagedProfile(
-    createGenesisExecutionBoundary('explore'),
-  );
-  return isDeepStrictEqual(profilePolicy, canonicalPolicy);
 }
 
 function assertGraphLookupIdentity(value: string, name: string): void {

--- a/scripts/computer-use/lab-root.test.mjs
+++ b/scripts/computer-use/lab-root.test.mjs
@@ -131,3 +131,10 @@ test('Lab-backed entry points require the configured root', async () => {
     );
   }
 });
+
+test('real AX harness supplies every explicit runtime permission authority', async () => {
+  const source = await readFile(new URL('real-ax-harness.mjs', import.meta.url), 'utf8');
+
+  assert.match(source, /readExecutionBoundary:\s*async \(\) =>/);
+  assert.match(source, /readPermissionMode:\s*async \(\) => 'bypass'/);
+});

--- a/scripts/computer-use/real-ax-harness.mjs
+++ b/scripts/computer-use/real-ax-harness.mjs
@@ -550,6 +550,7 @@ const runtime = new AiSdkBackend({
   apiKey,
   modelId,
   readExecutionBoundary: async () => ({ kind: 'bypass', revision: 0 }),
+  readPermissionMode: async () => 'bypass',
   modelFactory: (input) => getAIModel(input),
   tools: [computerTool],
   maxSteps: 8,


### PR DESCRIPTION
## Summary

Fixes #3349

A permission switch (Auto→Bypass) was not reliably observed by subsequent execution. Under Goal continuation, the switch could be rejected with `session_busy` because permission widening shared the quiescence requirement used for narrowing. Separately, `ctx.permissionMode` was frozen when the backend was built, so permission-sensitive tool admission could continue using the previous mode after the execution boundary changed.

Bash already reads the live execution boundary for its sandbox profile. The dispatch change here updates the permission mode consumed by the Client Capability and MCP admission paths.

The issue asks for one property in any session, not just Goals: *a permission change is observed by the next turn that starts after it, before that turn's first tool call.*

### What changed

Permission transitions — distinguish widening from narrowing:

- The Host coordinator identifies an exact permission-only `session.configuration.update` patch. `SessionManager.transitionSessionConfiguration` independently verifies that no other configuration field changes, then routes the update through `commitExecutionBoundaryTransition`. This covers the production Desktop and CLI permission-picker paths.
- Permission widening commits through the existing admission-mutation tail without requiring the current turn to finish. The boundary revision check and commit are serialized together, preventing concurrent boundary writes from committing with stale transition classifications.
- Permission narrowing and mixed configuration updates retain the existing quiescent `commitExecutionResourceTransition` path, including linked-session checks, shell termination, backend disposal and rollback behavior. Actual configuration changes still reject while the session is `waiting_for_user`.
- Runtime and Storage share `isCanonicalReadOnlyPermissionProfile`. A transition that restores the canonical Explore policy after an extra read, write or network grant is classified as a possible narrowing.
- For stores exposing versioned configuration authority, `setPermissionMode` delegates to `transitionSessionConfiguration`. The compatibility path for older stores uses the same boundary-transition logic.

Live permission mode and execution boundary:

- `ToolRuntime` reads the selected session permission mode live for each dispatch. A `bypass` execution boundary overrides that value; otherwise the selected mode is read from the current session header.
- An approved expansion of a managed Explore boundary therefore does not silently promote the selected mode to `ask` or open Client Capability admission.
- `resolveCollaborationPermissionMode` moves to core so backend composition and tool dispatch share the existing Plan-mode overlay.
- Client Capability admission, preparation and execution context use the same resolved permission mode.

Backend refresh:

- Widening calls `runtimeKernel.invalidateBackend`, preserving the active turn while arranging a backend refresh when execution permits.
- Invalidation is retained across header reads, preflight, backend preparation, construction and run reservation, including cold activation. A refresh arriving during activation is not lost before the resulting run exits.
- The current turn keeps its composed tool catalog and prompts; live permission checks observe the committed grant, while backend recomposition happens after active execution settles.

### How this meets the issue's stated goals

- *"Observed by the next turn that starts after it, before that turn's first tool call"* — widening can commit during active execution, subsequent dispatches read the live permission authority, and backend invalidation refreshes the composition for subsequent execution.
- *Not Goal-specific* — the production Host operation is covered for ordinary sessions and active Goal continuations. The plain-session regression also verifies that the successor turn's first tool call sees `executionBoundary.kind === 'bypass'` and `ctx.permissionMode === 'bypass'` together.
- *Return a truthful outcome* — widening no longer fails solely because a turn is active. Narrowing and mixed updates still reject when their quiescence requirements are not met, and pending interactions retain their existing refusal behavior.
- *Preserve the narrowing guarantees* — the change removes the unnecessary quiescence requirement from permission widening while keeping the existing resource-transition path for permission reductions.

### Verification

Regression coverage includes:

- A plain session whose successor turn observes the committed Bypass boundary and permission mode together.
- A permission widening submitted through `session.configuration.update` while an ordinary turn is active, followed by a successful permission-sensitive tool call in the next turn.
- A widening submitted through the same Host operation during an active Goal continuation, observed by a subsequent Client Capability call in that continuation.
- Mid-turn widening without stopping the live turn or terminating existing shells.
- Busy-session rejection for narrowing and mixed configuration updates.
- Expanded Explore profiles retaining the selected Explore mode at dispatch, and canonical Explore resets recognizing revoked read, write and network grants.
- Concurrent boundary transitions and backend invalidation during preflight and activation.

Validation at local head `21ddeca9f`:

- Builds for `@maka/core`, `@maka/storage`, `@maka/mcp`, `@maka/runtime` and `@maka/runtime-host` — passed.
- Affected core, runtime and runtime-host tests — 549 passed, 0 failed.
- `node --test scripts/computer-use/lab-root.test.mjs` — 5 passed, 0 failed.

Previously reported checks, not rerun during this review:

- `npm run format:check` — clean.
- `npm run lint` — passed.
- `npm run typecheck` — passed.

Not run during this review: the full workspace test suites and manual Desktop verification of the picker.

## Root cause

Two related problems affected permission changes: widening was subject to the quiescence requirement needed for narrowing, and tool contexts used a permission mode captured at backend construction.

The fix routes production permission-only updates through a widening-aware boundary transition and reads the selected permission mode live at dispatch, preserving the Plan overlay. Explicit backend invalidation refreshes composed state without stopping the active turn and remains effective across activation races.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: ZCode (Z.ai GLM) authored the implementation, tests, and review fixes; the contributor directed the design, reviewed each finding, and made the rebase decisions.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No