### PR TITLE
docs: remove nonexistent task ledger tool switch

### DIFF
--- a/docs/session-task-ledger-lifecycle.md
+++ b/docs/session-task-ledger-lifecycle.md
@@ -150,10 +150,6 @@ and `agent_spawn.task_id` accept UUIDs or short keys. `task_list` supports exact
 `status`, `include_terminal`, and `include_archived` filters; its no-argument
 behavior remains compatible with the original full-list behavior.
 
-`MAKA_TASK_LEDGER_TOOLS=false` disables registration. Legacy
-PascalCase aliases are not advertised and require an explicit compatibility
-flag in main-process wiring.
-
 ### Runtime Host Authority
 
 The non-serving Runtime Host composition opens the interactive Task Ledger


### PR DESCRIPTION
## Summary

Remove documentation for the nonexistent `MAKA_TASK_LEDGER_TOOLS` registration switch and the adjacent stale compatibility-alias claim. The current Runtime Host registers the four `task_*` tools without this environment switch, and the repository contains no implementation of the documented flag.

The larger Task Ledger simplification remains tracked in #2290; this PR only makes the current lifecycle document accurate.

Refs #2290

## Verification

- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka identified the stale claim and prepared this documentation-only change. I reviewed the diff.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
