### PR TITLE
fix(desktop): snapshot linked children for side conversations

### DIFF
--- a/apps/desktop/src/main/__tests__/quote-companion-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-cleanup.test.ts
@@ -38,6 +38,44 @@ afterEach(async () => {
 });
 
 describe('quote companion cleanup authority', () => {
+  it('forgets a known rejected creation without trying to resume or remove it', async () => {
+    const workspaceRoot = await createWorkspace();
+    let resumes = 0;
+    let removals = 0;
+    const authority = createSessionCopyCleanupAuthority({
+      workspaceRoot,
+      resumeSessionCopy: async () => {
+        resumes += 1;
+      },
+      removeSession: async () => {
+        removals += 1;
+      },
+    });
+    const creation = {
+      sessionId: 'fork-rejected',
+      kind: 'branch' as const,
+      sourceSessionId: 'source-session',
+      sourceTurnId: 'source-turn',
+      intent: 'side_conversation' as const,
+      ownerId: 'web-contents:1',
+    };
+
+    await assert.rejects(
+      authority.ownCreation(creation, async () => {
+        throw new Error('session busy');
+      }),
+      /session busy/,
+    );
+    assert.deepEqual(await readPendingIds(workspaceRoot), ['fork-rejected']);
+
+    await authority.rejectCreation('fork-rejected');
+
+    assert.deepEqual(await readPendingIds(workspaceRoot), []);
+    assert.equal(resumes, 0);
+    assert.equal(removals, 0);
+    assert.equal(await authority.ownCreation(creation, async () => 'retried'), 'retried');
+  });
+
   it('releases a rejected creation lease so the same identity can retry', async () => {
     const workspaceRoot = await createWorkspace();
     let removalFails = true;
@@ -124,6 +162,7 @@ describe('quote companion cleanup authority', () => {
           kind: 'branch',
           sourceSessionId: 'source-session',
           sourceTurnId: 'source-turn',
+          intent: 'side_conversation',
           ownerId: 'web-contents:2',
         },
         async () => {
@@ -138,7 +177,7 @@ describe('quote companion cleanup authority', () => {
       workspaceRoot,
       processId: 'process-after-crash',
       resumeSessionCopy: async (creation) => {
-        events.push(`resume:${creation.sessionId}:${creation.sourceTurnId}`);
+        events.push(`resume:${creation.sessionId}:${creation.sourceTurnId}:${creation.intent}`);
       },
       removeSession: async (sessionId) => {
         events.push(`remove:${sessionId}`);
@@ -150,7 +189,7 @@ describe('quote companion cleanup authority', () => {
       failed: [],
     });
     assert.deepEqual(events, [
-      'resume:fork-unknown-create:source-turn',
+      'resume:fork-unknown-create:source-turn:side_conversation',
       'remove:fork-unknown-create',
     ]);
     assert.deepEqual(await readPendingIds(workspaceRoot), []);

--- a/apps/desktop/src/main/__tests__/quote-companion-disposal.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-disposal.test.ts
@@ -23,6 +23,7 @@ import type { SessionSummary, TurnRecord } from '@maka/core/session';
 import {
   abandonPendingCompanionCopy,
   createFakeWorkbarServices,
+  ensureCompanionFork,
   performCompanionTurn,
   type PerformCompanionTurnDeps,
   type WorkbarServices,
@@ -92,6 +93,26 @@ afterEach(async () => {
 });
 
 describe('quote companion disposal fencing', () => {
+  it('preserves a retryable busy reason from Side Conversation creation', async () => {
+    const defaults = createFakeWorkbarServices();
+    const sideChat = {
+      ...defaults.sideChat,
+      listTurns: async () => [settledTurn('source-turn')],
+      branchFromTurn: async () => ({ ok: false as const, reason: 'session_busy' as const }),
+    };
+
+    assert.deepEqual(
+      await ensureCompanionFork({
+        api: sideChat,
+        sourceSession,
+        panelId,
+        name: 'Side chat',
+        isDisposed: () => false,
+      }),
+      { status: 'error', code: 'fork_source_busy' },
+    );
+  });
+
   it('does not start a send when the panel was disposed after fork setup', async () => {
     let sends = 0;
     let armed = 0;
@@ -152,7 +173,7 @@ describe('quote companion disposal fencing', () => {
     const sideChat = {
       ...defaults.sideChat,
       listTurns: async () => [settledTurn('source-turn')],
-      branchFromTurn: () => pendingFork.promise,
+      branchFromTurn: async () => ({ ok: true as const, session: await pendingFork.promise }),
       cleanupSessionCopy: async (sessionId: string) => {
         cleaned.push(sessionId);
       },

--- a/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { SessionChangedEvent, SessionSummary, TurnRecord } from '@maka/core/session';
+import {
+  createFakeWorkbarServices,
+  useQuoteCompanion,
+  WorkbarServicesProvider,
+  type WorkbarServices,
+} from '../../renderer/features/workbar/testing.js';
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+  HTMLElement: globalThis.HTMLElement,
+  HTMLIFrameElement: globalThis.HTMLIFrameElement,
+  Event: globalThis.Event,
+  Node: globalThis.Node,
+  IS_REACT_ACT_ENVIRONMENT: (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT,
+};
+
+let mountedRoot: Root | undefined;
+const SOURCE_SESSION = session('source-session');
+
+afterEach(async () => {
+  if (mountedRoot) {
+    await act(async () => {
+      mountedRoot?.unmount();
+      await Promise.resolve();
+    });
+  }
+  mountedRoot = undefined;
+  Object.assign(globalThis, originalGlobals);
+});
+
+test('retries a busy Side Conversation at the newest settled boundary and clears its banner', async () => {
+  const parsed = parseHTML('<html><body><div id="root"></div></body></html>');
+  const { document, window } = parsed;
+  Object.assign(globalThis, {
+    document,
+    window,
+    HTMLElement: window.HTMLElement,
+    HTMLIFrameElement: window.HTMLIFrameElement ?? class HTMLIFrameElement {},
+    Event: window.Event,
+    Node: window.Node,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+
+  let listCount = 0;
+  let sessionChange: ((event: SessionChangedEvent) => void) | undefined;
+  const branchInputs: Array<{ sourceTurnId: string; copyId: string }> = [];
+  const defaults = createFakeWorkbarServices();
+  const services: WorkbarServices = {
+    ...defaults,
+    sideChat: {
+      ...defaults.sideChat,
+      listTurns: async () => {
+        listCount += 1;
+        return listCount === 1
+          ? [settledTurn('turn-before-busy')]
+          : [settledTurn('turn-before-busy'), settledTurn('turn-after-busy')];
+      },
+      branchFromTurn: async (_sessionId, input) => {
+        branchInputs.push({ sourceTurnId: input.sourceTurnId, copyId: input.copyId });
+        return branchInputs.length === 1
+          ? { ok: false as const, reason: 'session_busy' as const }
+          : { ok: true as const, session: session('side-conversation') };
+      },
+      subscribeSessionChanges: (handler) => {
+        sessionChange = handler;
+        return () => {
+          if (sessionChange === handler) sessionChange = undefined;
+        };
+      },
+    },
+  };
+  const container = document.querySelector('#root');
+  assert.ok(container);
+  const root = createRoot(container);
+  mountedRoot = root;
+
+  await act(async () => {
+    root.render(
+      createElement(WorkbarServicesProvider, {
+        services,
+        children: createElement(QuoteCompanionProbe),
+      }),
+    );
+    await Promise.resolve();
+  });
+  await waitUntil(() => branchInputs.length === 1 && sessionChange !== undefined);
+  assert.match(container.textContent, /source conversation is still running/i);
+  const probe = container.firstElementChild;
+  assert.ok(probe);
+
+  await act(async () => {
+    sessionChange?.({
+      reason: 'turn-status-change',
+      sessionId: 'source-session',
+      turnId: 'turn-after-busy',
+      ts: Date.now(),
+    });
+    await Promise.resolve();
+  });
+  await waitUntil(
+    () => probe.getAttribute('data-companion-id') === 'side-conversation',
+    () =>
+      `branch inputs: ${JSON.stringify(branchInputs)}; companion: ${probe.getAttribute('data-companion-id')}; error: ${probe.getAttribute('data-error')}`,
+  );
+
+  assert.deepEqual(
+    branchInputs.map(({ sourceTurnId }) => sourceTurnId),
+    ['turn-before-busy', 'turn-after-busy'],
+  );
+  assert.notEqual(branchInputs[0]?.copyId, branchInputs[1]?.copyId);
+  assert.equal(probe.getAttribute('data-error'), '');
+});
+
+function QuoteCompanionProbe() {
+  const companion = useQuoteCompanion({
+    panelId: 'retry-panel',
+    pendingQuotes: [],
+    sourceSession: SOURCE_SESSION,
+    locale: 'en',
+    onQuotesConsumed: () => undefined,
+  });
+  return createElement('div', {
+    'data-error': companion.error ?? '',
+    'data-companion-id': companion.companionSession?.id ?? '',
+  }, companion.error);
+}
+
+function session(id: string): SessionSummary {
+  return {
+    id,
+    name: id,
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test',
+    connectionLocked: false,
+    model: 'test-model',
+    permissionMode: 'ask',
+  };
+}
+
+function settledTurn(turnId: string): TurnRecord {
+  return { turnId, status: 'completed', partialOutputRetained: false };
+}
+
+async function waitUntil(predicate: () => boolean, diagnostics?: () => string): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return;
+    await act(async () => {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    });
+  }
+  assert.fail(
+    `Timed out waiting for the Side Conversation state${diagnostics ? ` (${diagnostics()})` : ''}`,
+  );
+}

--- a/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
@@ -151,11 +151,72 @@ test('retries a busy Side Conversation at the newest settled boundary and clears
   assert.equal(probe.getAttribute('data-error'), '');
 });
 
-function QuoteCompanionProbe() {
+test('does not restart foreground setup when the source Session object refreshes', async () => {
+  const parsed = parseHTML('<html><body><div id="root"></div></body></html>');
+  const { document, window } = parsed;
+  Object.assign(globalThis, {
+    document,
+    window,
+    HTMLElement: window.HTMLElement,
+    HTMLIFrameElement: window.HTMLIFrameElement ?? class HTMLIFrameElement {},
+    Event: window.Event,
+    Node: window.Node,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+
+  let branchCount = 0;
+  const defaults = createFakeWorkbarServices();
+  const services: WorkbarServices = {
+    ...defaults,
+    sideChat: {
+      ...defaults.sideChat,
+      listTurns: async () => [settledTurn('settled-turn')],
+      branchFromTurn: async () => {
+        branchCount += 1;
+        if (branchCount === 1) {
+          return { ok: false as const, reason: 'session_busy' as const };
+        }
+        return await new Promise<never>(() => undefined);
+      },
+    },
+  };
+  const container = document.querySelector('#root');
+  assert.ok(container);
+  const root = createRoot(container);
+  mountedRoot = root;
+
+  const render = (sourceSession: SessionSummary) =>
+    root.render(
+      createElement(WorkbarServicesProvider, {
+        services,
+        children: createElement(QuoteCompanionProbe, { sourceSession }),
+      }),
+    );
+
+  await act(async () => {
+    render(session('source-session'));
+    await Promise.resolve();
+  });
+  const probe = container.firstElementChild;
+  assert.ok(probe);
+  await waitUntil(
+    () => branchCount === 1 && probe.getAttribute('data-preparing') === 'false',
+  );
+
+  await act(async () => {
+    render(session('source-session'));
+    await Promise.resolve();
+  });
+
+  assert.equal(branchCount, 1);
+  assert.equal(probe.getAttribute('data-preparing'), 'false');
+});
+
+function QuoteCompanionProbe(props: { sourceSession?: SessionSummary }) {
   const companion = useQuoteCompanion({
     panelId: 'retry-panel',
     pendingQuotes: [],
-    sourceSession: SOURCE_SESSION,
+    sourceSession: props.sourceSession ?? SOURCE_SESSION,
     locale: 'en',
     onQuotesConsumed: () => undefined,
   });

--- a/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
@@ -116,7 +116,7 @@ test('retries a busy Side Conversation at the newest settled boundary and clears
     await Promise.resolve();
   });
   await waitUntil(() => branchInputs.length === 1 && sessionChange !== undefined);
-  assert.match(container.textContent, /source conversation is still running/i);
+  assert.match(container.textContent, /main conversation or a linked task is still running/i);
   const probe = container.firstElementChild;
   assert.ok(probe);
 
@@ -131,7 +131,7 @@ test('retries a busy Side Conversation at the newest settled boundary and clears
   });
   await waitUntil(() => branchInputs.length === 2 && releaseRetry !== undefined);
   assert.equal(probe.getAttribute('data-preparing'), 'false');
-  assert.match(container.textContent, /source conversation is still running/i);
+  assert.match(container.textContent, /main conversation or a linked task is still running/i);
 
   await act(async () => {
     releaseRetry?.();

--- a/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
@@ -70,6 +70,7 @@ test('retries a busy Side Conversation at the newest settled boundary and clears
 
   let listCount = 0;
   let sessionChange: ((event: SessionChangedEvent) => void) | undefined;
+  let releaseRetry: (() => void) | undefined;
   const branchInputs: Array<{ sourceTurnId: string; copyId: string }> = [];
   const defaults = createFakeWorkbarServices();
   const services: WorkbarServices = {
@@ -84,9 +85,13 @@ test('retries a busy Side Conversation at the newest settled boundary and clears
       },
       branchFromTurn: async (_sessionId, input) => {
         branchInputs.push({ sourceTurnId: input.sourceTurnId, copyId: input.copyId });
-        return branchInputs.length === 1
-          ? { ok: false as const, reason: 'session_busy' as const }
-          : { ok: true as const, session: session('side-conversation') };
+        if (branchInputs.length === 1) {
+          return { ok: false as const, reason: 'session_busy' as const };
+        }
+        await new Promise<void>((resolve) => {
+          releaseRetry = resolve;
+        });
+        return { ok: true as const, session: session('side-conversation') };
       },
       subscribeSessionChanges: (handler) => {
         sessionChange = handler;
@@ -124,6 +129,14 @@ test('retries a busy Side Conversation at the newest settled boundary and clears
     });
     await Promise.resolve();
   });
+  await waitUntil(() => branchInputs.length === 2 && releaseRetry !== undefined);
+  assert.equal(probe.getAttribute('data-preparing'), 'false');
+  assert.match(container.textContent, /source conversation is still running/i);
+
+  await act(async () => {
+    releaseRetry?.();
+    await Promise.resolve();
+  });
   await waitUntil(
     () => probe.getAttribute('data-companion-id') === 'side-conversation',
     () =>
@@ -149,6 +162,7 @@ function QuoteCompanionProbe() {
   return createElement('div', {
     'data-error': companion.error ?? '',
     'data-companion-id': companion.companionSession?.id ?? '',
+    'data-preparing': String(companion.preparing),
   }, companion.error);
 }
 

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -257,6 +257,7 @@ test('drives the renderer Session catalog facade through real UDS framing', asyn
       completeComputerUseTurn() {},
       createSessionCopyCleanup: () => ({
         ownCreation: (_creation, operation) => operation(),
+        rejectCreation: async () => undefined,
         cleanup: async () => undefined,
         schedule: async () => undefined,
         abandonOwner: async () => undefined,
@@ -571,6 +572,7 @@ function ipcHarness() {
 function unusedSessionCopyCleanup() {
   return {
     ownCreation: async <T>(_creation: unknown, operation: () => Promise<T>) => operation(),
+    async rejectCreation() {},
     async cleanup() {},
     async schedule() {},
     async abandonOwner() {},

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -524,6 +524,7 @@ test('does not release or report a Revision the Host retained during cleanup', a
       removeSessionCopy = removeSession;
       return {
         ownCreation: (_creation, operation) => operation(),
+        rejectCreation: async () => undefined,
         cleanup: async () => undefined,
         schedule: async () => undefined,
         abandonOwner: async () => undefined,
@@ -864,6 +865,7 @@ function deps(
     completeComputerUseTurn() {},
     createSessionCopyCleanup: () => ({
       ownCreation: (_creation, operation) => operation(),
+      rejectCreation: async () => undefined,
       cleanup: async () => undefined,
       schedule: async () => undefined,
       abandonOwner: async () => undefined,

--- a/apps/desktop/src/main/__tests__/runtime-host-session-catalog-running-turns.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-catalog-running-turns.test.ts
@@ -36,6 +36,7 @@ test('projects observed running Turn identities into renderer Session lists', as
       emitSessionsChanged() {},
       releaseSessionResources() {},
       sessionCopyCleanup: {
+        async rejectCreation() {},
         recover: async () => ({ failed: [] }),
       } as never,
     },
@@ -76,6 +77,7 @@ test('merges catalog and observed running Turn identities in stable order', asyn
       emitSessionsChanged() {},
       releaseSessionResources() {},
       sessionCopyCleanup: {
+        async rejectCreation() {},
         recover: async () => ({ failed: [] }),
       } as never,
     },

--- a/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
@@ -201,13 +201,15 @@ test("retries committed Branch and Revision copies with the renderer-owned ident
   assert.equal(committed.size, 3);
 });
 
-test("marks Runtime Host Branch copies as side conversations", async () => {
+test("sends Side Conversation intent and metadata atomically to Runtime Host", async () => {
+  const copyInputs: unknown[] = [];
   const metadataUpdates: unknown[] = [];
   const abandonedOwners: string[] = [];
   const backgroundErrors: unknown[] = [];
   const ipc = ipcHarness();
   const sessionCopyCleanup = {
     ownCreation: <T>(_creation: unknown, operation: () => Promise<T>) => operation(),
+    async rejectCreation() {},
     async cleanup() {},
     async schedule() {},
     async abandonOwner(ownerId: string) {
@@ -221,17 +223,20 @@ test("marks Runtime Host Branch copies as side conversations", async () => {
   registerExecutionIpc(
     {
       client: executionClient({
-        copySession: async (_kind, input) => ({
-          ...session(),
-          id: input.targetSessionId,
-          labels: ["source-label"],
-        }),
+        copySession: async (_kind, input) => {
+          copyInputs.push(input);
+          return {
+            ...session(),
+            id: input.targetSessionId,
+            labels: ["source-label", SIDE_CONVERSATION_SESSION_LABEL],
+          };
+        },
         updateSessionMetadata: async (sessionId, patch) => {
           metadataUpdates.push({ sessionId, patch });
           return {
             ...session(),
             id: sessionId,
-            labels: patch.labels ?? [],
+            labels: patch.labels ?? ['source-label', SIDE_CONVERSATION_SESSION_LABEL],
           };
         },
       }),
@@ -247,23 +252,26 @@ test("marks Runtime Host Branch copies as side conversations", async () => {
     ipc,
   );
 
-  const branch = (await ipc.invoke("sessions:branchFromTurn", "source-session", {
+  const branchResult = (await ipc.invoke("sessions:branchFromTurn", "source-session", {
     sourceTurnId: "source-turn",
     copyId: "side-copy",
     name: "Side chat",
     sideConversation: true,
-  })) as { labels: string[] };
+  })) as { ok: true; session: { labels: string[] } };
 
-  assert.deepEqual(metadataUpdates, [
+  assert.deepEqual(copyInputs, [
     {
-      sessionId: "side-copy",
-      patch: {
-        name: "Side chat",
-        labels: ["source-label", SIDE_CONVERSATION_SESSION_LABEL],
-      },
+      sourceSessionId: 'source-session',
+      targetSessionId: 'side-copy',
+      sourceTurnId: 'source-turn',
+      intent: 'side_conversation',
     },
   ]);
-  assert.deepEqual(branch.labels, [
+  assert.deepEqual(metadataUpdates, [
+    { sessionId: 'side-copy', patch: { name: 'Side chat' } },
+  ]);
+  assert.equal(branchResult.ok, true);
+  assert.deepEqual(branchResult.session.labels, [
     "source-label",
     SIDE_CONVERSATION_SESSION_LABEL,
   ]);
@@ -274,6 +282,50 @@ test("marks Runtime Host Branch copies as side conversations", async () => {
   assert.deepEqual(backgroundErrors.map((error) => (error as Error).message), [
     'cleanup unavailable',
   ]);
+});
+
+test('returns structured Side Conversation setup failures across IPC', async () => {
+  for (const reason of ['session_busy', 'operation_unavailable'] as const) {
+    const ipc = ipcHarness();
+    const rejectedCreations: string[] = [];
+    registerExecutionIpc(
+      {
+        client: executionClient({
+          copySession: async () => {
+            throw new RuntimeHostOperationError(
+              'session.branch.create',
+              reason,
+              'Side Conversation setup failed',
+            );
+          },
+        }),
+        observer: unusedObserver(),
+        attachmentApprovals: createAttachmentApprovalRegistry(),
+        emitSessionsChanged() {},
+        stat: async () => ({ size: 0 }),
+        resizeImage: async (bytes) => bytes,
+        beforeStop() {},
+        newId: () => 'id-1',
+        sessionCopyCleanup: {
+          ...unusedSessionCopyCleanup(),
+          async rejectCreation(sessionId) {
+            rejectedCreations.push(sessionId);
+          },
+        },
+      },
+      ipc,
+    );
+
+    assert.deepEqual(
+      await ipc.invoke('sessions:branchFromTurn', 'source-session', {
+        sourceTurnId: 'source-turn',
+        copyId: `side-copy-${reason}`,
+        sideConversation: true,
+      }),
+      { ok: false, reason },
+    );
+    assert.deepEqual(rejectedCreations, [`side-copy-${reason}`]);
+  }
 });
 
 test("sends canonical content and uploads owned Attachment bytes through the Host", async () => {
@@ -1089,6 +1141,7 @@ function registerExecutionIpc(
 function unusedSessionCopyCleanup(): RuntimeHostSessionExecutionIpcDeps['sessionCopyCleanup'] {
   return {
     ownCreation: async (_creation, operation) => operation(),
+    async rejectCreation() {},
     async cleanup() {},
     async schedule() {},
     async abandonOwner() {},

--- a/apps/desktop/src/main/quote-companion-cleanup.ts
+++ b/apps/desktop/src/main/quote-companion-cleanup.ts
@@ -25,6 +25,7 @@ export interface SessionCopyCreationLease {
   kind: 'branch' | 'revision';
   sourceSessionId: string;
   sourceTurnId: string;
+  intent?: 'side_conversation';
   ownerId: string;
 }
 
@@ -61,6 +62,7 @@ export interface SessionCopyCleanupRecovery {
 
 export interface SessionCopyCleanupAuthority {
   ownCreation<T>(creation: SessionCopyCreationLease, operation: () => Promise<T>): Promise<T>;
+  rejectCreation(sessionId: string): Promise<void>;
   cleanup(sessionId: string): Promise<void>;
   schedule(sessionId: string): Promise<void>;
   abandonOwner(ownerId: string): Promise<void>;
@@ -123,6 +125,17 @@ class SessionCopyCleanupAuthorityImpl implements SessionCopyCleanupAuthority {
     })();
     this.creations.set(normalized.sessionId, { creation: normalized, operation: task });
     return task;
+  }
+
+  async rejectCreation(sessionId: string): Promise<void> {
+    const normalized = normalizeSessionId(sessionId);
+    await this.creations.get(normalized)?.operation.catch(() => undefined);
+    const record = await this.store.read(normalized);
+    if (!record) return;
+    if (record.phase !== 'creating') {
+      throw new Error(`Session copy ${normalized} is no longer awaiting creation`);
+    }
+    await this.store.forget(normalized);
   }
 
   async cleanup(sessionId: string): Promise<void> {
@@ -258,6 +271,7 @@ class SqliteSessionCopyCleanupStore implements SessionCopyCleanupStore {
           kind: creation.kind,
           sourceSessionId: creation.sourceSessionId,
           sourceTurnId: creation.sourceTurnId,
+          ...(creation.intent ? { intent: creation.intent } : {}),
         },
       };
     });
@@ -396,6 +410,7 @@ function normalizeCreationLease(creation: SessionCopyCreationLease): SessionCopy
     kind: creation.kind,
     sourceSessionId: normalizeSessionId(creation.sourceSessionId),
     sourceTurnId: normalizeSessionId(creation.sourceTurnId),
+    ...(creation.intent === 'side_conversation' ? { intent: creation.intent } : {}),
     ownerId: normalizeOwnerId(creation.ownerId),
   };
 }
@@ -409,6 +424,7 @@ function sameCreation(
     left.kind === right.kind &&
     left.sourceSessionId === right.sourceSessionId &&
     left.sourceTurnId === right.sourceTurnId &&
+    left.intent === right.intent &&
     left.ownerId === right.ownerId
   );
 }
@@ -420,7 +436,8 @@ function samePersistedCreation(
   return (
     left.kind === right.kind &&
     left.sourceSessionId === right.sourceSessionId &&
-    left.sourceTurnId === right.sourceTurnId
+    left.sourceTurnId === right.sourceTurnId &&
+    left.intent === right.intent
   );
 }
 

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -130,6 +130,7 @@ export interface DesktopRuntimeHostCandidateDeps {
       kind: 'branch' | 'revision';
       sourceSessionId: string;
       sourceTurnId: string;
+      intent?: 'side_conversation';
     }) => Promise<void>;
   }) => SessionCopyCleanupAuthority;
   readonly registerClientIpc?: (
@@ -638,11 +639,12 @@ export async function createDesktopRuntimeHostCandidate(
         emitSessionsChanged("deleted", sessionId);
         return disposition;
       },
-      resumeSessionCopy: async ({ sessionId, kind, sourceSessionId, sourceTurnId }) => {
+      resumeSessionCopy: async ({ sessionId, kind, sourceSessionId, sourceTurnId, intent }) => {
         await client.copySession(kind, {
           sourceSessionId,
           targetSessionId: sessionId,
           sourceTurnId,
+          ...(intent ? { intent } : {}),
         });
       },
     });

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -26,7 +26,6 @@ import {
   type SessionChangedEvent,
   type SessionChangedReason,
 } from '@maka/core/session';
-import { SIDE_CONVERSATION_SESSION_LABEL } from '@maka/core/side-conversation';
 import { type ActiveInteractionRequestEvent, type AttachmentRef } from '@maka/core/events';
 import { type PermissionMode } from '@maka/core/permission';
 import { type SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
@@ -59,6 +58,10 @@ import {
 import type { DesktopTranscriptRangeRequest } from '../preload/transcript-contract.js';
 import { toDesktopHostSessionSummary } from "./runtime-host-session-catalog-ipc-main.js";
 import { mergeWorkspaceFileInlineReferences } from "./session-workspace-inline-references.js";
+
+type SideConversationBranchResult =
+  | { readonly ok: true; readonly session: ReturnType<typeof toDesktopHostSessionSummary> }
+  | { readonly ok: false; readonly reason: 'session_busy' | 'operation_unavailable' };
 
 type RuntimeHostSessionExecutionClient = Pick<
   DesktopRuntimeHostClient,
@@ -624,36 +627,47 @@ export function registerRuntimeHostSessionExecutionIpc(
           sourceSessionId: sessionId,
           targetSessionId: normalized.copyId,
           sourceTurnId: normalized.sourceTurnId,
+          ...(normalized.sideConversation ? { intent: 'side_conversation' as const } : {}),
         });
-      let branch = normalized.sideConversation
-        ? await deps.sessionCopyCleanup.ownCreation(
-            {
-              sessionId: normalized.copyId,
-              kind: 'branch',
-              sourceSessionId: sessionId,
-              sourceTurnId: normalized.sourceTurnId,
-              ownerId: bindCopyOwner(event),
-            },
-            createBranch,
-          )
-        : await createBranch();
-      if (normalized.name || normalized.sideConversation) {
+      let branch;
+      try {
+        branch = normalized.sideConversation
+          ? await deps.sessionCopyCleanup.ownCreation(
+              {
+                sessionId: normalized.copyId,
+                kind: 'branch',
+                sourceSessionId: sessionId,
+                sourceTurnId: normalized.sourceTurnId,
+                intent: 'side_conversation',
+                ownerId: bindCopyOwner(event),
+              },
+              createBranch,
+            )
+          : await createBranch();
+      } catch (error) {
+        if (
+          normalized.sideConversation &&
+          error instanceof RuntimeHostOperationError &&
+          (error.code === 'session_busy' || error.code === 'operation_unavailable')
+        ) {
+          await deps.sessionCopyCleanup.rejectCreation(normalized.copyId);
+          return {
+            ok: false,
+            reason: error.code,
+          } satisfies SideConversationBranchResult;
+        }
+        throw error;
+      }
+      if (normalized.name) {
         branch = await deps.client.updateSessionMetadata(branch.id, {
-          ...(normalized.name ? { name: normalized.name } : {}),
-          ...(normalized.sideConversation
-            ? {
-                labels: [
-                  ...new Set([
-                    ...branch.labels,
-                    SIDE_CONVERSATION_SESSION_LABEL,
-                  ]),
-                ],
-              }
-            : {}),
+          name: normalized.name,
         });
       }
       deps.emitSessionsChanged("created", branch.id);
-      return toDesktopHostSessionSummary(branch);
+      const summary = toDesktopHostSessionSummary(branch);
+      return normalized.sideConversation
+        ? ({ ok: true, session: summary } satisfies SideConversationBranchResult)
+        : summary;
     },
   );
   ipcMain.handle(

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -200,6 +200,10 @@ export type DesktopBranchFromTurnInput = BranchFromTurnInput & {
   copyId: string;
 };
 
+export type DesktopSideConversationBranchResult =
+  | { ok: true; session: DesktopSessionSummary }
+  | { ok: false; reason: 'session_busy' | 'operation_unavailable' };
+
 export type DesktopReviseBeforeTurnInput = ReviseBeforeTurnInput & {
   /** Stable target identity for retrying one Desktop copy action. */
   copyId: string;
@@ -772,7 +776,14 @@ export interface MakaBridge {
       | { disposition: 'park'; rejectionReasons: string[]; diagnostics: unknown[] }
     >;
     regenerateTurn(sessionId: string, input: RegenerateTurnInput): Promise<void>;
-    branchFromTurn(sessionId: string, input: DesktopBranchFromTurnInput): Promise<DesktopSessionSummary>;
+    branchFromTurn(
+      sessionId: string,
+      input: DesktopBranchFromTurnInput & { sideConversation: true },
+    ): Promise<DesktopSideConversationBranchResult>;
+    branchFromTurn(
+      sessionId: string,
+      input: DesktopBranchFromTurnInput & { sideConversation?: false },
+    ): Promise<DesktopSessionSummary>;
     reviseBeforeTurn(sessionId: string, input: DesktopReviseBeforeTurnInput): Promise<DesktopSessionSummary>;
     respondToSandboxBoundary(sessionId: string, response: SandboxBoundaryResponse): Promise<void>;
     respondToUserQuestion(sessionId: string, response: UserQuestionResponse): Promise<void>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -30,6 +30,7 @@ import type {
   PermissionOverlayStartResult,
   RendererIngestInput,
   DesktopBranchFromTurnInput,
+  DesktopSideConversationBranchResult,
   DesktopReviseBeforeTurnInput,
   AppUpdateInstallRequest,
   AppUpdateInstallResult,
@@ -606,6 +607,34 @@ async function invokeSessionSummary(
     ...args,
   ) as SessionSummary;
   return projectSessionSummary(session.scope, summary);
+}
+
+async function invokeBranchFromTurn(
+  sessionId: string,
+  input: DesktopBranchFromTurnInput & { sideConversation: true },
+): Promise<DesktopSideConversationBranchResult>;
+async function invokeBranchFromTurn(
+  sessionId: string,
+  input: DesktopBranchFromTurnInput & { sideConversation?: false },
+): Promise<DesktopSessionSummary>;
+async function invokeBranchFromTurn(
+  sessionId: string,
+  input: DesktopBranchFromTurnInput,
+): Promise<DesktopSessionSummary | DesktopSideConversationBranchResult> {
+  const ref = await runtimeHostSessionRef(sessionId);
+  const result = await ipcRenderer.invoke(
+    'sessions:branchFromTurn',
+    ref.scope,
+    ref.sessionId,
+    input,
+  ) as SessionSummary | { ok: true; session: SessionSummary } | { ok: false; reason: string };
+  if (input.sideConversation) {
+    if (!('ok' in result) || result.ok === false) {
+      return result as DesktopSideConversationBranchResult;
+    }
+    return { ok: true, session: projectSessionSummary(ref.scope, result.session) };
+  }
+  return projectSessionSummary(ref.scope, result as SessionSummary);
 }
 
 async function invokeSessionInput<T, I extends { readonly sessionId: string }>(
@@ -1619,13 +1648,7 @@ const makaBridge = {
     regenerateTurn(sessionId: string, input: RegenerateTurnInput): Promise<void> {
       return invokeSessionRuntimeHost('sessions:regenerateTurn', sessionId, input);
     },
-    async branchFromTurn(sessionId: string, input: DesktopBranchFromTurnInput): Promise<DesktopSessionSummary> {
-      const ref = await runtimeHostSessionRef(sessionId);
-      const summary = await ipcRenderer.invoke(
-        'sessions:branchFromTurn', ref.scope, ref.sessionId, input,
-      ) as SessionSummary;
-      return projectSessionSummary(ref.scope, summary);
-    },
+    branchFromTurn: invokeBranchFromTurn,
     async reviseBeforeTurn(sessionId: string, input: DesktopReviseBeforeTurnInput): Promise<DesktopSessionSummary> {
       const ref = await runtimeHostSessionRef(sessionId);
       const summary = await ipcRenderer.invoke(

--- a/apps/desktop/src/renderer/features/workbar/ports.ts
+++ b/apps/desktop/src/renderer/features/workbar/ports.ts
@@ -36,6 +36,7 @@ import type { PermissionMode } from '@maka/core/permission';
 import type { RegenerateTurnInput } from '@maka/core/runtime-inputs';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type {
+  SessionChangedEvent,
   SessionSummary,
   StoredMessage,
   TurnRecord,
@@ -212,9 +213,12 @@ export interface SideChatSessionPort {
       sourceTurnId: string;
       name?: string;
       copyId: string;
-      sideConversation?: boolean;
+      sideConversation: true;
     },
-  ): Promise<SessionSummary>;
+  ): Promise<
+    | { ok: true; session: SessionSummary }
+    | { ok: false; reason: 'session_busy' | 'operation_unavailable' }
+  >;
   cleanupSessionCopy(sessionId: string): Promise<void>;
   abandonSessionCopy(sourceSessionId: string, copyId: string): Promise<void>;
   send(
@@ -246,6 +250,7 @@ export interface SideChatSessionPort {
     sessionId: string,
     handler: (event: SessionEvent) => void,
   ): WorkbarUnsubscribe;
+  subscribeSessionChanges(handler: (event: SessionChangedEvent) => void): WorkbarUnsubscribe;
 }
 
 export interface WorkbarServices {

--- a/apps/desktop/src/renderer/features/workbar/testing.ts
+++ b/apps/desktop/src/renderer/features/workbar/testing.ts
@@ -37,6 +37,7 @@ export * from './tools/inspector/session-inspector-overview-model.js';
 export * from './tools/side-chat/quote-companion-panel-state.js';
 export * from './tools/side-chat/quote-companion-core.js';
 export * from './tools/side-chat/quote-companion-visibility.js';
+export { useQuoteCompanion } from './tools/side-chat/use-quote-companion.js';
 export * from './tools/terminal/session-terminal-hydration.js';
 export * from './tools/terminal/session-terminal-query.js';
 export * from './tools/terminal/session-terminal-frame.js';
@@ -136,6 +137,7 @@ export function createFakeWorkbarServices(
       respondToSandboxBoundary: async () => undefined,
       respondToUserQuestion: async () => undefined,
       subscribeEvents: noopSubscription,
+      subscribeSessionChanges: noopSubscription,
     },
     ...overrides,
   };

--- a/apps/desktop/src/renderer/features/workbar/tools/side-chat/quote-companion-core.ts
+++ b/apps/desktop/src/renderer/features/workbar/tools/side-chat/quote-companion-core.ts
@@ -50,6 +50,8 @@ import { sessionEventErrorMessage } from '../../../../model-connection-errors.js
  *  `{ok:false}`. */
 export type CompanionErrorCode =
   | 'fork_setup_failed'
+  | 'fork_source_busy'
+  | 'fork_unsupported'
   | 'send_failed'
   | 'send_rejected';
 
@@ -247,12 +249,20 @@ export async function ensureCompanionFork(
     ) {
       return { status: 'error', code: 'fork_setup_failed' };
     }
-    created = await api.branchFromTurn(sourceSession.id, {
+    const result = await api.branchFromTurn(sourceSession.id, {
       sourceTurnId: copyAttempt.sourceTurnId,
       name,
       copyId: copyAttempt.copyId,
       sideConversation: true,
     });
+    if (!result.ok) {
+      copyAttempt.complete();
+      return {
+        status: 'error',
+        code: result.reason === 'session_busy' ? 'fork_source_busy' : 'fork_unsupported',
+      };
+    }
+    created = result.session;
   } catch {
     return { status: 'error', code: 'fork_setup_failed' };
   }

--- a/apps/desktop/src/renderer/features/workbar/tools/side-chat/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/features/workbar/tools/side-chat/use-quote-companion.ts
@@ -151,8 +151,11 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   // A created fork is hidden immediately, but is not considered usable until
   // onForkCommitted promotes it.
   const pendingForkIdRef = useRef<string | null>(null);
+  const sourceSessionRef = useRef(sourceSession);
+  sourceSessionRef.current = sourceSession;
+  const sourceSessionId = sourceSession?.id;
   const sourceSessionIdRef = useRef(sourceSession?.id);
-  sourceSessionIdRef.current = sourceSession?.id;
+  sourceSessionIdRef.current = sourceSessionId;
   const forkSetupPromiseRef = useRef<Promise<EnsureCompanionForkResult> | null>(null);
   const stopRequestedRef = useRef(false);
   const activeTurnIdRef = useRef<string | null>(null);
@@ -272,7 +275,8 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       const existing = companionRef.current;
       if (existing) return Promise.resolve({ status: 'ready', session: existing });
       if (forkSetupPromiseRef.current) return forkSetupPromiseRef.current;
-      if (!sourceSession) {
+      const currentSourceSession = sourceSessionRef.current;
+      if (!currentSourceSession) {
         return Promise.resolve({ status: 'error', code: 'fork_setup_failed' });
       }
 
@@ -280,7 +284,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       if (showPreparing) setPreparing(true);
       const promise = ensureCompanionFork({
         api: sideChat,
-        sourceSession,
+        sourceSession: currentSourceSession,
         panelId,
         name,
         isDisposed: () => !mountedRef.current,
@@ -326,15 +330,15 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       forkSetupPromiseRef.current = promise;
       return promise;
     },
-    [commitFork, mountedRef, panelId, sideChat, sourceSession],
+    [commitFork, mountedRef, panelId, sideChat],
   );
 
   useEffect(() => {
-    if (sourceSession) void ensureFork(copyRef.current.defaultName);
-  }, [ensureFork, sourceSession]);
+    if (sourceSessionId) void ensureFork(copyRef.current.defaultName);
+  }, [ensureFork, sourceSessionId]);
 
   useEffect(() => {
-    if (!sourceSession || !forkRetryPending) return;
+    if (!sourceSessionId || !forkRetryPending) return;
     let retrying = false;
     const retry = () => {
       if (retrying || !mountedRef.current || companionRef.current) return;
@@ -350,7 +354,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
     };
     const unsubscribe = sideChat.subscribeSessionChanges((event) => {
       if (
-        event.sessionId === sourceSession.id &&
+        event.sessionId === sourceSessionId &&
         (event.reason === 'turn-status-change' ||
           event.reason === 'status-change' ||
           event.reason === 'message-appended')
@@ -363,7 +367,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       globalThis.clearInterval(retryTimer);
       unsubscribe();
     };
-  }, [ensureFork, forkRetryPending, mountedRef, sideChat, sourceSession]);
+  }, [ensureFork, forkRetryPending, mountedRef, sideChat, sourceSessionId]);
 
   // The fork is ephemeral (用完即弃): when the panel is dismissed — 退出,
   // switching source session — unsubscribe and remove the fork so it never

--- a/apps/desktop/src/renderer/features/workbar/tools/side-chat/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/features/workbar/tools/side-chat/use-quote-companion.ts
@@ -51,15 +51,15 @@ import {
   performCompanionTurn,
   type CompanionErrorCode,
   type EnsureCompanionForkResult,
-} from './quote-companion-core';
+} from './quote-companion-core.js';
 import { mergeSettledMessages } from '../../../../settled-message-merge.js';
 import { getDesktopConversationCopy } from '../../../../locales/conversation-copy.js';
 import {
   snapshotCompanionQuotes,
   type CompanionQuoteSnapshot,
   type StagedCompanionQuote,
-} from './quote-companion-panel-state';
-import type { CompanionForkVisibilityEvent } from './quote-companion-visibility';
+} from './quote-companion-panel-state.js';
+import type { CompanionForkVisibilityEvent } from './quote-companion-visibility.js';
 
 export interface UseQuoteCompanionInput {
   /** Stable owner for the currently mounted panel generation. */
@@ -178,6 +178,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   );
   const [hasContent, setHasContent] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [forkRetryPending, setForkRetryPending] = useState(false);
   // Bumped whenever the own-turn set changes so the render picks up the new
   // filter result (the set lives in a ref to stay stable for the event handler).
   const [, setOwnTurnTick] = useState(0);
@@ -298,9 +299,19 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       })
         .then((result) => {
           if (result.status === 'ready' && mountedRef.current) {
+            setForkRetryPending(false);
+            setError(null);
             commitFork(result.session);
           } else if (result.status === 'error' && mountedRef.current) {
-            setError(copyRef.current.errors.forkSetupFailed);
+            setForkRetryPending(result.code === 'fork_source_busy');
+            const errors = copyRef.current.errors;
+            setError(
+              result.code === 'fork_source_busy'
+                ? errors.forkSourceBusy
+                : result.code === 'fork_unsupported'
+                  ? errors.forkUnsupported
+                  : errors.forkSetupFailed,
+            );
           }
           return result;
         })
@@ -317,6 +328,38 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   useEffect(() => {
     if (sourceSession) void ensureFork(copyRef.current.defaultName);
   }, [ensureFork, sourceSession]);
+
+  useEffect(() => {
+    if (!sourceSession || !forkRetryPending) return;
+    let retrying = false;
+    const retry = () => {
+      if (retrying || !mountedRef.current || companionRef.current) return;
+      retrying = true;
+      const currentSetup = forkSetupPromiseRef.current;
+      void (async () => {
+        if (currentSetup) await currentSetup;
+        if (!mountedRef.current || companionRef.current) return;
+        await ensureFork(copyRef.current.defaultName);
+      })().finally(() => {
+        retrying = false;
+      });
+    };
+    const unsubscribe = sideChat.subscribeSessionChanges((event) => {
+      if (
+        event.sessionId === sourceSession.id &&
+        (event.reason === 'turn-status-change' ||
+          event.reason === 'status-change' ||
+          event.reason === 'message-appended')
+      ) {
+        retry();
+      }
+    });
+    const retryTimer = globalThis.setInterval(retry, 2_000);
+    return () => {
+      globalThis.clearInterval(retryTimer);
+      unsubscribe();
+    };
+  }, [ensureFork, forkRetryPending, mountedRef, sideChat, sourceSession]);
 
   // The fork is ephemeral (用完即弃): when the panel is dismissed — 退出,
   // switching source session — unsubscribe and remove the fork so it never
@@ -427,6 +470,8 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
         const errors = copyRef.current.errors;
         const byCode: Record<CompanionErrorCode, string> = {
           fork_setup_failed: errors.forkSetupFailed,
+          fork_source_busy: errors.forkSourceBusy,
+          fork_unsupported: errors.forkUnsupported,
           send_failed: errors.sendFailed,
           send_rejected: errors.sendRejected,
         };

--- a/apps/desktop/src/renderer/features/workbar/tools/side-chat/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/features/workbar/tools/side-chat/use-quote-companion.ts
@@ -265,7 +265,10 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   );
 
   const ensureFork = useCallback(
-    (name: string): Promise<EnsureCompanionForkResult> => {
+    (
+      name: string,
+      options: { readonly showPreparing?: boolean } = {},
+    ): Promise<EnsureCompanionForkResult> => {
       const existing = companionRef.current;
       if (existing) return Promise.resolve({ status: 'ready', session: existing });
       if (forkSetupPromiseRef.current) return forkSetupPromiseRef.current;
@@ -273,7 +276,8 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
         return Promise.resolve({ status: 'error', code: 'fork_setup_failed' });
       }
 
-      setPreparing(true);
+      const showPreparing = options.showPreparing ?? true;
+      if (showPreparing) setPreparing(true);
       const promise = ensureCompanionFork({
         api: sideChat,
         sourceSession,
@@ -317,7 +321,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
         })
         .finally(() => {
           forkSetupPromiseRef.current = null;
-          if (mountedRef.current) setPreparing(false);
+          if (showPreparing && mountedRef.current) setPreparing(false);
         });
       forkSetupPromiseRef.current = promise;
       return promise;
@@ -339,7 +343,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       void (async () => {
         if (currentSetup) await currentSetup;
         if (!mountedRef.current || companionRef.current) return;
-        await ensureFork(copyRef.current.defaultName);
+        await ensureFork(copyRef.current.defaultName, { showPreparing: false });
       })().finally(() => {
         retrying = false;
       });

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -280,6 +280,10 @@ export interface DesktopConversationCopy {
     errors: {
       /** Reading the source boundary or creating the companion fork failed. */
       forkSetupFailed: string;
+      /** The source or one of its linked child runs is still active. */
+      forkSourceBusy: string;
+      /** The retained source context cannot be represented safely. */
+      forkUnsupported: string;
       /** `sessions.send` was rejected without throwing (e.g. an unresolved skill). */
       sendRejected: string;
       /** `sessions.send` threw / the turn could not be started. */
@@ -558,6 +562,8 @@ const COPY = {
       },
       errors: {
         forkSetupFailed: '无法创建侧边对话，请稍后重试。',
+        forkSourceBusy: '主对话或子任务仍在运行，请等待完成后重试。',
+        forkUnsupported: '当前对话上下文暂不支持创建侧边对话。',
         sendRejected: '追问未能开始，请稍后重试。',
         sendFailed: '追问失败，请稍后重试。',
         settlementFailed: '运行已结束，但消息加载失败。请重试或重新打开侧边对话。',
@@ -761,6 +767,8 @@ const COPY = {
       },
       errors: {
         forkSetupFailed: 'Could not open the side chat. Please try again.',
+        forkSourceBusy: 'The source conversation is still running. Try again when it finishes.',
+        forkUnsupported: 'This conversation context cannot be opened as a side chat yet.',
         sendRejected: 'The companion could not start. Please try again.',
         sendFailed: 'The companion request failed. Please try again.',
         settlementFailed: 'The run ended, but its messages could not be loaded. Retry or reopen the side chat.',

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -767,7 +767,8 @@ const COPY = {
       },
       errors: {
         forkSetupFailed: 'Could not open the side chat. Please try again.',
-        forkSourceBusy: 'The source conversation is still running. Try again when it finishes.',
+        forkSourceBusy:
+          'The main conversation or a linked task is still running. Try again when it finishes.',
         forkUnsupported: 'This conversation context cannot be opened as a side chat yet.',
         sendRejected: 'The companion could not start. Please try again.',
         sendFailed: 'The companion request failed. Please try again.',

--- a/apps/desktop/src/renderer/platform/desktop/create-workbar-services.ts
+++ b/apps/desktop/src/renderer/platform/desktop/create-workbar-services.ts
@@ -132,6 +132,7 @@ export function createDesktopWorkbarServices(
         bridge.sessions.respondToUserQuestion(sessionId, response),
       subscribeEvents: (sessionId, handler) =>
         bridge.sessions.subscribeEvents(sessionId, handler),
+      subscribeSessionChanges: (handler) => bridge.sessions.subscribeChanges(handler),
     },
   };
 }

--- a/apps/desktop/stories/session-workbar.stories.tsx
+++ b/apps/desktop/stories/session-workbar.stories.tsx
@@ -706,7 +706,7 @@ function bridge(options: {
         },
       ],
       readSettledMessages: async () => ({ messages: [], settled: true }),
-      branchFromTurn: async () => SIDE_CHAT_SESSION,
+      branchFromTurn: async () => ({ ok: true, session: SIDE_CHAT_SESSION }),
       cleanupSessionCopy: async () => undefined,
       abandonSessionCopy: async () => undefined,
       send: async () => ({ ok: true }),
@@ -720,6 +720,7 @@ function bridge(options: {
       respondToSandboxBoundary: async () => undefined,
       respondToUserQuestion: async () => undefined,
       subscribeEvents: unsubscribe,
+      subscribeSessionChanges: unsubscribe,
     },
   });
   return (Story) => (

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -158,6 +158,7 @@ export interface SessionConversationCopy {
   sourceTurnId: string;
   requestFingerprint: `sha256:${string}`;
   state: 'preparing' | 'committed';
+  intent?: 'side_conversation';
 }
 
 export type SubagentSessionRuntimeSummary = Omit<
@@ -452,7 +453,7 @@ const SUBAGENT_SESSION_SPAWN_IDENTITY_SHAPE = defineObjectShape<SubagentSessionS
 );
 const SESSION_CONVERSATION_COPY_SHAPE = defineObjectShape<SessionConversationCopy>()(
   ['kind', 'sourceSessionId', 'sourceTurnId', 'requestFingerprint', 'state'],
-  [],
+  ['intent'],
 );
 const SESSION_LINEAGE_ID_MAX_CHARS = 512;
 const SESSION_LINEAGE_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
@@ -551,6 +552,8 @@ export function isSessionConversationCopy(value: unknown): value is SessionConve
     isRecord(value) &&
     hasExactShape(value, SESSION_CONVERSATION_COPY_SHAPE) &&
     (value.kind === 'branch' || value.kind === 'revision') &&
+    (value.intent === undefined ||
+      (value.kind === 'branch' && value.intent === 'side_conversation')) &&
     isSessionLineageId(value.sourceSessionId) &&
     isSessionLineageId(value.sourceTurnId) &&
     typeof value.requestFingerprint === 'string' &&

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -182,6 +182,13 @@ describe('Runtime Host bootstrap protocol', () => {
     assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 46);
   });
 
+  test('publishes a new compatibility epoch for Side Conversation copy intent', () => {
+    // Epoch 47 belongs to project registration preferences on current main.
+    // Side Conversation adds another closed branch-copy input and therefore
+    // needs its own later handshake boundary.
+    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 47);
+  });
+
   test('adds credential rotation without changing existing credential inputs', () => {
     const issueInput = {
       principalKind: 'remote_owner',

--- a/packages/runtime-host/src/__tests__/session-revision-graph-references.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-graph-references.test.ts
@@ -72,6 +72,76 @@ test('Agent Graph revision references preserve only exact terminal provenance', 
   assert.equal(archived.ok, true);
 });
 
+test('Side Conversation references accept terminal linked children as snapshots', async () => {
+  const accepted = await prepare({ kind: 'side_conversation' });
+  assert.equal(accepted.ok, true);
+  if (!accepted.ok) assert.fail('Expected accepted Side Conversation references');
+  assert.deepEqual([...accepted.references.keys()], [CHILD_SESSION_ID]);
+});
+
+test('Side Conversation references accept terminal non-Graph child Sessions as snapshots', async () => {
+  const accepted = await prepare({
+    kind: 'side_conversation',
+    messages: [linkedSubagentResult('completed')],
+    sessionHeaders: [sessionHeader(ROOT_SESSION_ID), childHeader({ graph: false })],
+  });
+  assert.equal(accepted.ok, true);
+  if (!accepted.ok) assert.fail('Expected accepted linked-child snapshot');
+  assert.deepEqual([...accepted.references.keys()], [CHILD_SESSION_ID]);
+});
+
+test('Side Conversation references wait for live Graph and child state', async () => {
+  for (const input of [
+    { graphState: 'live' as const },
+    { childActive: true },
+    { messages: [linkedSubagentResult('running')] },
+  ]) {
+    const outcome = await prepare({ kind: 'side_conversation', ...input });
+    assert.equal(outcome.ok, false);
+    if (!outcome.ok) assert.equal(outcome.code, 'session_busy');
+  }
+});
+
+test('Side Conversation rejects a retained child without a terminal result snapshot', async () => {
+  const outcome = await prepare({
+    kind: 'side_conversation',
+    messages: [],
+    sessionHeaders: [sessionHeader(ROOT_SESSION_ID), childHeader({ graph: false })],
+  });
+  assert.deepEqual(outcome, {
+    ok: false,
+    code: 'operation_unavailable',
+    message: 'Side Conversation requires a terminal result for every retained linked child',
+  });
+});
+
+test('Side Conversation waits for a live retained child before its result is committed', async () => {
+  const outcome = await prepare({
+    kind: 'side_conversation',
+    messages: [],
+    childActive: true,
+    sessionHeaders: [sessionHeader(ROOT_SESSION_ID), childHeader({ graph: false })],
+  });
+  assert.deepEqual(outcome, {
+    ok: false,
+    code: 'session_busy',
+    message: 'A retained linked child is still active',
+  });
+});
+
+test('Side Conversation waits for a live retained Graph before its result is committed', async () => {
+  const outcome = await prepare({
+    kind: 'side_conversation',
+    messages: [],
+    graphState: 'live',
+  });
+  assert.deepEqual(outcome, {
+    ok: false,
+    code: 'session_busy',
+    message: 'A retained Agent Graph is not terminal',
+  });
+});
+
 test('Agent Graph revision references reject incomplete or mismatched provenance', async () => {
   const cases: ReadonlyArray<{
     name: string;
@@ -228,7 +298,7 @@ test('Agent Graph revision admission includes only retained direct and reference
 });
 
 interface PrepareOverrides {
-  readonly kind?: 'branch' | 'revision';
+  readonly kind?: 'branch' | 'revision' | 'side_conversation';
   readonly messages?: readonly StoredMessage[];
   readonly archivedResults?: readonly string[];
   readonly sessionHeaders?: readonly SessionHeader[];

--- a/packages/runtime-host/src/__tests__/session-revision-graph-references.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-graph-references.test.ts
@@ -102,6 +102,25 @@ test('Side Conversation references wait for live Graph and child state', async (
   }
 });
 
+test('Side Conversation validates the retained Graph instead of a newer live Graph', async () => {
+  const sideConversation = await prepare({
+    kind: 'side_conversation',
+    sessionGraphState: 'live',
+    graphState: 'terminal',
+  });
+  assert.equal(sideConversation.ok, true);
+
+  const revision = await prepare({
+    sessionGraphState: 'live',
+    graphState: 'terminal',
+  });
+  assert.deepEqual(revision, {
+    ok: false,
+    code: 'session_busy',
+    message: 'A retained Agent Graph is not terminal',
+  });
+});
+
 test('Side Conversation rejects a retained child without a terminal result snapshot', async () => {
   const outcome = await prepare({
     kind: 'side_conversation',
@@ -303,6 +322,7 @@ interface PrepareOverrides {
   readonly archivedResults?: readonly string[];
   readonly sessionHeaders?: readonly SessionHeader[];
   readonly runs?: readonly AgentRunHeader[];
+  readonly sessionGraphState?: 'absent' | 'live' | 'terminal';
   readonly graphState?: 'absent' | 'live' | 'terminal';
   readonly artifactTurnId?: string;
   readonly artifactStatus?: 'live' | 'deleted';
@@ -349,7 +369,8 @@ async function prepare(overrides: PrepareOverrides = {}) {
         }),
       },
       graph: {
-        readSessionState: async () => overrides.graphState ?? 'terminal',
+        readSessionState: async () =>
+          overrides.sessionGraphState ?? overrides.graphState ?? 'terminal',
         readGraphState: async (_rootSessionId, graphId) => {
           if (graphId !== agentGraphIdForRootSession(ROOT_SESSION_ID)) {
             throw new Error('Graph is not bound to this root Session');

--- a/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
@@ -28,6 +28,63 @@ import {
 } from '../protocol/index.js';
 
 describe('Session revision protocol', () => {
+  test('accepts only the Side Conversation branch intent', () => {
+    assert.deepEqual(
+      decodeClientFrame({
+        requestId: 'request-side-conversation',
+        operation: 'session.branch.create',
+        input: {
+          sourceSessionId: 'source-session',
+          targetSessionId: 'target-session',
+          sourceTurnId: 'turn-1',
+          expectedSourceRevision: 1,
+          intent: 'side_conversation',
+        },
+      }),
+      {
+        requestId: 'request-side-conversation',
+        operation: 'session.branch.create',
+        input: {
+          sourceSessionId: 'source-session',
+          targetSessionId: 'target-session',
+          sourceTurnId: 'turn-1',
+          expectedSourceRevision: 1,
+          intent: 'side_conversation',
+        },
+      },
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          requestId: 'request-invalid-purpose',
+          operation: 'session.branch.create',
+          input: {
+            sourceSessionId: 'source-session',
+            targetSessionId: 'target-session',
+            sourceTurnId: 'turn-1',
+            expectedSourceRevision: 1,
+            intent: 'ordinary',
+          },
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          requestId: 'request-revision-purpose',
+          operation: 'session.revision.create',
+          input: {
+            sourceSessionId: 'source-session',
+            targetSessionId: 'target-session',
+            sourceTurnId: 'turn-1',
+            expectedSourceRevision: 1,
+            intent: 'side_conversation',
+          },
+        }),
+      isInvalidFrame,
+    );
+  });
+
   test('rejects aliasing, unknown fields, and mismatched response identities', () => {
     assert.throws(
       () =>

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -66,6 +66,7 @@ const GRAPH_REVISION_TARGET_ID = 'graph-revision-target';
 const GRAPH_SIDE_CONVERSATION_TARGET_ID = 'graph-side-conversation-target';
 const GRAPH_SIDE_CONVERSATION_REMOVAL_TARGET_ID = 'graph-side-conversation-removal-target';
 const ARCHIVED_SIDE_CONVERSATION_TARGET_ID = 'archived-side-conversation-target';
+const ACTIVE_SOURCE_SIDE_CONVERSATION_TARGET_ID = 'active-source-side-conversation-target';
 
 test('two Clients share exact retryable Session branch and revision authority', {
   skip: process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false,
@@ -121,6 +122,7 @@ test('two Clients share exact retryable Session branch and revision authority', 
       GRAPH_REVISION_TARGET_ID,
       GRAPH_SIDE_CONVERSATION_TARGET_ID,
       ARCHIVED_SIDE_CONVERSATION_TARGET_ID,
+      ACTIVE_SOURCE_SIDE_CONVERSATION_TARGET_ID,
       graphChildSessionId,
     );
   } finally {
@@ -461,6 +463,66 @@ async function verifyConcurrentRevisionAuthority(
         throw new AggregateError(
           [assertionError, cleanupError],
           'session_busy check failed and parked-turn cleanup failed',
+        );
+      }
+      throw cleanupError;
+    }
+    if (assertionError !== undefined) throw assertionError;
+
+    const activeSourceTurn = requireStartedTurn(
+      await desktop.startTurn({
+        sessionId: sourceSessionId,
+        turnId: 'active-source-turn',
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+      }),
+    );
+    assertionError = undefined;
+    try {
+      const activeSource = await querySession(desktop, sourceSessionId);
+      const historicalCopyInput = {
+        sourceSessionId,
+        sourceTurnId: 'turn-2',
+        expectedSourceRevision: activeSource.revision,
+      };
+      await assert.rejects(
+        tui.request('session.branch.create', {
+          ...historicalCopyInput,
+          targetSessionId: 'active-source-ordinary-branch-target',
+        }),
+        operationError('session_busy'),
+      );
+      const sideConversation = await tui.request('session.branch.create', {
+        ...historicalCopyInput,
+        targetSessionId: ACTIVE_SOURCE_SIDE_CONVERSATION_TARGET_ID,
+        intent: 'side_conversation',
+      });
+      assert.equal(sideConversation.kind, 'committed');
+      if (sideConversation.kind !== 'committed') {
+        assert.fail('Side Conversation must fork a settled Turn while the source keeps running');
+      }
+      assert.ok(
+        requireSessionProjection(sideConversation.session).labels.includes(
+          'mode:side_conversation',
+        ),
+      );
+    } catch (error) {
+      assertionError = error;
+    }
+    try {
+      const stopped = await desktop.stopTurn(
+        {
+          sessionId: sourceSessionId,
+          turnId: 'active-source-turn',
+          runId: activeSourceTurn.runId,
+        },
+        PROCESS_TIMEOUT_MS,
+      );
+      assert.equal(stopped.status, 'cancelled');
+    } catch (cleanupError) {
+      if (assertionError !== undefined) {
+        throw new AggregateError(
+          [assertionError, cleanupError],
+          'active-source Side Conversation check failed and parked-turn cleanup failed',
         );
       }
       throw cleanupError;
@@ -1416,6 +1478,7 @@ async function verifyDurableBranch(
   graphRevisionTargetId: string,
   graphSideConversationTargetId: string,
   archivedSideConversationTargetId: string,
+  activeSourceSideConversationTargetId: string,
   graphChildSessionId: string,
 ): Promise<void> {
   const owner = await tryAcquireInteractiveRootOwner(capability);
@@ -1490,6 +1553,15 @@ async function verifyDurableBranch(
     assert.equal(sideConversationResult.content.items[0]?.runId, undefined);
     const sideConversationArtifactId = sideConversationResult.content.items[0]?.artifactIds[0];
     assert.ok(sideConversationArtifactId);
+    const activeSourceSideConversationMessages = await execution.sessionStore.readMessagesSnapshot(
+      activeSourceSideConversationTargetId,
+    );
+    assert.ok(activeSourceSideConversationMessages.some((message) => message.turnId === 'turn-2'));
+    assert.ok(
+      activeSourceSideConversationMessages.every(
+        (message) => message.turnId !== 'active-source-turn',
+      ),
+    );
     const sideConversationRuns = await execution.agentRunStore.listSessionRuns(
       graphSideConversationTargetId,
     );

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -63,6 +63,9 @@ const ADMITTED_REVISION_TARGET_ID = 'admitted-revision-target';
 const LINEAGE_REVISION_TARGET_ID = 'lineage-revision-target';
 const LINEAGE_BRANCH_TARGET_ID = 'lineage-branch-target';
 const GRAPH_REVISION_TARGET_ID = 'graph-revision-target';
+const GRAPH_SIDE_CONVERSATION_TARGET_ID = 'graph-side-conversation-target';
+const GRAPH_SIDE_CONVERSATION_REMOVAL_TARGET_ID = 'graph-side-conversation-removal-target';
+const ARCHIVED_SIDE_CONVERSATION_TARGET_ID = 'archived-side-conversation-target';
 
 test('two Clients share exact retryable Session branch and revision authority', {
   skip: process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false,
@@ -116,6 +119,8 @@ test('two Clients share exact retryable Session branch and revision authority', 
       LINEAGE_REVISION_TARGET_ID,
       LINEAGE_BRANCH_TARGET_ID,
       GRAPH_REVISION_TARGET_ID,
+      GRAPH_SIDE_CONVERSATION_TARGET_ID,
+      ARCHIVED_SIDE_CONVERSATION_TARGET_ID,
       graphChildSessionId,
     );
   } finally {
@@ -178,6 +183,50 @@ async function verifyConcurrentRevisionAuthority(
       }),
       { kind: 'session', session: null },
     );
+    const sideConversation = await desktop.request('session.branch.create', {
+      sourceSessionId: linkedChildSourceSessionId,
+      targetSessionId: GRAPH_SIDE_CONVERSATION_TARGET_ID,
+      sourceTurnId: 'linked-turn',
+      expectedSourceRevision: linkedChildSource.revision,
+      intent: 'side_conversation',
+    });
+    assert.equal(sideConversation.kind, 'committed');
+    if (sideConversation.kind !== 'committed') {
+      assert.fail('Side Conversation must commit');
+    }
+    const sideConversationSession = requireSessionProjection(sideConversation.session);
+    assert.ok(sideConversationSession.labels.includes('mode:side_conversation'));
+    await assert.rejects(
+      desktop.request('session.branch.create', {
+        sourceSessionId: linkedChildSourceSessionId,
+        targetSessionId: GRAPH_SIDE_CONVERSATION_TARGET_ID,
+        sourceTurnId: 'linked-turn',
+        expectedSourceRevision: linkedChildSource.revision,
+      }),
+      operationError('operation_conflict'),
+    );
+    const removableSideConversation = await desktop.request('session.branch.create', {
+      sourceSessionId: linkedChildSourceSessionId,
+      targetSessionId: GRAPH_SIDE_CONVERSATION_REMOVAL_TARGET_ID,
+      sourceTurnId: 'linked-turn',
+      expectedSourceRevision: linkedChildSource.revision,
+      intent: 'side_conversation',
+    });
+    assert.equal(removableSideConversation.kind, 'committed');
+    if (removableSideConversation.kind !== 'committed') {
+      assert.fail('Removable Side Conversation must commit');
+    }
+    const removableSideConversationSession = requireSessionProjection(
+      removableSideConversation.session,
+    );
+    assert.deepEqual(
+      await desktop.request('session.remove', {
+        sessionId: GRAPH_SIDE_CONVERSATION_REMOVAL_TARGET_ID,
+        expectedRevision: removableSideConversationSession.revision,
+      }),
+      { kind: 'removed', sessionId: GRAPH_SIDE_CONVERSATION_REMOVAL_TARGET_ID },
+    );
+    assert.equal((await querySession(tui, graphChildSessionId)).id, graphChildSessionId);
     const graphRevision = await desktop.request('session.revision.create', {
       sourceSessionId: linkedChildSourceSessionId,
       targetSessionId: GRAPH_REVISION_TARGET_ID,
@@ -240,6 +289,14 @@ async function verifyConcurrentRevisionAuthority(
       }),
       operationError('operation_unavailable'),
     );
+    const archivedSideConversation = await desktop.request('session.branch.create', {
+      sourceSessionId: archivedOwnedSourceSessionId,
+      targetSessionId: ARCHIVED_SIDE_CONVERSATION_TARGET_ID,
+      sourceTurnId: 'archived-owned-turn',
+      expectedSourceRevision: archivedOwnedSource.revision,
+      intent: 'side_conversation',
+    });
+    assert.equal(archivedSideConversation.kind, 'committed');
     for (const sessionId of ['metadata-linked-copy-target', 'archived-owned-copy-target']) {
       assert.deepEqual(
         await tui.request('session.catalog.query', {
@@ -1357,6 +1414,8 @@ async function verifyDurableBranch(
   lineageRevisionTargetId: string,
   lineageBranchTargetId: string,
   graphRevisionTargetId: string,
+  graphSideConversationTargetId: string,
+  archivedSideConversationTargetId: string,
   graphChildSessionId: string,
 ): Promise<void> {
   const owner = await tryAcquireInteractiveRootOwner(capability);
@@ -1408,6 +1467,101 @@ async function verifyDurableBranch(
       (await execution.sessionStore.readHeaderSnapshot(lineageBranchTargetId)).parentSessionId,
       lineageRevisionTargetId,
     );
+    const sideConversationHeader = await execution.sessionStore.readHeaderSnapshot(
+      graphSideConversationTargetId,
+    );
+    assert.equal(sideConversationHeader.conversationCopy?.intent, 'side_conversation');
+    assert.ok(sideConversationHeader.labels.includes('mode:side_conversation'));
+    const sideConversationMessages = await execution.sessionStore.readMessagesSnapshot(
+      graphSideConversationTargetId,
+    );
+    const sideConversationResult = sideConversationMessages.find(
+      (message) => message.type === 'tool_result' && message.content.kind === 'agent_swarm',
+    );
+    assert.ok(sideConversationResult?.type === 'tool_result');
+    if (
+      sideConversationResult?.type !== 'tool_result' ||
+      sideConversationResult.content.kind !== 'agent_swarm'
+    ) {
+      assert.fail('Side Conversation must retain the Agent Graph summary');
+    }
+    assert.equal(sideConversationResult.content.items[0]?.summary, 'done');
+    assert.equal(sideConversationResult.content.items[0]?.childSessionId, undefined);
+    assert.equal(sideConversationResult.content.items[0]?.runId, undefined);
+    const sideConversationArtifactId = sideConversationResult.content.items[0]?.artifactIds[0];
+    assert.ok(sideConversationArtifactId);
+    const sideConversationRuns = await execution.agentRunStore.listSessionRuns(
+      graphSideConversationTargetId,
+    );
+    const sideConversationRun = sideConversationRuns.find((run) => run.turnId === 'linked-turn');
+    assert.ok(sideConversationRun);
+    const sideConversationRuntimeResult = (
+      await execution.runtimeEventStore.readRuntimeEvents(
+        graphSideConversationTargetId,
+        sideConversationRun.runId,
+      )
+    ).find((event) => event.content?.kind === 'function_response')?.content;
+    assert.ok(sideConversationRuntimeResult?.kind === 'function_response');
+    if (sideConversationRuntimeResult?.kind !== 'function_response') {
+      assert.fail('Side Conversation must retain its RuntimeEvent result snapshot');
+    }
+    const runtimeSideConversationResult = decodeCanonicalToolResultContent(
+      sideConversationRuntimeResult.result,
+    );
+    assert.equal(runtimeSideConversationResult.kind, 'agent_swarm');
+    if (runtimeSideConversationResult.kind !== 'agent_swarm') {
+      assert.fail('Copied RuntimeEvent result must remain an Agent Graph result');
+    }
+    assert.equal(runtimeSideConversationResult.items[0]?.childSessionId, undefined);
+    assert.equal(runtimeSideConversationResult.items[0]?.runId, undefined);
+    assert.deepEqual(runtimeSideConversationResult.items[0]?.artifactIds, [
+      sideConversationArtifactId,
+    ]);
+    assert.deepEqual(
+      await artifacts.readTextInSession(graphSideConversationTargetId, sideConversationArtifactId),
+      {
+        ok: true,
+        text: 'graph child result',
+      },
+    );
+    const archivedSideConversationRuns = await execution.agentRunStore.listSessionRuns(
+      archivedSideConversationTargetId,
+    );
+    const archivedSideConversationChildRun = archivedSideConversationRuns.find(
+      (run) => run.turnId === 'archived-owned-child-turn',
+    );
+    assert.ok(archivedSideConversationChildRun);
+    const archivedSideConversationResult = (
+      await execution.runtimeEventStore.readRuntimeEvents(
+        archivedSideConversationTargetId,
+        archivedSideConversationChildRun.runId,
+      )
+    ).find((event) => event.content?.kind === 'function_response')?.content;
+    assert.ok(archivedSideConversationResult?.kind === 'function_response');
+    if (archivedSideConversationResult?.kind !== 'function_response') {
+      assert.fail('Side Conversation must retain its archived tool result placeholder');
+    }
+    const archivedSideConversationContent = decodeCanonicalToolResultContent(
+      archivedSideConversationResult.result,
+    );
+    assert.equal(archivedSideConversationContent.kind, 'subagent');
+    if (archivedSideConversationContent.kind !== 'subagent') {
+      assert.fail('Copied archived child result must be restored as a static snapshot');
+    }
+    assert.deepEqual(archivedSideConversationContent, {
+      kind: 'subagent',
+      agentName: 'Worker',
+      turnId: 'archived-owned-child-turn',
+      status: 'completed',
+      permissionMode: 'ask',
+      summary: 'done',
+      artifactIds: [],
+    });
+    const archivedSideConversationArtifacts = await artifacts.listPage(
+      archivedSideConversationTargetId,
+      { offset: 0, limit: 10 },
+    );
+    assert.equal(archivedSideConversationArtifacts.total, 0);
     const graphRevisionMessages =
       await execution.sessionStore.readMessagesSnapshot(graphRevisionTargetId);
     const graphResult = graphRevisionMessages.find(

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -1620,10 +1620,12 @@ async function verifyDurableBranch(
     if (archivedSideConversationContent.kind !== 'subagent') {
       assert.fail('Copied archived child result must be restored as a static snapshot');
     }
+    assert.notEqual(archivedSideConversationContent.runId, 'archived-owned-child-run');
     assert.deepEqual(archivedSideConversationContent, {
       kind: 'subagent',
       agentName: 'Worker',
       turnId: 'archived-owned-child-turn',
+      runId: archivedSideConversationChildRun.runId,
       status: 'completed',
       permissionMode: 'ask',
       summary: 'done',

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -91,7 +91,9 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 47 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 48 as const;
+// 48: Session branch creation accepts an explicit Side Conversation intent.
+// Older peers reject the strict input shape or cannot apply its snapshot semantics.
 // 47: Project registration can carry an explicit location preference. Epoch-46
 // hosts reject that optional field on the closed registration input.
 // 46: Queued message content can be edited in place (queue.entry.update).

--- a/packages/runtime-host/src/protocol/session-revision.ts
+++ b/packages/runtime-host/src/protocol/session-revision.ts
@@ -17,7 +17,13 @@
  * under the License.
  */
 
-import { requireCount, requireEntityId, requireExactRecord, requireRecord } from './codec.js';
+import {
+  requireCount,
+  requireEntityId,
+  requireExactRecord,
+  requireRecord,
+  requireShapedRecord,
+} from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
 import { defineOperation } from './operation-spec.js';
 import { decodeSessionCatalogItem, type SessionCatalogItem } from './session-catalog.js';
@@ -40,6 +46,7 @@ export interface SessionConversationCopyInput {
   readonly targetSessionId: string;
   readonly sourceTurnId: string;
   readonly expectedSourceRevision: number;
+  readonly intent?: 'side_conversation';
 }
 
 export type SessionConversationCopyResult =
@@ -82,7 +89,7 @@ export const SESSION_REVISION_OPERATION_SPECS = {
     mode: 'command',
     availability: 'ready',
     errors: SESSION_COPY_ERRORS,
-    decodeInput: decodeSessionConversationCopyInput,
+    decodeInput: decodeSessionRevisionCopyInput,
     decodeOutput: decodeSessionConversationCopyResult,
     assertOutputForInput: assertConversationCopyOutput,
   }),
@@ -104,6 +111,14 @@ export const SESSION_REVISION_OPERATION_SPECS = {
   }),
 } as const;
 
+function decodeSessionRevisionCopyInput(value: unknown): SessionConversationCopyInput {
+  const input = decodeSessionConversationCopyInput(value);
+  if (input.intent !== undefined) {
+    throw invalidProtocolFrame('Session revision copy does not support an intent');
+  }
+  return input;
+}
+
 function decodeSessionRevisionAbandonInput(value: unknown): SessionRevisionAbandonInput {
   const input = requireExactRecord(value, 'Session revision abandon input', ['targetSessionId']);
   return { targetSessionId: requireEntityId(input.targetSessionId, 'targetSessionId') };
@@ -124,16 +139,19 @@ function decodeSessionRevisionAbandonResult(value: unknown): SessionRevisionAban
 }
 
 export function decodeSessionConversationCopyInput(value: unknown): SessionConversationCopyInput {
-  const input = requireExactRecord(value, 'Session conversation-copy input', [
-    'sourceSessionId',
-    'targetSessionId',
-    'sourceTurnId',
-    'expectedSourceRevision',
-  ]);
+  const input = requireShapedRecord(
+    value,
+    'Session conversation-copy input',
+    ['sourceSessionId', 'targetSessionId', 'sourceTurnId', 'expectedSourceRevision'],
+    ['intent'],
+  );
   const sourceSessionId = requireEntityId(input.sourceSessionId, 'sourceSessionId');
   const targetSessionId = requireEntityId(input.targetSessionId, 'targetSessionId');
   if (sourceSessionId === targetSessionId) {
     throw invalidProtocolFrame('Session conversation copy requires distinct Sessions');
+  }
+  if (input.intent !== undefined && input.intent !== 'side_conversation') {
+    throw invalidProtocolFrame('Invalid Session conversation-copy intent');
   }
   return {
     sourceSessionId,
@@ -143,6 +161,7 @@ export function decodeSessionConversationCopyInput(value: unknown): SessionConve
       input.expectedSourceRevision,
       'expected source Session revision',
     ),
+    ...(input.intent === 'side_conversation' ? { intent: input.intent } : {}),
   };
 }
 

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -19,6 +19,7 @@
 
 import { createHash, randomUUID } from 'node:crypto';
 import { isDeepResearchSession } from '@maka/core/explore-agent';
+import { SIDE_CONVERSATION_SESSION_LABEL } from '@maka/core/side-conversation';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
 import {
@@ -28,6 +29,7 @@ import {
   type StoredMessage,
 } from '@maka/core/session';
 import {
+  archivedToolResultContainsLinkedChildReferences,
   archivedToolResultContainsConversationOwnedReferences,
   cloneConversationRuntimeLedger,
   collectConversationCopyLinkedChildReferences,
@@ -71,6 +73,7 @@ import {
 import { purgeSessionSidecars } from './session-sidecar-purge.js';
 
 type ConversationCopyKind = 'branch' | 'revision';
+type ConversationCopySemanticKind = ConversationCopyKind | 'side_conversation';
 type ConversationCopyOperationKey = Exclude<
   SessionRevisionOperationKey,
   'session.revision.abandon'
@@ -172,9 +175,10 @@ export class HostSessionRevisionCoordinator {
     kind: ConversationCopyKind,
     input: SessionConversationCopyInput,
   ): Promise<ConversationCopyOutcome> {
-    const requestFingerprint = conversationCopyFingerprint(kind, input);
+    const semanticKind = conversationCopySemanticKind(kind, input);
+    const requestFingerprint = conversationCopyFingerprint(semanticKind, input);
     const retry = await this.options.admission.run(input.targetSessionId, async () =>
-      this.#resolveExistingTarget(kind, input, requestFingerprint, true),
+      this.#resolveExistingTarget(semanticKind, input, requestFingerprint, true),
     );
     if (retry) return retry;
 
@@ -200,7 +204,7 @@ export class HostSessionRevisionCoordinator {
     // lanes and keep the complete lease through validation and publication.
     for (let pass = 0; pass < CONVERSATION_COPY_ADMISSION_PASSES; pass += 1) {
       const result = await this.options.admission.runMany([...admittedSessionIds], (lease) =>
-        this.#copyAdmitted(kind, input, requestFingerprint, lease, admittedSessionIds),
+        this.#copyAdmitted(semanticKind, input, requestFingerprint, lease, admittedSessionIds),
       );
       if ('ok' in result) return result;
       for (const sessionId of result.sessionIds) admittedSessionIds.add(sessionId);
@@ -245,7 +249,7 @@ export class HostSessionRevisionCoordinator {
   }
 
   async #copyAdmitted(
-    kind: ConversationCopyKind,
+    kind: ConversationCopySemanticKind,
     input: SessionConversationCopyInput,
     requestFingerprint: `sha256:${string}`,
     lease: SessionAdmissionLease,
@@ -306,7 +310,7 @@ export class HostSessionRevisionCoordinator {
     const slice = createConversationCopySlice(
       source.messages,
       input.sourceTurnId,
-      kind === 'branch' ? 'through' : 'before',
+      kind === 'revision' ? 'before' : 'through',
     );
     if (!slice) {
       return copyFailure('invalid_request', 'Source turn does not exist');
@@ -388,6 +392,7 @@ export class HostSessionRevisionCoordinator {
       return copyFailure(linkedReferences.code, linkedReferences.message);
     }
     if (
+      kind !== 'side_conversation' &&
       archivePreflight.serializedResults.some((serializedResult) =>
         archivedToolResultContainsConversationOwnedReferences(
           serializedResult,
@@ -447,10 +452,34 @@ export class HostSessionRevisionCoordinator {
     }
 
     try {
+      const archivedSnapshotResults = new Map(
+        archivePreflight.results
+          .filter(
+            ({ serializedResult }) =>
+              archivedToolResultContainsLinkedChildReferences(serializedResult) ||
+              archivedToolResultContainsConversationOwnedReferences(
+                serializedResult,
+                input.sourceSessionId,
+                linkedReferences.references,
+              ),
+          )
+          .map(({ descriptor, serializedResult }) => [descriptor.artifactId, serializedResult]),
+      );
       const artifactCopy = await this.#artifacts.copyConversationArtifacts({
         sourceSessionId: input.sourceSessionId,
         targetSessionId: input.targetSessionId,
         turnIds: copyTurnIds,
+        ...(kind === 'side_conversation' && archivedSnapshotResults.size > 0
+          ? { excludeArtifactIds: [...archivedSnapshotResults.keys()] }
+          : {}),
+        ...(kind === 'side_conversation' && linkedReferences.references.size > 0
+          ? {
+              linkedArtifacts: [...linkedReferences.references].map(([sessionId, references]) => ({
+                sessionId,
+                artifactIds: [...references.artifactIds],
+              })),
+            }
+          : {}),
       });
       const references = {
         mode: 'exact' as const,
@@ -459,12 +488,18 @@ export class HostSessionRevisionCoordinator {
         artifactIds: artifactCopy.artifactIds,
         relativePaths: artifactCopy.relativePaths,
         linkedChildren:
-          linkedReferences.references.size > 0
+          kind === 'side_conversation'
             ? {
-                mode: 'preserve_validated' as const,
-                references: linkedReferences.references,
+                mode: 'snapshot' as const,
+                archivedResults: archivedSnapshotResults,
+                artifactIds: artifactCopy.artifactIds,
               }
-            : { mode: 'reject' as const },
+            : linkedReferences.references.size > 0
+              ? {
+                  mode: 'preserve_validated' as const,
+                  references: linkedReferences.references,
+                }
+              : { mode: 'reject' as const },
       };
       const runtimeCopy = await cloneConversationRuntimeLedger({
         plan,
@@ -481,6 +516,7 @@ export class HostSessionRevisionCoordinator {
         turnIds: copyTurnIds,
         ...(slice.beforeTs === undefined ? {} : { beforeTs: slice.beforeTs }),
         runIdMap: runtimeCopy.runIdMap,
+        ...(kind === 'side_conversation' ? { linkedChildren: 'snapshot' as const } : {}),
       });
       if (copiedMessages.length > 0) {
         await this.#stores.sessionStore.appendMessages(input.targetSessionId, [...copiedMessages]);
@@ -523,7 +559,14 @@ export class HostSessionRevisionCoordinator {
     copiedMessages: readonly StoredMessage[],
     copyTurnIds: readonly string[],
   ): Promise<
-    | { readonly ok: true; readonly serializedResults: readonly string[] }
+    | {
+        readonly ok: true;
+        readonly results: readonly {
+          readonly descriptor: ArchivedToolResultCopyDescriptor;
+          readonly serializedResult: string;
+        }[];
+        readonly serializedResults: readonly string[];
+      }
     | { readonly ok: false; readonly outcome: ConversationCopyOutcome }
   > {
     const archives = collectArchivedToolResultPlaceholders(
@@ -537,7 +580,10 @@ export class HostSessionRevisionCoordinator {
         outcome: copyFailure('persistence_failed', 'Archived tool result metadata is invalid'),
       };
     }
-    const serializedResults: string[] = [];
+    const results: Array<{
+      descriptor: ArchivedToolResultCopyDescriptor;
+      serializedResult: string;
+    }> = [];
     for (const archive of archives) {
       const read = await this.#artifacts
         .readTextInSession(sourceSessionId, archive.artifactId, {
@@ -557,13 +603,17 @@ export class HostSessionRevisionCoordinator {
           ),
         };
       }
-      serializedResults.push(read.text);
+      results.push({ descriptor: archive, serializedResult: read.text });
     }
-    return { ok: true, serializedResults };
+    return {
+      ok: true,
+      results,
+      serializedResults: results.map(({ serializedResult }) => serializedResult),
+    };
   }
 
   async #createInput(
-    kind: ConversationCopyKind,
+    kind: ConversationCopySemanticKind,
     input: SessionConversationCopyInput,
     requestFingerprint: `sha256:${string}`,
     source: SessionHeader,
@@ -578,17 +628,21 @@ export class HostSessionRevisionCoordinator {
       collaborationMode: source.collaborationMode ?? 'agent',
       orchestrationMode: source.orchestrationMode ?? 'default',
       name: source.name,
-      labels: [...source.labels],
+      labels:
+        kind === 'side_conversation'
+          ? [...new Set([...source.labels, SIDE_CONVERSATION_SESSION_LABEL])]
+          : [...source.labels],
       conversationCopy: {
-        kind,
+        kind: kind === 'revision' ? 'revision' : 'branch',
         sourceSessionId: input.sourceSessionId,
         sourceTurnId: input.sourceTurnId,
         requestFingerprint,
         state: 'preparing',
+        ...(kind === 'side_conversation' ? { intent: kind } : {}),
       },
       status: 'active',
     };
-    if (kind === 'branch') {
+    if (kind !== 'revision') {
       return {
         ...common,
         parentSessionId: input.sourceSessionId,
@@ -617,7 +671,7 @@ export class HostSessionRevisionCoordinator {
   }
 
   async #resolveExistingTarget(
-    kind: ConversationCopyKind,
+    kind: ConversationCopySemanticKind,
     input: SessionConversationCopyInput,
     requestFingerprint: `sha256:${string}`,
     discardPreparing: boolean,
@@ -640,7 +694,8 @@ export class HostSessionRevisionCoordinator {
     }
     const copy = probe.record.header.conversationCopy;
     if (
-      copy?.kind !== kind ||
+      copy?.kind !== (kind === 'revision' ? 'revision' : 'branch') ||
+      copy.intent !== (kind === 'side_conversation' ? kind : undefined) ||
       copy.sourceSessionId !== input.sourceSessionId ||
       copy.sourceTurnId !== input.sourceTurnId ||
       copy.requestFingerprint !== requestFingerprint
@@ -679,7 +734,7 @@ export class HostSessionRevisionCoordinator {
   }
 
   async #rollbackIncompleteCopy(
-    kind: ConversationCopyKind,
+    kind: ConversationCopySemanticKind,
     input: SessionConversationCopyInput,
     requestFingerprint: `sha256:${string}`,
     message: string,
@@ -703,7 +758,7 @@ export class HostSessionRevisionCoordinator {
   }
 
   async #unknownAfterCommitAttempt(
-    kind: ConversationCopyKind,
+    kind: ConversationCopySemanticKind,
     input: SessionConversationCopyInput,
     requestFingerprint: `sha256:${string}`,
     message: string,
@@ -771,27 +826,33 @@ function isConversationRuntimeFactRewriteUnsupported(error: unknown): boolean {
 }
 
 function conversationCopyFingerprint(
-  kind: ConversationCopyKind,
+  kind: ConversationCopySemanticKind,
   input: SessionConversationCopyInput,
 ): `sha256:${string}` {
   // The optimistic source revision guards only the initial create. Once this
   // target exists, its stable identity must resolve the committed outcome even
   // if a reconnecting Client observes a newer source revision.
-  return `sha256:${createHash('sha256')
-    .update(
-      JSON.stringify([
-        'session.conversation-copy.v1',
-        kind,
-        input.sourceSessionId,
-        input.targetSessionId,
-        input.sourceTurnId,
-      ]),
-    )
-    .digest('hex')}`;
+  const identity =
+    kind === 'side_conversation'
+      ? [
+          'session.conversation-copy.v2',
+          kind,
+          input.sourceSessionId,
+          input.targetSessionId,
+          input.sourceTurnId,
+        ]
+      : [
+          'session.conversation-copy.v1',
+          kind,
+          input.sourceSessionId,
+          input.targetSessionId,
+          input.sourceTurnId,
+        ];
+  return `sha256:${createHash('sha256').update(JSON.stringify(identity)).digest('hex')}`;
 }
 
 function conversationCopyStartNote(
-  kind: ConversationCopyKind,
+  kind: ConversationCopySemanticKind,
   input: SessionConversationCopyInput,
   createInput: ConversationCopyCreateInput,
 ): StoredMessage {
@@ -801,7 +862,7 @@ function conversationCopyStartNote(
     ts: Date.now(),
     kind: 'session_start',
     data:
-      kind === 'branch'
+      kind !== 'revision'
         ? {
             parentSessionId: input.sourceSessionId,
             branchOfTurnId: input.sourceTurnId,
@@ -814,6 +875,13 @@ function conversationCopyStartNote(
             revisionState: 'preparing',
           },
   };
+}
+
+function conversationCopySemanticKind(
+  kind: ConversationCopyKind,
+  input: SessionConversationCopyInput,
+): ConversationCopySemanticKind {
+  return kind === 'branch' && input.intent === 'side_conversation' ? input.intent : kind;
 }
 
 function isRevisionStartData(value: unknown): boolean {

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -297,7 +297,7 @@ export class HostSessionRevisionCoordinator {
         'Deep Research Sessions cannot be copied without an exact research ledger boundary',
       );
     }
-    if (this.options.isSessionActive(input.sourceSessionId)) {
+    if (kind !== 'side_conversation' && this.options.isSessionActive(input.sourceSessionId)) {
       return copyFailure('session_busy', 'Source Session has an active Turn');
     }
 

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -632,7 +632,7 @@ export class HostSessionRevisionCoordinator {
           ? [...new Set([...source.labels, SIDE_CONVERSATION_SESSION_LABEL])]
           : [...source.labels],
       conversationCopy: {
-        kind: kind === 'revision' ? 'revision' : 'branch',
+        kind: persistedConversationCopyKind(kind),
         sourceSessionId: input.sourceSessionId,
         sourceTurnId: input.sourceTurnId,
         requestFingerprint,
@@ -693,7 +693,7 @@ export class HostSessionRevisionCoordinator {
     }
     const copy = probe.record.header.conversationCopy;
     if (
-      copy?.kind !== (kind === 'revision' ? 'revision' : 'branch') ||
+      copy?.kind !== persistedConversationCopyKind(kind) ||
       copy.intent !== (kind === 'side_conversation' ? kind : undefined) ||
       copy.sourceSessionId !== input.sourceSessionId ||
       copy.sourceTurnId !== input.sourceTurnId ||
@@ -831,22 +831,13 @@ function conversationCopyFingerprint(
   // The optimistic source revision guards only the initial create. Once this
   // target exists, its stable identity must resolve the committed outcome even
   // if a reconnecting Client observes a newer source revision.
-  const identity =
-    kind === 'side_conversation'
-      ? [
-          'session.conversation-copy.v2',
-          kind,
-          input.sourceSessionId,
-          input.targetSessionId,
-          input.sourceTurnId,
-        ]
-      : [
-          'session.conversation-copy.v1',
-          kind,
-          input.sourceSessionId,
-          input.targetSessionId,
-          input.sourceTurnId,
-        ];
+  const identity = [
+    kind === 'side_conversation' ? 'session.conversation-copy.v2' : 'session.conversation-copy.v1',
+    kind,
+    input.sourceSessionId,
+    input.targetSessionId,
+    input.sourceTurnId,
+  ];
   return `sha256:${createHash('sha256').update(JSON.stringify(identity)).digest('hex')}`;
 }
 
@@ -881,6 +872,10 @@ function conversationCopySemanticKind(
   input: SessionConversationCopyInput,
 ): ConversationCopySemanticKind {
   return kind === 'branch' && input.intent === 'side_conversation' ? input.intent : kind;
+}
+
+function persistedConversationCopyKind(kind: ConversationCopySemanticKind): ConversationCopyKind {
+  return kind === 'revision' ? 'revision' : 'branch';
 }
 
 function isRevisionStartData(value: unknown): boolean {

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -492,7 +492,6 @@ export class HostSessionRevisionCoordinator {
             ? {
                 mode: 'snapshot' as const,
                 archivedResults: archivedSnapshotResults,
-                artifactIds: artifactCopy.artifactIds,
               }
             : linkedReferences.references.size > 0
               ? {

--- a/packages/runtime-host/src/server/session-revision-graph-references.ts
+++ b/packages/runtime-host/src/server/session-revision-graph-references.ts
@@ -106,11 +106,18 @@ export async function prepareAgentGraphRevisionReferences(
     return failure('session_busy', 'A retained linked child is still active');
   }
   const headersById = new Map(input.sessionHeaders.map((header) => [header.id, header]));
-  const hasRetainedGraph =
-    directChildren.some((child) => child.subagentParent?.graph !== undefined) ||
-    requests.some(
-      (request) => headersById.get(request.childSessionId)?.subagentParent?.graph !== undefined,
-    );
+  const referencedGraphs = new Map<string, Set<string>>();
+  const retainGraph = (header: SessionHeader | undefined) => {
+    const parent = header?.subagentParent;
+    if (!parent?.graph) return;
+    const graphIds = referencedGraphs.get(parent.parentSessionId) ?? new Set<string>();
+    graphIds.add(parent.graph.graphId);
+    referencedGraphs.set(parent.parentSessionId, graphIds);
+  };
+  for (const request of requests) retainGraph(headersById.get(request.childSessionId));
+  if (input.kind === 'side_conversation') {
+    for (const child of directChildren) retainGraph(child);
+  }
   const retainedSessionGraphFailure = async () => {
     try {
       if ((await dependencies.graph.readSessionState(input.sourceSessionId)) === 'live') {
@@ -121,8 +128,30 @@ export async function prepareAgentGraphRevisionReferences(
     }
     return undefined;
   };
-  if (input.kind === 'side_conversation' && hasRetainedGraph) {
-    const graphFailure = await retainedSessionGraphFailure();
+  const retainedExactGraphFailure = async () => {
+    for (const [rootSessionId, graphIds] of referencedGraphs) {
+      for (const graphId of graphIds) {
+        let state: 'absent' | 'live' | 'terminal';
+        try {
+          state = await dependencies.graph.readGraphState(rootSessionId, graphId);
+        } catch {
+          return failure('operation_unavailable', 'Retained Agent Graph state is unavailable');
+        }
+        if (state === 'live') {
+          return failure('session_busy', 'A retained Agent Graph is not terminal');
+        }
+        if (state === 'absent') {
+          return failure(
+            'operation_unavailable',
+            'Retained Agent Graph control state is unavailable',
+          );
+        }
+      }
+    }
+    return undefined;
+  };
+  if (input.kind === 'side_conversation') {
+    const graphFailure = await retainedExactGraphFailure();
     if (graphFailure) return graphFailure;
   }
   if (
@@ -142,33 +171,8 @@ export async function prepareAgentGraphRevisionReferences(
   if (input.kind === 'revision') {
     const graphFailure = await retainedSessionGraphFailure();
     if (graphFailure) return graphFailure;
-  }
-  const referencedGraphs = new Map<string, Set<string>>();
-  for (const request of requests) {
-    const parent = headersById.get(request.childSessionId)?.subagentParent;
-    if (!parent?.graph) continue;
-    const graphIds = referencedGraphs.get(parent.parentSessionId) ?? new Set<string>();
-    graphIds.add(parent.graph.graphId);
-    referencedGraphs.set(parent.parentSessionId, graphIds);
-  }
-  for (const [rootSessionId, graphIds] of referencedGraphs) {
-    for (const graphId of graphIds) {
-      let state: 'absent' | 'live' | 'terminal';
-      try {
-        state = await dependencies.graph.readGraphState(rootSessionId, graphId);
-      } catch {
-        return failure('operation_unavailable', 'Retained Agent Graph state is unavailable');
-      }
-      if (state === 'live') {
-        return failure('session_busy', 'A retained Agent Graph is not terminal');
-      }
-      if (state === 'absent') {
-        return failure(
-          'operation_unavailable',
-          'Retained Agent Graph control state is unavailable',
-        );
-      }
-    }
+    const exactGraphFailure = await retainedExactGraphFailure();
+    if (exactGraphFailure) return exactGraphFailure;
   }
 
   const references = new Map<string, MutableExternalChildReferences>();

--- a/packages/runtime-host/src/server/session-revision-graph-references.ts
+++ b/packages/runtime-host/src/server/session-revision-graph-references.ts
@@ -26,7 +26,7 @@ import {
 } from '@maka/runtime/conversation-copy';
 import type { InteractiveArtifactStoreWriter } from '@maka/storage/artifact-stores';
 
-type ConversationCopyKind = 'branch' | 'revision';
+type ConversationCopyKind = 'branch' | 'revision' | 'side_conversation';
 
 export type AgentGraphRevisionReferencePreparation =
   | {
@@ -98,22 +98,50 @@ export async function prepareAgentGraphRevisionReferences(
     return { ok: true, references: new Map() };
   }
   const requestedChildIds = new Set(requests.map((request) => request.childSessionId));
+  const unrepresentedChildren = directChildren.filter((child) => !requestedChildIds.has(child.id));
   if (
-    directChildren.some((child) => !child.subagentParent?.graph || !requestedChildIds.has(child.id))
+    input.kind === 'side_conversation' &&
+    unrepresentedChildren.some((child) => dependencies.isSessionActive(child.id))
+  ) {
+    return failure('session_busy', 'A retained linked child is still active');
+  }
+  const headersById = new Map(input.sessionHeaders.map((header) => [header.id, header]));
+  const hasRetainedGraph =
+    directChildren.some((child) => child.subagentParent?.graph !== undefined) ||
+    requests.some(
+      (request) => headersById.get(request.childSessionId)?.subagentParent?.graph !== undefined,
+    );
+  const retainedSessionGraphFailure = async () => {
+    try {
+      if ((await dependencies.graph.readSessionState(input.sourceSessionId)) === 'live') {
+        return failure('session_busy', 'A retained Agent Graph is not terminal');
+      }
+    } catch {
+      return failure('operation_unavailable', 'Retained Agent Graph state is unavailable');
+    }
+    return undefined;
+  };
+  if (input.kind === 'side_conversation' && hasRetainedGraph) {
+    const graphFailure = await retainedSessionGraphFailure();
+    if (graphFailure) return graphFailure;
+  }
+  if (
+    directChildren.some(
+      (child) =>
+        (input.kind === 'revision' && !child.subagentParent?.graph) ||
+        !requestedChildIds.has(child.id),
+    )
   ) {
     return failure(
       'operation_unavailable',
-      'Session revision requires a terminal result for every retained Agent Graph child',
+      input.kind === 'side_conversation'
+        ? 'Side Conversation requires a terminal result for every retained linked child'
+        : 'Session revision requires a terminal result for every retained Agent Graph child',
     );
   }
-
-  const headersById = new Map(input.sessionHeaders.map((header) => [header.id, header]));
-  try {
-    if ((await dependencies.graph.readSessionState(input.sourceSessionId)) === 'live') {
-      return failure('session_busy', 'A retained Agent Graph is not terminal');
-    }
-  } catch {
-    return failure('operation_unavailable', 'Retained Agent Graph state is unavailable');
+  if (input.kind === 'revision') {
+    const graphFailure = await retainedSessionGraphFailure();
+    if (graphFailure) return graphFailure;
   }
   const referencedGraphs = new Map<string, Set<string>>();
   for (const request of requests) {
@@ -151,9 +179,11 @@ export async function prepareAgentGraphRevisionReferences(
     const parent = child?.subagentParent;
     if (
       !child ||
-      !parent?.graph ||
+      !parent ||
       !familySessionIds.has(parent.parentSessionId) ||
-      !referencedGraphs.get(parent.parentSessionId)?.has(parent.graph.graphId) ||
+      (input.kind === 'revision' && !parent.graph) ||
+      (parent.graph !== undefined &&
+        !referencedGraphs.get(parent.parentSessionId)?.has(parent.graph.graphId)) ||
       !retainedTurnIds.has(parent.spawnedBy.parentTurnId)
     ) {
       return failure(

--- a/packages/runtime/src/__tests__/conversation-copy.test.ts
+++ b/packages/runtime/src/__tests__/conversation-copy.test.ts
@@ -292,12 +292,11 @@ test('Side Conversation snapshots remove linked child ownership identifiers', ()
     mode: 'exact',
     sourceSessionId: 'session-source',
     targetSessionId: 'session-target',
-    artifactIds: new Map(),
+    artifactIds: new Map([['child-artifact', 'child-artifact-snapshot']]),
     relativePaths: new Map(),
     linkedChildren: {
       mode: 'snapshot',
       archivedResults: new Map(),
-      artifactIds: new Map([['child-artifact', 'child-artifact-snapshot']]),
     },
     runIds: new Map(),
     runtimeEventIds: new Map(),
@@ -355,7 +354,6 @@ test('Side Conversation snapshots preserve ordinary archived tool results', () =
     linkedChildren: {
       mode: 'snapshot',
       archivedResults: new Map(),
-      artifactIds: new Map(),
     },
     runIds: new Map(),
     runtimeEventIds: new Map([['event-source', 'event-target']]),
@@ -408,7 +406,7 @@ test('Side Conversation snapshots retire archived linked-child results', () => {
     mode: 'exact',
     sourceSessionId: 'session-source',
     targetSessionId: 'session-target',
-    artifactIds: new Map(),
+    artifactIds: new Map([['child-artifact', 'child-artifact-snapshot']]),
     relativePaths: new Map(),
     linkedChildren: {
       mode: 'snapshot',
@@ -428,7 +426,6 @@ test('Side Conversation snapshots retire archived linked-child results', () => {
           }),
         ],
       ]),
-      artifactIds: new Map([['child-artifact', 'child-artifact-snapshot']]),
     },
     runIds: new Map(),
     runtimeEventIds: new Map([['event-source', 'event-target']]),

--- a/packages/runtime/src/__tests__/conversation-copy.test.ts
+++ b/packages/runtime/src/__tests__/conversation-copy.test.ts
@@ -35,6 +35,7 @@ import {
   createWorkspaceRuntimeStore,
 } from '@maka/storage';
 import {
+  archivedToolResultContainsLinkedChildReferences,
   archivedToolResultContainsConversationOwnedReferences,
   cloneConversationRuntimeLedger,
   collectConversationCopyLinkedChildReferences,
@@ -229,6 +230,222 @@ test('conversation copy discovers linked children in persisted retired tool resu
       },
     ],
   );
+});
+
+test('Side Conversation preflight identifies linked-child archive bodies', () => {
+  assert.equal(
+    archivedToolResultContainsLinkedChildReferences(
+      JSON.stringify({
+        kind: 'subagent',
+        childSessionId: 'child-session',
+        agentName: 'Researcher',
+        turnId: 'child-turn',
+        runId: 'child-run',
+        status: 'completed',
+        permissionMode: 'ask',
+        summary: 'done',
+        artifactIds: ['child-artifact'],
+      }),
+    ),
+    true,
+  );
+  assert.equal(
+    archivedToolResultContainsLinkedChildReferences(
+      JSON.stringify({ kind: 'text', text: 'safe result' }),
+    ),
+    false,
+  );
+});
+
+test('Side Conversation snapshots remove linked child ownership identifiers', () => {
+  const message: Extract<StoredMessage, { readonly type: 'tool_result' }> = {
+    type: 'tool_result',
+    id: 'linked-result',
+    turnId: 'turn-1',
+    ts: 1,
+    toolUseId: 'linked-call',
+    isError: false,
+    content: {
+      kind: 'agent_swarm',
+      status: 'completed',
+      items: [
+        {
+          itemId: 'item-1',
+          index: 0,
+          profile: 'default',
+          started: true,
+          childSessionId: 'child-session',
+          turnId: 'child-turn',
+          runId: 'child-run',
+          resumedFromRunId: 'child-parent-run',
+          status: 'completed',
+          summary: 'The delegated review found one issue.',
+          artifactIds: ['child-artifact'],
+        },
+      ],
+      startedAt: 1,
+      completedAt: 2,
+      durationMs: 1,
+    },
+  };
+  const rewritten = rewriteConversationCopyMessage(message, {
+    mode: 'exact',
+    sourceSessionId: 'session-source',
+    targetSessionId: 'session-target',
+    artifactIds: new Map(),
+    relativePaths: new Map(),
+    linkedChildren: {
+      mode: 'snapshot',
+      archivedResults: new Map(),
+      artifactIds: new Map([['child-artifact', 'child-artifact-snapshot']]),
+    },
+    runIds: new Map(),
+    runtimeEventIds: new Map(),
+    providerTraceIds: new Map(),
+  });
+
+  assert.equal(rewritten.type, 'tool_result');
+  if (rewritten.type !== 'tool_result' || rewritten.content.kind !== 'agent_swarm') {
+    assert.fail('Expected the Agent Graph result snapshot');
+  }
+  assert.deepEqual(rewritten.content.items, [
+    {
+      itemId: 'item-1',
+      index: 0,
+      profile: 'default',
+      started: true,
+      turnId: 'child-turn',
+      status: 'completed',
+      summary: 'The delegated review found one issue.',
+      artifactIds: ['child-artifact-snapshot'],
+    },
+  ]);
+});
+
+test('Side Conversation snapshots preserve ordinary archived tool results', () => {
+  const message: Extract<StoredMessage, { readonly type: 'tool_result' }> = {
+    type: 'tool_result',
+    id: 'archived-result',
+    turnId: 'turn-1',
+    ts: 1,
+    toolUseId: 'tool-1',
+    isError: false,
+    content: {
+      kind: 'json',
+      value: {
+        kind: 'maka.archived_tool_result',
+        rewriteVersion: 1,
+        artifactId: 'artifact-source',
+        runtimeEventId: 'event-source',
+        toolCallId: 'tool-1',
+        toolName: 'search',
+        bodySha256: 'a'.repeat(64),
+        originalEstimatedTokens: 42,
+        originalBytes: 128,
+        reason: 'stale_tool_result_pruned_before_compact',
+      },
+    },
+  };
+  const rewritten = rewriteConversationCopyMessage(message, {
+    mode: 'exact',
+    sourceSessionId: 'session-source',
+    targetSessionId: 'session-target',
+    artifactIds: new Map([['artifact-source', 'artifact-target']]),
+    relativePaths: new Map(),
+    linkedChildren: {
+      mode: 'snapshot',
+      archivedResults: new Map(),
+      artifactIds: new Map(),
+    },
+    runIds: new Map(),
+    runtimeEventIds: new Map([['event-source', 'event-target']]),
+    providerTraceIds: new Map(),
+  });
+
+  assert.equal(rewritten.type, 'tool_result');
+  if (rewritten.type !== 'tool_result' || rewritten.content.kind !== 'json') {
+    assert.fail('Expected an archived JSON tool result');
+  }
+  assert.deepEqual(rewritten.content.value, {
+    kind: 'maka.archived_tool_result',
+    rewriteVersion: 1,
+    artifactId: 'artifact-target',
+    runtimeEventId: 'event-target',
+    toolCallId: 'tool-1',
+    toolName: 'search',
+    bodySha256: 'a'.repeat(64),
+    originalEstimatedTokens: 42,
+    originalBytes: 128,
+    reason: 'stale_tool_result_pruned_before_compact',
+  });
+});
+
+test('Side Conversation snapshots retire archived linked-child results', () => {
+  const message: Extract<StoredMessage, { readonly type: 'tool_result' }> = {
+    type: 'tool_result',
+    id: 'archived-result',
+    turnId: 'turn-1',
+    ts: 1,
+    toolUseId: 'tool-1',
+    isError: false,
+    content: {
+      kind: 'json',
+      value: {
+        kind: 'maka.archived_tool_result',
+        rewriteVersion: 1,
+        artifactId: 'artifact-source',
+        runtimeEventId: 'event-source',
+        toolCallId: 'tool-1',
+        toolName: 'subagent',
+        bodySha256: 'b'.repeat(64),
+        originalEstimatedTokens: 42,
+        originalBytes: 128,
+        reason: 'stale_tool_result_pruned_before_compact',
+      },
+    },
+  };
+  const rewritten = rewriteConversationCopyMessage(message, {
+    mode: 'exact',
+    sourceSessionId: 'session-source',
+    targetSessionId: 'session-target',
+    artifactIds: new Map(),
+    relativePaths: new Map(),
+    linkedChildren: {
+      mode: 'snapshot',
+      archivedResults: new Map([
+        [
+          'artifact-source',
+          JSON.stringify({
+            kind: 'subagent',
+            childSessionId: 'child-session',
+            agentName: 'Researcher',
+            turnId: 'child-turn',
+            runId: 'child-run',
+            status: 'completed',
+            permissionMode: 'ask',
+            summary: 'The archived review found one issue.',
+            artifactIds: ['child-artifact'],
+          }),
+        ],
+      ]),
+      artifactIds: new Map([['child-artifact', 'child-artifact-snapshot']]),
+    },
+    runIds: new Map(),
+    runtimeEventIds: new Map([['event-source', 'event-target']]),
+    providerTraceIds: new Map(),
+  });
+
+  assert.equal(rewritten.type, 'tool_result');
+  if (rewritten.type !== 'tool_result') assert.fail('Expected a tool result');
+  assert.deepEqual(rewritten.content, {
+    kind: 'subagent',
+    agentName: 'Researcher',
+    turnId: 'child-turn',
+    status: 'completed',
+    permissionMode: 'ask',
+    summary: 'The archived review found one issue.',
+    artifactIds: ['child-artifact-snapshot'],
+  });
 });
 
 test('conversation copy slices exact turns on inclusive and exclusive boundaries', () => {

--- a/packages/runtime/src/__tests__/conversation-copy.test.ts
+++ b/packages/runtime/src/__tests__/conversation-copy.test.ts
@@ -321,6 +321,114 @@ test('Side Conversation snapshots remove linked child ownership identifiers', ()
   ]);
 });
 
+test('Side Conversation snapshots rewrite source-owned Agent Swarm identities', () => {
+  const message: Extract<StoredMessage, { readonly type: 'tool_result' }> = {
+    type: 'tool_result',
+    id: 'source-owned-result',
+    turnId: 'turn-1',
+    ts: 1,
+    toolUseId: 'source-owned-call',
+    isError: false,
+    content: {
+      kind: 'agent_swarm',
+      status: 'completed',
+      items: [
+        {
+          itemId: 'item-1',
+          index: 0,
+          profile: 'default',
+          started: true,
+          runId: 'run-source',
+          resumedFromRunId: 'run-parent-source',
+          status: 'completed',
+          summary: 'The source-owned run completed.',
+          artifactIds: ['artifact-source'],
+        },
+      ],
+      startedAt: 1,
+      completedAt: 2,
+      durationMs: 1,
+    },
+  };
+  const rewritten = rewriteConversationCopyMessage(message, {
+    mode: 'exact',
+    sourceSessionId: 'session-source',
+    targetSessionId: 'session-target',
+    artifactIds: new Map([['artifact-source', 'artifact-target']]),
+    relativePaths: new Map(),
+    linkedChildren: {
+      mode: 'snapshot',
+      archivedResults: new Map(),
+    },
+    runIds: new Map([
+      ['run-source', 'run-target'],
+      ['run-parent-source', 'run-parent-target'],
+    ]),
+    runtimeEventIds: new Map(),
+    providerTraceIds: new Map(),
+  });
+
+  assert.equal(rewritten.type, 'tool_result');
+  if (rewritten.type !== 'tool_result' || rewritten.content.kind !== 'agent_swarm') {
+    assert.fail('Expected the source-owned Agent Swarm result');
+  }
+  assert.deepEqual(rewritten.content.items, [
+    {
+      itemId: 'item-1',
+      index: 0,
+      profile: 'default',
+      started: true,
+      runId: 'run-target',
+      resumedFromRunId: 'run-parent-target',
+      status: 'completed',
+      summary: 'The source-owned run completed.',
+      artifactIds: ['artifact-target'],
+    },
+  ]);
+});
+
+test('Side Conversation snapshots rewrite source-owned subagent identities', () => {
+  const message: Extract<StoredMessage, { readonly type: 'tool_result' }> = {
+    type: 'tool_result',
+    id: 'source-owned-result',
+    turnId: 'turn-1',
+    ts: 1,
+    toolUseId: 'source-owned-call',
+    isError: false,
+    content: {
+      kind: 'subagent',
+      agentName: 'Researcher',
+      turnId: 'turn-1',
+      runId: 'run-source',
+      status: 'completed',
+      permissionMode: 'ask',
+      summary: 'The source-owned run completed.',
+      artifactIds: ['artifact-source'],
+    },
+  };
+  const rewritten = rewriteConversationCopyMessage(message, {
+    mode: 'exact',
+    sourceSessionId: 'session-source',
+    targetSessionId: 'session-target',
+    artifactIds: new Map([['artifact-source', 'artifact-target']]),
+    relativePaths: new Map(),
+    linkedChildren: {
+      mode: 'snapshot',
+      archivedResults: new Map(),
+    },
+    runIds: new Map([['run-source', 'run-target']]),
+    runtimeEventIds: new Map(),
+    providerTraceIds: new Map(),
+  });
+
+  assert.equal(rewritten.type, 'tool_result');
+  if (rewritten.type !== 'tool_result' || rewritten.content.kind !== 'subagent') {
+    assert.fail('Expected the source-owned subagent result');
+  }
+  assert.equal(rewritten.content.runId, 'run-target');
+  assert.deepEqual(rewritten.content.artifactIds, ['artifact-target']);
+});
+
 test('Side Conversation snapshots preserve ordinary archived tool results', () => {
   const message: Extract<StoredMessage, { readonly type: 'tool_result' }> = {
     type: 'tool_result',

--- a/packages/runtime/src/conversation-copy.ts
+++ b/packages/runtime/src/conversation-copy.ts
@@ -88,6 +88,11 @@ export type ConversationCopyArtifactReferenceMap =
       readonly linkedChildren:
         | { readonly mode: 'reject' }
         | {
+            readonly mode: 'snapshot';
+            readonly archivedResults: ReadonlyMap<string, string>;
+            readonly artifactIds: ReadonlyMap<string, string>;
+          }
+        | {
             readonly mode: 'preserve_validated';
             readonly references: ReadonlyMap<string, ConversationCopyExternalChildReferences>;
           };
@@ -530,6 +535,20 @@ export function archivedToolResultContainsConversationOwnedReferences(
     );
   }
   return false;
+}
+
+export function archivedToolResultContainsLinkedChildReferences(serializedResult: string): boolean {
+  const value = deserializeToolResultArchive(serializedResult);
+  if (isArchivedToolResultPlaceholder(value)) return false;
+  try {
+    return (
+      conversationCopyLinkedChildReferences(
+        decodePersistedToolResultContent(markPersisted<ToolResultContent>(value)),
+      ).length > 0
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function conversationCopyLinkedChildReferences(
@@ -1010,9 +1029,11 @@ function rewriteRuntimeEventReferences(
               }
             : {}),
           ...(event.refs.artifactId
-            ? {
-                artifactId: rewriteOwnedArtifactId(event.refs.artifactId, references),
-              }
+            ? archivedSnapshotResult(event.refs.artifactId, references) !== undefined
+              ? {}
+              : {
+                  artifactId: rewriteOwnedArtifactId(event.refs.artifactId, references),
+                }
             : {}),
           ...(event.refs.sourceInvocationId
             ? {
@@ -1111,6 +1132,8 @@ function rewriteToolResultContent(
     return { ...content, ref: rewriteStorageRef(content.ref, references) };
   }
   if (content.kind === 'archived_tool_result') {
+    const snapshot = rewriteArchivedSnapshot(content, references);
+    if (snapshot) return snapshot;
     return {
       ...content,
       runtimeEventId: rewriteOwnedId(
@@ -1124,12 +1147,21 @@ function rewriteToolResultContent(
     };
   }
   if (content.kind === 'json' && isArchivedToolResultPlaceholder(content.value)) {
+    const snapshot = rewriteArchivedSnapshot(content.value, references);
+    if (snapshot) return snapshot;
     return {
       ...content,
       value: rewriteArchivedToolResult(content.value, references),
     };
   }
   if (content.kind === 'subagent') {
+    if (linkedChildrenAreSnapshots(references)) {
+      const { childSessionId: _childSessionId, runId: _runId, ...snapshot } = content;
+      return {
+        ...snapshot,
+        artifactIds: rewriteSnapshotArtifactIds(content.artifactIds, references),
+      };
+    }
     return {
       ...content,
       ...(content.runId
@@ -1153,6 +1185,18 @@ function rewriteToolResultContent(
     return {
       ...content,
       items: content.items.map((item) => {
+        if (linkedChildrenAreSnapshots(references)) {
+          const {
+            childSessionId: _childSessionId,
+            runId: _runId,
+            resumedFromRunId: _resumedFromRunId,
+            ...snapshot
+          } = item;
+          return {
+            ...snapshot,
+            artifactIds: rewriteSnapshotArtifactIds(item.artifactIds, references),
+          };
+        }
         return {
           ...item,
           ...(item.runId
@@ -1183,6 +1227,8 @@ function rewriteRuntimeToolResult(
   references: ConversationCopyMessageReferenceMap,
 ): unknown {
   if (isArchivedToolResultPlaceholder(value)) {
+    const snapshot = rewriteArchivedSnapshot(value, references);
+    if (snapshot) return snapshot;
     return rewriteArchivedToolResult(value, references);
   }
   let content: ToolResultContent;
@@ -1206,6 +1252,7 @@ function validatedExternalChildReferences(
   references: ConversationCopyMessageReferenceMap,
 ): ConversationCopyExternalChildReferences | undefined {
   if (references.mode === 'preserve_external') return undefined;
+  if (references.linkedChildren.mode === 'snapshot') return undefined;
   if (references.linkedChildren.mode === 'reject') {
     throw new Error(`Conversation copy cannot retain linked child Session ${childSessionId}`);
   }
@@ -1214,6 +1261,82 @@ function validatedExternalChildReferences(
     throw new Error(`Conversation copy is missing linked child Session ${childSessionId}`);
   }
   return external;
+}
+
+function linkedChildrenAreSnapshots(references: ConversationCopyMessageReferenceMap): boolean {
+  return references.mode === 'exact' && references.linkedChildren.mode === 'snapshot';
+}
+
+function rewriteSnapshotArtifactIds(
+  artifactIds: readonly string[],
+  references: ConversationCopyMessageReferenceMap,
+): readonly string[] {
+  if (references.mode !== 'exact' || references.linkedChildren.mode !== 'snapshot') {
+    return artifactIds;
+  }
+  const snapshotArtifactIds = references.linkedChildren.artifactIds;
+  return artifactIds.map((artifactId) =>
+    requiredMappedId(snapshotArtifactIds, artifactId, 'linked Artifact'),
+  );
+}
+
+function rewriteArchivedSnapshot(
+  value:
+    | ArchivedToolResultPlaceholder
+    | Extract<ToolResultContent, { kind: 'archived_tool_result' }>,
+  references: ConversationCopyMessageReferenceMap,
+): ToolResultContent | undefined {
+  const serializedResult = archivedSnapshotResult(value.artifactId, references);
+  if (serializedResult === undefined) return undefined;
+  const archived = deserializeToolResultArchive(serializedResult);
+  if (isArchivedToolResultPlaceholder(archived)) {
+    return unavailableArchivedToolResult(value, references);
+  }
+  try {
+    const decoded = decodePersistedToolResultContent(markPersisted<ToolResultContent>(archived));
+    return decoded.kind === 'archived_tool_result'
+      ? unavailableArchivedToolResult(value, references)
+      : rewriteToolResultContent(decoded, references);
+  } catch {
+    return unavailableArchivedToolResult(value, references);
+  }
+}
+
+function archivedSnapshotResult(
+  artifactId: string | undefined,
+  references: ConversationCopyMessageReferenceMap,
+): string | undefined {
+  if (
+    artifactId === undefined ||
+    references.mode !== 'exact' ||
+    references.linkedChildren.mode !== 'snapshot'
+  ) {
+    return undefined;
+  }
+  return references.linkedChildren.archivedResults.get(artifactId);
+}
+
+function unavailableArchivedToolResult(
+  value:
+    | ArchivedToolResultPlaceholder
+    | Extract<ToolResultContent, { kind: 'archived_tool_result' }>,
+  references: ConversationCopyMessageReferenceMap,
+): Extract<ToolResultContent, { kind: 'archived_tool_result' }> {
+  return {
+    kind: 'archived_tool_result',
+    status: 'missing',
+    runtimeEventId: rewriteOwnedId(
+      value.runtimeEventId,
+      references.runtimeEventIds,
+      'RuntimeEvent',
+    ),
+    toolCallId: value.toolCallId,
+    toolName: value.toolName,
+    originalEstimatedTokens: value.originalEstimatedTokens,
+    originalBytes: value.originalBytes,
+    rewriteVersion: value.rewriteVersion,
+    reason: value.reason,
+  };
 }
 
 function rewriteLinkedRunId(

--- a/packages/runtime/src/conversation-copy.ts
+++ b/packages/runtime/src/conversation-copy.ts
@@ -90,7 +90,6 @@ export type ConversationCopyArtifactReferenceMap =
         | {
             readonly mode: 'snapshot';
             readonly archivedResults: ReadonlyMap<string, string>;
-            readonly artifactIds: ReadonlyMap<string, string>;
           }
         | {
             readonly mode: 'preserve_validated';
@@ -1274,9 +1273,8 @@ function rewriteSnapshotArtifactIds(
   if (references.mode !== 'exact' || references.linkedChildren.mode !== 'snapshot') {
     return artifactIds;
   }
-  const snapshotArtifactIds = references.linkedChildren.artifactIds;
   return artifactIds.map((artifactId) =>
-    requiredMappedId(snapshotArtifactIds, artifactId, 'linked Artifact'),
+    requiredMappedId(references.artifactIds, artifactId, 'linked Artifact'),
   );
 }
 

--- a/packages/runtime/src/conversation-copy.ts
+++ b/packages/runtime/src/conversation-copy.ts
@@ -1154,7 +1154,7 @@ function rewriteToolResultContent(
     };
   }
   if (content.kind === 'subagent') {
-    if (linkedChildrenAreSnapshots(references)) {
+    if (linkedChildrenAreSnapshots(references) && content.childSessionId) {
       const { childSessionId: _childSessionId, runId: _runId, ...snapshot } = content;
       return {
         ...snapshot,
@@ -1184,7 +1184,7 @@ function rewriteToolResultContent(
     return {
       ...content,
       items: content.items.map((item) => {
-        if (linkedChildrenAreSnapshots(references)) {
+        if (linkedChildrenAreSnapshots(references) && item.childSessionId) {
           const {
             childSessionId: _childSessionId,
             runId: _runId,

--- a/packages/storage/src/__tests__/artifact-store.test.ts
+++ b/packages/storage/src/__tests__/artifact-store.test.ts
@@ -322,6 +322,63 @@ describe('SQLite Artifact store', () => {
     });
   });
 
+  test('excludes selected Artifacts from a conversation snapshot', async () => {
+    await withWorkspace(async (root) => {
+      const authority = createArtifactStoreWriteAuthority(root);
+      await authority.recover();
+      const { store } = authority;
+      await store.create({
+        ...artifactInput('retained-artifact', 'retained', 10),
+        turnId: 'turn-retained',
+      });
+      await store.create({
+        ...artifactInput('excluded-archive', 'archived child result', 11),
+        turnId: 'turn-retained',
+        source: 'tool_result_archive',
+      });
+
+      const copied = await store.copyConversationArtifacts({
+        sourceSessionId: 'session-1',
+        targetSessionId: 'session-copy',
+        turnIds: ['turn-retained'],
+        excludeArtifactIds: ['excluded-archive'],
+      });
+
+      assert.equal(copied.artifactIds.has('excluded-archive'), false);
+      assert.deepEqual(
+        (await store.list('session-copy')).map((record) => record.name),
+        ['retained-artifact.txt'],
+      );
+      assert.equal((await store.get('excluded-archive'))?.sessionId, 'session-1');
+    });
+  });
+
+  test('copies explicit linked child Artifacts into a conversation snapshot', async () => {
+    await withWorkspace(async (root) => {
+      const authority = createArtifactStoreWriteAuthority(root);
+      await authority.recover();
+      const { store } = authority;
+      await store.create({
+        ...artifactInput('child-artifact', 'child result', 10),
+        sessionId: 'child-session',
+        turnId: 'child-turn',
+      });
+
+      const copied = await store.copyConversationArtifacts({
+        sourceSessionId: 'session-1',
+        targetSessionId: 'session-copy',
+        turnIds: ['turn-retained'],
+        linkedArtifacts: [{ sessionId: 'child-session', artifactIds: ['child-artifact'] }],
+      });
+
+      const copiedId = copied.artifactIds.get('child-artifact');
+      assert.ok(copiedId);
+      assert.deepEqual(await store.readText(copiedId), { ok: true, text: 'child result' });
+      assert.equal((await store.get(copiedId))?.sessionId, 'session-copy');
+      assert.equal((await store.get('child-artifact'))?.sessionId, 'child-session');
+    });
+  });
+
   test('user delete evaluates current-generation policy before tombstone state', async () => {
     await withWorkspace(async (root) => {
       const authority = createArtifactStoreWriteAuthority(root);

--- a/packages/storage/src/__tests__/task-ledger-authority.test.ts
+++ b/packages/storage/src/__tests__/task-ledger-authority.test.ts
@@ -112,6 +112,98 @@ describe('interactive task ledger authority', () => {
       );
     });
   });
+
+  test('copies child-owned tasks into an ownership-free Side Conversation snapshot', async () => {
+    await withInteractiveOwner(async ({ writer }) => {
+      const sourceSessionId = 'source-session';
+      const targetSessionId = 'side-conversation';
+      const created = await writer.create(sourceSessionId, [{ subject: 'Delegated review' }], {
+        turnId: 'root-turn',
+        source: 'tool',
+        actor: 'main_agent',
+      });
+      const taskId = created.created[0]!.id;
+      await writer.claim(
+        sourceSessionId,
+        taskId,
+        {
+          actor: 'child_agent',
+          sessionId: 'child-session',
+          agentId: 'reviewer',
+          runId: 'child-run',
+          turnId: 'child-turn',
+        },
+        {
+          turnId: 'root-turn',
+          runId: 'child-run',
+          source: 'tool',
+          actor: 'child_agent',
+        },
+      );
+      const legacy = await writer.create(sourceSessionId, [{ subject: 'Legacy child note' }], {
+        turnId: 'root-turn',
+        runId: 'legacy-child-run',
+        source: 'tool',
+        actor: 'child_agent',
+      });
+
+      await writer.copyConversationTaskLedger({
+        sourceSessionId,
+        targetSessionId,
+        turnIds: ['root-turn'],
+        runIdMap: [],
+        linkedChildren: 'snapshot',
+      });
+
+      const copied = await writer.list(targetSessionId);
+      assert.deepEqual(
+        copied.map((task) => ({ id: task.id, subject: task.subject, status: task.status })),
+        [
+          { id: taskId, subject: 'Delegated review', status: 'in_progress' },
+          { id: legacy.created[0]!.id, subject: 'Legacy child note', status: 'pending' },
+        ],
+      );
+      assert.ok(copied.every((task) => task.owner === undefined));
+      assert.equal((await writer.get(sourceSessionId, taskId))?.owner?.sessionId, 'child-session');
+      assert.equal((await writer.get(sourceSessionId, taskId))?.owner?.runId, 'child-run');
+    });
+  });
+
+  test('preserves main-agent ownership on child-authored snapshot events', async () => {
+    await withInteractiveOwner(async ({ writer }) => {
+      const sourceSessionId = 'source-main-owned';
+      const targetSessionId = 'side-main-owned';
+      const created = await writer.create(sourceSessionId, [{ subject: 'Parent-owned work' }], {
+        turnId: 'root-turn',
+        runId: 'root-run',
+        source: 'tool',
+        actor: 'main_agent',
+      });
+      await writer.update(
+        sourceSessionId,
+        created.created[0]!.id,
+        { subject: 'Child reported progress' },
+        {
+          turnId: 'root-turn',
+          runId: 'child-run',
+          source: 'tool',
+          actor: 'child_agent',
+        },
+      );
+
+      await writer.copyConversationTaskLedger({
+        sourceSessionId,
+        targetSessionId,
+        turnIds: ['root-turn'],
+        runIdMap: [{ sourceRunId: 'root-run', targetRunId: 'copied-root-run' }],
+        linkedChildren: 'snapshot',
+      });
+
+      const [copied] = await writer.list(targetSessionId);
+      assert.equal(copied?.owner?.actor, 'main_agent');
+      assert.equal(copied?.owner?.runId, 'copied-root-run');
+    });
+  });
 });
 
 async function withInteractiveOwner(

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -158,6 +158,11 @@ export interface ConversationArtifactCopyInput {
   readonly sourceSessionId: string;
   readonly targetSessionId: string;
   readonly turnIds: readonly string[];
+  readonly excludeArtifactIds?: readonly string[];
+  readonly linkedArtifacts?: readonly {
+    readonly sessionId: string;
+    readonly artifactIds: readonly string[];
+  }[];
 }
 
 export interface ConversationArtifactCopyResult {
@@ -383,21 +388,52 @@ class SqliteArtifactStore implements ArtifactAuthorityStore {
       throw new Error('Artifact conversation copy requires distinct Sessions');
     }
     const turnIds = new Set(input.turnIds);
+    const excludedArtifactIds = new Set(input.excludeArtifactIds ?? []);
     for (const turnId of turnIds) assertArtifactTurnKey(turnId);
+    const linkedArtifacts = input.linkedArtifacts ?? [];
+    const requestedLinkedArtifactIds = new Map<string, Set<string>>();
+    for (const linked of linkedArtifacts) {
+      assertCanonicalArtifactEntityId(linked.sessionId, 'sessionId');
+      if (linked.sessionId === input.targetSessionId) {
+        throw new Error('Linked Artifact copy requires a distinct source Session');
+      }
+      const artifactIds = requestedLinkedArtifactIds.get(linked.sessionId) ?? new Set<string>();
+      for (const artifactId of linked.artifactIds) {
+        assertCanonicalArtifactEntityId(artifactId, 'id');
+        artifactIds.add(artifactId);
+      }
+      requestedLinkedArtifactIds.set(linked.sessionId, artifactIds);
+    }
     const records = await this.enqueue(async () => {
       await this.load();
-      return this.records
+      const selected = this.records
         .filter(
-          (record) => record.sessionId === input.sourceSessionId && turnIds.has(record.turnId),
+          (record) =>
+            record.sessionId === input.sourceSessionId &&
+            turnIds.has(record.turnId) &&
+            !excludedArtifactIds.has(record.id),
         )
         .map((record) => ({ ...record }));
+      for (const [sessionId, artifactIds] of requestedLinkedArtifactIds) {
+        for (const artifactId of artifactIds) {
+          const record = this.records.find(
+            (candidate) =>
+              candidate.sessionId === sessionId &&
+              candidate.id === artifactId &&
+              candidate.status !== 'deleted',
+          );
+          if (!record) throw new Error(`Linked Artifact ${artifactId} could not be copied`);
+          selected.push({ ...record });
+        }
+      }
+      return selected;
     });
 
     const artifactIds = new Map<string, string>();
     const relativePaths = new Map<string, string>();
     for (const record of records) {
       const targetId = conversationCopyArtifactId(
-        input.sourceSessionId,
+        record.sessionId,
         input.targetSessionId,
         record.id,
       );

--- a/packages/storage/src/artifact-stores.ts
+++ b/packages/storage/src/artifact-stores.ts
@@ -152,6 +152,21 @@ function createWriterFacade(
       const acceptedInput: ConversationArtifactCopyInput = Object.freeze({
         ...input,
         turnIds: Object.freeze([...input.turnIds]),
+        ...(input.excludeArtifactIds
+          ? { excludeArtifactIds: Object.freeze([...input.excludeArtifactIds]) }
+          : {}),
+        ...(input.linkedArtifacts
+          ? {
+              linkedArtifacts: Object.freeze(
+                input.linkedArtifacts.map((linked) =>
+                  Object.freeze({
+                    sessionId: linked.sessionId,
+                    artifactIds: Object.freeze([...linked.artifactIds]),
+                  }),
+                ),
+              ),
+            }
+          : {}),
       });
       return run(() => store.copyConversationArtifacts(acceptedInput));
     },

--- a/packages/storage/src/session-conversation-copy.ts
+++ b/packages/storage/src/session-conversation-copy.ts
@@ -41,6 +41,7 @@ export function isValidConversationCopyTransition(
     previous.sourceSessionId === next.sourceSessionId &&
     previous.sourceTurnId === next.sourceTurnId &&
     previous.requestFingerprint === next.requestFingerprint &&
+    previous.intent === next.intent &&
     (previous.state !== 'committed' || next.state === 'committed') &&
     (previous.state !== 'preparing' || next.state === 'preparing' || next.state === 'committed')
   );

--- a/packages/storage/src/task-ledger-authority.ts
+++ b/packages/storage/src/task-ledger-authority.ts
@@ -145,6 +145,7 @@ function createInteractiveWriterFacade(
         ...input,
         turnIds: Object.freeze([...input.turnIds]),
         runIdMap: Object.freeze(input.runIdMap.map((entry) => Object.freeze({ ...entry }))),
+        ...(input.linkedChildren ? { linkedChildren: input.linkedChildren } : {}),
       });
       return run(() => store.copyConversationTaskLedger(acceptedInput));
     },

--- a/packages/storage/src/task-ledger-store.ts
+++ b/packages/storage/src/task-ledger-store.ts
@@ -65,6 +65,7 @@ export interface ConversationTaskLedgerCopyInput {
     readonly sourceRunId: string;
     readonly targetRunId: string;
   }[];
+  readonly linkedChildren?: 'preserve' | 'snapshot';
 }
 
 export interface TaskLedgerAuthorityStore extends TaskLedgerStore {
@@ -174,7 +175,13 @@ class SqliteTaskLedgerStoreImpl implements SqliteTaskLedgerStore {
         throw new Error('Task Ledger events cross the conversation-copy boundary');
       }
       selected.push(
-        rewriteConversationTaskEvent(event, input.sourceSessionId, input.targetSessionId, runIds),
+        rewriteConversationTaskEvent(
+          event,
+          input.sourceSessionId,
+          input.targetSessionId,
+          runIds,
+          input.linkedChildren ?? 'preserve',
+        ),
       );
     }
     if (selected.length === 0) return;
@@ -787,29 +794,37 @@ function rewriteConversationTaskEvent(
   sourceSessionId: string,
   targetSessionId: string,
   runIds: ReadonlyMap<string, string>,
+  linkedChildren: 'preserve' | 'snapshot',
 ): TaskLedgerEvent {
-  const owner = event.task.owner;
+  const { owner, ...task } = event.task;
+  const snapshotChildOwner = linkedChildren === 'snapshot' && owner?.actor === 'child_agent';
+  const snapshotChildRun = linkedChildren === 'snapshot' && event.actor === 'child_agent';
   const rewrittenOwner =
     owner === undefined
       ? undefined
-      : {
-          ...owner,
-          ...(owner.sessionId === sourceSessionId ? { sessionId: targetSessionId } : {}),
-          ...(owner.runId
-            ? {
-                runId: requiredConversationCopyRunId(runIds, owner.runId),
-              }
-            : {}),
-        };
+      : snapshotChildOwner
+        ? undefined
+        : {
+            ...owner,
+            ...(owner.sessionId === sourceSessionId ? { sessionId: targetSessionId } : {}),
+            ...(owner.runId
+              ? {
+                  runId: requiredConversationCopyRunId(runIds, owner.runId),
+                }
+              : {}),
+          };
   const refs =
     event.refs === undefined
       ? undefined
-      : {
-          ...event.refs,
-          ...(event.refs.runId
-            ? { runId: requiredConversationCopyRunId(runIds, event.refs.runId) }
-            : {}),
-        };
+      : (() => {
+          const { runId: sourceRunId, ...preserved } = event.refs;
+          return {
+            ...preserved,
+            ...(sourceRunId && !snapshotChildRun
+              ? { runId: requiredConversationCopyRunId(runIds, sourceRunId) }
+              : {}),
+          };
+        })();
   return {
     ...event,
     eventId: `task-copy-${createHash('sha256')
@@ -817,7 +832,7 @@ function rewriteConversationTaskEvent(
       .digest('hex')}`,
     sessionId: targetSessionId,
     task: {
-      ...event.task,
+      ...task,
       ...(rewrittenOwner ? { owner: rewrittenOwner } : {}),
     },
     ...(refs ? { refs } : {}),


### PR DESCRIPTION
## Summary

- carry an explicit Side Conversation intent from the renderer through Desktop IPC and the Runtime Host protocol
- snapshot terminal linked-child results without retaining child-session ownership or control identifiers
- let the main Session and a Side Conversation run independently: the side chat forks the latest settled turn even while a newer parent turn is active
- validate only Graphs retained by that historical slice, so newer parent Graph work does not block the snapshot
- keep eager setup stable across source-session projection refreshes, preventing the periodic “Preparing side chat…” flicker
- copy and rewrite referenced artifacts, drop child task-ledger ownership, and preserve ordinary branch/revision safety rules

Closes #3654

## Verification

- 32 targeted Desktop Side Conversation, cleanup, disposal, panel-state, copy-attempt, and revision tests passed
- 19 targeted Runtime Host Graph-reference, protocol, and two-client UDS integration tests passed
- integration coverage proves ordinary branches remain `session_busy` while a Side Conversation can snapshot `turn-2` during a newer active turn, and that the active turn is not copied
- Graph coverage proves retained live Graphs still block, while a newer unrelated live Graph does not
- typechecked `@maka/runtime-host` and all Desktop targets after rebuilding workspace dependencies
- ran Biome across all changed files and `git diff --check origin/main...HEAD`
- rebased onto `origin/main@d77e854f7`

before
<img width="2084" height="652" alt="image" src="https://github.com/user-attachments/assets/589305db-760c-4ccc-9141-d3c52d81d503" />

after
<img width="1028" height="526" alt="image" src="https://github.com/user-attachments/assets/e447e424-62e4-48d8-af6d-fc8bd9595083" />


## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex contributed implementation, tests, verification, and review; Claude performed an additional review of the completed change.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

