### PR TITLE
feat(cli): add ACP stdio server foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
     "node_modules/@ai-sdk/anthropic": {
       "version": "4.0.40",
       "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-4.0.40.tgz",
@@ -13870,6 +13879,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@agentclientprotocol/sdk": "1.4.0",
         "@earendil-works/pi-tui": "0.84.2",
         "@maka/core": "0.1.0",
         "@maka/eval": "0.1.0",

--- a/packages/cli/THIRD_PARTY_NOTICES.txt
+++ b/packages/cli/THIRD_PARTY_NOTICES.txt
@@ -9,6 +9,205 @@ Policy: every package must resolve to an ASF-compatible SPDX license. Compound
 expressions record the compatible selected license. Packages without a shipped
 license file require an exact name@version text override in the generator.
 
+Package: @agentclientprotocol/sdk@1.4.0
+Declared license: Apache-2.0
+Selected license: Apache-2.0
+Repository: git+https://github.com/agentclientprotocol/typescript-sdk.git
+
+--- LICENSE ---
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Zed Industries, Inc. and contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+================================================================================
+
 Package: @ai-sdk/anthropic@4.0.40
 Declared license: Apache-2.0
 Selected license: Apache-2.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
     "test:dist": "node --test \"dist/**/*.test.js\""
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "1.4.0",
     "@earendil-works/pi-tui": "0.84.2",
     "@maka/core": "0.1.0",
     "@maka/eval": "0.1.0",

--- a/packages/cli/src/__tests__/acp-agent.test.ts
+++ b/packages/cli/src/__tests__/acp-agent.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { client, methods, RequestError } from '@agentclientprotocol/sdk';
+import { createMakaAcpAgent } from '../acp/maka-acp-agent.js';
+
+describe('Maka ACP agent', () => {
+  test('returns only the Maka initialize identity', async () => {
+    await client({ name: 'test-client' }).connectWith(
+      createMakaAcpAgent({ version: '0.2.0' }),
+      async (agent) => {
+        assert.deepEqual(await agent.request(methods.agent.initialize, { protocolVersion: 1 }), {
+          protocolVersion: 1,
+          agentInfo: { name: 'maka', title: 'Maka', version: '0.2.0' },
+        });
+      },
+    );
+  });
+
+  test('rejects unimplemented session requests with method details', async () => {
+    await client({ name: 'test-client' }).connectWith(
+      createMakaAcpAgent({ version: '0.2.0' }),
+      async (agent) => {
+        await assert.rejects(
+          agent.request('session/new', { cwd: '/workspace' }),
+          (error: unknown) => {
+            assert.ok(error instanceof RequestError);
+            assert.equal(error.code, -32601);
+            assert.deepEqual(error.data, { method: 'session/new' });
+            return true;
+          },
+        );
+      },
+    );
+  });
+});

--- a/packages/cli/src/__tests__/acp-agent.test.ts
+++ b/packages/cli/src/__tests__/acp-agent.test.ts
@@ -23,12 +23,14 @@ import { client, methods, RequestError } from '@agentclientprotocol/sdk';
 import { createMakaAcpAgent } from '../acp/maka-acp-agent.js';
 
 describe('Maka ACP agent', () => {
-  test('returns only the Maka initialize identity', async () => {
+  test('returns the Maka identity with no advertised capabilities or authentication', async () => {
     await client({ name: 'test-client' }).connectWith(
       createMakaAcpAgent({ version: '0.2.0' }),
       async (agent) => {
         assert.deepEqual(await agent.request(methods.agent.initialize, { protocolVersion: 1 }), {
           protocolVersion: 1,
+          agentCapabilities: {},
+          authMethods: [],
           agentInfo: { name: 'maka', title: 'Maka', version: '0.2.0' },
         });
       },

--- a/packages/cli/src/__tests__/acp-agent.test.ts
+++ b/packages/cli/src/__tests__/acp-agent.test.ts
@@ -53,4 +53,16 @@ describe('Maka ACP agent', () => {
       },
     );
   });
+
+  test('selects v1 when the client requests an unsupported lower or higher version', async () => {
+    for (const protocolVersion of [0, 2]) {
+      await client({ name: 'test-client' }).connectWith(
+        createMakaAcpAgent({ version: '0.2.0' }),
+        async (agent) => {
+          const response = await agent.request(methods.agent.initialize, { protocolVersion });
+          assert.equal(response.protocolVersion, 1);
+        },
+      );
+    }
+  });
 });

--- a/packages/cli/src/__tests__/acp-child-process-harness.ts
+++ b/packages/cli/src/__tests__/acp-child-process-harness.ts
@@ -1,0 +1,514 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough, Readable, Writable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import {
+  client,
+  ndJsonStream,
+  type ClientApp,
+  type ClientConnection,
+  type ClientContext,
+} from '@agentclientprotocol/sdk';
+import {
+  startExecutionRuntimeHostService,
+  type RuntimeHostKernel,
+} from '@maka/runtime-host/server';
+import { deriveMakaDataRoots, resolveMakaClientDataRoot } from '../workspace-root.js';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export interface AcpChildProcessHarnessOptions {
+  readonly timeoutMs?: number;
+}
+
+export interface AcpChildProcessExit {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+export interface AcpChildProcessClient {
+  readonly context: ClientContext;
+  readonly connection: ClientConnection;
+}
+
+export type ConfigureAcpClient = (app: ClientApp) => ClientApp;
+
+/**
+ * An isolated, real ACP process boundary. The Runtime Host is started before
+ * the child so the child can only connect to that Host, never spawn one.
+ */
+export class AcpChildProcessHarness {
+  readonly #root: string;
+  readonly #workspaceRoot: string;
+  readonly #child: ChildProcessWithoutNullStreams;
+  readonly #host: RuntimeHostKernel;
+  readonly #stdout: StdoutCaptureBridge;
+  readonly #stderr: Buffer[] = [];
+  readonly #exit: Promise<AcpChildProcessExit>;
+  readonly #spawn: Promise<void>;
+  readonly #timeoutMs: number;
+  #connection: ClientConnection | undefined;
+  #clientOpened = false;
+  #stdinClosed = false;
+  #closePromise: Promise<void> | undefined;
+
+  constructor(input: {
+    root: string;
+    workspaceRoot: string;
+    child: ChildProcessWithoutNullStreams;
+    host: RuntimeHostKernel;
+    stdoutTap: PassThrough;
+    timeoutMs: number;
+  }) {
+    this.#root = input.root;
+    this.#workspaceRoot = input.workspaceRoot;
+    this.#child = input.child;
+    this.#host = input.host;
+    this.#stdout = new StdoutCaptureBridge(input.stdoutTap);
+    this.#timeoutMs = input.timeoutMs;
+    this.#child.stderr.on('data', (chunk: Buffer) => this.#stderr.push(Buffer.from(chunk)));
+    this.#spawn = waitForChildSpawn(this.#child);
+    this.#exit = new Promise<AcpChildProcessExit>((resolve, reject) => {
+      const onError = (error: Error) => {
+        this.#child.off('close', onClose);
+        reject(error);
+      };
+      const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+        this.#child.off('error', onError);
+        resolve({ code, signal });
+      };
+      this.#child.once('error', onError);
+      this.#child.once('close', onClose);
+    });
+    void this.#exit.catch(() => undefined);
+  }
+
+  get workspaceRoot(): string {
+    return this.#workspaceRoot;
+  }
+
+  get stdout(): string {
+    return this.#stdout.text;
+  }
+
+  get stderr(): string {
+    return Buffer.concat(this.#stderr).toString('utf8');
+  }
+
+  async withClient<T>(
+    operation: (client: AcpChildProcessClient) => Promise<T> | T,
+    configureClient: ConfigureAcpClient = (app) => app,
+  ): Promise<T> {
+    if (this.#clientOpened)
+      throw new Error('ACP child-process harness supports one client connection');
+    this.#clientOpened = true;
+    const app = configureClient(client({ name: 'maka-acp-child-process-test' }));
+    const stream = ndJsonStream(
+      Writable.toWeb(this.#child.stdin) as WritableStream<Uint8Array>,
+      this.#stdout.protocolInput(),
+    );
+    const connection = app.connect(stream);
+    this.#connection = connection;
+    let operationFailed = false;
+    try {
+      return await this.withTimeout(
+        operation({ context: connection.agent, connection }),
+        'ACP client operation',
+      );
+    } catch (error) {
+      operationFailed = true;
+      throw error;
+    } finally {
+      try {
+        connection.close();
+        await this.withTimeout(connection.closed, 'ACP client connection close');
+      } catch (error) {
+        if (!operationFailed) throw error;
+      } finally {
+        this.#connection = undefined;
+      }
+    }
+  }
+
+  async closeStdin(): Promise<void> {
+    if (this.#stdinClosed || this.#child.stdin.destroyed) return;
+    this.#stdinClosed = true;
+    const finished = waitForWritableFinish(this.#child.stdin);
+    this.#child.stdin.end();
+    await this.withTimeout(finished, 'ACP child stdin EOF');
+  }
+
+  async waitForExit(): Promise<AcpChildProcessExit> {
+    return this.withTimeout(this.#exit, 'ACP child process exit');
+  }
+
+  async waitForSpawn(): Promise<void> {
+    try {
+      await this.withTimeout(this.#spawn, 'ACP child process spawn');
+    } catch (error) {
+      throw new Error(
+        `ACP child process failed to start: ${errorMessage(error)}\n${this.diagnostics}`,
+      );
+    }
+  }
+
+  close(): Promise<void> {
+    this.#closePromise ??= this.closeOnce();
+    return this.#closePromise;
+  }
+
+  private async closeOnce(): Promise<void> {
+    let failure: unknown;
+    for (const cleanup of [
+      () => this.closeConnection(),
+      () => this.stopChild(),
+      () => this.#host.close(),
+    ]) {
+      try {
+        await cleanup();
+      } catch (error) {
+        failure ??= error;
+      }
+    }
+    await rm(this.#root, { recursive: true, force: true });
+    if (failure !== undefined) throw failure;
+  }
+
+  private async closeConnection(): Promise<void> {
+    if (!this.#connection) return;
+    this.#connection.close();
+    await this.withTimeout(this.#connection.closed, 'ACP client connection close during teardown');
+    this.#connection = undefined;
+  }
+
+  private async stopChild(): Promise<void> {
+    let failure: unknown;
+    try {
+      await this.closeStdin();
+    } catch (error) {
+      failure = error;
+    }
+    try {
+      await this.waitForExit();
+    } catch (error) {
+      failure ??= error;
+      if (this.#child.exitCode === null && this.#child.signalCode === null)
+        this.#child.kill('SIGTERM');
+      try {
+        await this.withTimeout(this.#exit, 'ACP child process SIGTERM exit');
+      } catch (terminationError) {
+        failure ??= terminationError;
+        if (this.#child.exitCode === null && this.#child.signalCode === null)
+          this.#child.kill('SIGKILL');
+        try {
+          await this.withTimeout(this.#exit, 'ACP child process SIGKILL exit');
+        } catch (killError) {
+          failure ??= killError;
+        }
+      }
+    }
+    if (failure !== undefined) throw failure;
+  }
+
+  private async withTimeout<T>(promise: Promise<T> | T, label: string): Promise<T> {
+    return withTimeout(promise, this.#timeoutMs, () => this.timeoutError(label));
+  }
+
+  private timeoutError(label: string): Error {
+    return new Error(`${label} timed out after ${this.#timeoutMs}ms; ${this.diagnostics}`);
+  }
+
+  private get diagnostics(): string {
+    return (
+      `exitCode=${this.#child.exitCode ?? 'null'} signal=${this.#child.signalCode ?? 'null'}\n` +
+      `stdout:\n${this.stdout}\nstderr:\n${this.stderr}`
+    );
+  }
+}
+
+export async function startAcpChildProcessHarness(
+  options: AcpChildProcessHarnessOptions = {},
+): Promise<AcpChildProcessHarness> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const root = await mkdtemp(join(tmpdir(), 'maka-acp-child-process-'));
+  const home = join(root, 'home');
+  const applicationData = join(root, 'application-data');
+  const env = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    APPDATA: applicationData,
+    XDG_CONFIG_HOME: applicationData,
+    XDG_DATA_HOME: join(root, 'xdg-data'),
+    XDG_STATE_HOME: join(root, 'xdg-state'),
+    XDG_CACHE_HOME: join(root, 'xdg-cache'),
+  };
+  const clientDataRoot = resolveMakaClientDataRoot({
+    env,
+    homeDir: home,
+    profileName: 'Maka Dev',
+  });
+  const dataRoots = deriveMakaDataRoots(clientDataRoot);
+  const workspaceRoot = dataRoots.workspaceRoot;
+  let host: RuntimeHostKernel | undefined;
+  let hostStartup: Promise<RuntimeHostKernel> | undefined;
+  let harness: AcpChildProcessHarness | undefined;
+  let rootCleanupFollowsHostStartup = false;
+  try {
+    await mkdir(workspaceRoot, { recursive: true });
+    hostStartup = startExecutionRuntimeHostService({ rootPath: workspaceRoot });
+    try {
+      host = await withStartupTimeout(
+        hostStartup,
+        timeoutMs,
+        'Runtime Host startup',
+        workspaceRoot,
+      );
+    } catch (error) {
+      if (error instanceof StartupTimeoutError) {
+        rootCleanupFollowsHostStartup = true;
+        void hostStartup
+          .then(
+            async (lateHost) => {
+              await lateHost.close().catch(() => undefined);
+            },
+            () => undefined,
+          )
+          .then(() => rm(root, { recursive: true, force: true }).catch(() => undefined))
+          .catch(() => undefined);
+      }
+      throw error;
+    }
+    const child = spawn(
+      process.execPath,
+      [fileURLToPath(new URL('../dev-cli.js', import.meta.url)), '--acp'],
+      { cwd: workspaceRoot, env, stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    const stdoutTap = new PassThrough();
+    pipeCapturedStdout(child.stdout, stdoutTap);
+    harness = new AcpChildProcessHarness({
+      root,
+      workspaceRoot,
+      child,
+      host,
+      stdoutTap,
+      timeoutMs,
+    });
+    await harness.waitForSpawn();
+    return harness;
+  } catch (error) {
+    await harness?.close().catch(() => undefined);
+    await host?.close().catch(() => undefined);
+    if (!rootCleanupFollowsHostStartup) await rm(root, { recursive: true, force: true });
+    throw new Error(
+      `ACP child-process harness startup failed; root=${workspaceRoot}: ${errorMessage(error)}`,
+    );
+  }
+}
+
+export async function withAcpChildProcessHarness<T>(
+  operation: (harness: AcpChildProcessHarness) => Promise<T> | T,
+  options: AcpChildProcessHarnessOptions = {},
+): Promise<T> {
+  const harness = await startAcpChildProcessHarness(options);
+  let operationFailed = false;
+  try {
+    return await operation(harness);
+  } catch (error) {
+    operationFailed = true;
+    throw error;
+  } finally {
+    try {
+      await harness.close();
+    } catch (error) {
+      if (!operationFailed) throw error;
+    }
+  }
+}
+
+export class StdoutCaptureBridge {
+  readonly #chunks: Buffer[] = [];
+  #controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+  #ended = false;
+  #error: Error | undefined;
+  #protocolInputCreated = false;
+
+  constructor(stream: Readable) {
+    stream.on('data', (chunk: Buffer) => {
+      const captured = Buffer.from(chunk);
+      this.#chunks.push(captured);
+      this.#controller?.enqueue(new Uint8Array(captured));
+    });
+    stream.once('end', () => {
+      this.#ended = true;
+      this.#controller?.close();
+      this.#controller = undefined;
+    });
+    stream.once('error', (error: Error) => {
+      this.#error = error;
+      this.#flushTerminalError();
+    });
+    stream.resume();
+  }
+
+  get text(): string {
+    return Buffer.concat(this.#chunks).toString('utf8');
+  }
+
+  get snapshot(): readonly Uint8Array[] {
+    return this.#chunks.map((chunk) => new Uint8Array(chunk));
+  }
+
+  get ended(): boolean {
+    return this.#ended;
+  }
+
+  get error(): Error | undefined {
+    return this.#error;
+  }
+
+  protocolInput(): ReadableStream<Uint8Array> {
+    if (this.#protocolInputCreated)
+      throw new Error('ACP stdout capture supports one protocol reader');
+    this.#protocolInputCreated = true;
+    return new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        for (const chunk of this.#chunks) controller.enqueue(new Uint8Array(chunk));
+        if (this.#ended) {
+          controller.close();
+        } else {
+          this.#controller = controller;
+          this.#flushTerminalError();
+        }
+      },
+      pull: () => {
+        this.#flushTerminalError();
+      },
+      cancel: () => {
+        this.#controller = undefined;
+      },
+    });
+  }
+
+  #flushTerminalError(): void {
+    if (
+      this.#error &&
+      this.#controller &&
+      (this.#controller.desiredSize === null || this.#controller.desiredSize > 0)
+    ) {
+      this.#controller.error(this.#error);
+      this.#controller = undefined;
+    }
+  }
+}
+
+export function pipeCapturedStdout(source: Readable, destination: PassThrough): void {
+  source.once('error', (error: Error) => destination.destroy(error));
+  source.pipe(destination);
+}
+
+function waitForWritableFinish(stream: Writable): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      stream.off('finish', onFinish);
+      stream.off('error', onError);
+    };
+    const onFinish = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    stream.once('finish', onFinish);
+    stream.once('error', onError);
+  });
+}
+
+function waitForChildSpawn(child: ChildProcessWithoutNullStreams): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      child.off('spawn', onSpawn);
+      child.off('error', onError);
+      child.off('close', onClose);
+    };
+    const onSpawn = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `ACP child exited before spawn: code=${code ?? 'null'} signal=${signal ?? 'null'}`,
+        ),
+      );
+    };
+    child.once('spawn', onSpawn);
+    child.once('error', onError);
+    child.once('close', onClose);
+  });
+}
+
+async function withStartupTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+  workspaceRoot: string,
+): Promise<T> {
+  return withTimeout(
+    promise,
+    timeoutMs,
+    () => new StartupTimeoutError(`${label} timed out after ${timeoutMs}ms; root=${workspaceRoot}`),
+  );
+}
+
+async function withTimeout<T>(
+  promise: Promise<T> | T,
+  timeoutMs: number,
+  createTimeoutError: () => Error,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(createTimeoutError()), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+class StartupTimeoutError extends Error {}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/cli/src/__tests__/acp-child-process-harness.ts
+++ b/packages/cli/src/__tests__/acp-child-process-harness.ts
@@ -40,6 +40,7 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 
 export interface AcpChildProcessHarnessOptions {
   readonly timeoutMs?: number;
+  readonly startRuntimeHost?: boolean;
 }
 
 export interface AcpChildProcessExit {
@@ -55,14 +56,14 @@ export interface AcpChildProcessClient {
 export type ConfigureAcpClient = (app: ClientApp) => ClientApp;
 
 /**
- * An isolated, real ACP process boundary. The Runtime Host is started before
- * the child so the child can only connect to that Host, never spawn one.
+ * An isolated, real ACP process boundary. Follow-up protocol tests can opt into
+ * a real in-process Runtime Host without allowing the child to spawn one.
  */
 export class AcpChildProcessHarness {
   readonly #root: string;
   readonly #workspaceRoot: string;
   readonly #child: ChildProcessWithoutNullStreams;
-  readonly #host: RuntimeHostKernel;
+  readonly #host: RuntimeHostKernel | undefined;
   readonly #stdout: StdoutCaptureBridge;
   readonly #stderr: Buffer[] = [];
   readonly #exit: Promise<AcpChildProcessExit>;
@@ -77,7 +78,7 @@ export class AcpChildProcessHarness {
     root: string;
     workspaceRoot: string;
     child: ChildProcessWithoutNullStreams;
-    host: RuntimeHostKernel;
+    host?: RuntimeHostKernel;
     stdoutTap: PassThrough;
     timeoutMs: number;
   }) {
@@ -183,7 +184,7 @@ export class AcpChildProcessHarness {
     for (const cleanup of [
       () => this.closeConnection(),
       () => this.stopChild(),
-      () => this.#host.close(),
+      () => this.#host?.close(),
     ]) {
       try {
         await cleanup();
@@ -277,28 +278,30 @@ export async function startAcpChildProcessHarness(
   let rootCleanupFollowsHostStartup = false;
   try {
     await mkdir(workspaceRoot, { recursive: true });
-    hostStartup = startExecutionRuntimeHostService({ rootPath: workspaceRoot });
-    try {
-      host = await withStartupTimeout(
-        hostStartup,
-        timeoutMs,
-        'Runtime Host startup',
-        workspaceRoot,
-      );
-    } catch (error) {
-      if (error instanceof StartupTimeoutError) {
-        rootCleanupFollowsHostStartup = true;
-        void hostStartup
-          .then(
-            async (lateHost) => {
-              await lateHost.close().catch(() => undefined);
-            },
-            () => undefined,
-          )
-          .then(() => rm(root, { recursive: true, force: true }).catch(() => undefined))
-          .catch(() => undefined);
+    if (options.startRuntimeHost) {
+      hostStartup = startExecutionRuntimeHostService({ rootPath: workspaceRoot });
+      try {
+        host = await withStartupTimeout(
+          hostStartup,
+          timeoutMs,
+          'Runtime Host startup',
+          workspaceRoot,
+        );
+      } catch (error) {
+        if (error instanceof StartupTimeoutError) {
+          rootCleanupFollowsHostStartup = true;
+          void hostStartup
+            .then(
+              async (lateHost) => {
+                await lateHost.close().catch(() => undefined);
+              },
+              () => undefined,
+            )
+            .then(() => rm(root, { recursive: true, force: true }).catch(() => undefined))
+            .catch(() => undefined);
+        }
+        throw error;
       }
-      throw error;
     }
     const child = spawn(
       process.execPath,
@@ -311,7 +314,7 @@ export async function startAcpChildProcessHarness(
       root,
       workspaceRoot,
       child,
-      host,
+      ...(host ? { host } : {}),
       stdoutTap,
       timeoutMs,
     });

--- a/packages/cli/src/__tests__/acp-child-process.test.ts
+++ b/packages/cli/src/__tests__/acp-child-process.test.ts
@@ -111,7 +111,7 @@ describe('Maka ACP child process', () => {
     }
   });
 
-  test('serves ACP over a clean stdio boundary and exits after stdin EOF', {
+  test('serves ACP without a Runtime Host and exits after stdin EOF', {
     timeout: 30_000,
   }, async () => {
     await withAcpChildProcessHarness(async (harness) => {

--- a/packages/cli/src/__tests__/acp-child-process.test.ts
+++ b/packages/cli/src/__tests__/acp-child-process.test.ts
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { describe, test } from 'node:test';
+import { RequestError, methods } from '@agentclientprotocol/sdk';
+import {
+  pipeCapturedStdout,
+  StdoutCaptureBridge,
+  withAcpChildProcessHarness,
+} from './acp-child-process-harness.js';
+
+describe('Maka ACP child process', () => {
+  test('replays pre-subscription stdout once and continues capture after protocol cancellation', async () => {
+    const tap = new PassThrough();
+    const bridge = new StdoutCaptureBridge(tap);
+    tap.write('early\n');
+
+    const reader = bridge.protocolInput().getReader();
+    tap.write('late\n');
+    assert.equal(new TextDecoder().decode((await reader.read()).value), 'early\n');
+    assert.equal(new TextDecoder().decode((await reader.read()).value), 'late\n');
+    await reader.cancel();
+
+    const ended = once(tap, 'end');
+    tap.end('after-cancel\n');
+    await ended;
+    assert.equal(bridge.text, 'early\nlate\nafter-cancel\n');
+    assert.deepEqual(
+      bridge.snapshot.map((chunk) => new TextDecoder().decode(chunk)),
+      ['early\n', 'late\n', 'after-cancel\n'],
+    );
+    assert.equal(bridge.ended, true);
+    assert.equal(bridge.error, undefined);
+
+    const endedTap = new PassThrough();
+    const endedBridge = new StdoutCaptureBridge(endedTap);
+    const endedEvent = once(endedTap, 'end');
+    endedTap.end('already-ended\n');
+    await endedEvent;
+    const endedReader = endedBridge.protocolInput().getReader();
+    assert.equal(new TextDecoder().decode((await endedReader.read()).value), 'already-ended\n');
+    assert.deepEqual(await endedReader.read(), { value: undefined, done: true });
+  });
+
+  test('replays captured stdout before surfacing its stored error', async () => {
+    const tap = new PassThrough();
+    const bridge = new StdoutCaptureBridge(tap);
+    tap.write('before-error\n');
+    const error = new Error('stdout failed');
+    const errorEvent = once(tap, 'error');
+    tap.destroy(error);
+    await errorEvent;
+
+    const reader = bridge.protocolInput().getReader();
+    assert.equal(new TextDecoder().decode((await reader.read()).value), 'before-error\n');
+    await assert.rejects(reader.read(), (actual: unknown) => actual === error);
+    assert.equal(bridge.error, error);
+  });
+
+  test('forwards a child stdout error into the capture tap', async () => {
+    const childStdout = new PassThrough();
+    const tap = new PassThrough();
+    const bridge = new StdoutCaptureBridge(tap);
+    pipeCapturedStdout(childStdout, tap);
+
+    const error = new Error('child stdout failed');
+    const errorEvent = once(tap, 'error');
+    childStdout.destroy(error);
+    await errorEvent;
+    assert.equal(bridge.error, error);
+  });
+
+  test('accepts only exclusive JSON-RPC request, notification, and response forms', () => {
+    for (const message of [
+      { jsonrpc: '2.0', method: 'initialize', id: 1 },
+      { jsonrpc: '2.0', method: 'session/update' },
+      { jsonrpc: '2.0', method: 'session/update', params: { sessionId: 'session-1' } },
+      { jsonrpc: '2.0', id: 1, result: {} },
+      { jsonrpc: '2.0', id: 1, error: { code: -32601, message: 'Method not found' } },
+    ]) {
+      assertJsonRpcMessage(message);
+    }
+
+    for (const message of [
+      { jsonrpc: '2.0', result: {} },
+      { jsonrpc: '2.0', id: 1, result: {}, error: { code: -32603, message: 'Internal error' } },
+      { jsonrpc: '2.0', method: 'initialize', id: 1, result: {} },
+      { jsonrpc: '2.0', method: 'session/update', params: 'not-an-object' },
+      { jsonrpc: '2.0', id: 1, error: { code: 'bad', message: 'Method not found' } },
+    ]) {
+      assert.throws(() => assertJsonRpcMessage(message));
+    }
+  });
+
+  test('serves ACP over a clean stdio boundary and exits after stdin EOF', {
+    timeout: 30_000,
+  }, async () => {
+    await withAcpChildProcessHarness(async (harness) => {
+      await harness.withClient(async ({ context }) => {
+        assert.deepEqual(await context.request(methods.agent.initialize, { protocolVersion: 1 }), {
+          protocolVersion: 1,
+          agentInfo: { name: 'maka', title: 'Maka', version: '0.2.0' },
+        });
+
+        await assert.rejects(
+          context.request('session/new', { cwd: harness.workspaceRoot }),
+          (error: unknown) => {
+            assert.ok(error instanceof RequestError);
+            assert.equal(error.code, -32601);
+            assert.deepEqual(error.data, { method: 'session/new' });
+            return true;
+          },
+        );
+      });
+
+      await harness.closeStdin();
+      assert.deepEqual(await harness.waitForExit(), { code: 0, signal: null });
+      assert.equal(harness.stderr, '');
+
+      const lines = harness.stdout.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+      assert.ok(lines.length >= 2, 'expected initialize and method-not-found responses');
+      for (const line of lines) {
+        const message: unknown = JSON.parse(line);
+        assertJsonRpcMessage(message);
+      }
+    });
+  });
+});
+
+function assertJsonRpcMessage(message: unknown): void {
+  assert.ok(message && typeof message === 'object' && !Array.isArray(message));
+  const record = message as Record<string, unknown>;
+  assert.equal(record.jsonrpc, '2.0');
+  if (Object.hasOwn(record, 'method')) {
+    assert.equal(typeof record.method, 'string');
+    assert.equal(Object.hasOwn(record, 'result'), false);
+    assert.equal(Object.hasOwn(record, 'error'), false);
+    if (Object.hasOwn(record, 'id')) assertJsonRpcId(record.id);
+    if (Object.hasOwn(record, 'params')) {
+      assert.ok(
+        record.params !== null && typeof record.params === 'object',
+        'JSON-RPC method params are an object or array when present',
+      );
+    }
+    return;
+  }
+
+  assert.equal(Object.hasOwn(record, 'id'), true, 'a JSON-RPC response requires an id');
+  assertJsonRpcId(record.id);
+  const hasResult = Object.hasOwn(record, 'result');
+  const hasError = Object.hasOwn(record, 'error');
+  assert.notEqual(hasResult, hasError, 'a JSON-RPC response has exactly one of result or error');
+  if (!hasError) return;
+  assert.ok(record.error && typeof record.error === 'object' && !Array.isArray(record.error));
+  const error = record.error as Record<string, unknown>;
+  assert.equal(typeof error.code, 'number');
+  assert.equal(Number.isFinite(error.code), true);
+  assert.equal(typeof error.message, 'string');
+}
+
+function assertJsonRpcId(id: unknown): void {
+  assert.ok(
+    id === null || typeof id === 'string' || (typeof id === 'number' && Number.isFinite(id)),
+    'a JSON-RPC id is a string, finite number, or null',
+  );
+}

--- a/packages/cli/src/__tests__/acp-child-process.test.ts
+++ b/packages/cli/src/__tests__/acp-child-process.test.ts
@@ -118,6 +118,8 @@ describe('Maka ACP child process', () => {
       await harness.withClient(async ({ context }) => {
         assert.deepEqual(await context.request(methods.agent.initialize, { protocolVersion: 1 }), {
           protocolVersion: 1,
+          agentCapabilities: {},
+          authMethods: [],
           agentInfo: { name: 'maka', title: 'Maka', version: '0.2.0' },
         });
 

--- a/packages/cli/src/__tests__/acp-stdio-server.test.ts
+++ b/packages/cli/src/__tests__/acp-stdio-server.test.ts
@@ -30,19 +30,39 @@ describe('Maka ACP stdio server', () => {
     assert.equal(harness.closeCalls(), 1);
   });
 
-  test('closes the Runtime Host context once after a protocol error', async () => {
+  test('returns a JSON-RPC parse error and closes the Runtime Host once after EOF', async () => {
     const harness = createHarness(['not json\n']);
 
     assert.equal(await harness.run(), 0);
+    assert.deepEqual(harness.stdoutMessages(), [
+      { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
+    ]);
+    assert.equal(harness.closeCalls(), 1);
+  });
+
+  test('propagates a stdin transport error after closing the Runtime Host once', async () => {
+    const transportError = new Error('stdin transport failed');
+    const stdin = Readable.from(
+      (async function* () {
+        throw transportError;
+      })(),
+    );
+    const harness = createHarness([], stdin);
+
+    await assert.rejects(harness.run(), (error: unknown) => error === transportError);
     assert.equal(harness.closeCalls(), 1);
   });
 });
 
-function createHarness(chunks: string[]) {
+function createHarness(
+  chunks: string[],
+  stdin = Readable.from(chunks.map((chunk) => Buffer.from(chunk))),
+) {
   let closes = 0;
-  const stdin = Readable.from(chunks.map((chunk) => Buffer.from(chunk)));
+  const stdoutChunks: Buffer[] = [];
   const stdout = new Writable({
-    write(_chunk, _encoding, callback) {
+    write(chunk, _encoding, callback) {
+      stdoutChunks.push(Buffer.from(chunk));
       callback();
     },
   });
@@ -64,5 +84,12 @@ function createHarness(chunks: string[]) {
         },
       ),
     closeCalls: () => closes,
+    stdoutMessages: () =>
+      Buffer.concat(stdoutChunks)
+        .toString('utf8')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as unknown),
   };
 }

--- a/packages/cli/src/__tests__/acp-stdio-server.test.ts
+++ b/packages/cli/src/__tests__/acp-stdio-server.test.ts
@@ -23,42 +23,61 @@ import { describe, test } from 'node:test';
 import { runMakaAcpStdioServer } from '../acp/stdio-server.js';
 
 describe('Maka ACP stdio server', () => {
-  test('closes the Runtime Host context once after normal EOF', async () => {
+  test('answers initialize without Runtime Host input or dependencies', async () => {
+    const harness = createHarness([
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: 1 },
+      })}\n`,
+    ]);
+
+    assert.equal(await harness.run(), 0);
+    assert.deepEqual(harness.stdoutMessages(), [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          protocolVersion: 1,
+          agentCapabilities: {},
+          authMethods: [],
+          agentInfo: { name: 'maka', title: 'Maka', version: '0.2.0' },
+        },
+      },
+    ]);
+  });
+
+  test('returns zero after normal EOF', async () => {
     const harness = createHarness([]);
 
     assert.equal(await harness.run(), 0);
-    assert.equal(harness.closeCalls(), 1);
   });
 
-  test('returns a JSON-RPC parse error and closes the Runtime Host once after EOF', async () => {
+  test('returns a JSON-RPC parse error and then zero after EOF', async () => {
     const harness = createHarness(['not json\n']);
 
     assert.equal(await harness.run(), 0);
     assert.deepEqual(harness.stdoutMessages(), [
       { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
     ]);
-    assert.equal(harness.closeCalls(), 1);
   });
 
-  test('propagates a stdin transport error after closing the Runtime Host once', async () => {
+  test('propagates a stdin transport error', async () => {
     const transportError = new Error('stdin transport failed');
     const stdin = Readable.from(
       (async function* () {
         throw transportError;
       })(),
     );
-    const harness = createHarness([], stdin);
+    const harness = createHarness([], { stdin });
 
     await assert.rejects(harness.run(), (error: unknown) => error === transportError);
-    assert.equal(harness.closeCalls(), 1);
   });
 });
 
-function createHarness(
-  chunks: string[],
-  stdin = Readable.from(chunks.map((chunk) => Buffer.from(chunk))),
-) {
-  let closes = 0;
+function createHarness(chunks: string[], options: { readonly stdin?: Readable } = {}) {
+  const stdin = options.stdin ?? Readable.from(chunks.map((chunk) => Buffer.from(chunk)));
   const stdoutChunks: Buffer[] = [];
   const stdout = new Writable({
     write(chunk, _encoding, callback) {
@@ -67,23 +86,7 @@ function createHarness(
     },
   });
   return {
-    run: () =>
-      runMakaAcpStdioServer(
-        { workspaceRoot: '/workspace', clientDataRoot: '/client-data', version: '0.2.0' },
-        {
-          stdin,
-          stdout,
-          connectRuntimeHostCli: async () =>
-            ({
-              close: async () => {
-                closes += 1;
-              },
-            }) as Awaited<
-              ReturnType<typeof import('../runtime-host-cli-context.js').connectRuntimeHostCli>
-            >,
-        },
-      ),
-    closeCalls: () => closes,
+    run: () => runMakaAcpStdioServer({ version: '0.2.0' }, { stdin, stdout }),
     stdoutMessages: () =>
       Buffer.concat(stdoutChunks)
         .toString('utf8')

--- a/packages/cli/src/__tests__/acp-stdio-server.test.ts
+++ b/packages/cli/src/__tests__/acp-stdio-server.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { Readable, Writable } from 'node:stream';
+import { describe, test } from 'node:test';
+import { runMakaAcpStdioServer } from '../acp/stdio-server.js';
+
+describe('Maka ACP stdio server', () => {
+  test('closes the Runtime Host context once after normal EOF', async () => {
+    const harness = createHarness([]);
+
+    assert.equal(await harness.run(), 0);
+    assert.equal(harness.closeCalls(), 1);
+  });
+
+  test('closes the Runtime Host context once after a protocol error', async () => {
+    const harness = createHarness(['not json\n']);
+
+    assert.equal(await harness.run(), 0);
+    assert.equal(harness.closeCalls(), 1);
+  });
+});
+
+function createHarness(chunks: string[]) {
+  let closes = 0;
+  const stdin = Readable.from(chunks.map((chunk) => Buffer.from(chunk)));
+  const stdout = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+  return {
+    run: () =>
+      runMakaAcpStdioServer(
+        { workspaceRoot: '/workspace', clientDataRoot: '/client-data', version: '0.2.0' },
+        {
+          stdin,
+          stdout,
+          connectRuntimeHostCli: async () =>
+            ({
+              close: async () => {
+                closes += 1;
+              },
+            }) as Awaited<
+              ReturnType<typeof import('../runtime-host-cli-context.js').connectRuntimeHostCli>
+            >,
+        },
+      ),
+    closeCalls: () => closes,
+  };
+}

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -51,7 +51,10 @@ describe('Maka CLI args', () => {
     assert.match(help.text, /^  maka run /m);
     assert.match(help.text, /^  maka activate /m);
     assert.match(help.text, /^  maka eval /m);
-    assert.match(help.text, /^  maka --acp      Serve ACP v1 over stdio$/m);
+    assert.match(
+      help.text,
+      /^  maka --acp      Serve ACP v1 over stdio \(initialize only; session support in progress\)$/m,
+    );
     assert.match(help.text, /^  maka runtime-host serve /m);
     assert.doesNotMatch(help.text, /cli:dev/);
   });

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -51,6 +51,7 @@ describe('Maka CLI args', () => {
     assert.match(help.text, /^  maka run /m);
     assert.match(help.text, /^  maka activate /m);
     assert.match(help.text, /^  maka eval /m);
+    assert.match(help.text, /^  maka --acp      Serve ACP v1 over stdio$/m);
     assert.match(help.text, /^  maka runtime-host serve /m);
     assert.doesNotMatch(help.text, /cli:dev/);
   });
@@ -61,6 +62,30 @@ describe('Maka CLI args', () => {
       hostProfileId: 'office',
       projectId: 'project-1',
     });
+  });
+
+  test('parses the ACP stdio command before TUI flags', () => {
+    assert.deepEqual(parseMakaCliArgs(['--acp'], '0.1.0'), { kind: 'acp' });
+    assert.deepEqual(parseMakaCliArgs(['--acp', 'extra'], '0.1.0'), {
+      kind: 'error',
+      message: 'maka --acp does not accept arguments',
+      exitCode: 2,
+      showHelp: false,
+    });
+    assert.deepEqual(parseMakaCliArgs(['--host', 'office', '--project', 'project-1'], '0.1.0'), {
+      kind: 'tui',
+      hostProfileId: 'office',
+      projectId: 'project-1',
+    });
+  });
+
+  test('compiled ACP launcher rejects trailing arguments without help output', async () => {
+    const result = await runCompiledCli('dev-cli.js', ['--acp', 'extra'], process.env);
+
+    assert.equal(result.signal, null);
+    assert.equal(result.code, 2);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'maka --acp does not accept arguments\n');
   });
 
   test('uses the active launcher in development help and rejects an empty profile name', async () => {
@@ -265,19 +290,24 @@ async function runCompiledCli(
   entrypoint: string,
   args: readonly string[],
   env: NodeJS.ProcessEnv,
-): Promise<{ code: number | null; signal: NodeJS.Signals | null; stderr: string }> {
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
   const child = spawn(
     process.execPath,
     [fileURLToPath(new URL(`../${entrypoint}`, import.meta.url)), ...args],
-    { env, stdio: ['ignore', 'ignore', 'pipe'], timeout: 15_000, killSignal: 'SIGKILL' },
+    { env, stdio: ['ignore', 'pipe', 'pipe'], timeout: 15_000, killSignal: 'SIGKILL' },
   );
+  let stdout = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk: string) => {
+    stdout += chunk;
+  });
   let stderr = '';
   child.stderr.setEncoding('utf8');
   child.stderr.on('data', (chunk: string) => {
     stderr += chunk;
   });
   const [code, signal] = (await once(child, 'close')) as [number | null, NodeJS.Signals | null];
-  return { code, signal, stderr };
+  return { code, signal, stdout, stderr };
 }
 
 function platformProfileRoot(home: string, applicationData: string, profileName: string): string {

--- a/packages/cli/src/acp/maka-acp-agent.ts
+++ b/packages/cli/src/acp/maka-acp-agent.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { agent, methods, type AgentApp } from '@agentclientprotocol/sdk';
+
+export interface MakaAcpAgentOptions {
+  readonly version: string;
+}
+
+export function createMakaAcpAgent(options: MakaAcpAgentOptions): AgentApp {
+  return agent({ name: 'maka' }).onRequest(methods.agent.initialize, () => ({
+    protocolVersion: 1,
+    agentInfo: { name: 'maka', title: 'Maka', version: options.version },
+  }));
+}

--- a/packages/cli/src/acp/maka-acp-agent.ts
+++ b/packages/cli/src/acp/maka-acp-agent.ts
@@ -26,6 +26,8 @@ export interface MakaAcpAgentOptions {
 export function createMakaAcpAgent(options: MakaAcpAgentOptions): AgentApp {
   return agent({ name: 'maka' }).onRequest(methods.agent.initialize, () => ({
     protocolVersion: 1,
+    agentCapabilities: {},
+    authMethods: [],
     agentInfo: { name: 'maka', title: 'Maka', version: options.version },
   }));
 }

--- a/packages/cli/src/acp/stdio-server.ts
+++ b/packages/cli/src/acp/stdio-server.ts
@@ -45,13 +45,27 @@ export async function runMakaAcpStdioServer(
   try {
     const stdin = dependencies.stdin ?? process.stdin;
     const stdout = dependencies.stdout ?? process.stdout;
-    const stream = ndJsonStream(
-      Writable.toWeb(stdout) as WritableStream<Uint8Array>,
-      Readable.toWeb(stdin) as ReadableStream<Uint8Array>,
-    );
-    const connection = createMakaAcpAgent({ version: input.version }).connect(stream);
-    await connection.closed;
-    return 0;
+    let stdioError: Error | undefined;
+    const recordStdioError = (error: Error) => {
+      stdioError ??= error;
+    };
+    stdin.once('error', recordStdioError);
+    stdout.once('error', recordStdioError);
+    try {
+      const stream = ndJsonStream(
+        Writable.toWeb(stdout) as WritableStream<Uint8Array>,
+        Readable.toWeb(stdin) as ReadableStream<Uint8Array>,
+      );
+      const connection = createMakaAcpAgent({ version: input.version }).connect(stream);
+      await connection.closed;
+      if (stdioError) {
+        throw stdioError;
+      }
+      return 0;
+    } finally {
+      stdin.off('error', recordStdioError);
+      stdout.off('error', recordStdioError);
+    }
   } finally {
     await context.close();
   }

--- a/packages/cli/src/acp/stdio-server.ts
+++ b/packages/cli/src/acp/stdio-server.ts
@@ -20,16 +20,12 @@
 import { Readable, Writable } from 'node:stream';
 import { ndJsonStream } from '@agentclientprotocol/sdk';
 import { createMakaAcpAgent } from './maka-acp-agent.js';
-import { connectRuntimeHostCli } from '../runtime-host-cli-context.js';
 
 export interface MakaAcpStdioServerInput {
-  readonly workspaceRoot: string;
-  readonly clientDataRoot: string;
   readonly version: string;
 }
 
 export interface MakaAcpStdioServerDependencies {
-  readonly connectRuntimeHostCli?: typeof connectRuntimeHostCli;
   readonly stdin?: Readable;
   readonly stdout?: Writable;
 }
@@ -38,35 +34,27 @@ export async function runMakaAcpStdioServer(
   input: MakaAcpStdioServerInput,
   dependencies: MakaAcpStdioServerDependencies = {},
 ): Promise<number> {
-  const context = await (dependencies.connectRuntimeHostCli ?? connectRuntimeHostCli)({
-    rootPath: input.workspaceRoot,
-    clientDataRoot: input.clientDataRoot,
-  });
+  const stdin = dependencies.stdin ?? process.stdin;
+  const stdout = dependencies.stdout ?? process.stdout;
+  let stdioError: Error | undefined;
+  const recordStdioError = (error: Error) => {
+    stdioError ??= error;
+  };
+  stdin.once('error', recordStdioError);
+  stdout.once('error', recordStdioError);
   try {
-    const stdin = dependencies.stdin ?? process.stdin;
-    const stdout = dependencies.stdout ?? process.stdout;
-    let stdioError: Error | undefined;
-    const recordStdioError = (error: Error) => {
-      stdioError ??= error;
-    };
-    stdin.once('error', recordStdioError);
-    stdout.once('error', recordStdioError);
-    try {
-      const stream = ndJsonStream(
-        Writable.toWeb(stdout) as WritableStream<Uint8Array>,
-        Readable.toWeb(stdin) as ReadableStream<Uint8Array>,
-      );
-      const connection = createMakaAcpAgent({ version: input.version }).connect(stream);
-      await connection.closed;
-      if (stdioError) {
-        throw stdioError;
-      }
-      return 0;
-    } finally {
-      stdin.off('error', recordStdioError);
-      stdout.off('error', recordStdioError);
+    const stream = ndJsonStream(
+      Writable.toWeb(stdout) as WritableStream<Uint8Array>,
+      Readable.toWeb(stdin) as ReadableStream<Uint8Array>,
+    );
+    const connection = createMakaAcpAgent({ version: input.version }).connect(stream);
+    await connection.closed;
+    if (stdioError) {
+      throw stdioError;
     }
+    return 0;
   } finally {
-    await context.close();
+    stdin.off('error', recordStdioError);
+    stdout.off('error', recordStdioError);
   }
 }

--- a/packages/cli/src/acp/stdio-server.ts
+++ b/packages/cli/src/acp/stdio-server.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Readable, Writable } from 'node:stream';
+import { ndJsonStream } from '@agentclientprotocol/sdk';
+import { createMakaAcpAgent } from './maka-acp-agent.js';
+import { connectRuntimeHostCli } from '../runtime-host-cli-context.js';
+
+export interface MakaAcpStdioServerInput {
+  readonly workspaceRoot: string;
+  readonly clientDataRoot: string;
+  readonly version: string;
+}
+
+export interface MakaAcpStdioServerDependencies {
+  readonly connectRuntimeHostCli?: typeof connectRuntimeHostCli;
+  readonly stdin?: Readable;
+  readonly stdout?: Writable;
+}
+
+export async function runMakaAcpStdioServer(
+  input: MakaAcpStdioServerInput,
+  dependencies: MakaAcpStdioServerDependencies = {},
+): Promise<number> {
+  const context = await (dependencies.connectRuntimeHostCli ?? connectRuntimeHostCli)({
+    rootPath: input.workspaceRoot,
+    clientDataRoot: input.clientDataRoot,
+  });
+  try {
+    const stdin = dependencies.stdin ?? process.stdin;
+    const stdout = dependencies.stdout ?? process.stdout;
+    const stream = ndJsonStream(
+      Writable.toWeb(stdout) as WritableStream<Uint8Array>,
+      Readable.toWeb(stdin) as ReadableStream<Uint8Array>,
+    );
+    const connection = createMakaAcpAgent({ version: input.version }).connect(stream);
+    await connection.closed;
+    return 0;
+  } finally {
+    await context.close();
+  }
+}

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -35,10 +35,11 @@ export type MakaCliCommand =
   | { kind: 'run'; args: string[] }
   | { kind: 'activate'; args: string[] }
   | { kind: 'eval'; args: string[] }
+  | { kind: 'acp' }
   | RuntimeHostCliCommand
   | { kind: 'help'; text: string }
   | { kind: 'version'; text: string }
-  | { kind: 'error'; message: string; exitCode: number };
+  | { kind: 'error'; message: string; exitCode: number; showHelp?: boolean };
 
 export interface MakaCliLaunchOptions {
   readonly dataProfileName: string;
@@ -61,6 +62,16 @@ export function parseMakaCliArgs(
   const [first] = argv;
   if (first === '--help' || first === '-h') return { kind: 'help', text: helpText(cliCommand) };
   if (first === '--version' || first === '-v') return { kind: 'version', text: version };
+  if (first === '--acp') {
+    return argv.length === 1
+      ? { kind: 'acp' }
+      : {
+          kind: 'error',
+          message: 'maka --acp does not accept arguments',
+          exitCode: 2,
+          showHelp: false,
+        };
+  }
   if (first?.startsWith('--')) return parseTuiArgs(argv);
   if (first === 'run' || first === '-p') return { kind: 'run', args: argv.slice(1) };
   if (first === 'activate') return { kind: 'activate', args: argv.slice(1) };
@@ -113,6 +124,7 @@ function helpText(cliCommand: string): string {
     '',
     'Commands:',
     `  ${cliCommand}              Start the TUI`,
+    `  ${cliCommand} --acp      Serve ACP v1 over stdio`,
     `  ${cliCommand} run ...      Run one non-interactive model turn`,
     `  ${cliCommand} activate ... Run one Cloud Session activation and emit JSONL`,
     `  ${cliCommand} -p ...       Alias for ${cliCommand} run`,
@@ -221,6 +233,14 @@ export async function runMakaCli(
       configureInstalledEvalBundle();
       const { runMakaEvalCli } = await import('@maka/eval');
       return runMakaEvalCli(command.args);
+    }
+    case 'acp': {
+      const { runMakaAcpStdioServer } = await import('./acp/stdio-server.js');
+      return runMakaAcpStdioServer({
+        workspaceRoot: dataRoots.workspaceRoot,
+        clientDataRoot: dataRoots.clientDataRoot,
+        version,
+      });
     }
     case 'runtime-host-serve': {
       const { runRuntimeHostServiceCli } = await import('./runtime-host-service-command.js');
@@ -470,7 +490,11 @@ export async function runMakaCli(
       process.stdout.write(`${command.text}\n`);
       return 0;
     case 'error':
-      process.stderr.write(`${command.message}\n\n${helpText(options.cliCommand)}\n`);
+      process.stderr.write(
+        'showHelp' in command && command.showHelp === false
+          ? `${command.message}\n`
+          : `${command.message}\n\n${helpText(options.cliCommand)}\n`,
+      );
       return command.exitCode;
     case 'tui': {
       const locale = resolveCliUiLocale(process.env);

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -124,7 +124,7 @@ function helpText(cliCommand: string): string {
     '',
     'Commands:',
     `  ${cliCommand}              Start the TUI`,
-    `  ${cliCommand} --acp      Serve ACP v1 over stdio`,
+    `  ${cliCommand} --acp      Serve ACP v1 over stdio (initialize only; session support in progress)`,
     `  ${cliCommand} run ...      Run one non-interactive model turn`,
     `  ${cliCommand} activate ... Run one Cloud Session activation and emit JSONL`,
     `  ${cliCommand} -p ...       Alias for ${cliCommand} run`,

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -236,11 +236,7 @@ export async function runMakaCli(
     }
     case 'acp': {
       const { runMakaAcpStdioServer } = await import('./acp/stdio-server.js');
-      return runMakaAcpStdioServer({
-        workspaceRoot: dataRoots.workspaceRoot,
-        clientDataRoot: dataRoots.clientDataRoot,
-        version,
-      });
+      return runMakaAcpStdioServer({ version });
     }
     case 'runtime-host-serve': {
       const { runRuntimeHostServiceCli } = await import('./runtime-host-service-command.js');


### PR DESCRIPTION
## Summary

- Add the `maka --acp` entry point and serve ACP v1 over stdio with `@agentclientprotocol/sdk@1.4.0`.
- Keep `initialize` probeable without a Runtime Host and defer Host connection until a follow-up session method actually needs it; stdout remains reserved for ACP NDJSON.
- Implement only the PR1 foundation and exact `initialize` identity; unsupported session requests remain standard `-32601` responses. Session, prompt, streaming, cancellation, and permission support remain follow-up work.
- Add reusable unit and child-process coverage using the official SDK client; the harness can opt into a real in-process Runtime Host for follow-up PRs.

Refs #3132

## Verification

- `npm --workspace maka-agent test` — 434 passed, 0 failed
- `npm run lint`
- `npm run format:check`
- `npm run check:asf-headers`
- `npm run check:cli-third-party-notices`
- `npm ls --workspace maka-agent --omit=dev --all`
- `npx --yes npm@11.19.0 run release:cli:pack`
- `npx --yes npm@11.19.0 run release:cli:smoke`
- Verified the packed tarball contains `@agentclientprotocol/sdk/dist/acp.js` and its package metadata.

Repository-wide `npm run typecheck` and `npm test` currently stop in unchanged `packages/ui` / `apps/desktop` code because the checked-in UI call sites reference `conversationKey`, `settledText`, `unlockAutoFollow`, and `trailingAction` fields absent from their installed component types. This branch does not modify `packages/ui` or `apps/desktop`; the CLI typecheck and affected suite pass above.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex assisted with implementation, tests, conflict resolution, and review. Each affected commit includes a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
