### PR TITLE
fix(runtime): replay checkpoints before tool pruning

### DIFF
--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -18,10 +18,12 @@
  */
 
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { test } from 'node:test';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import { applyRuntimeEventContextBudget } from '../context-budget.js';
 import { estimateRuntimeEventsTokens } from '../context-budget-helpers.js';
+import { buildHistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
 
 test('estimates only model-visible provider context', () => {
   const visible = textEvent('visible', 'visible context');
@@ -41,6 +43,56 @@ test('capacity policy keeps the canonical ledger until a checkpoint replaces it'
   assert.deepEqual(result?.events, events);
 });
 
+test('checkpoint replay uses the canonical ledger before stale tool results are pruned', () => {
+  const payload = 'large tool result '.repeat(200);
+  const serializedPayload = JSON.stringify(payload);
+  const coveredEvents = [
+    textEvent('user', 'inspect the result'),
+    toolCallEvent('call'),
+    toolResultEvent('result', payload),
+  ];
+  const tail = { ...textEvent('tail', 'newer history'), turnId: 'turn-2' };
+  const checkpoint = buildHistoryCompactCheckpoint({
+    sessionId: 'session-1',
+    coveredRuntimeEvents: coveredEvents,
+    charsPerToken: 1,
+    providerState: {
+      kind: 'openai_codex_remote_v2',
+      connectionSlug: 'codex',
+      modelId: 'gpt-test',
+      itemId: 'compact-item',
+      encryptedContent: 'encrypted',
+    },
+  });
+
+  const result = applyRuntimeEventContextBudget([...coveredEvents, tail], {
+    charsPerToken: 1,
+    staleToolResultPrune: {
+      enabled: true,
+      maxResultEstimatedTokens: 1,
+      minRecentTurnsFull: 0,
+      archiveRefs: [
+        {
+          runtimeEventId: 'result',
+          toolCallId: 'tool-call',
+          toolName: 'Bash',
+          artifactId: 'artifact-1',
+          bodySha256: createHash('sha256').update(serializedPayload).digest('hex'),
+          originalEstimatedTokens: serializedPayload.length,
+          originalBytes: Buffer.byteLength(serializedPayload, 'utf8'),
+          rewriteVersion: 1,
+          reason: 'stale_tool_result_pruned_before_compact',
+        },
+      ],
+    },
+    historyCompact: { enabled: true, checkpoint },
+  });
+
+  assert.equal(result?.historyCompactCheckpoint?.checkpointId, checkpoint.checkpointId);
+  assert.equal(result?.diagnostic.compactionDecisions?.[0]?.decision, 'replaced');
+  assert.deepEqual(result?.events, [tail]);
+});
+
 function textEvent(id: string, text: string): RuntimeEvent {
   return {
     id,
@@ -55,5 +107,23 @@ function textEvent(id: string, text: string): RuntimeEvent {
     status: 'completed',
     modelVisibility: 'visible',
     content: { kind: 'text', text },
+  };
+}
+
+function toolCallEvent(id: string): RuntimeEvent {
+  return {
+    ...textEvent(id, ''),
+    role: 'model',
+    author: 'agent',
+    content: { kind: 'function_call', id: 'tool-call', name: 'Bash', args: {} },
+  };
+}
+
+function toolResultEvent(id: string, result: string): RuntimeEvent {
+  return {
+    ...textEvent(id, ''),
+    role: 'tool',
+    author: 'tool',
+    content: { kind: 'function_response', id: 'tool-call', name: 'Bash', result },
   };
 }

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -138,19 +138,19 @@ export function applyRuntimeEventContextBudget(
   if (!policy) return undefined;
   const charsPerToken = policy?.charsPerToken ?? 4;
   const estimatedTokensBefore = estimateRuntimeEventsTokens(events, charsPerToken);
-  const pruned = pruneStaleToolResultsBeforeCompact(
-    events,
-    policy?.staleToolResultPrune,
-    charsPerToken,
-  );
   const compacted = applyRuntimeEventHistoryCompactNarrow(
-    pruned.events,
+    events,
     policy?.historyCompact,
     policy?.charsPerToken,
     policy?.maxHistoryEstimatedTokens,
     { charsPerToken },
   );
-  const keptEvents = compacted.events;
+  const pruned = pruneStaleToolResultsBeforeCompact(
+    compacted.events,
+    policy?.staleToolResultPrune,
+    charsPerToken,
+  );
+  const keptEvents = pruned.events;
   const keptTurnIds = new Set(keptEvents.map((event) => runtimeEventTurnKey(event)));
   const originalTurnIds = new Set(events.map((event) => runtimeEventTurnKey(event)));
 
@@ -165,7 +165,7 @@ export function applyRuntimeEventContextBudget(
     keptTurns: keptTurnIds.size,
     droppedTurns: Math.max(0, originalTurnIds.size - keptTurnIds.size),
     keptEvents: keptEvents.length,
-    droppedEvents: Math.max(0, pruned.events.length - keptEvents.length),
+    droppedEvents: Math.max(0, events.length - keptEvents.length),
     ...compacted.diagnosticPatch,
     ...(pruned.prunedToolResults > 0
       ? {


### PR DESCRIPTION
Replay durable history checkpoints against the immutable RuntimeEvent ledger before stale Tool Result pruning shapes the uncovered remainder. This keeps checkpoint source validation stable as the recent-turn pruning window moves.

The regression test covers a checkpoint whose oversized covered Tool Result has become stale and has a valid archive ref. It fails with `source_hash_mismatch` before the fix and replays the checkpoint after the order change.

Fixes #3631

## Verification

- `cd packages/core && npm run build`
- `cd packages/runtime && npm run build`
- `node --test dist/__tests__/context-budget.test.js`
- `npx biome format packages/runtime/src/context-budget.ts packages/runtime/src/__tests__/context-budget.test.ts`
- `git diff --check`

Full repository tests were not run locally.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka diagnosed the local failure, traced the checkpoint/pruning order, and authored the implementation and regression test under human direction.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — checkpoint replay now precedes stale Tool Result pruning
- [ ] No
