### PR TITLE
fix(desktop): align goal adapter event fixtures

### DIFF
--- a/apps/desktop/src/main/__tests__/goal-services-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/goal-services-adapter.test.ts
@@ -61,19 +61,16 @@ describe('createDesktopGoalServices', () => {
       changes.push(sessionId);
     });
     sessionHandler?.({
-      type: 'sessions_changed',
       reason: 'updated',
       sessionId: 'ignored',
       ts: 1,
     });
     sessionHandler?.({
-      type: 'sessions_changed',
       reason: 'goal-change',
       sessionId: 's',
       ts: 2,
     });
     sessionHandler?.({
-      type: 'sessions_changed',
       reason: 'goal-change',
       ts: 3,
     });


### PR DESCRIPTION
## Summary

Remove the obsolete `sessions_changed` discriminator from the Goal services adapter test fixtures. The fixtures now match the current `SessionChangedEvent` contract, restoring the Desktop main-process build and repository-wide typechecking.

Fixes #3641

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npm --workspace @maka/desktop test` — 1331 passed
- `npx knip --workspace apps/desktop` — passed with two existing configuration hints
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the regression, searched for duplicate issues and pull requests, aligned the test fixtures with the shared event contract, and ran the verification. The commit includes a `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
