### PR TITLE
ci: enforce Astryx inventory for code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,14 @@ jobs:
         if: steps.plan.outputs.code == 'true'
         run: npm run format:check
 
+      # This generated artifact describes the whole renderer/UI tree, so every
+      # code-validation run checks it even when the triggering diff is outside
+      # an Astryx surface. Keep it before Build so stale output is reported
+      # directly instead of being hidden behind an earlier compilation failure.
+      - name: Astryx surface inventory
+        if: steps.plan.outputs.code == 'true' || steps.plan.outputs.astryx_surface == 'true'
+        run: npm run astryx:surface-inventory
+
       - name: Build
         if: steps.plan.outputs.code == 'true' || steps.plan.outputs.cli_package == 'true' || steps.plan.outputs.release_contract == 'true'
         run: npm run build
@@ -154,10 +162,6 @@ jobs:
       - name: Typecheck
         if: steps.plan.outputs.code == 'true'
         run: npm run typecheck
-
-      - name: Astryx surface inventory
-        if: steps.plan.outputs.astryx_surface == 'true'
-        run: npm run astryx:surface-inventory
 
       - name: Astryx theme drift
         if: steps.plan.outputs.code == 'true'

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -5,7 +5,7 @@ Each row is one on-disk product surface file. Regenerated inventory must stay in
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 204 files — blocker 0, polish 0, aligned 204.
+**Totals:** 206 files — blocker 0, polish 0, aligned 206.
 
 ## Exclusions (explicit)
 

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -287,6 +287,23 @@ test('contract checks run before dependency setup and can fail the job', () => {
   }
 });
 
+test('core CI checks the Astryx inventory for every code change before building', () => {
+  const workflow = readWorkflow('ci.yml');
+  const inventoryStart = workflow.indexOf('      - name: Astryx surface inventory\n');
+  const inventoryEnd = workflow.indexOf('\n      - ', inventoryStart + 1);
+  const buildStart = workflow.indexOf('      - name: Build\n');
+
+  assert.ok(inventoryStart >= 0);
+  assert.ok(inventoryStart < buildStart);
+
+  const inventoryStep = workflow.slice(inventoryStart, inventoryEnd);
+  assert.match(
+    inventoryStep,
+    /if: steps\.plan\.outputs\.code == 'true' \|\| steps\.plan\.outputs\.astryx_surface == 'true'/u,
+  );
+  assert.doesNotMatch(inventoryStep, /continue-on-error/u);
+});
+
 test('core CI validates affected installed CLI packages on its existing runner', () => {
   const workflow = readWorkflow('ci.yml');
   const toolchain = workflow.indexOf(


### PR DESCRIPTION
## Summary

While validating the Desktop build fix in #3643, we found that the generated Astryx surface inventory still reported 204 files even though the current path list and table contain 206. Because the gate was selected only for direct Astryx-surface changes, repository-wide drift could escape ordinary code validation.

- Refresh the generated total to 206 files.
- Run the Astryx inventory for every code validation while preserving the inventory-only path.
- Place the inexpensive gate before Build so drift is reported directly.
- Add workflow contract regression coverage.

Fixes #3646

## Verification

Passed locally:

- `node --test scripts/ci-test-plan.test.mjs` (30/30)
- `npm run astryx:surface-inventory` (206 files)
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `git diff --check`

Also attempted `NODE_NO_WARNINGS=1 npm test`. The suites covering this change passed, while the repository-wide run remained non-green on three unrelated checks: an existing UI deferred-activation assertion, a Runtime Host real-model terminal timeout, and a Python test that uses Python 3.10 union syntax on the local Python 3.9.6 runtime.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex helped diagnose the CI coverage gap, implement the workflow and regression-test changes, and draft the issue and PR text.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No