### PR TITLE
docs(ui): align thinking-level default comments

### DIFF
--- a/apps/desktop/src/renderer/use-shell-chat-model.ts
+++ b/apps/desktop/src/renderer/use-shell-chat-model.ts
@@ -110,8 +110,9 @@ export function useShellChatModel(options: {
   // Renderer-only — it never mutates the persisted Settings · 模型 default.
   // Three states, because two cannot say this: `undefined` is an untouched
   // picker, so Settings → 通用 → 默认思考级别 applies; `null` is the user
-  // explicitly choosing 模型默认 for this one chat, which must beat the
-  // configured default or the per-chat picker could not undo it.
+  // explicitly choosing the per-chat `默认` option (use the model default),
+  // which must beat the configured Settings default or the picker could not
+  // undo it.
   //
   // The pick carries its target key so a Host or Project switch cannot apply it
   // to a different execution authority, even for an identically named model.

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -437,7 +437,8 @@ const CONVERSATION_COPY = {
     model: {
       thinkingLevel: '思考级别', thinkingUnsupported: '当前模型不支持思考级别切换', changeThinkingLevel: '切换当前模型的思考级别', defaultLevel: '默认',
       // Short single-token labels — trigger + popout size to content.
-      // Canonical ladder: 默认 / 关 / 低 / 中 / 高 / 超高 (minimal/max when offered).
+      // Canonical per-chat ladder: 默认 (model default, overriding Settings) / 关 / 低 / 中 / 高 / 超高
+      // (minimal/max when offered).
       level: { off: '关', minimal: '最少', low: '低', medium: '中', high: '高', xhigh: '超高', max: '最高' },
       switching: '切换中', model: '模型', switchAriaLabel: '切换当前任务模型',
       switchWarning: '切换模型可能需要重建服务商提示缓存，使下一次请求更慢或成本更高。',


### PR DESCRIPTION
## Summary

Clarify the three-state thinking-level contract using the Chinese label that now ships: an untouched picker inherits the Settings-wide default, while explicitly choosing the per-chat `默认` option means using the model default and must override that setting.

Update the nearby canonical-ladder comment with the same distinction. This changes comments only; runtime behavior and localized copy are unchanged.

Fixes #3614

## Verification

- `npm run format:check` — passed (1,595 files)
- `npm run lint` — passed (2,619 files)
- `npm run build` — all workspaces passed
- `npm run typecheck` — all workspaces passed
- `npx knip --workspace apps/desktop` — passed
- `npx knip --workspace packages/ui` — passed
- `npm --workspace @maka/ui test` — 220 passed

No test was added because the issue explicitly scopes this to correcting non-executable comments with no behavior or copy change. The existing localized-copy regression test remains green.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with issue triage, drafted the two comment updates, and ran the local verification commands. The commit includes the required `Generated-by: OpenAI Codex` trailer.

## Checklist

- [ ] Tests cover the change and fail without it — N/A for a comment-only correction; see Verification
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
