### PR TITLE
test(storage): use the canonical message decoder

### DIFF
--- a/packages/storage/src/__tests__/codex-session-adapter.test.ts
+++ b/packages/storage/src/__tests__/codex-session-adapter.test.ts
@@ -264,7 +264,7 @@ describe('CodexSessionAdapter', () => {
         ['user', 'assistant', 'assistant', 'turn_state'],
       );
       for (const message of session.messages) {
-        assert.deepEqual(decodeStoredMessage(message), message);
+        assert.deepEqual(decodeCanonicalMessage(message), message);
       }
 
       assert.deepEqual(session.messages[0], {


### PR DESCRIPTION
## Summary

- Replace the undefined `decodeStoredMessage` call added to the Codex completed-item regression test with the already-imported `decodeCanonicalMessage`.
- Preserve the test intent: every message produced by the read-only external adapter must satisfy the canonical in-memory message schema.
- Restore the current main branch build without changing production behavior.

Fixes #3655

## Verification

- Before the change: `npm --workspace @maka/storage run build` fails with `TS2304: Cannot find name 'decodeStoredMessage'` at `codex-session-adapter.test.ts:267`.
- After the change: `npm --workspace @maka/storage run build` — passed.
- `node --test packages/storage/dist/__tests__/codex-session-adapter.test.js` — 9 passed, 0 failed.
- `npm run build` — all workspace and desktop production builds passed.
- `npm run lint` — 2660 files passed.
- `npm run format:check` — 1605 files passed.
- `git diff --check` — passed.
- The complete storage test command was also run on local Node 23.11.0; unrelated SQLite suites fail with the existing `cannot start a transaction within a transaction` environment failure. The affected Codex adapter suite passes independently, and hosted CI remains the authority for the full matrix.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the current-main compile failure, identified the mismatched test decoder call, made the one-line correction, and ran verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No