### PR TITLE
fix(ui): contain expanded tool call rows

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -147,8 +147,11 @@
 
 /* Astryx clips the animated group body with overflow:hidden. `clip` preserves
    that visual boundary without becoming a scroll ancestor that captures the
-   nested sticky row. */
+   nested sticky row. The inner wrapper is also a grid item: without an explicit
+   zero minimum its long, nowrap call preview becomes the track's minimum size
+   and stretches every expanded row past the turn instead of ellipsizing it. */
 .maka-turn .maka-tool-activity-card > [role="button"] + div > div {
+  min-width: 0;
   overflow: clip;
 }
 

--- a/packages/ui/stories/tool-activity.stories.tsx
+++ b/packages/ui/stories/tool-activity.stories.tsx
@@ -266,11 +266,15 @@ export const LongIntentGroupNarrow: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', { name: /2 次工具调用|2 tool calls/i }));
     const turn = canvas.getByTestId('narrow-turn');
     const group = turn.querySelector<HTMLElement>('.maka-tool-activity-card');
     expect(group).not.toBeNull();
-    const rows = Array.from(group?.querySelectorAll<HTMLElement>('[role="button"]') ?? []);
+    const disclosure = group!.querySelector<HTMLElement>(
+      ':scope > [role="button"][aria-controls]',
+    );
+    expect(disclosure).not.toBeNull();
+    await userEvent.click(disclosure!);
+    const rows = Array.from(group!.querySelectorAll<HTMLElement>('[role="button"]'));
     expect(Math.max(...rows.map((row) => row.getBoundingClientRect().width))).toBeLessThanOrEqual(
       turn.clientWidth + 8,
     );

--- a/packages/ui/stories/tool-activity.stories.tsx
+++ b/packages/ui/stories/tool-activity.stories.tsx
@@ -19,6 +19,7 @@
 
 import { useEffect, useRef } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
 import { ToolCallDetail, ToolTrow } from '../src/tool-activity.js';
 import type { ToolActivityItem } from '../src/materialize.js';
 import {
@@ -230,4 +231,48 @@ export const ContiguousDiffGroup: Story = {
       <ToolTrow items={args.items} />
     </Board>
   ),
+};
+
+const longIntentItems: ToolActivityItem[] = [
+  {
+    toolUseId: 'explore-agent-long-intent',
+    toolName: 'ExploreAgent',
+    displayName: '只读探索',
+    activityKind: 'tool',
+    status: 'completed',
+    intent: '审计模型选择、切换、持久化、event log、replay/resume 路径：当前模型事实由谁持有，何时切换，是否已有事件或消息可表达',
+    args: {},
+  },
+  {
+    toolUseId: 'explore-agent-long-intent-2',
+    toolName: 'ExploreAgent',
+    displayName: '只读探索',
+    activityKind: 'tool',
+    status: 'completed',
+    intent: '审计提示词构筑与缓存路径：追踪 durable system prompt、turnTailPrompt、provider-visible messages 与 request shape',
+    args: {},
+  },
+];
+
+// Regression path: a narrow conversation contains a grouped ExploreAgent run
+// whose intent summaries are much wider than the reading column. Expanding the
+// group must truncate those rows without widening the turn itself.
+export const LongIntentGroupNarrow: Story = {
+  args: { items: longIntentItems },
+  render: (args) => (
+    <div className="maka-turn" data-testid="narrow-turn" style={{ margin: '0 auto', width: 320 }}>
+      <ToolTrow items={args.items} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /2 次工具调用|2 tool calls/i }));
+    const turn = canvas.getByTestId('narrow-turn');
+    const group = turn.querySelector<HTMLElement>('.maka-tool-activity-card');
+    expect(group).not.toBeNull();
+    const rows = Array.from(group?.querySelectorAll<HTMLElement>('[role="button"]') ?? []);
+    expect(Math.max(...rows.map((row) => row.getBoundingClientRect().width))).toBeLessThanOrEqual(
+      turn.clientWidth + 8,
+    );
+  },
 };


### PR DESCRIPTION
## Summary

- Keep expanded grouped tool-call rows within the conversation width when intents are long.
- Reset the grid item's automatic minimum width so Astryx can ellipsize nowrap previews instead of using them as the grid track minimum.
- Add a narrow Storybook regression that expands a long-intent group and checks every row remains within the turn.

## Before and after

<img width="1072" height="400" alt="image" src="https://github.com/user-attachments/assets/f28c98fd-aec5-4b6b-b056-210ef8cb25c6" />

## Verification

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run typecheck:stories`
- `npm --workspace @maka/desktop run build:workspace-deps`
- `npm --workspace @maka/desktop run build-storybook`
- Browser layout check at a 320 px turn width: affected rows shrink from 910 px before the fix to 328 px after it, including Astryx's intentional 8 px hover overhang.

## AI use

- [ ] No generative AI materially contributed to this pull request.
- [x] Generative AI materially contributed to this pull request.

Tool(s): Maka — diagnosis, implementation, regression story, browser verification, and PR drafting. The contributor must review and verify the final diff before merge.

## Checklist

- [x] Tests cover the change and fail without it.
- [x] Lint, format, typecheck, and affected suites pass locally.
- [x] This changes user-visible behavior.
