### PR TITLE
fix(desktop): align the connection base URL gate with the Runtime Host

### DIFF
--- a/apps/desktop/src/main/__tests__/provider-add-submission.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-add-submission.test.ts
@@ -214,6 +214,66 @@ test('the field gate still reports the rules that survived', () => {
   });
 });
 
+test('the field gate refuses endpoints the Runtime Host would refuse', () => {
+  // Before #3672 each of these passed the form and failed the write, and the
+  // failure read "the model connection service is temporarily unavailable" —
+  // wrong about the cause and wrong about retrying being worth anything.
+  assert.deepEqual(
+    validateAddProviderDraft(draft({ baseUrl: 'https://user:pw@relay.example.com/v1' })),
+    { field: 'baseUrl', reason: 'invalid', rejection: 'credentials' },
+  );
+  assert.deepEqual(
+    validateAddProviderDraft(draft({ baseUrl: 'https://relay.example.com/v1?api-version=2024-06' })),
+    { field: 'baseUrl', reason: 'invalid', rejection: 'query_or_fragment' },
+  );
+  assert.deepEqual(validateAddProviderDraft(draft({ baseUrl: 'https://relay.example.com/v1#x' })), {
+    field: 'baseUrl',
+    reason: 'invalid',
+    rejection: 'query_or_fragment',
+  });
+  assert.deepEqual(validateAddProviderDraft(draft({ baseUrl: 'not-a-url' })), {
+    field: 'baseUrl',
+    reason: 'invalid',
+    rejection: 'malformed',
+  });
+  assert.deepEqual(validateAddProviderDraft(draft({ baseUrl: 'javascript:alert(1)' })), {
+    field: 'baseUrl',
+    reason: 'invalid',
+    rejection: 'scheme',
+  });
+
+  // A provider that ships its own endpoint still exposes the field for local
+  // runtimes, so the rule is not relay-only.
+  assert.deepEqual(
+    validateAddProviderDraft(
+      draft({ providerType: 'ollama', baseUrl: 'http://127.0.0.1:11434/v1?x=1' }),
+    ),
+    { field: 'baseUrl', reason: 'invalid', rejection: 'query_or_fragment' },
+  );
+
+  // Cloudflare's field carries an account id, not a URL — there is nothing to
+  // parse until the template is interpolated after submission.
+  assert.equal(
+    validateAddProviderDraft(
+      draft({
+        providerType: 'cloudflare-workers-ai',
+        cloudflareAccountId: 'abc123',
+        baseUrl: '',
+      }),
+    ),
+    null,
+  );
+
+  // Still accepted: a bare host, a local port, and a percent-encoded `?`.
+  for (const baseUrl of [
+    'https://relay.example.com',
+    'http://127.0.0.1:8080/v1',
+    'https://relay.example.com/a%3Fb',
+  ]) {
+    assert.equal(validateAddProviderDraft(draft({ baseUrl })), null, baseUrl);
+  }
+});
+
 test('a duplicate slug outranks a missing key, so one fix is asked for at a time', () => {
   assert.deepEqual(
     validateAddProviderDraft(

--- a/apps/desktop/src/renderer/locales/settings-provider-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-provider-copy.ts
@@ -156,6 +156,15 @@ const zhCopy = {
     modelKeyAria: (name: string) => `${name} 模型密钥`,
   },
   shared: {
+    // One sentence per rule the Runtime Host enforces on a service URL. The
+    // form checks these before it writes, so the user reads the rule they
+    // broke instead of `actionFallback`, which used to blame the service and
+    // suggest a retry that could never succeed (#3672).
+    endpointInvalidUrl: '服务地址不是有效的 URL，请填写完整地址，例如 https://example.com/v1。',
+    endpointScheme: '服务地址只支持 http:// 或 https:// 开头。',
+    endpointCredentials: '服务地址不能包含用户名或密码，请把密钥填在上方的 API Key 中。',
+    endpointQueryOrFragment: '服务地址不能包含查询参数（?）或锚点（#）。如需附加参数，请使用下方的高级请求设置。',
+    endpointTooLong: '服务地址过长，请控制在 2048 字节以内。',
     actionFallback: '模型连接服务暂时不可用，请稍后重试。', rateLimit: '当前账号或模型服务触发速率限制，请稍后重试。',
     timeout: '请求超时，请检查网络或代理后重试。', unavailable: '模型服务暂时不可用，请稍后重试。',
     network: '网络错误，请检查服务地址或代理设置后重试。', statusUnavailable: '连接测试状态暂时无法显示，请重新测试。',
@@ -306,6 +315,11 @@ const enCopy: ProviderSettingsCopy = {
     modelKeyAria: (name: string) => `${name} model key`,
   },
   shared: {
+    endpointInvalidUrl: 'The service URL is not a valid URL. Enter a full address, for example https://example.com/v1.',
+    endpointScheme: 'The service URL must start with http:// or https://.',
+    endpointCredentials: 'The service URL must not contain a username or password. Put the secret in the API key field above.',
+    endpointQueryOrFragment: 'The service URL must not contain a query (?) or fragment (#). Use the advanced request settings below to add parameters.',
+    endpointTooLong: 'The service URL is too long. Keep it under 2048 bytes.',
     actionFallback: 'The model connection service is temporarily unavailable. Try again later.', rateLimit: 'This account or model service is rate-limited. Try again later.',
     timeout: 'The request timed out. Check the network or proxy and try again.', unavailable: 'The model service is temporarily unavailable. Try again later.',
     network: 'Network error. Check the service URL or proxy settings and try again.', statusUnavailable: 'The connection test status is temporarily unavailable. Test again.',

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -43,6 +43,7 @@ import { providerDisplay } from './provider-display';
 import { useActionGuard } from './use-action-guard';
 import {
   categoryLabel,
+  connectionEndpointRejectionMessage,
   providerPanelActionErrorMessage,
   type ConnectionsBridge,
 } from './provider-panel-shared';
@@ -125,7 +126,11 @@ export function AddProviderForm(props: {
     }
     if (issue.field === 'apiKey') return copy.keyRequired(display.name);
     if (issue.field === 'accountId') return copy.cloudflareAccount;
-    if (issue.field === 'baseUrl') return copy.endpointRequired;
+    if (issue.field === 'baseUrl') {
+      return issue.reason === 'required'
+        ? copy.endpointRequired
+        : connectionEndpointRejectionMessage(issue.rejection, locale);
+    }
     return copy.accountLogin;
   }
 

--- a/apps/desktop/src/renderer/settings/provider-add-submission.ts
+++ b/apps/desktop/src/renderer/settings/provider-add-submission.ts
@@ -18,11 +18,13 @@
  */
 
 import {
+  canonicalizeConnectionBaseUrl,
   PROVIDER_DEFAULTS,
   providerAuthRequiresSecret,
   providerAuthSupportsApiKey,
   providerSupportsModelDiscovery,
   validateSlug,
+  type ConnectionBaseUrlRejection,
   type ProviderType,
 } from '@maka/core/llm-connections';
 import type { CreateConnectionInput, LlmConnection } from '@maka/core/llm-connections';
@@ -47,6 +49,11 @@ export type AddProviderIssue =
   | { readonly field: 'apiKey'; readonly reason: 'required' }
   | { readonly field: 'accountId'; readonly reason: 'required' }
   | { readonly field: 'baseUrl'; readonly reason: 'required' }
+  | {
+      readonly field: 'baseUrl';
+      readonly reason: 'invalid';
+      readonly rejection: ConnectionBaseUrlRejection;
+    }
   | { readonly field: 'form'; readonly reason: 'experimental' };
 
 export interface AddProviderDraft {
@@ -88,6 +95,16 @@ export function validateAddProviderDraft(draft: AddProviderDraft): AddProviderIs
   // missing one — it just has not composed it yet.
   const requiresBaseUrl = !defaults.baseUrl && !isCloudflareWorkersAi;
   if (requiresBaseUrl && !draft.baseUrl.trim()) return { field: 'baseUrl', reason: 'required' };
+  // Not gated on `requiresBaseUrl`: a provider that ships a default endpoint
+  // still lets a local runtime's port be edited, and a typo there fails the
+  // same write. Cloudflare is the one exception — its field holds an account
+  // id that gets interpolated into a template, so there is no URL to check yet.
+  if (!isCloudflareWorkersAi && draft.baseUrl.trim()) {
+    const endpoint = canonicalizeConnectionBaseUrl(draft.baseUrl);
+    if (!endpoint.ok) {
+      return { field: 'baseUrl', reason: 'invalid', rejection: endpoint.reason };
+    }
+  }
   if (defaults.status === 'phase3-experimental') return { field: 'form', reason: 'experimental' };
   return null;
 }

--- a/apps/desktop/src/renderer/settings/provider-panel-shared.ts
+++ b/apps/desktop/src/renderer/settings/provider-panel-shared.ts
@@ -19,6 +19,7 @@
 
 import { generalizedErrorMessage, generalizedErrorMessageChinese, redactSecrets } from '@maka/core/redaction';
 import {
+  type ConnectionBaseUrlRejection,
   type ConnectionTestResult,
   type CreateConnectionInput,
   type LlmConnection,
@@ -52,6 +53,38 @@ export interface ConnectionsBridge {
 }
 
 export type CredentialPresenceStatus = boolean | 'loading' | 'error';
+
+/**
+ * The localized sentence for a rejected service URL.
+ *
+ * Both write surfaces call this — the add form marks its endpoint field with
+ * it, and the detail page's endpoint row reports it instead of letting the
+ * Host's English domain error fall through to `actionFallback`, which named
+ * neither the field nor the rule (#3672).
+ */
+export function connectionEndpointRejectionMessage(
+  rejection: ConnectionBaseUrlRejection,
+  locale: UiLocale = 'zh',
+): string {
+  const shared = getProviderSettingsCopy(locale).shared;
+  switch (rejection) {
+    case 'malformed':
+      return shared.endpointInvalidUrl;
+    case 'scheme':
+      return shared.endpointScheme;
+    case 'credentials':
+      return shared.endpointCredentials;
+    case 'query_or_fragment':
+      return shared.endpointQueryOrFragment;
+    case 'too_long':
+    case 'too_many_bytes':
+    // A non-string can only come from a caller that bypassed the field, so
+    // there is no field-specific advice to give; the generic URL sentence is
+    // the closest true statement.
+    case 'not_a_string':
+      return shared.endpointTooLong;
+  }
+}
 
 export function providerPanelActionErrorMessage(error: unknown, locale: UiLocale = 'zh'): string {
   const shared = getProviderSettingsCopy(locale).shared;

--- a/apps/desktop/src/renderer/settings/use-connection-detail.ts
+++ b/apps/desktop/src/renderer/settings/use-connection-detail.ts
@@ -30,7 +30,11 @@ import {
   type ModelInfo,
   type ProviderType,
 } from '@maka/core/llm-connections';
-import { PROVIDER_DEFAULTS, connectionEnabledModelIds } from '@maka/core/llm-connections';
+import {
+  PROVIDER_DEFAULTS,
+  canonicalizeConnectionBaseUrl,
+  connectionEnabledModelIds,
+} from '@maka/core/llm-connections';
 import { buildConnectionModelCatalogEntries } from '@maka/core/model-catalog';
 import { isRetiredProvider } from '@maka/core/provider-registry';
 import {
@@ -52,6 +56,7 @@ import { applyBulkThinkingLevel, relayProfileWithThinkingLevels } from './relay-
 import { useKeyedActionGuard } from './use-action-guard';
 import type { OAuthLoginFlowBridge } from './use-oauth-login-flow';
 import {
+  connectionEndpointRejectionMessage,
   connectionLastTestMessageDisplay,
   connectionTestFailureMessage,
   providerPanelActionErrorMessage,
@@ -299,6 +304,21 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
    * the draft intact instead of collapsing as if it had succeeded.
    */
   async function save(field: 'key' | 'endpoint' | 'name'): Promise<boolean> {
+    // Check the endpoint before the write, not after it fails. The Runtime
+    // Host refuses credentials, a query, a fragment, or an oversize URL, and
+    // its English domain error reaches this page unclassified — so the user
+    // used to be told the service was unavailable and to retry, when the
+    // address they had just typed could never be accepted (#3672).
+    if (field === 'endpoint') {
+      const endpoint = canonicalizeConnectionBaseUrl(baseUrl);
+      if (!endpoint.ok) {
+        reportHostError(
+          copy.saveFailed,
+          connectionEndpointRejectionMessage(endpoint.reason, locale),
+        );
+        return false;
+      }
+    }
     const releaseSave = connectionDetailActionGuard.beginExclusive('save');
     if (!releaseSave) return false;
     const lifecycle = connectionDetailLifecycleRef.current;

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -38,6 +38,7 @@ import {
   validateConnectionBaseUrl,
   type ProviderType,
 } from '../llm-connections.js';
+import { normalizeCatalogConnectionBaseUrl } from '../runtime-policy/connection-catalog-codec.js';
 import { isRealConnection } from '../connection-readiness.js';
 import { buildChatModelChoices } from '../chat-model-choice.js';
 
@@ -52,6 +53,75 @@ test('connection base URLs allow HTTP(S) and reject unsafe or malformed inputs',
   const exactLimit = `https://example.com/${'a'.repeat(2048 - 'https://example.com/'.length)}`;
   assert.equal(exactLimit.length, 2048);
   assert.equal(validateConnectionBaseUrl(exactLimit), null);
+
+  // The rules the Host had and the client did not, until #3672. A user typing
+  // one of these got a save that failed with "the model connection service is
+  // temporarily unavailable" — a diagnosis that named neither the field nor
+  // the rule, and asked for a retry that could never succeed.
+  assert.match(
+    String(validateConnectionBaseUrl('https://user:pw@gw.example.com/v1')),
+    /must not contain credentials/,
+  );
+  assert.match(
+    String(validateConnectionBaseUrl('https://gw.example.com/v1?api-version=2024-06')),
+    /must not contain a query or fragment/,
+  );
+  assert.match(
+    String(validateConnectionBaseUrl('https://gw.example.com/v1#section')),
+    /must not contain a query or fragment/,
+  );
+  assert.match(
+    String(validateConnectionBaseUrl(`https://example.test/${'界'.repeat(2_000)}`)),
+    /must not exceed 2048 bytes/,
+  );
+  // A percent-encoded `?` is a path segment, not a query. Reading the typed
+  // text rather than the parsed URL is what keeps this accepted, and the Host
+  // reads it the same way.
+  assert.equal(validateConnectionBaseUrl('https://gw.example.com/a%3Fb'), null);
+});
+
+test('the client base URL gate accepts exactly what the Runtime Host codec accepts', () => {
+  // The defect in #3672 was drift between these two, not either one's rules.
+  // Any endpoint the form lets through must survive the write, and any it
+  // refuses must be one the Host would have refused too.
+  const candidates = [
+    'https://gw.example.com',
+    'https://gw.example.com/v1',
+    'https://Gateway.Example.COM:443/V1',
+    'http://127.0.0.1:8080/v1',
+    'http://localhost:11434',
+    'https://gw.example.com/a%3Fb',
+    'https://user:pw@gw.example.com/v1',
+    'https://user@gw.example.com/v1',
+    'https://gw.example.com/v1?api-version=2024-06',
+    'https://gw.example.com/v1#section',
+    'javascript:alert(1)',
+    'file:///etc/passwd',
+    'not-a-url',
+    `https://example.test/${'界'.repeat(2_000)}`,
+    `https://example.com/${'a'.repeat(2_050)}`,
+  ];
+  for (const candidate of candidates) {
+    const client = normalizeConnectionBaseUrl(candidate);
+    let host: { ok: true; value: string | undefined } | { ok: false };
+    try {
+      host = { ok: true, value: normalizeCatalogConnectionBaseUrl(candidate, 'openai-compatible') };
+    } catch {
+      host = { ok: false };
+    }
+    assert.equal(
+      client.ok,
+      host.ok,
+      `client and Host disagree on whether ${candidate} is a usable endpoint`,
+    );
+    if (client.ok && host.ok) {
+      assert.equal(
+        client.value,
+        host.value,
+        `client and Host canonicalize ${candidate} differently`,
+      );
+    }
+  }
 });
 
 test('persisted base URLs retain only meaningful overrides', () => {
@@ -70,9 +140,14 @@ test('persisted base URLs retain only meaningful overrides', () => {
 
 test('base URL normalization preserves clear intent and rejects untrusted runtime types', () => {
   assert.deepEqual(normalizeConnectionBaseUrl('  '), { ok: true, value: '' });
+  // Canonical, not as-typed. This used to assert `https://Example.com:443/V1`
+  // came back untouched, on the reasoning that rewriting it would surprise
+  // whoever typed it that way. The Host canonicalizes on write regardless, so
+  // that form was never what got stored — the client was preserving a value
+  // the system discarded one hop later (#3672).
   assert.deepEqual(normalizeConnectionBaseUrl('  https://Example.com:443/V1  '), {
     ok: true,
-    value: 'https://Example.com:443/V1',
+    value: 'https://example.com/V1',
   });
 
   assert.equal(normalizeConnectionBaseUrl('javascript:alert(1)').ok, false);

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -554,9 +554,38 @@ export function deriveConnectionSlug(
   }
 }
 
+export const CONNECTION_BASE_URL_MAX_LENGTH = 2048;
+export const CONNECTION_BASE_URL_MAX_BYTES = 2048;
+
+/**
+ * Why a connection `baseUrl` is refused, as a code rather than a sentence.
+ *
+ * The same rule is enforced at three sites that each speak a different
+ * vocabulary — the Desktop form wants localized field copy, the IPC gate
+ * wants an English developer message, and the Runtime Host codec wants its
+ * wire-facing domain error. Returning a code lets all three share one
+ * implementation without any of them inheriting another's wording.
+ */
+export type ConnectionBaseUrlRejection =
+  | 'not_a_string'
+  | 'too_long'
+  | 'too_many_bytes'
+  | 'malformed'
+  | 'scheme'
+  | 'credentials'
+  | 'query_or_fragment';
+
+export interface ConnectionBaseUrlRejected {
+  readonly ok: false;
+  readonly reason: ConnectionBaseUrlRejection;
+  /** The offending scheme, when `reason` is `'scheme'`. */
+  readonly scheme?: string;
+}
+
 /**
  * PR-UI-IPC-1 (@kenji msg 35260e29 + 2e495eb7): connection `baseUrl`
- * scheme allowlist gate.
+ * scheme allowlist gate, widened in #3672 to the full contract the
+ * Runtime Host already enforced.
  *
  * The renderer can submit any string for `CreateConnectionInput.baseUrl`
  * / `UpdateConnectionInput.baseUrl`; the AI SDK fetch downstream
@@ -571,30 +600,81 @@ export function deriveConnectionSlug(
  * — we intentionally do NOT block private-network / localhost URLs
  * (Ollama, LM Studio, vLLM and other local providers need
  * `http://localhost:11434`, `http://127.0.0.1:8000`, etc. to work).
- * Provider/setupMode-specific further restrictions are a separate
- * future PR.
  *
- * **Pair with `normalizeConnectionBaseUrl` for the IPC site.**
- * This function only validates; it does NOT trim or canonicalize.
- * The IPC handler should use `normalizeConnectionBaseUrl` so the
- * store only ever sees the canonical form (trimmed URL or
- * undefined) — not raw whitespace-padded input. See @kenji msg
- * 8755ffb3.
+ * **This is the only implementation of the rule.** `normalizeCatalogConnectionBaseUrl`
+ * (the Host's catalog codec) delegates here, so the client cannot accept an
+ * endpoint the Host will refuse. Before #3672 the two drifted: the client
+ * checked scheme and length only, so a URL carrying a query string or
+ * embedded credentials passed the form, passed IPC, and then failed the
+ * write — surfacing as "the model connection service is temporarily
+ * unavailable", which named neither the field nor the rule and invited a
+ * retry that could never succeed.
  *
  * Accepts:
- *   - `undefined` / empty string / whitespace-only: no override,
- *     fall back to provider default. Returns `null` (valid). The
- *     caller treats this as "user wants the provider's canonical
- *     baseUrl".
- *   - `http:` / `https:` schemes parsing as valid `URL` (case-
- *     insensitive scheme via WHATWG URL spec).
+ *   - empty / whitespace-only: no override, `value` is `''` — the caller's
+ *     "fall back to the provider default" or explicit-clear case.
+ *   - `http:` / `https:` URLs with no credentials, query, or fragment,
+ *     returned in WHATWG canonical form (`URL.toString()`).
  *
- * Rejects (returns error message):
- *   - Any other scheme (`file:`, `javascript:`, `data:`, `vbscript:`,
- *     `chrome-extension:`, `app:`, `maka:`, custom).
- *   - Malformed URL strings the `URL` constructor throws on.
- *   - Pathological lengths (> 2048 chars — defense against
- *     adversarial inputs; real-world baseUrls are < 100 chars).
+ * Rejects: non-strings, anything over 2048 characters or whose canonical
+ * form exceeds 2048 bytes, unparseable URLs, any other scheme,
+ * `user:password@` credentials, and `?`/`#`.
+ *
+ * Canonicalization is deliberate and matches the Host byte for byte. The
+ * previous "trim is the only canonicalization" note argued that rewriting
+ * `https://Example.com:443/V1` could surprise someone who typed it that
+ * way — but the Host canonicalizes on write regardless, so that form was
+ * never what got stored. Doing it here only moves the surprise to where
+ * the user can still see and correct it.
+ */
+export function canonicalizeConnectionBaseUrl(
+  baseUrl: unknown,
+): { ok: true; value: string } | ConnectionBaseUrlRejected {
+  // Defensive runtime-type guard (@kenji msg 57ac8a8c): the TypeScript
+  // signature is a compile-time guarantee, but IPC payloads cross a process
+  // boundary and could be `null` / number / object / array regardless.
+  if (typeof baseUrl !== 'string') return { ok: false, reason: 'not_a_string' };
+  // Length is checked before the trim, matching the Host's `stringValue`
+  // bound on the value it receives.
+  if (baseUrl.length > CONNECTION_BASE_URL_MAX_LENGTH) {
+    return { ok: false, reason: 'too_long' };
+  }
+  const trimmed = baseUrl.trim();
+  // An empty trimmed value is the explicit-clear intent (user typed
+  // whitespace = "remove my override"); preserve it as `''` so the store's
+  // existing clear semantics fire. The caller must NOT convert this to
+  // `undefined` — that would be "don't touch" and silently swallow the
+  // user's clear intent.
+  if (trimmed === '') return { ok: true, value: '' };
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+  // Closed scheme allowlist. `URL.protocol` includes the trailing colon and
+  // is lowercased by the WHATWG URL spec for special schemes.
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'scheme', scheme: parsed.protocol };
+  }
+  // Credentials in the endpoint would be persisted in the connection
+  // catalog, which — unlike the API key — is not the credential store.
+  if (parsed.username || parsed.password) return { ok: false, reason: 'credentials' };
+  // Read the typed text, not the parsed URL: a percent-encoded `%3F` in a
+  // path is a path, and only a literal `?`/`#` starts a query or fragment.
+  if (trimmed.includes('?') || trimmed.includes('#')) {
+    return { ok: false, reason: 'query_or_fragment' };
+  }
+  const canonical = parsed.toString();
+  if (new TextEncoder().encode(canonical).byteLength > CONNECTION_BASE_URL_MAX_BYTES) {
+    return { ok: false, reason: 'too_many_bytes' };
+  }
+  return { ok: true, value: canonical };
+}
+
+/**
+ * The developer-facing English sentence for a rejection, used by the IPC
+ * gate whose message reaches a log or a raw error rather than a user.
  *
  * Returns `null` on accept, an error string on reject. Mirrors
  * `validateSlug`'s shape.
@@ -603,24 +683,28 @@ export function validateConnectionBaseUrl(baseUrl: string | undefined | null): s
   // No baseUrl override is valid — the caller falls back to the
   // provider default.
   if (baseUrl === undefined || baseUrl === null) return null;
-  const trimmed = baseUrl.trim();
-  if (trimmed === '') return null;
-  if (trimmed.length > 2048) {
-    return 'baseUrl must be 2048 characters or fewer';
+  const result = canonicalizeConnectionBaseUrl(baseUrl);
+  if (result.ok) return null;
+  return connectionBaseUrlRejectionMessage(result);
+}
+
+export function connectionBaseUrlRejectionMessage(rejection: ConnectionBaseUrlRejected): string {
+  switch (rejection.reason) {
+    case 'not_a_string':
+      return 'baseUrl must be a string';
+    case 'too_long':
+      return `baseUrl must be ${CONNECTION_BASE_URL_MAX_LENGTH} characters or fewer`;
+    case 'too_many_bytes':
+      return `baseUrl must not exceed ${CONNECTION_BASE_URL_MAX_BYTES} bytes`;
+    case 'malformed':
+      return 'baseUrl must be a valid URL';
+    case 'scheme':
+      return `baseUrl scheme '${rejection.scheme}' is not allowed (use http: or https:)`;
+    case 'credentials':
+      return 'baseUrl must not contain credentials';
+    case 'query_or_fragment':
+      return 'baseUrl must not contain a query or fragment';
   }
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed);
-  } catch {
-    return 'baseUrl must be a valid URL';
-  }
-  // Closed scheme allowlist. `URL.protocol` includes the trailing
-  // colon and is lowercased by the WHATWG URL spec for special
-  // schemes.
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return `baseUrl scheme '${parsed.protocol}' is not allowed (use http: or https:)`;
-  }
-  return null;
 }
 
 /**
@@ -647,50 +731,22 @@ export function validateConnectionBaseUrl(baseUrl: string | undefined | null): s
  * validation).
  *
  * Return shape:
- *   - `{ ok: false, error }` — bad scheme / malformed / oversize.
- *   - `{ ok: true, value: '<trimmed URL>' }` — accepted override.
+ *   - `{ ok: false, error }` — rejected; see `canonicalizeConnectionBaseUrl`.
+ *   - `{ ok: true, value: '<canonical URL>' }` — accepted override.
  *     Caller sets the store payload's `baseUrl` to this value.
- *   - `{ ok: true, value: '' }` — EXPLICIT CLEAR INTENT (user
- *     typed whitespace meaning "remove my override"). Caller must
+ *   - `{ ok: true, value: '' }` — EXPLICIT CLEAR INTENT. Caller must
  *     preserve this as `''` so the store's existing clear semantics
  *     (`patch.baseUrl !== undefined ? patch.baseUrl || undefined :
  *     current.baseUrl`) treat it as "clear existing override". DO
  *     NOT convert to `undefined` — that would be "don't touch" and
  *     silently swallow the user's clear intent.
- *
- * The trim is the only canonicalization performed. We deliberately
- * do NOT change scheme/host case, strip default ports, drop
- * fragments, etc. — that's a different normalization (URL
- * canonicalization) and could surprise users who deliberately
- * configured `https://Example.com:443/V1`. Trim is the minimum
- * needed to prevent whitespace from becoming a stored override.
  */
 export function normalizeConnectionBaseUrl(
   baseUrl: unknown,
 ): { ok: true; value: string } | { ok: false; error: string } {
-  // PR-UI-IPC-1 review fixup v3 (@kenji msg 57ac8a8c): defensive
-  // runtime-type guard. TypeScript signature `(input: string)` is
-  // a compile-time guarantee, but IPC payloads from the renderer
-  // arrive over a process boundary and could be `null` / number /
-  // object / array regardless. Without this guard, `baseUrl.trim()`
-  // would throw TypeError on non-string and the IPC handler would
-  // surface an opaque crash instead of the typed reject the gate
-  // promises.
-  if (typeof baseUrl !== 'string') {
-    return { ok: false, error: 'baseUrl must be a string' };
-  }
-  // Validate first so bad schemes / malformed / oversize reject
-  // before we report a normalized value.
-  const error = validateConnectionBaseUrl(baseUrl);
-  if (error !== null) {
-    return { ok: false, error };
-  }
-  // Validate accepted. Trim is the only canonicalization. An empty
-  // trimmed value is the explicit-clear intent (user typed
-  // whitespace = "remove my override"); preserve it as `''` so the
-  // store's existing clear semantics fire. The caller must NOT
-  // convert this to `undefined` — see contract note above.
-  return { ok: true, value: baseUrl.trim() };
+  const result = canonicalizeConnectionBaseUrl(baseUrl);
+  if (result.ok) return { ok: true, value: result.value };
+  return { ok: false, error: connectionBaseUrlRejectionMessage(result) };
 }
 
 export interface CreateConnectionInput {

--- a/packages/core/src/runtime-policy/connection-catalog-codec.ts
+++ b/packages/core/src/runtime-policy/connection-catalog-codec.ts
@@ -18,10 +18,14 @@
  */
 
 import {
+  canonicalizeConnectionBaseUrl,
+  CONNECTION_BASE_URL_MAX_BYTES,
+  CONNECTION_BASE_URL_MAX_LENGTH,
   isRelayProviderType,
   PROVIDER_DEFAULTS,
   providerDefaultsOf,
   validateSlug,
+  type ConnectionBaseUrlRejection,
   type ProviderType,
 } from '../llm-connections.js';
 import {
@@ -635,28 +639,15 @@ export function normalizeCatalogConnectionBaseUrl(
   providerType?: ProviderType,
 ): string | undefined {
   if (value === undefined) return undefined;
-  const raw = stringValue(value, 'connection base URL', 2_048);
-  const trimmed = raw.trim();
-  if (!trimmed) return undefined;
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed);
-  } catch {
-    throw domainError('connection base URL must be a valid URL');
-  }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw domainError('connection base URL must use http or https');
-  }
-  if (parsed.username || parsed.password) {
-    throw domainError('connection base URL must not contain credentials');
-  }
-  if (trimmed.includes('?') || trimmed.includes('#')) {
-    throw domainError('connection base URL must not contain a query or fragment');
-  }
-  const canonical = parsed.toString();
-  if (new TextEncoder().encode(canonical).byteLength > 2_048) {
-    throw domainError('connection base URL must not exceed 2048 bytes');
-  }
+  // One rule, three vocabularies: the shape check, the scheme allowlist, the
+  // credential and query/fragment bans, and the canonical form all live in
+  // `canonicalizeConnectionBaseUrl` so the Desktop form and the IPC gate
+  // cannot accept an endpoint this codec would refuse (#3672). Only the
+  // wording is ours — these sentences are wire-facing and pinned by tests.
+  const result = canonicalizeConnectionBaseUrl(value);
+  if (!result.ok) throw domainError(catalogBaseUrlRejectionMessage(result.reason));
+  const canonical = result.value;
+  if (!canonical) return undefined;
   const providerDefault =
     providerType === undefined ? undefined : canonicalProviderBaseUrl(providerType);
   const override = canonical === providerDefault ? undefined : canonical;
@@ -668,6 +659,24 @@ export function normalizeCatalogConnectionBaseUrl(
     throw domainError('OAuth provider endpoint cannot be overridden');
   }
   return override;
+}
+
+function catalogBaseUrlRejectionMessage(reason: ConnectionBaseUrlRejection): string {
+  switch (reason) {
+    case 'not_a_string':
+    case 'too_long':
+      return `connection base URL must be a string no longer than ${CONNECTION_BASE_URL_MAX_LENGTH} characters`;
+    case 'too_many_bytes':
+      return `connection base URL must not exceed ${CONNECTION_BASE_URL_MAX_BYTES} bytes`;
+    case 'malformed':
+      return 'connection base URL must be a valid URL';
+    case 'scheme':
+      return 'connection base URL must use http or https';
+    case 'credentials':
+      return 'connection base URL must not contain credentials';
+    case 'query_or_fragment':
+      return 'connection base URL must not contain a query or fragment';
+  }
 }
 
 export function decodeCanonicalConnectionBaseUrl(


### PR DESCRIPTION
## Summary

The Desktop connection forms accepted endpoints the Runtime Host refuses. A service URL carrying a query string, a fragment, or embedded credentials passed the add form's field gate, passed the main-process IPC gate, and then failed at the write — where the Host's English domain error reached the renderer unclassified and fell through to `actionFallback`:

> 模型连接服务暂时不可用，请稍后重试。
> The model connection service is temporarily unavailable. Try again later.

That names neither the field nor the rule, and asks for a retry that can never succeed. Both write paths were affected: adding a custom relay and editing an existing endpoint.

Two validators had drifted. `validateConnectionBaseUrl` checked length, `URL` parseability, and an http/https allowlist, and documented "trim is the only canonicalization". `normalizeCatalogConnectionBaseUrl` additionally rejected credentials and `?`/`#`, canonicalized through `URL.toString()`, and capped the canonical form at 2048 **bytes**.

The rule now has one implementation. `canonicalizeConnectionBaseUrl` holds the shape check, the scheme allowlist, the credential and query/fragment bans, both caps, and the canonical form. `validateConnectionBaseUrl`, `normalizeConnectionBaseUrl`, and the Host's `normalizeCatalogConnectionBaseUrl` all delegate to it and keep only their own wording — the Host's wire-facing sentences are byte-identical to before, since they are pinned by protocol tests. A rejection travels as a code (`credentials`, `query_or_fragment`, …), which is what lets the Desktop form render localized field copy from the same decision the Host makes.

Both write surfaces now check before they write: the add form marks its `baseUrl` field, and the detail page's endpoint row reports the rule that was broken instead of the generic service message.

Two notes on scope:

- **Canonicalization on the client is new and deliberate.** The previous comment argued that rewriting `https://Example.com:443/V1` could surprise whoever typed it that way. But the Host canonicalized on write regardless, so that form was never what got stored — the client was preserving a value the system discarded one hop later. Doing it here only moves the surprise to where the user can still see and correct it. The one test that pinned the old behavior is updated with that reasoning.
- **The Host contract is untouched.** Relaxing it to allow query strings, which Azure-style `?api-version=` gateways want, is a product and security decision for `dev@maka.apache.org`, not an implementation detail. This PR only makes the client agree with the contract that already exists.

Fixes #3672

## Verification

`npm run lint`, `npm run format:check`, `npm run build`, `npm run typecheck`, `npx knip --workspace apps/desktop`, `npx knip --workspace packages/ui` — all clean.

| Suite | Result |
| --- | --- |
| `@maka/core` | 651 pass / 0 fail |
| `@maka/desktop` | 1356 pass / 0 fail |
| `@maka/storage` | 906 pass / 0 fail (14 pre-existing skips) |
| `@maka/runtime-host` | 1119 pass / 0 fail |

The reported scenario, before and after, run against the built tree:

```
                          before                  after
1. add-form field gate    ACCEPTED                REJECTED {field: 'baseUrl', reason: 'invalid',
                                                            rejection: 'query_or_fragment'}
2. main-process IPC gate  ACCEPTED                REJECTED baseUrl must not contain a query or fragment
3. Runtime Host codec     REJECTED                REJECTED connection base URL must not contain a
                                                           query or fragment
```

The message the user reads at step 1 is now the rule, on the endpoint field:

```
en -> The service URL must not contain a query (?) or fragment (#). Use the advanced request
      settings below to add parameters.
zh -> 服务地址不能包含查询参数（?）或锚点（#）。如需附加参数，请使用下方的高级请求设置。
```

New tests, each pinning one contract:

- core: the four rules the client did not have (credentials, query, fragment, byte cap), plus a percent-encoded `?` staying accepted — the Host reads the typed text rather than the parsed URL, and so does the client now.
- core: **the anti-drift test** — a table of fifteen endpoints asserting the client gate and the Host codec agree on both the accept/reject verdict and the canonical value. The defect was drift between the two, not either one's rules, so this is the test that fails if they separate again.
- desktop: the field gate's new `invalid` issues, that the rule is not relay-only (a local runtime's editable port is checked too), that Cloudflare stays exempt because its field holds an account id rather than a URL, and that a bare host, a local port, and a percent-encoded `?` remain accepted.

Driven through the real app, using the `settings-models` e2e fixture whose seeded `no-models` connection is an `openai-compatible` relay with an editable endpoint row. Same steps in both: edit the service URL row, enter the URL above, save.

| | Toast |
| --- | --- |
| Before | **Failed to save model connection** — The model connection service is temporarily unavailable. Try again later. |
| After | **Failed to save model connection** — The service URL must not contain a query (?) or fragment (#). Use the advanced request settings below to add parameters. |

The row stays open with the draft intact either way; what changes is whether the message describes the thing that went wrong. Screenshots follow in a comment.

## Review focus

The canonicalization change is the one behavior change a reviewer should weigh rather than read past — it is what required editing an existing test's expectation rather than only adding to it. If the project would rather keep the client's as-typed value and fix only the misleading error, dropping the canonical form from `canonicalizeConnectionBaseUrl` and reverting that one assertion leaves the rest of the fix intact.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code diagnosed the drift between the two validators, implemented the shared rule across core / the Host codec / the Desktop forms and copy, and wrote the tests and verification above. I reviewed and verified the result.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
