### PR TITLE
fix(release): close final G3 source inventory gaps

### DIFF
--- a/apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt
+++ b/apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt
@@ -194,7 +194,8 @@ SOFTWARE.
 - Source: `dingtalk-fill`
 - License: Apache-2.0
 - Covered source asset: `packages/ui/src/bot-brand-logo.tsx` `DingTalkLogo`
-- Full license text: packaged as `licenses/renderer/MINGCUTE_APACHE_LICENSE.txt`.
+- Full license text: the repository-root `LICENSE`; desktop packages copy that file to
+  `licenses/renderer/MINGCUTE_APACHE_LICENSE.txt`.
 - Trademark boundary: DingTalk and its logo remain trademarks of their owner.
 
 ## Allogo Feishu mark

--- a/docs/code-origin-audit.md
+++ b/docs/code-origin-audit.md
@@ -148,7 +148,7 @@ No `NOTICE` addition is warranted. The fixed Astryx and `trycua/cua` revisions h
 
 ## Other provenance evidence
 
-The SCANOSS table above covers only what its winnowing scanner fingerprints, which is source code in supported formats. Two further categories of incoming material were found outside it and are recorded here. Both are attribution gaps rather than license conflicts, and both are tracked for the release legal-files gate in #3270; neither is resolved by this report.
+The SCANOSS table above covers only what its winnowing scanner fingerprints, which is source code in supported formats. Additional incoming-material and same-author transfer records that sit outside that scan are recorded here. The records distinguish third-party attribution obligations from contributor-confirmed ASF contributions rather than treating every cross-repository lineage as third-party code.
 
 ### Adapted opencode source
 
@@ -162,6 +162,43 @@ Upstream is MIT, Copyright (c) 2025 opencode. The repository now resolves to `an
 ### models.dev data snapshot
 
 `packages/core/src/model-metadata.generated.ts` and `packages/runtime/src/telemetry/model-pricing.generated.ts` are checked-in, shipped derivations of `https://models.dev/api.json`, together about 27,800 lines. Upstream `sst/models.dev` is MIT, Copyright (c) 2025 models.dev. The individual entries are facts and are not themselves copyrightable, but the selection and arrangement — which providers and fields are carried, and upstream's normalized structures such as `lifecycle` and `thinkingOptions.efforts` — come from that database. The same generator boundary applies: models.dev is not an npm dependency, and it appears in none of the four attribution surfaces. The generated headers also record no snapshot date or upstream revision, so the fixed source cannot currently be identified.
+
+### PawWork browser port
+
+The embedded-browser work introduced by Maka commit `fab537af179232cc88dc39314038000f70d15d05` was ported from two fixed source batches in [`Astro-Han/pawwork`](https://github.com/Astro-Han/pawwork):
+
+- CDP bridge and browser options: `aff7ce202f5ccb9a7166a95172aa754b0d4de7db`;
+- `BrowserSession`, generic observe→act tools, and their desktop integration: `e3595b705c687c369828736ecd154127ed44f545`.
+
+Both PawWork snapshots are Apache-2.0. On 2026-08-23, their author AstroHan confirmed that these are the only two source batches, that all code carried into Maka was his own work, and that he submitted it directly as an ASF contribution. PawWork's repository-level `NOTICE` also describes unrelated OpenCode material, but that notice does not pertain to this contributor-confirmed slice. No PawWork or OpenCode bytes outside the two stated batches are part of this port.
+
+The exact Maka introduction boundary is the following 23-file change. This list records the transfer boundary, not an assertion that every byte in each integration file came from PawWork:
+
+- `apps/desktop/src/global.d.ts`
+- `apps/desktop/src/main/__tests__/automation-host.test.ts`
+- `apps/desktop/src/main/__tests__/browser-logic.test.ts`
+- `apps/desktop/src/main/__tests__/browser-session.test.ts`
+- `apps/desktop/src/main/__tests__/browser-tools.test.ts`
+- `apps/desktop/src/main/__tests__/browser-view-manager.test.ts`
+- `apps/desktop/src/main/__tests__/cdp-bridge.test.ts`
+- `apps/desktop/src/main/browser/automation-host.ts`
+- `apps/desktop/src/main/browser/browser-host.ts`
+- `apps/desktop/src/main/browser/browser-tools.ts`
+- `apps/desktop/src/main/browser/cdp-bridge.ts`
+- `apps/desktop/src/main/browser/controller.ts`
+- `apps/desktop/src/main/browser/logic.ts`
+- `apps/desktop/src/main/browser/options.ts`
+- `apps/desktop/src/main/browser/session.ts`
+- `apps/desktop/src/main/browser/view-manager.ts`
+- `apps/desktop/src/main/main.ts`
+- `apps/desktop/src/preload/preload.ts`
+- `apps/desktop/src/renderer/browser-panel.tsx`
+- `apps/desktop/src/renderer/main.tsx`
+- `apps/desktop/src/renderer/styles.css`
+- `packages/core/src/browser.ts`
+- `packages/core/src/index.ts`
+
+Subsequent refactors moved `apps/desktop/src/renderer/browser-panel.tsx` to `apps/desktop/src/renderer/features/workbar/tools/browser/browser-panel.tsx` and deleted the old `packages/core/src/index.ts` barrel. Those changes do not add another source batch; the introduction commit and fixed upstream revisions remain the provenance anchors.
 
 ### Bundled Skills
 

--- a/scripts/source-legal-inventory.test.mjs
+++ b/scripts/source-legal-inventory.test.mjs
@@ -52,6 +52,63 @@ test('mixed-origin DeepSeek profile carries both scopes without a whole-file ASF
   assert.doesNotMatch(profile, /Licensed to the Apache Software Foundation \(ASF\)/);
 });
 
+test('PawWork browser provenance is pinned to the confirmed transfer boundary', async () => {
+  const audit = await readFile(join(root, 'docs/code-origin-audit.md'), 'utf8');
+  const section = audit
+    .split('### PawWork browser port\n', 2)[1]
+    ?.split('\n### Bundled Skills\n', 1)[0];
+  assert.ok(section, 'PawWork browser provenance section is missing');
+  assert.match(section, /fab537af179232cc88dc39314038000f70d15d05/);
+  assert.match(section, /aff7ce202f5ccb9a7166a95172aa754b0d4de7db/);
+  assert.match(section, /e3595b705c687c369828736ecd154127ed44f545/);
+  assert.match(section, /only two source batches/);
+  assert.match(section, /submitted it directly as an ASF contribution/);
+
+  const inventoriedPaths = [...section.matchAll(/^- `([^`]+)`$/gm)].map((match) => match[1]);
+  assert.deepEqual(inventoriedPaths, [
+    'apps/desktop/src/global.d.ts',
+    'apps/desktop/src/main/__tests__/automation-host.test.ts',
+    'apps/desktop/src/main/__tests__/browser-logic.test.ts',
+    'apps/desktop/src/main/__tests__/browser-session.test.ts',
+    'apps/desktop/src/main/__tests__/browser-tools.test.ts',
+    'apps/desktop/src/main/__tests__/browser-view-manager.test.ts',
+    'apps/desktop/src/main/__tests__/cdp-bridge.test.ts',
+    'apps/desktop/src/main/browser/automation-host.ts',
+    'apps/desktop/src/main/browser/browser-host.ts',
+    'apps/desktop/src/main/browser/browser-tools.ts',
+    'apps/desktop/src/main/browser/cdp-bridge.ts',
+    'apps/desktop/src/main/browser/controller.ts',
+    'apps/desktop/src/main/browser/logic.ts',
+    'apps/desktop/src/main/browser/options.ts',
+    'apps/desktop/src/main/browser/session.ts',
+    'apps/desktop/src/main/browser/view-manager.ts',
+    'apps/desktop/src/main/main.ts',
+    'apps/desktop/src/preload/preload.ts',
+    'apps/desktop/src/renderer/browser-panel.tsx',
+    'apps/desktop/src/renderer/main.tsx',
+    'apps/desktop/src/renderer/styles.css',
+    'packages/core/src/browser.ts',
+    'packages/core/src/index.ts',
+  ]);
+});
+
+test('MingCute license pointer resolves in both source and packaged layouts', async () => {
+  const [license, inventory, builderConfig] = await Promise.all([
+    readFile(join(root, 'LICENSE'), 'utf8'),
+    readFile(join(root, 'apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt'), 'utf8'),
+    readFile(join(root, 'apps/desktop/electron-builder.config.mjs'), 'utf8'),
+  ]);
+  const entry = inventory.split('## MingCute DingTalk mark\n', 2)[1]?.split('\n## ', 1)[0];
+  assert.ok(entry, 'MingCute inventory entry is missing');
+  assert.match(entry, /repository-root `LICENSE`/);
+  assert.match(entry, /`licenses\/renderer\/MINGCUTE_APACHE_LICENSE\.txt`/);
+  assert.match(license, /Apache License\n\s+Version 2\.0, January 2004/);
+  assert.match(
+    builderConfig,
+    /from: '\.\.\/\.\.\/LICENSE',\n\s+to: 'licenses\/renderer\/MINGCUTE_APACHE_LICENSE\.txt'/,
+  );
+});
+
 test('every vendored provider mark is bound to its reviewed inventory and digest', async () => {
   const assetDirectory = join(root, 'apps/desktop/src/renderer/assets/provider-brands');
   const inventory = await readFile(


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Record the contributor-confirmed PawWork browser transfer boundary: Maka import commit `fab537af179232cc88dc39314038000f70d15d05`, the two fixed PawWork revisions, and the exact 23-file introduction surface.
- Guard that record in the ASF source legal-inventory test so the revisions, contribution status, and file boundary cannot silently drift.
- Clarify that the MingCute Apache-2.0 text resolves to the repository-root `LICENSE` in the source distribution and is copied to `licenses/renderer/MINGCUTE_APACHE_LICENSE.txt` only in desktop packages.

This closes the two concrete inventory gaps found while auditing the unsigned G3 source candidate. It does not change runtime behavior.

Refs #3270

## Verification

- Generated `apache-maka-0.2.0-incubating-src.tar.gz` from exact commit `f261fea8d93008ef1545e4e38e6b67ad51105c16` (2,884 files; SHA-512 `15cea6ac2d42a35d26eefe45c40ae06885b5418c76f20f8bf9a4d2159f9a9b70ee3149da25750f0a96e1a7b256626d9d1a67fa2eeb8376c9338c6535f4a4c225`).
- Extracted the exact archive and ran the source header audit: 2,751 covered files + 133 reviewed exclusions, all passing.
- Extracted-candidate checks passed with the repository-pinned `npm@11.19.0`: all three dependency notice inventories, `check:asf-source` (67/67), format, lint, full build, and all workspace typechecks.
- `git diff --check` passed.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the source-candidate gaps, implemented the provenance record and guards, and ran the verification above. The commit carries a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

</details>

<details>
<summary>中文</summary>

## 摘要

- 记录经贡献者确认的 PawWork 浏览器移植边界：Maka 引入提交 `fab537af179232cc88dc39314038000f70d15d05`、两个固定 PawWork revision，以及精确的 23 文件引入范围。
- 在 ASF 源码法律清单测试中守住这条记录，避免 revision、贡献状态或文件边界静默漂移。
- 明确 MingCute 的 Apache-2.0 全文在源码发行包中对应仓库根 `LICENSE`，只有桌面安装包才将它复制到 `licenses/renderer/MINGCUTE_APACHE_LICENSE.txt`。

这关闭了 G3 未签名源码候选人工审计发现的两个具体清单缺口，不改变运行时行为。

关联 #3270

## 验证

- 从 exact commit `f261fea8d93008ef1545e4e38e6b67ad51105c16` 生成 `apache-maka-0.2.0-incubating-src.tar.gz`（2,884 个文件；SHA-512 `15cea6ac2d42a35d26eefe45c40ae06885b5418c76f20f8bf9a4d2159f9a9b70ee3149da25750f0a96e1a7b256626d9d1a67fa2eeb8376c9338c6535f4a4c225`）。
- 解压真实归档并运行源码 header 审计：2,751 个 covered 文件 + 133 个已审查 exclusion，全部通过。
- 在解压后的候选中使用仓库固定的 `npm@11.19.0` 通过：三套依赖 notice 清单、`check:asf-source`（67/67）、format、lint、完整 build、全部 workspace typecheck。
- `git diff --check` 通过。

## AI 使用

- [ ] 没有生成式工具做出实质贡献
- [x] 生成式工具做出了实质贡献

工具与范围：OpenAI Codex 调查源码候选缺口、实现来源记录与守卫，并执行上述验证。提交带有 `Generated-by: Codex` trailer。

## 检查清单

- [x] 测试覆盖该变更，并会在缺少修复时失败
- [x] lint、format、typecheck 与受影响测试均在本地通过

本 PR 是否改变行为？

- [ ] 是——已在摘要中说明
- [x] 否

</details>
