### PR TITLE
feat(runtime): represent parallel tool calls as a model capability

### DIFF
--- a/apps/desktop/src/renderer/settings/use-connection-detail.ts
+++ b/apps/desktop/src/renderer/settings/use-connection-detail.ts
@@ -826,6 +826,7 @@ function modelListsEqual(left: ModelInfo[], right: ModelInfo[]): boolean {
     if (leftModel.capabilities?.vision !== rightModel.capabilities?.vision) return false;
     if (leftModel.capabilities?.reasoning !== rightModel.capabilities?.reasoning) return false;
     if (leftModel.capabilities?.functionCalling !== rightModel.capabilities?.functionCalling) return false;
+    if (leftModel.capabilities?.parallelToolCalls !== rightModel.capabilities?.parallelToolCalls) return false;
     if (leftModel.capabilities?.imageGeneration !== rightModel.capabilities?.imageGeneration) return false;
   }
   return true;

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -82,6 +82,24 @@ test('chat-default validation blocks image-only models but accepts merged partia
   assert.deepEqual(verdict(partial), { ok: true });
 });
 
+test('catalog entries preserve advertised parallel tool-call support', () => {
+  const [entry] = buildModelCatalogEntries({
+    providerType: 'openai-compatible',
+    defaultModel: 'relay-model',
+    models: [
+      {
+        id: 'relay-model',
+        capabilities: { functionCalling: true, parallelToolCalls: true },
+      },
+    ],
+    modelSource: 'fetched',
+  });
+  assert.deepEqual(entry?.capabilities, {
+    functionCalling: true,
+    parallelToolCalls: true,
+  });
+});
+
 test('stale provider inventory warns without blocking sends', () => {
   const input = {
     providerType: 'anthropic' as const,

--- a/packages/core/src/__tests__/runtime-policy-codec.test.ts
+++ b/packages/core/src/__tests__/runtime-policy-codec.test.ts
@@ -458,12 +458,12 @@ test('relay model profiles round-trip canonical entries and drafts, strictly', (
 test('normalizes exact bounded model discovery results', () => {
   assert.deepEqual(
     normalizeConnectionModelDiscoveryResult({
-      models: [{ id: 'gpt-5', capabilities: { chat: true } }],
+      models: [{ id: 'gpt-5', capabilities: { chat: true, parallelToolCalls: false } }],
       source: 'fetched',
       fetchedAt: 42,
     }),
     {
-      models: [{ id: 'gpt-5', capabilities: { chat: true } }],
+      models: [{ id: 'gpt-5', capabilities: { chat: true, parallelToolCalls: false } }],
       source: 'fetched',
       fetchedAt: 42,
     },

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -102,6 +102,8 @@ export interface ModelInfo {
     vision?: boolean;
     reasoning?: boolean;
     functionCalling?: boolean;
+    /** Whether one response may contain multiple independent tool calls. */
+    parallelToolCalls?: boolean;
     imageGeneration?: boolean;
     /** Provider-hosted live web search, using this exact model and connection. */
     webSearch?: boolean;

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -61,6 +61,7 @@ export interface KnownModelCapabilities {
   vision?: true;
   reasoning?: true;
   functionCalling?: true;
+  parallelToolCalls?: true;
   imageGeneration?: true;
 }
 
@@ -399,6 +400,8 @@ function mergeCapabilities(
     vision: providerCapabilities.vision ?? metadataCapabilities.vision,
     reasoning: providerCapabilities.reasoning ?? metadataCapabilities.reasoning,
     functionCalling: providerCapabilities.functionCalling ?? metadataCapabilities.functionCalling,
+    parallelToolCalls:
+      providerCapabilities.parallelToolCalls ?? metadataCapabilities.parallelToolCalls,
     imageGeneration: providerCapabilities.imageGeneration ?? metadataCapabilities.imageGeneration,
   };
 }
@@ -637,6 +640,7 @@ function normalizeCapabilities(caps: ModelInfo['capabilities']): KnownModelCapab
     ...(caps.vision === true ? { vision: true as const } : {}),
     ...(caps.reasoning === true ? { reasoning: true as const } : {}),
     ...(caps.functionCalling === true ? { functionCalling: true as const } : {}),
+    ...(caps.parallelToolCalls === true ? { parallelToolCalls: true as const } : {}),
     ...(caps.imageGeneration === true ? { imageGeneration: true as const } : {}),
   };
 }

--- a/packages/core/src/runtime-policy/connection-catalog-codec.ts
+++ b/packages/core/src/runtime-policy/connection-catalog-codec.ts
@@ -481,7 +481,15 @@ export function decodeConnectionModel(value: unknown): ConnectionModel {
     const raw = exactRecord(
       item.capabilities,
       'connection model capabilities',
-      ['chat', 'vision', 'reasoning', 'functionCalling', 'imageGeneration', 'webSearch'],
+      [
+        'chat',
+        'vision',
+        'reasoning',
+        'functionCalling',
+        'parallelToolCalls',
+        'imageGeneration',
+        'webSearch',
+      ],
       [],
     );
     capabilities = {};

--- a/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
+++ b/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
@@ -129,7 +129,7 @@ describe('Claude subscription runtime wiring', () => {
 
   test('Codex OAuth provider options use non-persistent ChatGPT backend defaults', () => {
     assert.deepEqual(buildProviderOptions(codexOAuthConnection(), 'gpt-5.5'), {
-      openai: { store: false, textVerbosity: 'medium' },
+      openai: { store: false, textVerbosity: 'medium', parallelToolCalls: true },
     });
   });
 });

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -122,29 +122,114 @@ describe('buildProviderOptions: thinking level', () => {
 
   test('openai gpt-5.5 sends reasoningEffort (none for off, max for max); gpt-4o drops level', () => {
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-4o', 'high'), {
-      openai: { store: false },
+      openai: { store: false, parallelToolCalls: true },
     });
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-5.5', 'medium'), {
-      openai: { store: false, reasoningEffort: 'medium' },
+      openai: { store: false, reasoningEffort: 'medium', parallelToolCalls: true },
     });
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-5.5', 'xhigh'), {
-      openai: { store: false, reasoningEffort: 'xhigh' },
+      openai: { store: false, reasoningEffort: 'xhigh', parallelToolCalls: true },
     });
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-5.5', 'off'), {
-      openai: { store: false, reasoningEffort: 'none' },
+      openai: { store: false, reasoningEffort: 'none', parallelToolCalls: true },
     });
   });
 
   test('openai-codex (gpt-5.5) preserves store:false / textVerbosity and merges reasoningEffort', () => {
     assert.deepEqual(buildProviderOptions(conn('openai-codex'), 'gpt-5.5'), {
-      openai: { store: false, textVerbosity: 'medium' },
+      openai: { store: false, textVerbosity: 'medium', parallelToolCalls: true },
     });
     assert.deepEqual(buildProviderOptions(conn('openai-codex'), 'gpt-5.5', 'high'), {
-      openai: { store: false, textVerbosity: 'medium', reasoningEffort: 'high' },
+      openai: {
+        store: false,
+        textVerbosity: 'medium',
+        reasoningEffort: 'high',
+        parallelToolCalls: true,
+      },
     });
     assert.deepEqual(buildProviderOptions(conn('openai-codex'), 'gpt-5.5', 'off'), {
-      openai: { store: false, textVerbosity: 'medium', reasoningEffort: 'none' },
+      openai: {
+        store: false,
+        textVerbosity: 'medium',
+        reasoningEffort: 'none',
+        parallelToolCalls: true,
+      },
     });
+  });
+
+  test('parallel tool-call capability overrides wire defaults and stays opt-in on compatible providers', () => {
+    const disabled: LlmConnection = {
+      ...conn('openai'),
+      models: [{ id: 'gpt-5.5', capabilities: { parallelToolCalls: false } }],
+    };
+    assert.deepEqual(buildProviderOptions(disabled, 'gpt-5.5'), {
+      openai: { store: false, parallelToolCalls: false },
+    });
+
+    const compatible: LlmConnection = {
+      ...conn('openai-compatible', 'my-relay'),
+      baseUrl: 'https://relay.example/v1',
+      models: [{ id: 'relay-model', capabilities: { parallelToolCalls: true } }],
+    };
+    assert.deepEqual(buildProviderOptions(compatible, 'relay-model'), {
+      myRelay: { parallel_tool_calls: true },
+    });
+    assert.deepEqual(
+      buildProviderOptions(
+        { ...conn('openai-compatible', 'my-relay'), baseUrl: 'https://relay.example/v1' },
+        'relay-model',
+      ),
+      {},
+    );
+  });
+
+  test('parallel tool-call capability reaches native and compatible chat request bodies', async () => {
+    const cases: Array<{ connection: LlmConnection; modelId: string; expected: boolean }> = [
+      { connection: conn('openai'), modelId: 'gpt-4o', expected: true },
+      {
+        connection: {
+          ...conn('openai-compatible', 'my-relay'),
+          baseUrl: 'https://relay.example/v1',
+          models: [{ id: 'relay-model', capabilities: { parallelToolCalls: false } }],
+        },
+        modelId: 'relay-model',
+        expected: false,
+      },
+    ];
+
+    for (const { connection, modelId, expected } of cases) {
+      let body: Record<string, unknown> = {};
+      const model = getAIModel({
+        connection,
+        apiKey: 'test-key',
+        modelId,
+        fetch: async (_input, init) => {
+          body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+          return new Response(
+            JSON.stringify({
+              id: 'chatcmpl-1',
+              object: 'chat.completion',
+              created: 1,
+              model: modelId,
+              choices: [
+                {
+                  index: 0,
+                  message: { role: 'assistant', content: 'ok' },
+                  finish_reason: 'stop',
+                },
+              ],
+              usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        },
+      });
+      await model.doGenerate({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        providerOptions: buildProviderOptions(connection, modelId),
+      });
+      assert.equal(body.parallel_tool_calls, expected);
+    }
   });
 
   test('google effort model (gemini-3) sends thinkingLevel; Gemini 2.5 Flash off sends thinkingBudget 0; safetySettings always present', () => {
@@ -265,7 +350,12 @@ describe('buildProviderOptions: thinking level', () => {
     // gpt-5.5 resolves to the Responses wire, so it takes the wire branch and
     // its encrypted-reasoning terms rather than a bare effort.
     assert.deepEqual(buildProviderOptions(conn('opencode'), 'gpt-5.5', 'high'), {
-      openai: { store: false, forceReasoning: true, reasoningEffort: 'high' },
+      openai: {
+        store: false,
+        forceReasoning: true,
+        reasoningEffort: 'high',
+        parallelToolCalls: true,
+      },
     });
     assert.deepEqual(buildProviderOptions(conn('opencode'), 'claude-fable-5', 'high'), {
       anthropic: { effort: 'high' },
@@ -426,7 +516,7 @@ describe('buildProviderOptions: thinking level', () => {
 
   test('a level the model does not support is dropped (defensive)', () => {
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-4o', 'high'), {
-      openai: { store: false },
+      openai: { store: false, parallelToolCalls: true },
     });
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-haiku-4-5', 'max'), {
       anthropic: { cacheControl: { type: 'ephemeral' } },
@@ -572,13 +662,23 @@ describe('buildProviderOptions: openai-compatible namespace', () => {
       },
     };
     assert.deepEqual(buildProviderOptions(declared, 'custom-reasoner', 'high'), {
-      openai: { store: false, forceReasoning: true, reasoningEffort: 'high' },
+      openai: {
+        store: false,
+        forceReasoning: true,
+        reasoningEffort: 'high',
+        parallelToolCalls: true,
+      },
     });
     assert.deepEqual(buildProviderOptions(declared, 'custom-reasoner', 'max'), {
-      openai: { store: false, forceReasoning: true, reasoningEffort: 'max' },
+      openai: {
+        store: false,
+        forceReasoning: true,
+        reasoningEffort: 'max',
+        parallelToolCalls: true,
+      },
     });
     assert.deepEqual(buildProviderOptions(declared, 'custom-reasoner', 'xhigh'), {
-      openai: { store: false, forceReasoning: true },
+      openai: { store: false, forceReasoning: true, parallelToolCalls: true },
     });
   });
 
@@ -596,7 +696,12 @@ describe('buildProviderOptions: openai-compatible namespace', () => {
       relayModelProfiles: { 'gpt-5-relay': { serviceTier: 'fast' } },
     };
     assert.deepEqual(buildProviderOptions(responses, 'gpt-5-relay'), {
-      openai: { store: false, forceReasoning: true, serviceTier: 'fast' },
+      openai: {
+        store: false,
+        forceReasoning: true,
+        serviceTier: 'fast',
+        parallelToolCalls: true,
+      },
     });
     assert.deepEqual(
       buildProviderOptions(
@@ -631,6 +736,7 @@ describe('buildProviderOptions: openai-compatible namespace', () => {
           store: false,
           forceReasoning: true,
           ...(supported ? { serviceTier: 'fast' } : {}),
+          parallelToolCalls: true,
         },
       });
     }

--- a/packages/runtime/src/__tests__/responses-wire-contract.test.ts
+++ b/packages/runtime/src/__tests__/responses-wire-contract.test.ts
@@ -138,6 +138,37 @@ describe('responses wire contract', () => {
     });
   });
 
+  test('resolves parallel tool calls from model facts before native wire defaults', () => {
+    assert.equal(
+      resolveModelRuntime({ providerType: 'openai' }, 'gpt-5.5').parallelToolCalls,
+      true,
+    );
+    assert.equal(
+      resolveModelRuntime(
+        {
+          providerType: 'openai',
+          models: [{ id: 'gpt-5.5', capabilities: { parallelToolCalls: false } }],
+        },
+        'gpt-5.5',
+      ).parallelToolCalls,
+      false,
+    );
+    assert.equal(
+      resolveModelRuntime({ providerType: 'openai-compatible' }, 'relay-model').parallelToolCalls,
+      undefined,
+    );
+    assert.equal(
+      resolveModelRuntime(
+        {
+          providerType: 'openai-compatible',
+          models: [{ id: 'relay-model', capabilities: { parallelToolCalls: true } }],
+        },
+        'relay-model',
+      ).parallelToolCalls,
+      true,
+    );
+  });
+
   test('enables Responses only through an explicit supported contract', () => {
     const configured = Object.entries(PROVIDER_REGISTRY).flatMap(([providerType, definition]) => {
       const adapter = definition.runtimeAdapter;

--- a/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
+++ b/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
@@ -20,6 +20,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core/llm-connections';
+import { buildProviderOptions, getAIModel } from '../model-factory.js';
 import { buildSubscriptionModelFetch } from '../subscription-model-fetch.js';
 
 describe('subscription model fetch', () => {
@@ -44,6 +45,7 @@ describe('subscription model fetch', () => {
       body: JSON.stringify({
         system: 'Use the Maka system prompt.',
         input: [{ role: 'user', content: 'hi' }],
+        parallel_tool_calls: true,
       }),
     });
 
@@ -55,6 +57,41 @@ describe('subscription model fetch', () => {
     assert.equal(body.store, false);
     assert.equal(body.parallel_tool_calls, true);
     assert.equal(body.text.verbosity, 'medium');
+  });
+
+  test('sends the resolved Codex parallel-tool-call default through the OpenAI SDK', async () => {
+    const connection = openAiCodexConnection();
+    let observedBody: Record<string, unknown> = {};
+    const modelFetch = buildSubscriptionModelFetch({
+      connection,
+      sessionId: 'session-parallel-tools',
+      modelId: connection.defaultModel,
+      fetchFn: async (_url, init) => {
+        observedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return Response.json({
+          id: 'resp-1',
+          object: 'response',
+          model: connection.defaultModel,
+          status: 'completed',
+          output: [],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        });
+      },
+    });
+    assert.ok(modelFetch);
+    const model = getAIModel({
+      connection,
+      apiKey: codexToken('account-parallel-tools'),
+      modelId: connection.defaultModel,
+      fetch: modelFetch,
+    });
+
+    await model.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      providerOptions: buildProviderOptions(connection, connection.defaultModel),
+    });
+
+    assert.equal(observedBody.parallel_tool_calls, true);
   });
 
   test('force-refreshes one Codex 401 without consuming the independent edge retry budget', async () => {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -379,6 +379,18 @@ export function buildProviderOptions(
   modelId: string,
   thinkingLevel?: ThinkingLevel,
 ): SharedV4ProviderOptions {
+  return withParallelToolCallOptions(
+    connection,
+    modelId,
+    buildThinkingProviderOptions(connection, modelId, thinkingLevel),
+  );
+}
+
+function buildThinkingProviderOptions(
+  connection: RuntimeExecutionConnection,
+  modelId: string,
+  thinkingLevel?: ThinkingLevel,
+): SharedV4ProviderOptions {
   const thinkingOptions = thinkingOptionsForModel(connection.providerType, modelId);
   const level = resolveThinkingLevel(connection, modelId, thinkingLevel);
   switch (connection.providerType) {
@@ -529,6 +541,51 @@ export function buildProviderOptions(
     default:
       return buildFamilyWire(connection, modelId, level, thinkingOptions);
   }
+}
+
+function withParallelToolCallOptions(
+  connection: RuntimeExecutionConnection,
+  modelId: string,
+  options: SharedV4ProviderOptions,
+): SharedV4ProviderOptions {
+  const runtime = resolveModelRuntime(connection, modelId);
+  if (runtime.parallelToolCalls === undefined) return options;
+
+  let providerKey: string;
+  let optionKey: 'parallelToolCalls' | 'parallel_tool_calls';
+  if (runtime.adapter.kind === 'openai' || runtime.adapter.kind === 'openai-codex') {
+    providerKey = 'openai';
+    optionKey = 'parallelToolCalls';
+  } else if (runtime.adapter.kind === 'github-copilot') {
+    if (runtime.wire === 'anthropic-messages') return options;
+    providerKey = runtime.wire === 'openai-responses' ? 'openai' : 'githubCopilot';
+    optionKey = runtime.wire === 'openai-responses' ? 'parallelToolCalls' : 'parallel_tool_calls';
+  } else if (runtime.adapter.kind === 'openai-compatible') {
+    if (runtime.wire === 'openai-responses') {
+      if (
+        runtime.reasoningReplay.kind !== 'responses' ||
+        runtime.reasoningReplay.contract.adapter !== 'openai'
+      ) {
+        return options;
+      }
+      providerKey = 'openai';
+      optionKey = 'parallelToolCalls';
+    } else {
+      providerKey = openAiCompatibleProviderOptionsKey(runtime.adapter, connection);
+      optionKey = 'parallel_tool_calls';
+    }
+  } else {
+    return options;
+  }
+
+  const current = options[providerKey];
+  return {
+    ...options,
+    [providerKey]: {
+      ...(isRecord(current) ? current : {}),
+      [optionKey]: runtime.parallelToolCalls,
+    },
+  };
 }
 
 function buildFamilyWire(

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -25,7 +25,11 @@ import {
   type ProviderRuntimeAdapter,
   type ProviderType,
 } from '@maka/core/llm-connections';
-import { lookupModelProviderOverride, openAiAdapterApiProtocol } from '@maka/core/model-metadata';
+import {
+  lookupModelMetadata,
+  lookupModelProviderOverride,
+  openAiAdapterApiProtocol,
+} from '@maka/core/model-metadata';
 import { isRetiredProvider } from '@maka/core/provider-registry';
 import { resolveApplyPatchProfile, type ApplyPatchProfile } from './apply-patch-profile.js';
 
@@ -51,6 +55,8 @@ export interface ResolvedModelRuntime {
   wire: ModelRuntimeWire;
   /** Durable reasoning replay semantics carried by that wire. */
   reasoningReplay: ReasoningReplayContract;
+  /** Effective parallel-tool-call support after model facts and wire defaults are resolved. */
+  parallelToolCalls?: boolean;
   /** Effective ApplyPatch contract after provider, model, and request wire are resolved. */
   applyPatchProfile: ApplyPatchProfile | null;
 }
@@ -111,6 +117,7 @@ export function resolveModelRuntime(
     ? effectiveBaseUrl(connection)
     : (override?.api ?? effectiveBaseUrl(connection));
   const wire = resolveModelRuntimeWire(connection.providerType, modelId, adapter, apiProtocol);
+  const parallelToolCalls = resolveParallelToolCalls(connection, modelId, adapter);
   return {
     adapter,
     baseUrl:
@@ -120,6 +127,7 @@ export function resolveModelRuntime(
     ...(apiProtocol ? { apiProtocol } : {}),
     wire,
     reasoningReplay: reasoningReplayContract(adapter, wire),
+    ...(parallelToolCalls === undefined ? {} : { parallelToolCalls }),
     applyPatchProfile: resolveApplyPatchProfile(
       {
         wire,
@@ -128,6 +136,24 @@ export function resolveModelRuntime(
       modelId,
     ),
   };
+}
+
+function resolveParallelToolCalls(
+  connection: ModelRuntimeConnection,
+  modelId: string,
+  adapter: ProviderRuntimeAdapter,
+): boolean | undefined {
+  const stored = connection.models?.find((model) => model.id === modelId)?.capabilities
+    ?.parallelToolCalls;
+  if (stored !== undefined) return stored;
+  const metadata = lookupModelMetadata(connection.providerType, modelId).capabilities
+    ?.parallelToolCalls;
+  if (metadata !== undefined) return metadata;
+
+  // The native OpenAI adapters expose the parallel_tool_calls request switch
+  // on both Chat Completions and Responses. Compatible providers vary, so
+  // they require an explicit model declaration instead of inheriting this.
+  return adapter.kind === 'openai' || adapter.kind === 'openai-codex' ? true : undefined;
 }
 
 export function modelUsesAnthropicMessages(

--- a/packages/runtime/src/subscription-model-fetch.ts
+++ b/packages/runtime/src/subscription-model-fetch.ts
@@ -153,7 +153,6 @@ function buildOpenAiCodexFetch(
           ...parsedBody,
           instructions: codexInstructionsFromBody(parsedBody),
           store: false,
-          parallel_tool_calls: parsedBody.parallel_tool_calls ?? true,
           text: {
             ...(parsedBody.text !== null && typeof parsedBody.text === 'object'
               ? (parsedBody.text as Record<string, unknown>)


### PR DESCRIPTION
## Summary

- add a per-model parallelToolCalls capability and preserve explicit true/false values through connection decoding and catalog updates
- resolve the capability against the effective provider adapter, defaulting supported native OpenAI Chat/Responses wires on while keeping compatible providers opt-in
- route the resolved flag through provider options and remove the Codex subscription fetch special case
- keep the existing generic concurrent tool settlement path unchanged

## Reproduction

On main cd0163a1e, a discovered model carrying parallelToolCalls is rejected as an unknown capability, and an observed native OpenAI Chat request omits parallel_tool_calls.

On this head:

- the codec preserves an explicit false value
- native OpenAI defaults the actual request body to parallel_tool_calls: true
- an explicit native false reaches the actual request body
- an unknown compatible provider still omits the field
- an explicitly capable compatible provider sends parallel_tool_calls: true

## Local validation

- npm run format:check
- npm run lint
- 20 focused core tests passed
- 74 focused runtime and request-wire tests passed
- npm run build
- npm run typecheck
- npm run check:asf-headers

A full npm test run also completed. It reproduced one storage cross-process authority failure and eight cancelled desktop OAuth timeout tests. Both results were independently reproduced in a clean worktree at main cd0163a1e.

## Limitation

The pinned @ai-sdk/open-responses 2.0.28 adapter does not expose or serialize a request-side parallel tool-call option, so that adapter remains unchanged. Native OpenAI Responses uses the supported OpenAI provider option.

Closes #3500