### PR TITLE
test(desktop): match session change event contract

### DIFF
--- a/apps/desktop/src/main/__tests__/goal-services-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/goal-services-adapter.test.ts
@@ -61,19 +61,16 @@ describe('createDesktopGoalServices', () => {
       changes.push(sessionId);
     });
     sessionHandler?.({
-      type: 'sessions_changed',
       reason: 'updated',
       sessionId: 'ignored',
       ts: 1,
     });
     sessionHandler?.({
-      type: 'sessions_changed',
       reason: 'goal-change',
       sessionId: 's',
       ts: 2,
     });
     sessionHandler?.({
-      type: 'sessions_changed',
       reason: 'goal-change',
       ts: 3,
     });


### PR DESCRIPTION
## Summary

Align the Goal adapter test fixture with the current `SessionChangedEvent` contract so Desktop main-process compilation succeeds on `main` again.

The production contract and all live emitters use `reason`, optional identifiers, and `ts`; only the new test fixture from #3531 retained the removed `type: 'sessions_changed'` discriminator. This removes those three stale properties without changing production behavior or adding another event representation.

## Verification

- Reproduced on `main` with `npm --workspace @maka/desktop run build:main`: three TS2353 failures in `goal-services-adapter.test.ts`.
- `npm --workspace @maka/desktop run build:main`
- `node --test --test-concurrency=1 apps/desktop/dist/main/__tests__/goal-services-adapter.test.js` (1/1 passed)
- `npm run format:check`
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the CI failure, verified the event authority, removed the stale test-only fields, and ran focused validation.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
