### PR TITLE
fix(storage): validate imported Codex messages canonically

### DIFF
--- a/packages/storage/src/__tests__/codex-session-adapter.test.ts
+++ b/packages/storage/src/__tests__/codex-session-adapter.test.ts
@@ -264,7 +264,7 @@ describe('CodexSessionAdapter', () => {
         ['user', 'assistant', 'assistant', 'turn_state'],
       );
       for (const message of session.messages) {
-        assert.deepEqual(decodeStoredMessage(message), message);
+        assert.deepEqual(decodeCanonicalMessage(message), message);
       }
 
       assert.deepEqual(session.messages[0], {


### PR DESCRIPTION
## Summary

Use `decodeCanonicalMessage` when validating messages returned by `CodexSessionAdapter`.

The test currently calls an undefined `decodeStoredMessage`, which prevents `@maka/storage` and the repository CI build from compiling. Adapter output is canonical in-memory data, so the canonical decoder is the appropriate boundary and matches the existing validation in the same test file.

## Verification

- `npm --workspace @maka/storage run build`
- `node --test packages/storage/dist/__tests__/codex-session-adapter.test.js` — 9 passed
- `npx biome format packages/storage/src/__tests__/codex-session-adapter.test.ts`
- `npx biome lint packages/storage/src/__tests__/codex-session-adapter.test.ts`
- `git diff --check`
- `npm run build` now passes the previously failing Storage stage; it later encounters an unrelated existing CLI dependency/type mismatch.
- Full Storage suite: 905 passed, 14 skipped, and one unrelated cross-process authority test failed because a child-process SQLite experimental warning was treated as error output.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the CI failure, applied the one-line decoder correction, and ran verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
