### PR TITLE
feat(runtime-host): discover managed Host updates

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-management.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-management.test.ts
@@ -577,7 +577,10 @@ test('rechecks uninstall intent before retrying the remote service', async () =>
 function serviceResult(
   action: DesktopRuntimeHostSshManagementInput['action'],
   operatorAccess = false,
-): Extract<RuntimeHostServiceManagementFrame, { kind: 'result' }> {
+): Exclude<
+  Extract<RuntimeHostServiceManagementFrame, { kind: 'result' }>,
+  { action: 'check_update' | 'update' }
+> {
   const result = {
     schemaVersion: 1 as const,
     kind: 'result' as const,

--- a/apps/desktop/src/main/runtime-host-management.ts
+++ b/apps/desktop/src/main/runtime-host-management.ts
@@ -134,15 +134,19 @@ export function createDesktopRuntimeHostManagement(input: {
     };
     if (managementAction !== 'uninstall') {
       const response = await input.runServiceManagement(managementInput);
+      if (response.action !== managementAction) {
+        throw new Error('Remote Runtime Host returned a different management action');
+      }
       return response.kind === 'result'
         ? {
             ...response,
+            action: managementAction,
             accessManagementAvailable:
               response.operatorCapabilities?.includes(
                 RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY,
               ) ?? false,
           }
-        : response;
+        : { ...response, action: managementAction };
     }
 
     let pending = managed;
@@ -152,7 +156,10 @@ export function createDesktopRuntimeHostManagement(input: {
         ...managementInput,
         retainManagedDeployment: true,
       });
-      if (response.kind === 'error') return response;
+      if (response.action !== managementAction) {
+        throw new Error('Remote Runtime Host returned a different management action');
+      }
+      if (response.kind === 'error') return { ...response, action: managementAction };
       assertUninstalled(response);
       pending = await input.profiles.markManagedServiceCleanupPending(pending);
     }

--- a/apps/desktop/src/main/runtime-host-ssh-terminal.ts
+++ b/apps/desktop/src/main/runtime-host-ssh-terminal.ts
@@ -85,7 +85,7 @@ export interface DesktopRuntimeHostSshManagementInput {
   readonly destination: string;
   readonly sshPort?: number;
   readonly operatorPath: string;
-  readonly action: Exclude<RuntimeHostServiceManagementAction, 'update'>;
+  readonly action: Exclude<RuntimeHostServiceManagementAction, 'check_update' | 'update'>;
   readonly expectedTarget: {
     readonly serviceId: string;
     readonly rootPath: string;

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -424,12 +424,15 @@ export type DesktopRuntimeHostManagementResult = Extract<
   RuntimeHostServiceManagementFrame,
   { kind: 'result' }
 > & {
+  readonly action: DesktopRuntimeHostManagementAction | 'update';
   readonly accessManagementAvailable: boolean;
 };
 
 export type DesktopRuntimeHostManagementResponse =
   | DesktopRuntimeHostManagementResult
-  | Extract<RuntimeHostServiceManagementFrame, { kind: 'error' }>
+  | (Extract<RuntimeHostServiceManagementFrame, { kind: 'error' }> & {
+      readonly action: DesktopRuntimeHostManagementAction | 'update';
+    })
   | {
       readonly kind: 'uninstalled';
       readonly retainedStateRoot: string;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -134,7 +134,8 @@ maka runtime-host service check-update --target next --json
 
 The result pins the selected channel to an exact version and package integrity. It also reports
 whether the package carries enough compatibility evidence for a future unattended update; this
-command never installs or switches a package.
+command never installs or switches a package. An updater must still verify the downloaded archive
+against that integrity and confirm the compatibility value from its extracted package manifest.
 
 ## Uninstall
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -126,6 +126,16 @@ npx --yes --package maka-agent@next maka runtime-host setup \
 Rerunning setup replaces that Client credential. The service no longer depends on the temporary
 `npx` cache after setup succeeds.
 
+Check a managed service against a release channel without changing the running Host:
+
+```sh
+maka runtime-host service check-update --target next --json
+```
+
+The result pins the selected channel to an exact version and package integrity. It also reports
+whether the package carries enough compatibility evidence for a future unattended update; this
+command never installs or switches a package.
+
 ## Uninstall
 
 ```sh

--- a/packages/cli/README.zh-CN.md
+++ b/packages/cli/README.zh-CN.md
@@ -118,6 +118,15 @@ npx --yes --package maka-agent@next maka runtime-host setup \
 
 重复设置会替换该 Client credential。设置成功后，service 不再依赖临时 `npx` cache。
 
+可以在不改变当前 Host 的情况下检查 managed service 对应的发布频道：
+
+```sh
+maka runtime-host service check-update --target next --json
+```
+
+结果会把频道固定为精确版本和 package integrity，并说明 package 是否提供足够的兼容性证据，
+可供未来的无人值守更新使用；该命令不会安装或切换 package。
+
 ## 卸载
 
 ```sh

--- a/packages/cli/README.zh-CN.md
+++ b/packages/cli/README.zh-CN.md
@@ -125,7 +125,8 @@ maka runtime-host service check-update --target next --json
 ```
 
 结果会把频道固定为精确版本和 package integrity，并说明 package 是否提供足够的兼容性证据，
-可供未来的无人值守更新使用；该命令不会安装或切换 package。
+可供未来的无人值守更新使用；该命令不会安装或切换 package。更新程序仍须以该 integrity
+校验下载的 archive，并从解压后的 package manifest 中再次确认兼容性值。
 
 ## 卸载
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,9 @@
   "bin": {
     "maka": "./dist/cli.js"
   },
+  "maka": {
+    "managedRuntimeHostUpdateCompatibility": 1
+  },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",
     "build": "tsc -p tsconfig.json && node scripts/chmod-bin.mjs",

--- a/packages/cli/src/__tests__/runtime-host-launch-agent-service.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-launch-agent-service.test.ts
@@ -96,6 +96,7 @@ test('maps install, stop, start, restart, and uninstall onto one LaunchAgent ser
     await backend.stop();
     assert.equal(processChecks, 1);
     assert.equal((await backend.status()).state, 'stopped');
+    await backend.verifyDeployment(config);
     await backend.start();
     await backend.restart();
     assert.equal((await backend.status()).pid, 4103);

--- a/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
@@ -32,6 +32,26 @@ import {
 
 const INTEGRITY =
   'sha512-jUKdo/5dbM94KXq+kOZ1d+obhDLAENfI/QWr1PnXWcdu2PqDyLklJBtiVO6HRwoL1l40z1NE9Rq+hLAxCN0Fyg==';
+const FRAME = {
+  schemaVersion: 1,
+  kind: 'result',
+  action: 'check_update',
+  service: {
+    platform: 'darwin',
+    arch: 'arm64',
+    osRelease: 'test',
+    state: 'stopped',
+    pid: null,
+    lastExitCode: 0,
+    installedVersion: '1.0.0',
+    projectDirectoryRoots: [],
+  },
+  updateCheck: {
+    selector: { kind: 'exact', version: '2.0.0' },
+    candidate: { version: '2.0.0', integrity: INTEGRITY },
+    outcome: { kind: 'unattended_update', compatibility: 4 },
+  },
+} as const satisfies RuntimeHostServiceManagementFrame;
 
 describe('managed Runtime Host update discovery', () => {
   it('accepts only channels or canonical exact versions', () => {
@@ -156,63 +176,46 @@ describe('managed Runtime Host update discovery', () => {
     );
     assert.match(
       formatRuntimeHostUpdateCheck({
-        selector: { kind: 'channel', channel: 'next' },
-        currentVersion: '1.0.0',
-        candidate: { version: '2.0.0', integrity: INTEGRITY },
-        outcome: manual,
+        ...FRAME,
+        updateCheck: { ...FRAME.updateCheck, outcome: manual },
       }),
       /target package has no unattended-update compatibility evidence/u,
     );
   });
 
   it('rejects malformed or contradictory machine evidence', () => {
-    const frame: RuntimeHostServiceManagementFrame = {
-      schemaVersion: 1,
-      kind: 'result',
-      action: 'check_update',
-      service: {
-        platform: 'darwin',
-        arch: 'arm64',
-        osRelease: 'test',
-        state: 'stopped',
-        pid: null,
-        lastExitCode: 0,
-        installedVersion: '1.0.0',
-        projectDirectoryRoots: [],
-      },
-      updateCheck: {
-        selector: { kind: 'exact', version: '2.0.0' },
-        currentVersion: '1.0.0',
-        candidate: { version: '2.0.0', integrity: INTEGRITY },
-        outcome: { kind: 'unattended_update', compatibility: 4 },
-      },
-    };
-    assert.doesNotThrow(() => encodeRuntimeHostServiceManagementFrame(frame));
+    assert.doesNotThrow(() => encodeRuntimeHostServiceManagementFrame(FRAME));
     assert.throws(() =>
       encodeRuntimeHostServiceManagementFrame({
-        ...frame,
+        ...FRAME,
         updateCheck: {
-          ...frame.updateCheck,
+          ...FRAME.updateCheck,
           candidate: { version: '9.0.0', integrity: INTEGRITY },
         },
       }),
     );
     assert.throws(() =>
       encodeRuntimeHostServiceManagementFrame({
-        ...frame,
+        ...FRAME,
         updateCheck: {
-          ...frame.updateCheck,
+          ...FRAME.updateCheck,
           candidate: { version: '2.0.0', integrity: 'not-a-digest' },
         },
       }),
     );
     assert.throws(() =>
       encodeRuntimeHostServiceManagementFrame({
-        ...frame,
+        ...FRAME,
         updateCheck: {
-          ...frame.updateCheck,
+          ...FRAME.updateCheck,
           outcome: { kind: 'current' },
         },
+      }),
+    );
+    assert.throws(() =>
+      encodeRuntimeHostServiceManagementFrame({
+        ...FRAME,
+        service: { ...FRAME.service, installedVersion: 'not-a-version' },
       }),
     );
   });

--- a/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseRuntimeHostCommand } from '../runtime-host-cli.js';
+import {
+  assessRuntimeHostUpdate,
+  resolveRuntimeHostRegistryUpdateCandidate,
+} from '../runtime-host-update-discovery.js';
+
+describe('managed Runtime Host update discovery', () => {
+  it('accepts only channels or canonical exact versions', () => {
+    assert.deepEqual(
+      parseRuntimeHostCommand(['service', 'check-update', '--target', 'latest', '--json']),
+      {
+        kind: 'runtime-host-service-check-update',
+        json: true,
+        selector: { kind: 'channel', channel: 'latest' },
+      },
+    );
+    assert.deepEqual(
+      parseRuntimeHostCommand(['service', 'check-update', '--target', '1.2.3-beta.4']),
+      {
+        kind: 'runtime-host-service-check-update',
+        json: false,
+        selector: { kind: 'exact', version: '1.2.3-beta.4' },
+      },
+    );
+    for (const target of ['1.2', '01.2.3', '1.2.3-beta.01', '../latest']) {
+      assert.equal(
+        parseRuntimeHostCommand(['service', 'check-update', '--target', target]).kind,
+        'error',
+      );
+    }
+  });
+
+  it('pins registry metadata to an exact version and integrity', async () => {
+    let observedArgs: readonly string[] = [];
+    const candidate = await resolveRuntimeHostRegistryUpdateCandidate(
+      { kind: 'channel', channel: 'next' },
+      async (args) => {
+        observedArgs = args;
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            version: '2.0.0-beta.1',
+            'dist.integrity': 'sha512-YWJjZA==',
+            'maka.managedRuntimeHostUpdateCompatibility': 7,
+          }),
+        };
+      },
+    );
+    assert.deepEqual(observedArgs, [
+      'view',
+      'maka-agent@next',
+      'version',
+      'dist.integrity',
+      'maka.managedRuntimeHostUpdateCompatibility',
+      '--json',
+    ]);
+    assert.deepEqual(candidate, {
+      version: '2.0.0-beta.1',
+      integrity: 'sha512-YWJjZA==',
+      compatibility: 7,
+    });
+
+    await assert.rejects(
+      resolveRuntimeHostRegistryUpdateCandidate({ kind: 'exact', version: '9.0.0' }, async () => ({
+        exitCode: 1,
+        stdout: JSON.stringify({ error: { code: 'E404' } }),
+      })),
+      (error: unknown) =>
+        error instanceof Error && 'code' in error && error.code === 'target_unavailable',
+    );
+    await assert.rejects(
+      resolveRuntimeHostRegistryUpdateCandidate(
+        { kind: 'channel', channel: 'latest' },
+        async () => ({ exitCode: 1, stdout: '' }),
+      ),
+      (error: unknown) =>
+        error instanceof Error && 'code' in error && error.code === 'registry_unavailable',
+    );
+  });
+
+  it('admits only newer packages with matching compatibility evidence', () => {
+    const integrity = 'sha512-YWJjZA==';
+    assert.deepEqual(assessRuntimeHostUpdate('1.0.0', undefined, { version: '1.0.0', integrity }), {
+      status: 'current',
+      unattended: { kind: 'not_needed' },
+    });
+    assert.deepEqual(
+      assessRuntimeHostUpdate('1.0.0-beta.1', 4, {
+        version: '1.0.0-beta.2',
+        integrity,
+        compatibility: 4,
+      }),
+      { status: 'newer', unattended: { kind: 'allowed', compatibility: 4 } },
+    );
+    assert.deepEqual(assessRuntimeHostUpdate('1.0.0', 4, { version: '2.0.0', integrity }), {
+      status: 'newer',
+      unattended: { kind: 'manual_only', reason: 'target_compatibility_unknown' },
+    });
+    assert.deepEqual(
+      assessRuntimeHostUpdate('1.0.0', 4, {
+        version: '0.9.0',
+        integrity,
+        compatibility: 4,
+      }),
+      {
+        status: 'older',
+        unattended: { kind: 'manual_only', reason: 'target_not_newer' },
+      },
+    );
+  });
+});

--- a/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
@@ -22,8 +22,12 @@ import { describe, it } from 'node:test';
 import { parseRuntimeHostCommand } from '../runtime-host-cli.js';
 import {
   assessRuntimeHostUpdate,
+  formatRuntimeHostUpdateCheck,
   resolveRuntimeHostRegistryUpdateCandidate,
 } from '../runtime-host-update-discovery.js';
+
+const INTEGRITY =
+  'sha512-jUKdo/5dbM94KXq+kOZ1d+obhDLAENfI/QWr1PnXWcdu2PqDyLklJBtiVO6HRwoL1l40z1NE9Rq+hLAxCN0Fyg==';
 
 describe('managed Runtime Host update discovery', () => {
   it('accepts only channels or canonical exact versions', () => {
@@ -61,7 +65,7 @@ describe('managed Runtime Host update discovery', () => {
           exitCode: 0,
           stdout: JSON.stringify({
             version: '2.0.0-beta.1',
-            'dist.integrity': 'sha512-YWJjZA==',
+            'dist.integrity': INTEGRITY,
             'maka.managedRuntimeHostUpdateCompatibility': 7,
           }),
         };
@@ -77,10 +81,21 @@ describe('managed Runtime Host update discovery', () => {
     ]);
     assert.deepEqual(candidate, {
       version: '2.0.0-beta.1',
-      integrity: 'sha512-YWJjZA==',
+      integrity: INTEGRITY,
       compatibility: 7,
     });
 
+    await assert.rejects(
+      resolveRuntimeHostRegistryUpdateCandidate({ kind: 'channel', channel: 'next' }, async () => ({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          version: '2.0.0',
+          'dist.integrity': 'sha512-YWJjZA==',
+        }),
+      })),
+      (error: unknown) =>
+        error instanceof Error && 'code' in error && error.code === 'invalid_registry_metadata',
+    );
     await assert.rejects(
       resolveRuntimeHostRegistryUpdateCandidate({ kind: 'exact', version: '9.0.0' }, async () => ({
         exitCode: 1,
@@ -100,33 +115,39 @@ describe('managed Runtime Host update discovery', () => {
   });
 
   it('admits only newer packages with matching compatibility evidence', () => {
-    const integrity = 'sha512-YWJjZA==';
-    assert.deepEqual(assessRuntimeHostUpdate('1.0.0', undefined, { version: '1.0.0', integrity }), {
-      status: 'current',
-      unattended: { kind: 'not_needed' },
-    });
+    assert.deepEqual(
+      assessRuntimeHostUpdate('1.0.0', undefined, { version: '1.0.0', integrity: INTEGRITY }),
+      { kind: 'current' },
+    );
     assert.deepEqual(
       assessRuntimeHostUpdate('1.0.0-beta.1', 4, {
         version: '1.0.0-beta.2',
-        integrity,
+        integrity: INTEGRITY,
         compatibility: 4,
       }),
-      { status: 'newer', unattended: { kind: 'allowed', compatibility: 4 } },
+      { kind: 'unattended_update', compatibility: 4 },
     );
-    assert.deepEqual(assessRuntimeHostUpdate('1.0.0', 4, { version: '2.0.0', integrity }), {
-      status: 'newer',
-      unattended: { kind: 'manual_only', reason: 'target_compatibility_unknown' },
+    const manual = assessRuntimeHostUpdate('1.0.0', 4, {
+      version: '2.0.0',
+      integrity: INTEGRITY,
     });
+    assert.deepEqual(manual, { kind: 'manual_action', reason: 'target_compatibility_unknown' });
     assert.deepEqual(
       assessRuntimeHostUpdate('1.0.0', 4, {
         version: '0.9.0',
-        integrity,
+        integrity: INTEGRITY,
         compatibility: 4,
       }),
-      {
-        status: 'older',
-        unattended: { kind: 'manual_only', reason: 'target_not_newer' },
-      },
+      { kind: 'manual_action', reason: 'target_not_newer' },
+    );
+    assert.match(
+      formatRuntimeHostUpdateCheck({
+        selector: { kind: 'channel', channel: 'next' },
+        currentVersion: '1.0.0',
+        candidate: { version: '2.0.0', integrity: INTEGRITY },
+        outcome: manual,
+      }),
+      /target package has no unattended-update compatibility evidence/u,
     );
   });
 });

--- a/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
@@ -19,6 +19,10 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import {
+  encodeRuntimeHostServiceManagementFrame,
+  type RuntimeHostServiceManagementFrame,
+} from '@maka/runtime-host/operator';
 import { parseRuntimeHostCommand } from '../runtime-host-cli.js';
 import {
   assessRuntimeHostUpdate,
@@ -78,6 +82,8 @@ describe('managed Runtime Host update discovery', () => {
       'dist.integrity',
       'maka.managedRuntimeHostUpdateCompatibility',
       '--json',
+      '--registry',
+      'https://registry.npmjs.org/',
     ]);
     assert.deepEqual(candidate, {
       version: '2.0.0-beta.1',
@@ -140,6 +146,14 @@ describe('managed Runtime Host update discovery', () => {
       }),
       { kind: 'manual_action', reason: 'target_not_newer' },
     );
+    assert.deepEqual(
+      assessRuntimeHostUpdate('1.0.0', 4, {
+        version: '2.0.0',
+        integrity: INTEGRITY,
+        compatibility: 5,
+      }),
+      { kind: 'manual_action', reason: 'compatibility_mismatch' },
+    );
     assert.match(
       formatRuntimeHostUpdateCheck({
         selector: { kind: 'channel', channel: 'next' },
@@ -148,6 +162,58 @@ describe('managed Runtime Host update discovery', () => {
         outcome: manual,
       }),
       /target package has no unattended-update compatibility evidence/u,
+    );
+  });
+
+  it('rejects malformed or contradictory machine evidence', () => {
+    const frame: RuntimeHostServiceManagementFrame = {
+      schemaVersion: 1,
+      kind: 'result',
+      action: 'check_update',
+      service: {
+        platform: 'darwin',
+        arch: 'arm64',
+        osRelease: 'test',
+        state: 'stopped',
+        pid: null,
+        lastExitCode: 0,
+        installedVersion: '1.0.0',
+        projectDirectoryRoots: [],
+      },
+      updateCheck: {
+        selector: { kind: 'exact', version: '2.0.0' },
+        currentVersion: '1.0.0',
+        candidate: { version: '2.0.0', integrity: INTEGRITY },
+        outcome: { kind: 'unattended_update', compatibility: 4 },
+      },
+    };
+    assert.doesNotThrow(() => encodeRuntimeHostServiceManagementFrame(frame));
+    assert.throws(() =>
+      encodeRuntimeHostServiceManagementFrame({
+        ...frame,
+        updateCheck: {
+          ...frame.updateCheck,
+          candidate: { version: '9.0.0', integrity: INTEGRITY },
+        },
+      }),
+    );
+    assert.throws(() =>
+      encodeRuntimeHostServiceManagementFrame({
+        ...frame,
+        updateCheck: {
+          ...frame.updateCheck,
+          candidate: { version: '2.0.0', integrity: 'not-a-digest' },
+        },
+      }),
+    );
+    assert.throws(() =>
+      encodeRuntimeHostServiceManagementFrame({
+        ...frame,
+        updateCheck: {
+          ...frame.updateCheck,
+          outcome: { kind: 'current' },
+        },
+      }),
     );
   });
 });

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -122,6 +122,7 @@ function helpText(cliCommand: string): string {
     `  ${cliCommand} runtime-host service install [options]`,
     `  ${cliCommand} runtime-host service status|start|stop|restart|logs|uninstall [--json]`,
     `  ${cliCommand} runtime-host service retire --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
+    `  ${cliCommand} runtime-host service check-update --target <latest|next|version> [--json]`,
     `  ${cliCommand} runtime-host service update --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
     `  ${cliCommand} runtime-host access issue --principal <id> --grant <operation>`,
     `  ${cliCommand} runtime-host access issue --principal <id> --preset <desktop-client|terminal-client>`,
@@ -290,6 +291,22 @@ export async function runMakaCli(
         version,
         expectedTarget: command.expectedTarget,
         ...(command.allowInterruptActiveTasks ? { allowInterruptActiveTasks: true } : {}),
+      });
+    }
+    case 'runtime-host-service-check-update': {
+      const { runManagedRuntimeHostUpdateCheckCli } = await import(
+        './runtime-host-update-discovery.js'
+      );
+      const serviceDataRoots = command.clientDataRoot
+        ? deriveMakaDataRoots(command.clientDataRoot)
+        : dataRoots;
+      return runManagedRuntimeHostUpdateCheckCli({
+        json: command.json,
+        framed: command.framed ?? false,
+        clientDataRoot: serviceDataRoots.clientDataRoot,
+        defaultRootPath: serviceDataRoots.workspaceRoot,
+        selector: command.selector,
+        ...(command.expectedTarget ? { expectedTarget: command.expectedTarget } : {}),
       });
     }
     case 'runtime-host-managed-deployment-cleanup': {

--- a/packages/cli/src/product-release-version.ts
+++ b/packages/cli/src/product-release-version.ts
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+interface ProductReleaseVersion {
+  readonly core: readonly [bigint, bigint, bigint];
+  readonly prerelease: readonly string[];
+}
+
+export function isProductReleaseVersion(value: string): boolean {
+  return parseProductReleaseVersion(value) !== undefined;
+}
+
+export function compareProductReleaseVersions(left: string, right: string): -1 | 0 | 1 {
+  const a = parseProductReleaseVersion(left);
+  const b = parseProductReleaseVersion(right);
+  if (!a || !b) throw new TypeError('Expected canonical Maka release versions');
+  for (let index = 0; index < a.core.length; index += 1) {
+    if (a.core[index] < b.core[index]) return -1;
+    if (a.core[index] > b.core[index]) return 1;
+  }
+  if (a.prerelease.length === 0) return b.prerelease.length === 0 ? 0 : 1;
+  if (b.prerelease.length === 0) return -1;
+  for (let index = 0; index < Math.max(a.prerelease.length, b.prerelease.length); index += 1) {
+    const leftIdentifier = a.prerelease[index];
+    const rightIdentifier = b.prerelease[index];
+    if (leftIdentifier === undefined) return -1;
+    if (rightIdentifier === undefined) return 1;
+    if (leftIdentifier === rightIdentifier) continue;
+    const leftNumeric = /^\d+$/u.test(leftIdentifier);
+    const rightNumeric = /^\d+$/u.test(rightIdentifier);
+    if (leftNumeric && rightNumeric) {
+      return BigInt(leftIdentifier) < BigInt(rightIdentifier) ? -1 : 1;
+    }
+    if (leftNumeric) return -1;
+    if (rightNumeric) return 1;
+    return leftIdentifier < rightIdentifier ? -1 : 1;
+  }
+  return 0;
+}
+
+function parseProductReleaseVersion(value: string): ProductReleaseVersion | undefined {
+  if (value.length > 512) return undefined;
+  const match =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u.exec(
+      value,
+    );
+  if (!match) return undefined;
+  const prerelease = match[4]?.split('.') ?? [];
+  if (prerelease.some((part) => /^\d+$/u.test(part) && part.length > 1 && part[0] === '0')) {
+    return undefined;
+  }
+  return {
+    core: [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])],
+    prerelease,
+  };
+}

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -23,9 +23,14 @@ import {
   PROJECT_DIRECTORY_MAX_ROOTS,
   PROJECT_DIRECTORY_ROOT_LABEL_MAX_BYTES,
 } from '@maka/runtime-host/protocol';
+import { isProductReleaseVersion } from './product-release-version.js';
 import type { RuntimeHostManagedServiceTarget } from './runtime-host-service-manager.js';
 
 type RuntimeHostCliError = { kind: 'error'; message: string; exitCode: number };
+
+export type RuntimeHostUpdateSelector =
+  | { readonly kind: 'channel'; readonly channel: 'latest' | 'next' }
+  | { readonly kind: 'exact'; readonly version: string };
 
 export type RuntimeHostCliCommand =
   | {
@@ -68,6 +73,14 @@ export type RuntimeHostCliCommand =
       expectedTarget?: RuntimeHostManagedServiceTarget;
       retainManagedDeployment?: true;
       allowInterruptActiveTasks?: true;
+    }
+  | {
+      kind: 'runtime-host-service-check-update';
+      json: boolean;
+      framed?: true;
+      clientDataRoot?: string;
+      selector: RuntimeHostUpdateSelector;
+      expectedTarget?: RuntimeHostManagedServiceTarget;
     }
   | {
       kind: 'runtime-host-service-update';
@@ -235,6 +248,7 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
     action !== 'stop' &&
     action !== 'restart' &&
     action !== 'retire' &&
+    action !== 'check-update' &&
     action !== 'update' &&
     action !== 'logs' &&
     action !== 'uninstall'
@@ -242,13 +256,14 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
     return error(
       action
         ? `Unexpected runtime-host service command: ${action}`
-        : 'runtime-host service requires install, status, start, stop, restart, retire, update, logs, or uninstall',
+        : 'runtime-host service requires install, status, start, stop, restart, retire, check-update, update, logs, or uninstall',
     );
   }
 
   let retainManagedDeployment = false;
   let allowInterruptActiveTasks = false;
   let clientDataRoot: string | undefined;
+  let updateTarget: string | undefined;
   const flagOptions: Readonly<Record<string, () => void | RuntimeHostCliError>> =
     action === 'uninstall'
       ? {
@@ -276,12 +291,32 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
         if (!isSafeAbsolutePath(value)) return error('--client-data-root must be an absolute path');
         clientDataRoot = value;
       },
+      ...(action === 'check-update'
+        ? {
+            '--target': (value: string) => {
+              if (updateTarget !== undefined) return error('Duplicate --target');
+              updateTarget = value;
+            },
+          }
+        : {}),
     },
     flagOptions,
   });
   if ('kind' in options) return options;
   if ((action === 'retire' || action === 'update') && !options.expectedTarget) {
     return error(`runtime-host service ${action} requires an expected target`);
+  }
+  if (action === 'check-update') {
+    const selector = parseUpdateSelector(updateTarget);
+    if ('kind' in selector && selector.kind === 'error') return selector;
+    return {
+      kind: 'runtime-host-service-check-update',
+      json: options.json,
+      ...(options.framed ? { framed: true } : {}),
+      ...(clientDataRoot ? { clientDataRoot } : {}),
+      selector,
+      ...(options.expectedTarget ? { expectedTarget: options.expectedTarget } : {}),
+    };
   }
   if (action === 'update') {
     return {
@@ -301,6 +336,19 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
     ...(retainManagedDeployment ? { retainManagedDeployment: true } : {}),
     ...(allowInterruptActiveTasks ? { allowInterruptActiveTasks: true } : {}),
   };
+}
+
+function parseUpdateSelector(
+  value: string | undefined,
+): RuntimeHostUpdateSelector | RuntimeHostCliError {
+  if (!value) return error('runtime-host service check-update requires --target');
+  if (value === 'latest' || value === 'next') {
+    return { kind: 'channel', channel: value };
+  }
+  if (!isProductReleaseVersion(value)) {
+    return error('--target must be latest, next, or an exact Maka version');
+  }
+  return { kind: 'exact', version: value };
 }
 
 interface ManagedServiceOptions {

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -18,12 +18,12 @@
  */
 
 import { isAbsolute } from 'node:path';
+import { isProductReleaseVersion } from '@maka/runtime-host/operator';
 import {
   isCanonicalRuntimeHostWebSocketPath,
   PROJECT_DIRECTORY_MAX_ROOTS,
   PROJECT_DIRECTORY_ROOT_LABEL_MAX_BYTES,
 } from '@maka/runtime-host/protocol';
-import { isProductReleaseVersion } from './product-release-version.js';
 import type { RuntimeHostManagedServiceTarget } from './runtime-host-service-manager.js';
 
 type RuntimeHostCliError = { kind: 'error'; message: string; exitCode: number };

--- a/packages/cli/src/runtime-host-launch-agent-service.ts
+++ b/packages/cli/src/runtime-host-launch-agent-service.ts
@@ -135,10 +135,10 @@ export function createLaunchAgentRuntimeHostService(
           throw error;
         }),
       ]);
-      if (!status.loaded || plist !== renderLaunchAgentPlist(config, context)) {
+      if (!status.installed || plist !== renderLaunchAgentPlist(config, context)) {
         throw new RuntimeHostServiceManagerError(
           'target_mismatch',
-          'The loaded Runtime Host LaunchAgent does not match its managed deployment',
+          'The installed Runtime Host LaunchAgent does not match its managed deployment',
         );
       }
     },

--- a/packages/cli/src/runtime-host-update-discovery.ts
+++ b/packages/cli/src/runtime-host-update-discovery.ts
@@ -85,6 +85,7 @@ export async function runManagedRuntimeHostUpdateCheckCli(
 ): Promise<number> {
   try {
     const serviceId = resolveRuntimeHostManagedServiceId(options.clientDataRoot);
+    const backend = createPlatformRuntimeHostServiceBackend(serviceId);
     const status = await manageRuntimeHostService(
       {
         action: 'status',
@@ -94,7 +95,7 @@ export async function runManagedRuntimeHostUpdateCheckCli(
         cliPath: process.argv[1] ?? '',
         ...(options.expectedTarget ? { expectedTarget: options.expectedTarget } : {}),
       },
-      createPlatformRuntimeHostServiceBackend(serviceId),
+      backend,
     );
     const currentVersion = status.service.installedVersion;
     const config = status.service.config;
@@ -104,6 +105,7 @@ export async function runManagedRuntimeHostUpdateCheckCli(
         'A Maka-managed Runtime Host service is required to check for updates',
       );
     }
+    await backend.verifyDeployment(config);
     const [candidate, currentCompatibility] = await Promise.all([
       resolveRuntimeHostRegistryUpdateCandidate(options.selector),
       readPackageCompatibility(config.launch.cliPath, currentVersion),
@@ -118,7 +120,7 @@ export async function runManagedRuntimeHostUpdateCheckCli(
         selector: options.selector,
         currentVersion,
         candidate: { version: candidate.version, integrity: candidate.integrity },
-        ...assessment,
+        outcome: assessment,
       },
     };
     writeSuccess(frame, options);
@@ -139,35 +141,21 @@ export function assessRuntimeHostUpdate(
   currentVersion: string,
   currentCompatibility: number | undefined,
   candidate: RuntimeHostUpdateCandidate,
-): Pick<RuntimeHostUpdateCheck, 'status' | 'unattended'> {
+): RuntimeHostUpdateCheck['outcome'] {
   const relation = compareProductReleaseVersions(candidate.version, currentVersion);
-  if (relation === 0) return { status: 'current', unattended: { kind: 'not_needed' } };
+  if (relation === 0) return { kind: 'current' };
   if (relation < 0) {
-    return {
-      status: 'older',
-      unattended: { kind: 'manual_only', reason: 'target_not_newer' },
-    };
+    return { kind: 'manual_action', reason: 'target_not_newer' };
   }
-  const status = 'newer' as const;
   if (currentCompatibility === undefined) {
-    return {
-      status,
-      unattended: { kind: 'manual_only', reason: 'current_compatibility_unknown' },
-    };
+    return { kind: 'manual_action', reason: 'current_compatibility_unknown' };
   }
   if (candidate.compatibility === undefined) {
-    return {
-      status,
-      unattended: { kind: 'manual_only', reason: 'target_compatibility_unknown' },
-    };
+    return { kind: 'manual_action', reason: 'target_compatibility_unknown' };
   }
-  return {
-    status,
-    unattended:
-      candidate.compatibility === currentCompatibility
-        ? { kind: 'allowed', compatibility: currentCompatibility }
-        : { kind: 'manual_only', reason: 'compatibility_mismatch' },
-  };
+  return candidate.compatibility === currentCompatibility
+    ? { kind: 'unattended_update', compatibility: currentCompatibility }
+    : { kind: 'manual_action', reason: 'compatibility_mismatch' };
 }
 
 export async function resolveRuntimeHostRegistryUpdateCandidate(
@@ -211,8 +199,7 @@ export async function resolveRuntimeHostRegistryUpdateCandidate(
     !isProductReleaseVersion(version) ||
     (selector.kind === 'exact' && version !== selector.version) ||
     typeof integrity !== 'string' ||
-    !/^sha512-[A-Za-z0-9+/]+={0,2}$/u.test(integrity) ||
-    Buffer.byteLength(integrity, 'utf8') > 512
+    !isSha512Integrity(integrity)
   ) {
     return invalidMetadata();
   }
@@ -292,25 +279,25 @@ function writeSuccess(
 ): void {
   if (options.framed) process.stdout.write(encodeRuntimeHostServiceManagementFrame(frame));
   else if (options.json) process.stdout.write(`${JSON.stringify({ ...frame, ok: true })}\n`);
-  else {
-    const check = frame.updateCheck;
-    if (check.status === 'current') {
-      process.stdout.write(
-        `Runtime Host ${check.currentVersion} already matches the selected target.\n`,
-      );
-    } else if (check.unattended.kind === 'allowed') {
-      process.stdout.write(
-        `Runtime Host ${check.candidate.version} is available for unattended update.\n`,
-      );
-    } else if (check.status === 'older') {
-      process.stdout.write(
-        `Selected Runtime Host ${check.candidate.version} is older than installed ${check.currentVersion}; manual selection is required.\n`,
-      );
-    } else {
-      process.stdout.write(
-        `Runtime Host ${check.candidate.version} is available for manual update.\n`,
-      );
-    }
+  else process.stdout.write(`${formatRuntimeHostUpdateCheck(frame.updateCheck)}\n`);
+}
+
+export function formatRuntimeHostUpdateCheck(check: RuntimeHostUpdateCheck): string {
+  if (check.outcome.kind === 'current') {
+    return `Runtime Host ${check.currentVersion} already matches the selected target.`;
+  }
+  if (check.outcome.kind === 'unattended_update') {
+    return `Runtime Host ${check.candidate.version} is available for unattended update.`;
+  }
+  switch (check.outcome.reason) {
+    case 'target_not_newer':
+      return `Selected Runtime Host ${check.candidate.version} is older than installed ${check.currentVersion}; manual selection is required.`;
+    case 'current_compatibility_unknown':
+      return `Runtime Host ${check.candidate.version} requires a manual update because the installed package has no unattended-update compatibility evidence.`;
+    case 'target_compatibility_unknown':
+      return `Runtime Host ${check.candidate.version} requires a manual update because the target package has no unattended-update compatibility evidence.`;
+    case 'compatibility_mismatch':
+      return `Runtime Host ${check.candidate.version} requires a manual update because it crosses the declared compatibility boundary.`;
   }
 }
 
@@ -350,6 +337,14 @@ function invalidMetadata(): never {
 
 function positiveInteger(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+function isSha512Integrity(value: string): boolean {
+  if (!value.startsWith('sha512-')) return false;
+  const encoded = value.slice('sha512-'.length);
+  if (encoded.length !== 88 || !/^[A-Za-z0-9+/]+={2}$/u.test(encoded)) return false;
+  const digest = Buffer.from(encoded, 'base64');
+  return digest.length === 64 && digest.toString('base64') === encoded;
 }
 
 function parseJson(value: string): unknown {

--- a/packages/cli/src/runtime-host-update-discovery.ts
+++ b/packages/cli/src/runtime-host-update-discovery.ts
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { truncateUtf8 } from '@maka/core/diagnostic-log';
+import {
+  encodeRuntimeHostServiceManagementFrame,
+  RUNTIME_HOST_SERVICE_ERROR_CODE_MAX_BYTES,
+  RUNTIME_HOST_SERVICE_ERROR_MESSAGE_MAX_BYTES,
+  type RuntimeHostServiceManagementFrame,
+} from '@maka/runtime-host/operator';
+import {
+  manageRuntimeHostService,
+  resolveRuntimeHostManagedServiceId,
+  RuntimeHostServiceManagerError,
+  type RuntimeHostManagedServiceTarget,
+} from './runtime-host-service-manager.js';
+import {
+  compareProductReleaseVersions,
+  isProductReleaseVersion,
+} from './product-release-version.js';
+import {
+  createPlatformRuntimeHostServiceBackend,
+  runtimeHostServiceSummary,
+} from './runtime-host-service-management-command.js';
+import type { RuntimeHostUpdateSelector } from './runtime-host-cli.js';
+
+const PACKAGE_NAME = 'maka-agent';
+const COMPATIBILITY_FIELD = 'maka.managedRuntimeHostUpdateCompatibility';
+const REGISTRY_TIMEOUT_MS = 30_000;
+const REGISTRY_OUTPUT_MAX_BYTES = 64 * 1024;
+const MANIFEST_MAX_BYTES = 64 * 1024;
+
+export interface RuntimeHostUpdateCandidate {
+  readonly version: string;
+  readonly integrity: string;
+  readonly compatibility?: number;
+}
+
+type RuntimeHostUpdateCheck = Extract<
+  RuntimeHostServiceManagementFrame,
+  { kind: 'result'; action: 'check_update' }
+>['updateCheck'];
+
+export interface RuntimeHostUpdateCheckCliOptions {
+  readonly json: boolean;
+  readonly framed: boolean;
+  readonly clientDataRoot: string;
+  readonly defaultRootPath: string;
+  readonly selector: RuntimeHostUpdateSelector;
+  readonly expectedTarget?: RuntimeHostManagedServiceTarget;
+}
+
+class RuntimeHostUpdateDiscoveryError extends Error {
+  constructor(
+    readonly code: 'target_unavailable' | 'registry_unavailable' | 'invalid_registry_metadata',
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'RuntimeHostUpdateDiscoveryError';
+  }
+}
+
+export async function runManagedRuntimeHostUpdateCheckCli(
+  options: RuntimeHostUpdateCheckCliOptions,
+): Promise<number> {
+  try {
+    const serviceId = resolveRuntimeHostManagedServiceId(options.clientDataRoot);
+    const status = await manageRuntimeHostService(
+      {
+        action: 'status',
+        clientDataRoot: options.clientDataRoot,
+        defaultRootPath: options.defaultRootPath,
+        nodePath: process.execPath,
+        cliPath: process.argv[1] ?? '',
+        ...(options.expectedTarget ? { expectedTarget: options.expectedTarget } : {}),
+      },
+      createPlatformRuntimeHostServiceBackend(serviceId),
+    );
+    const currentVersion = status.service.installedVersion;
+    const config = status.service.config;
+    if (!status.service.installed || !currentVersion || !config?.managedDeploymentRoot) {
+      throw new RuntimeHostServiceManagerError(
+        'not_installed',
+        'A Maka-managed Runtime Host service is required to check for updates',
+      );
+    }
+    const [candidate, currentCompatibility] = await Promise.all([
+      resolveRuntimeHostRegistryUpdateCandidate(options.selector),
+      readPackageCompatibility(config.launch.cliPath, currentVersion),
+    ]);
+    const assessment = assessRuntimeHostUpdate(currentVersion, currentCompatibility, candidate);
+    const frame: RuntimeHostServiceManagementFrame = {
+      schemaVersion: 1,
+      kind: 'result',
+      action: 'check_update',
+      service: runtimeHostServiceSummary(status),
+      updateCheck: {
+        selector: options.selector,
+        currentVersion,
+        candidate: { version: candidate.version, integrity: candidate.integrity },
+        ...assessment,
+      },
+    };
+    writeSuccess(frame, options);
+    return 0;
+  } catch (error) {
+    const code =
+      error instanceof RuntimeHostUpdateDiscoveryError ||
+      error instanceof RuntimeHostServiceManagerError
+        ? error.code
+        : 'update_check_failed';
+    const message = error instanceof Error ? error.message : String(error);
+    writeFailure(code, message, options);
+    return 1;
+  }
+}
+
+export function assessRuntimeHostUpdate(
+  currentVersion: string,
+  currentCompatibility: number | undefined,
+  candidate: RuntimeHostUpdateCandidate,
+): Pick<RuntimeHostUpdateCheck, 'status' | 'unattended'> {
+  const relation = compareProductReleaseVersions(candidate.version, currentVersion);
+  if (relation === 0) return { status: 'current', unattended: { kind: 'not_needed' } };
+  if (relation < 0) {
+    return {
+      status: 'older',
+      unattended: { kind: 'manual_only', reason: 'target_not_newer' },
+    };
+  }
+  const status = 'newer' as const;
+  if (currentCompatibility === undefined) {
+    return {
+      status,
+      unattended: { kind: 'manual_only', reason: 'current_compatibility_unknown' },
+    };
+  }
+  if (candidate.compatibility === undefined) {
+    return {
+      status,
+      unattended: { kind: 'manual_only', reason: 'target_compatibility_unknown' },
+    };
+  }
+  return {
+    status,
+    unattended:
+      candidate.compatibility === currentCompatibility
+        ? { kind: 'allowed', compatibility: currentCompatibility }
+        : { kind: 'manual_only', reason: 'compatibility_mismatch' },
+  };
+}
+
+export async function resolveRuntimeHostRegistryUpdateCandidate(
+  selector: RuntimeHostUpdateSelector,
+  run: (args: readonly string[]) => Promise<NpmViewResult> = runNpmView,
+): Promise<RuntimeHostUpdateCandidate> {
+  const target = selector.kind === 'channel' ? selector.channel : selector.version;
+  const result = await run([
+    'view',
+    `${PACKAGE_NAME}@${target}`,
+    'version',
+    'dist.integrity',
+    COMPATIBILITY_FIELD,
+    '--json',
+  ]);
+  if (result.exitCode !== 0) {
+    const failure = parseJson(result.stdout);
+    const code = isRecord(failure) && isRecord(failure.error) ? failure.error.code : undefined;
+    throw new RuntimeHostUpdateDiscoveryError(
+      code === 'E404' ? 'target_unavailable' : 'registry_unavailable',
+      code === 'E404'
+        ? `No Maka package is published for ${target}`
+        : 'The Maka package registry is unavailable',
+    );
+  }
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(result.stdout);
+  } catch (error) {
+    throw new RuntimeHostUpdateDiscoveryError(
+      'invalid_registry_metadata',
+      'The npm registry returned invalid Maka package metadata',
+      { cause: error },
+    );
+  }
+  if (!isRecord(metadata)) return invalidMetadata();
+  const version = metadata.version;
+  const integrity = metadata['dist.integrity'];
+  if (
+    typeof version !== 'string' ||
+    !isProductReleaseVersion(version) ||
+    (selector.kind === 'exact' && version !== selector.version) ||
+    typeof integrity !== 'string' ||
+    !/^sha512-[A-Za-z0-9+/]+={0,2}$/u.test(integrity) ||
+    Buffer.byteLength(integrity, 'utf8') > 512
+  ) {
+    return invalidMetadata();
+  }
+  const compatibility = positiveInteger(metadata[COMPATIBILITY_FIELD]);
+  return { version, integrity, ...(compatibility === undefined ? {} : { compatibility }) };
+}
+
+async function readPackageCompatibility(
+  cliPath: string,
+  expectedVersion: string,
+): Promise<number | undefined> {
+  try {
+    const raw = await readFile(join(dirname(dirname(cliPath)), 'package.json'), 'utf8');
+    if (Buffer.byteLength(raw, 'utf8') > MANIFEST_MAX_BYTES) return undefined;
+    const manifest: unknown = JSON.parse(raw);
+    if (
+      !isRecord(manifest) ||
+      manifest.name !== PACKAGE_NAME ||
+      manifest.version !== expectedVersion
+    ) {
+      return undefined;
+    }
+    return isRecord(manifest.maka)
+      ? positiveInteger(manifest.maka.managedRuntimeHostUpdateCompatibility)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+interface NpmViewResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+}
+
+function runNpmView(args: readonly string[]): Promise<NpmViewResult> {
+  return new Promise((resolve, reject) => {
+    // Windows requires its command shell to resolve npm.cmd. The only dynamic
+    // argument has already passed the strict release-version/channel parser.
+    const child = spawn('npm', args, {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+      shell: process.platform === 'win32',
+      timeout: REGISTRY_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+    let stdout = '';
+    let bytes = 0;
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      bytes += Buffer.byteLength(chunk, 'utf8');
+      if (bytes > REGISTRY_OUTPUT_MAX_BYTES) {
+        child.kill('SIGKILL');
+        return;
+      }
+      stdout += chunk;
+    });
+    child.once('error', reject);
+    child.once('close', (exitCode) => {
+      if (bytes > REGISTRY_OUTPUT_MAX_BYTES) {
+        reject(
+          new RuntimeHostUpdateDiscoveryError(
+            'invalid_registry_metadata',
+            'The npm registry returned oversized Maka package metadata',
+          ),
+        );
+        return;
+      }
+      resolve({ exitCode: exitCode ?? 1, stdout });
+    });
+  });
+}
+
+function writeSuccess(
+  frame: Extract<RuntimeHostServiceManagementFrame, { kind: 'result'; action: 'check_update' }>,
+  options: RuntimeHostUpdateCheckCliOptions,
+): void {
+  if (options.framed) process.stdout.write(encodeRuntimeHostServiceManagementFrame(frame));
+  else if (options.json) process.stdout.write(`${JSON.stringify({ ...frame, ok: true })}\n`);
+  else {
+    const check = frame.updateCheck;
+    if (check.status === 'current') {
+      process.stdout.write(
+        `Runtime Host ${check.currentVersion} already matches the selected target.\n`,
+      );
+    } else if (check.unattended.kind === 'allowed') {
+      process.stdout.write(
+        `Runtime Host ${check.candidate.version} is available for unattended update.\n`,
+      );
+    } else if (check.status === 'older') {
+      process.stdout.write(
+        `Selected Runtime Host ${check.candidate.version} is older than installed ${check.currentVersion}; manual selection is required.\n`,
+      );
+    } else {
+      process.stdout.write(
+        `Runtime Host ${check.candidate.version} is available for manual update.\n`,
+      );
+    }
+  }
+}
+
+function writeFailure(
+  code: string,
+  message: string,
+  options: RuntimeHostUpdateCheckCliOptions,
+): void {
+  const error = {
+    code: truncateUtf8(code, RUNTIME_HOST_SERVICE_ERROR_CODE_MAX_BYTES) || 'update_check_failed',
+    message:
+      truncateUtf8(message, RUNTIME_HOST_SERVICE_ERROR_MESSAGE_MAX_BYTES) ||
+      'Runtime Host update check failed',
+  };
+  if (options.framed) {
+    process.stdout.write(
+      encodeRuntimeHostServiceManagementFrame({
+        schemaVersion: 1,
+        kind: 'error',
+        action: 'check_update',
+        error,
+      }),
+    );
+  } else if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify({ schemaVersion: 1, ok: false, action: 'check_update', error })}\n`,
+    );
+  } else process.stderr.write(`${error.message}\n`);
+}
+
+function invalidMetadata(): never {
+  throw new RuntimeHostUpdateDiscoveryError(
+    'invalid_registry_metadata',
+    'The npm registry returned incomplete Maka package metadata',
+  );
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/cli/src/runtime-host-update-discovery.ts
+++ b/packages/cli/src/runtime-host-update-discovery.ts
@@ -247,13 +247,9 @@ interface NpmViewResult {
 
 function runNpmView(args: readonly string[]): Promise<NpmViewResult> {
   return new Promise((resolve, reject) => {
-    // Windows requires its command shell to resolve npm.cmd. The only dynamic
-    // argument has already passed the strict release-version/channel parser.
     const child = spawn('npm', args, {
       cwd: homedir(),
       stdio: ['ignore', 'pipe', 'ignore'],
-      windowsHide: true,
-      shell: process.platform === 'win32',
       timeout: REGISTRY_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });

--- a/packages/cli/src/runtime-host-update-discovery.ts
+++ b/packages/cli/src/runtime-host-update-discovery.ts
@@ -56,10 +56,11 @@ export interface RuntimeHostUpdateCandidate {
   readonly compatibility?: number;
 }
 
-type RuntimeHostUpdateCheck = Extract<
+type RuntimeHostUpdateCheckFrame = Extract<
   RuntimeHostServiceManagementFrame,
   { kind: 'result'; action: 'check_update' }
->['updateCheck'];
+>;
+type RuntimeHostUpdateCheck = RuntimeHostUpdateCheckFrame['updateCheck'];
 
 export interface RuntimeHostUpdateCheckCliOptions {
   readonly json: boolean;
@@ -100,7 +101,14 @@ export async function runManagedRuntimeHostUpdateCheckCli(
     );
     const currentVersion = status.service.installedVersion;
     const config = status.service.config;
-    if (!status.service.installed || !currentVersion || !config?.managedDeploymentRoot) {
+    const service = runtimeHostServiceSummary(status);
+    const serviceState = service.state;
+    if (
+      !status.service.installed ||
+      serviceState === 'not_installed' ||
+      !currentVersion ||
+      !config?.managedDeploymentRoot
+    ) {
       throw new RuntimeHostServiceManagerError(
         'not_installed',
         'A Maka-managed Runtime Host service is required to check for updates',
@@ -112,14 +120,13 @@ export async function runManagedRuntimeHostUpdateCheckCli(
       readPackageCompatibility(config.launch.cliPath, currentVersion),
     ]);
     const assessment = assessRuntimeHostUpdate(currentVersion, currentCompatibility, candidate);
-    const frame: RuntimeHostServiceManagementFrame = {
+    const frame: RuntimeHostUpdateCheckFrame = {
       schemaVersion: 1,
       kind: 'result',
       action: 'check_update',
-      service: runtimeHostServiceSummary(status),
+      service: { ...service, state: serviceState, installedVersion: currentVersion },
       updateCheck: {
         selector: options.selector,
-        currentVersion,
         candidate: { version: candidate.version, integrity: candidate.integrity },
         outcome: assessment,
       },
@@ -278,24 +285,25 @@ function runNpmView(args: readonly string[]): Promise<NpmViewResult> {
 }
 
 function writeSuccess(
-  frame: Extract<RuntimeHostServiceManagementFrame, { kind: 'result'; action: 'check_update' }>,
+  frame: RuntimeHostUpdateCheckFrame,
   options: RuntimeHostUpdateCheckCliOptions,
 ): void {
   if (options.framed) process.stdout.write(encodeRuntimeHostServiceManagementFrame(frame));
   else if (options.json) process.stdout.write(`${JSON.stringify({ ...frame, ok: true })}\n`);
-  else process.stdout.write(`${formatRuntimeHostUpdateCheck(frame.updateCheck)}\n`);
+  else process.stdout.write(`${formatRuntimeHostUpdateCheck(frame)}\n`);
 }
 
-export function formatRuntimeHostUpdateCheck(check: RuntimeHostUpdateCheck): string {
+export function formatRuntimeHostUpdateCheck(frame: RuntimeHostUpdateCheckFrame): string {
+  const check = frame.updateCheck;
   if (check.outcome.kind === 'current') {
-    return `Runtime Host ${check.currentVersion} already matches the selected target.`;
+    return `Runtime Host ${frame.service.installedVersion} already matches the selected target.`;
   }
   if (check.outcome.kind === 'unattended_update') {
     return `Runtime Host ${check.candidate.version} is available for unattended update.`;
   }
   switch (check.outcome.reason) {
     case 'target_not_newer':
-      return `Selected Runtime Host ${check.candidate.version} is older than installed ${check.currentVersion}; manual selection is required.`;
+      return `Selected Runtime Host ${check.candidate.version} is older than installed ${frame.service.installedVersion}; manual selection is required.`;
     case 'current_compatibility_unknown':
       return `Runtime Host ${check.candidate.version} requires a manual update because the installed package has no unattended-update compatibility evidence.`;
     case 'target_compatibility_unknown':

--- a/packages/cli/src/runtime-host-update-discovery.ts
+++ b/packages/cli/src/runtime-host-update-discovery.ts
@@ -19,10 +19,14 @@
 
 import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { truncateUtf8 } from '@maka/core/diagnostic-log';
 import {
+  compareProductReleaseVersions,
   encodeRuntimeHostServiceManagementFrame,
+  isProductReleaseVersion,
+  isSha512PackageIntegrity,
   RUNTIME_HOST_SERVICE_ERROR_CODE_MAX_BYTES,
   RUNTIME_HOST_SERVICE_ERROR_MESSAGE_MAX_BYTES,
   type RuntimeHostServiceManagementFrame,
@@ -34,16 +38,13 @@ import {
   type RuntimeHostManagedServiceTarget,
 } from './runtime-host-service-manager.js';
 import {
-  compareProductReleaseVersions,
-  isProductReleaseVersion,
-} from './product-release-version.js';
-import {
   createPlatformRuntimeHostServiceBackend,
   runtimeHostServiceSummary,
 } from './runtime-host-service-management-command.js';
 import type { RuntimeHostUpdateSelector } from './runtime-host-cli.js';
 
 const PACKAGE_NAME = 'maka-agent';
+const NPM_REGISTRY = 'https://registry.npmjs.org/';
 const COMPATIBILITY_FIELD = 'maka.managedRuntimeHostUpdateCompatibility';
 const REGISTRY_TIMEOUT_MS = 30_000;
 const REGISTRY_OUTPUT_MAX_BYTES = 64 * 1024;
@@ -170,6 +171,8 @@ export async function resolveRuntimeHostRegistryUpdateCandidate(
     'dist.integrity',
     COMPATIBILITY_FIELD,
     '--json',
+    '--registry',
+    NPM_REGISTRY,
   ]);
   if (result.exitCode !== 0) {
     const failure = parseJson(result.stdout);
@@ -199,7 +202,7 @@ export async function resolveRuntimeHostRegistryUpdateCandidate(
     !isProductReleaseVersion(version) ||
     (selector.kind === 'exact' && version !== selector.version) ||
     typeof integrity !== 'string' ||
-    !isSha512Integrity(integrity)
+    !isSha512PackageIntegrity(integrity)
   ) {
     return invalidMetadata();
   }
@@ -240,6 +243,7 @@ function runNpmView(args: readonly string[]): Promise<NpmViewResult> {
     // Windows requires its command shell to resolve npm.cmd. The only dynamic
     // argument has already passed the strict release-version/channel parser.
     const child = spawn('npm', args, {
+      cwd: homedir(),
       stdio: ['ignore', 'pipe', 'ignore'],
       windowsHide: true,
       shell: process.platform === 'win32',
@@ -337,14 +341,6 @@ function invalidMetadata(): never {
 
 function positiveInteger(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : undefined;
-}
-
-function isSha512Integrity(value: string): boolean {
-  if (!value.startsWith('sha512-')) return false;
-  const encoded = value.slice('sha512-'.length);
-  if (encoded.length !== 88 || !/^[A-Za-z0-9+/]+={2}$/u.test(encoded)) return false;
-  const digest = Buffer.from(encoded, 'base64');
-  return digest.length === 64 && digest.toString('base64') === encoded;
 }
 
 function parseJson(value: string): unknown {

--- a/packages/runtime-host/src/operator/index.ts
+++ b/packages/runtime-host/src/operator/index.ts
@@ -55,3 +55,8 @@ export {
   type RuntimeHostSetupFrame,
   type RuntimeHostSetupPhase,
 } from './setup-frame.js';
+export {
+  compareProductReleaseVersions,
+  isProductReleaseVersion,
+  isSha512PackageIntegrity,
+} from './update-package-evidence.js';

--- a/packages/runtime-host/src/operator/service-management-frame.ts
+++ b/packages/runtime-host/src/operator/service-management-frame.ts
@@ -39,6 +39,7 @@ const SERVICE_ACTIONS = [
   'stop',
   'restart',
   'retire',
+  'check_update',
   'update',
   'logs',
   'uninstall',
@@ -53,6 +54,13 @@ const NON_RETIRE_SERVICE_ACTIONS = [
   'uninstall',
 ] as const;
 const UPDATE_PHASES = ['checking', 'staging', 'retiring', 'replacing'] as const;
+const UPDATE_CHANNELS = ['latest', 'next'] as const;
+const UPDATE_MANUAL_ONLY_REASONS = [
+  'target_not_newer',
+  'current_compatibility_unknown',
+  'target_compatibility_unknown',
+  'compatibility_mismatch',
+] as const;
 const SERVICE_STATES = ['not_installed', 'stopped', 'starting', 'running', 'failed'] as const;
 const OPERATOR_CAPABILITIES = [
   RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY,
@@ -120,6 +128,48 @@ const SERVICE_MANAGEMENT_FRAME_SCHEMA = z.union([
       phase: z.enum(UPDATE_PHASES),
       currentVersion: boundedNonEmptyString(FIELD_MAX_BYTES),
       targetVersion: boundedNonEmptyString(FIELD_MAX_BYTES),
+    })
+    .strict(),
+  z
+    .object({
+      ...SERVICE_RESULT_COMMON,
+      action: z.literal('check_update'),
+      updateCheck: z
+        .object({
+          selector: z.discriminatedUnion('kind', [
+            z.object({ kind: z.literal('channel'), channel: z.enum(UPDATE_CHANNELS) }).strict(),
+            z
+              .object({
+                kind: z.literal('exact'),
+                version: boundedNonEmptyString(FIELD_MAX_BYTES),
+              })
+              .strict(),
+          ]),
+          currentVersion: boundedNonEmptyString(FIELD_MAX_BYTES),
+          candidate: z
+            .object({
+              version: boundedNonEmptyString(FIELD_MAX_BYTES),
+              integrity: boundedNonEmptyString(FIELD_MAX_BYTES),
+            })
+            .strict(),
+          status: z.enum(['current', 'newer', 'older']),
+          unattended: z.discriminatedUnion('kind', [
+            z.object({ kind: z.literal('not_needed') }).strict(),
+            z
+              .object({
+                kind: z.literal('allowed'),
+                compatibility: z.number().int().positive(),
+              })
+              .strict(),
+            z
+              .object({
+                kind: z.literal('manual_only'),
+                reason: z.enum(UPDATE_MANUAL_ONLY_REASONS),
+              })
+              .strict(),
+          ]),
+        })
+        .strict(),
     })
     .strict(),
   z

--- a/packages/runtime-host/src/operator/service-management-frame.ts
+++ b/packages/runtime-host/src/operator/service-management-frame.ts
@@ -66,7 +66,8 @@ const MANUAL_ACTION_REASONS = [
   'target_compatibility_unknown',
   'compatibility_mismatch',
 ] as const;
-const SERVICE_STATES = ['not_installed', 'stopped', 'starting', 'running', 'failed'] as const;
+const INSTALLED_SERVICE_STATES = ['stopped', 'starting', 'running', 'failed'] as const;
+const SERVICE_STATES = ['not_installed', ...INSTALLED_SERVICE_STATES] as const;
 const OPERATOR_CAPABILITIES = [
   RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY,
   RUNTIME_HOST_OPERATOR_PROCESS_LIFETIME_LOCK_CAPABILITY,
@@ -93,7 +94,6 @@ const UPDATE_CHECK_SCHEMA = z
         })
         .strict(),
     ]),
-    currentVersion: PRODUCT_RELEASE_VERSION_SCHEMA,
     candidate: z
       .object({
         version: PRODUCT_RELEASE_VERSION_SCHEMA,
@@ -123,22 +123,6 @@ const UPDATE_CHECK_SCHEMA = z
         code: 'custom',
         path: ['candidate', 'version'],
         message: 'Exact update selector and candidate version must match',
-      });
-    }
-    const relation = compareProductReleaseVersions(check.candidate.version, check.currentVersion);
-    const consistent =
-      check.outcome.kind === 'current'
-        ? relation === 0
-        : check.outcome.kind === 'unattended_update'
-          ? relation > 0
-          : check.outcome.reason === 'target_not_newer'
-            ? relation < 0
-            : relation > 0;
-    if (!consistent) {
-      context.addIssue({
-        code: 'custom',
-        path: ['outcome'],
-        message: 'Update outcome must match the version relation',
       });
     }
   });
@@ -177,6 +161,10 @@ const SERVICE_SUMMARY_SCHEMA = z
       .max(64),
   })
   .strict();
+const INSTALLED_SERVICE_SUMMARY_SCHEMA = SERVICE_SUMMARY_SCHEMA.extend({
+  state: z.enum(INSTALLED_SERVICE_STATES),
+  installedVersion: PRODUCT_RELEASE_VERSION_SCHEMA,
+});
 
 const SERVICE_RESULT_COMMON = {
   schemaVersion: z.literal(1),
@@ -202,9 +190,32 @@ const SERVICE_MANAGEMENT_FRAME_SCHEMA = z.union([
     .object({
       ...SERVICE_RESULT_COMMON,
       action: z.literal('check_update'),
+      service: INSTALLED_SERVICE_SUMMARY_SCHEMA,
       updateCheck: UPDATE_CHECK_SCHEMA,
     })
-    .strict(),
+    .strict()
+    .superRefine((frame, context) => {
+      const relation = compareProductReleaseVersions(
+        frame.updateCheck.candidate.version,
+        frame.service.installedVersion,
+      );
+      const outcome = frame.updateCheck.outcome;
+      const consistent =
+        outcome.kind === 'current'
+          ? relation === 0
+          : outcome.kind === 'unattended_update'
+            ? relation > 0
+            : outcome.reason === 'target_not_newer'
+              ? relation < 0
+              : relation > 0;
+      if (!consistent) {
+        context.addIssue({
+          code: 'custom',
+          path: ['updateCheck', 'outcome'],
+          message: 'Update outcome must match the installed and candidate versions',
+        });
+      }
+    }),
   z
     .object({
       ...SERVICE_RESULT_COMMON,

--- a/packages/runtime-host/src/operator/service-management-frame.ts
+++ b/packages/runtime-host/src/operator/service-management-frame.ts
@@ -55,7 +55,7 @@ const NON_RETIRE_SERVICE_ACTIONS = [
 ] as const;
 const UPDATE_PHASES = ['checking', 'staging', 'retiring', 'replacing'] as const;
 const UPDATE_CHANNELS = ['latest', 'next'] as const;
-const UPDATE_MANUAL_ONLY_REASONS = [
+const MANUAL_ACTION_REASONS = [
   'target_not_newer',
   'current_compatibility_unknown',
   'target_compatibility_unknown',
@@ -152,19 +152,18 @@ const SERVICE_MANAGEMENT_FRAME_SCHEMA = z.union([
               integrity: boundedNonEmptyString(FIELD_MAX_BYTES),
             })
             .strict(),
-          status: z.enum(['current', 'newer', 'older']),
-          unattended: z.discriminatedUnion('kind', [
-            z.object({ kind: z.literal('not_needed') }).strict(),
+          outcome: z.discriminatedUnion('kind', [
+            z.object({ kind: z.literal('current') }).strict(),
             z
               .object({
-                kind: z.literal('allowed'),
+                kind: z.literal('unattended_update'),
                 compatibility: z.number().int().positive(),
               })
               .strict(),
             z
               .object({
-                kind: z.literal('manual_only'),
-                reason: z.enum(UPDATE_MANUAL_ONLY_REASONS),
+                kind: z.literal('manual_action'),
+                reason: z.enum(MANUAL_ACTION_REASONS),
               })
               .strict(),
           ]),

--- a/packages/runtime-host/src/operator/service-management-frame.ts
+++ b/packages/runtime-host/src/operator/service-management-frame.ts
@@ -18,6 +18,11 @@
  */
 
 import { z } from 'zod';
+import {
+  compareProductReleaseVersions,
+  isProductReleaseVersion,
+  isSha512PackageIntegrity,
+} from './update-package-evidence.js';
 
 export const RUNTIME_HOST_SERVICE_MANAGEMENT_FRAME_PREFIX =
   'MAKA_RUNTIME_HOST_SERVICE_MANAGEMENT_V1 ';
@@ -74,6 +79,69 @@ const boundedNonEmptyString = (maxBytes: number) =>
     .string()
     .min(1)
     .refine((value) => Buffer.byteLength(value, 'utf8') <= maxBytes);
+const PRODUCT_RELEASE_VERSION_SCHEMA = z.string().refine(isProductReleaseVersion);
+const PACKAGE_INTEGRITY_SCHEMA = z.string().refine(isSha512PackageIntegrity);
+
+const UPDATE_CHECK_SCHEMA = z
+  .object({
+    selector: z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('channel'), channel: z.enum(UPDATE_CHANNELS) }).strict(),
+      z
+        .object({
+          kind: z.literal('exact'),
+          version: PRODUCT_RELEASE_VERSION_SCHEMA,
+        })
+        .strict(),
+    ]),
+    currentVersion: PRODUCT_RELEASE_VERSION_SCHEMA,
+    candidate: z
+      .object({
+        version: PRODUCT_RELEASE_VERSION_SCHEMA,
+        integrity: PACKAGE_INTEGRITY_SCHEMA,
+      })
+      .strict(),
+    outcome: z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('current') }).strict(),
+      z
+        .object({
+          kind: z.literal('unattended_update'),
+          compatibility: z.number().int().positive(),
+        })
+        .strict(),
+      z
+        .object({
+          kind: z.literal('manual_action'),
+          reason: z.enum(MANUAL_ACTION_REASONS),
+        })
+        .strict(),
+    ]),
+  })
+  .strict()
+  .superRefine((check, context) => {
+    if (check.selector.kind === 'exact' && check.selector.version !== check.candidate.version) {
+      context.addIssue({
+        code: 'custom',
+        path: ['candidate', 'version'],
+        message: 'Exact update selector and candidate version must match',
+      });
+    }
+    const relation = compareProductReleaseVersions(check.candidate.version, check.currentVersion);
+    const consistent =
+      check.outcome.kind === 'current'
+        ? relation === 0
+        : check.outcome.kind === 'unattended_update'
+          ? relation > 0
+          : check.outcome.reason === 'target_not_newer'
+            ? relation < 0
+            : relation > 0;
+    if (!consistent) {
+      context.addIssue({
+        code: 'custom',
+        path: ['outcome'],
+        message: 'Update outcome must match the version relation',
+      });
+    }
+  });
 
 const RETIREMENT_RESULT_SCHEMA = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('active_tasks') }).strict(),
@@ -134,41 +202,7 @@ const SERVICE_MANAGEMENT_FRAME_SCHEMA = z.union([
     .object({
       ...SERVICE_RESULT_COMMON,
       action: z.literal('check_update'),
-      updateCheck: z
-        .object({
-          selector: z.discriminatedUnion('kind', [
-            z.object({ kind: z.literal('channel'), channel: z.enum(UPDATE_CHANNELS) }).strict(),
-            z
-              .object({
-                kind: z.literal('exact'),
-                version: boundedNonEmptyString(FIELD_MAX_BYTES),
-              })
-              .strict(),
-          ]),
-          currentVersion: boundedNonEmptyString(FIELD_MAX_BYTES),
-          candidate: z
-            .object({
-              version: boundedNonEmptyString(FIELD_MAX_BYTES),
-              integrity: boundedNonEmptyString(FIELD_MAX_BYTES),
-            })
-            .strict(),
-          outcome: z.discriminatedUnion('kind', [
-            z.object({ kind: z.literal('current') }).strict(),
-            z
-              .object({
-                kind: z.literal('unattended_update'),
-                compatibility: z.number().int().positive(),
-              })
-              .strict(),
-            z
-              .object({
-                kind: z.literal('manual_action'),
-                reason: z.enum(MANUAL_ACTION_REASONS),
-              })
-              .strict(),
-          ]),
-        })
-        .strict(),
+      updateCheck: UPDATE_CHECK_SCHEMA,
     })
     .strict(),
   z

--- a/packages/runtime-host/src/operator/update-package-evidence.ts
+++ b/packages/runtime-host/src/operator/update-package-evidence.ts
@@ -54,6 +54,14 @@ export function compareProductReleaseVersions(left: string, right: string): -1 |
   return 0;
 }
 
+export function isSha512PackageIntegrity(value: string): boolean {
+  if (!value.startsWith('sha512-')) return false;
+  const encoded = value.slice('sha512-'.length);
+  if (encoded.length !== 88 || !/^[A-Za-z0-9+/]+={2}$/u.test(encoded)) return false;
+  const digest = Buffer.from(encoded, 'base64');
+  return digest.length === 64 && digest.toString('base64') === encoded;
+}
+
 function parseProductReleaseVersion(value: string): ProductReleaseVersion | undefined {
   if (value.length > 512) return undefined;
   const match =

--- a/scripts/release-cli-package.mjs
+++ b/scripts/release-cli-package.mjs
@@ -464,6 +464,12 @@ function writeReleaseManifest(cli, publishable) {
   }
   const undici = findDependency(cli, 'undici', '8.10.0');
   const dependencies = { ...source.dependencies, undici: undici.version };
+  const updateCompatibility = source.maka?.managedRuntimeHostUpdateCompatibility;
+  if (!Number.isSafeInteger(updateCompatibility) || updateCompatibility < 1) {
+    throw new Error(
+      'CLI manifest must define a positive managed Runtime Host update compatibility',
+    );
+  }
   const manifest = {
     name: source.name,
     version: source.version,
@@ -472,6 +478,7 @@ function writeReleaseManifest(cli, publishable) {
     type: source.type,
     exports: {},
     bin: source.bin,
+    maka: { managedRuntimeHostUpdateCompatibility: updateCompatibility },
     engines: root.engines,
     repository: {
       type: 'git',


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- add a read-only `runtime-host service check-update` command for `latest`, `next`, or an exact version
- resolve mutable channels through the official npm registry to an exact version and package integrity
- publish an explicit package compatibility epoch and admit unattended use only for newer packages with matching evidence
- reject malformed or contradictory machine evidence; this PR does not download, install, retire, or switch a Host

Fixes #3664

## Verification

- `npm --workspace maka-agent test` — 432 tests passed
- `npm --workspace @maka/runtime-host test` — 1120 tests passed
- `npm --workspace @maka/desktop run typecheck`
- `npm run release:cli:pack -- --allow-dirty` — development tarball contains the compatibility epoch
- real npm lookups for the `next` channel and an unavailable exact version
- affected Biome lint/format checks, `git diff --check`, and `npm run check:asf-headers`

Not run: the full repository test suite; the affected CLI suite and Desktop type boundary were run directly

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex authored implementation, focused tests, and documentation under maintainer direction

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## 摘要

- 新增只读的 `runtime-host service check-update` 命令，支持 `latest`、`next` 或精确版本
- 通过官方 npm registry 将可变频道一次性解析为精确版本与 package integrity
- 在 package 中发布显式兼容性 epoch；只有版本更新且证据匹配时才允许未来的无人值守流程使用
- 拒绝格式错误或相互矛盾的机器证据；本 PR 不下载、安装、退场或切换 Host

修复 #3664

## 验证

- `npm --workspace maka-agent test` — 432 项测试通过
- `npm --workspace @maka/runtime-host test` — 1120 项测试通过
- `npm --workspace @maka/desktop run typecheck`
- `npm run release:cli:pack -- --allow-dirty` — development tarball 已携带兼容性 epoch
- 使用真实 npm registry 验证 `next` 频道和不存在的精确版本
- 相关 Biome lint/format、`git diff --check` 与 `npm run check:asf-headers`

未运行仓库完整测试套件；已直接运行受影响的 CLI 套件与 Desktop 类型边界检查

## AI 使用

Codex 在维护者指导下完成实现、聚焦测试与文档

## 检查清单

- [x] 测试覆盖该变更，且在缺少实现时会失败
- [x] lint、format、typecheck 与受影响测试套件均在本地通过

本 PR 是否改变行为？是，具体见上方摘要

</details>
