### PR TITLE
fix(desktop): expose full usage request values

### DIFF
--- a/apps/desktop/src/renderer/settings/usage-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/usage-settings-page.tsx
@@ -324,14 +324,14 @@ function UsageRequestsPanel(props: {
       <UsageStatsTable
         ariaLabel={props.copy.tables.requestsAria}
         columns={[
-          { header: props.copy.tables.requestHeaders[0] },
-          { header: props.copy.tables.requestHeaders[1] },
+          { header: props.copy.tables.requestHeaders[0], width: 192 },
+          { header: props.copy.tables.requestHeaders[1], width: 72 },
           { header: props.copy.tables.requestHeaders[2], grow: true },
           { header: props.copy.tables.requestHeaders[3] },
           { header: props.copy.tables.requestHeaders[4], numeric: true },
           { header: props.copy.tables.requestHeaders[5], numeric: true },
           { header: props.copy.tables.requestHeaders[6], numeric: true },
-          { header: props.copy.tables.requestHeaders[7] },
+          { header: props.copy.tables.requestHeaders[7], width: 72 },
         ]}
         rows={props.logs.map((row) => [
           new Date(row.ts).toLocaleString(uiLocaleToIntlLocale(props.locale)),
@@ -469,18 +469,33 @@ interface UsageColumn {
   header: string;
   numeric?: boolean;
   grow?: boolean;
+  width?: number;
 }
 
-type UsageTableRow = Record<string, unknown> & {
-  id: number;
-  cells: Array<ReactNode>;
-};
+type UsageTableRow = Record<string, unknown> & { id: number };
+
+function usageCellNeedsCustomRenderer(value: ReactNode) {
+  return value !== null
+    && value !== undefined
+    && !['string', 'number', 'boolean', 'bigint'].includes(typeof value);
+}
 
 const usageTablePlugins = {
-  rowHeader: {
-    transformBodyCell: (cell, _column, _row, columnIndex) => columnIndex === 0
-      ? { ...cell, htmlProps: { ...cell.htmlProps, role: 'rowheader' } }
-      : cell,
+  cellSemantics: {
+    transformBodyCell: (cell, column, _row, columnIndex) => ({
+      ...cell,
+      htmlProps: {
+        ...cell.htmlProps,
+        ...(columnIndex === 0 ? { role: 'rowheader' as const } : {}),
+        ...(column.align === 'end'
+          ? {
+              className: [cell.htmlProps.className, 'settingsUsageNumericCell']
+                .filter(Boolean)
+                .join(' '),
+            }
+          : {}),
+      },
+    }),
   },
 } satisfies Record<string, TablePlugin<UsageTableRow>>;
 
@@ -510,18 +525,25 @@ function UsageStatsTable(props: {
       />
     );
   }
-  const data: UsageTableRow[] = props.rows.map((cells, id) => ({ id, cells }));
-  const columns: Array<TableColumn<UsageTableRow>> = props.columns.map((column, index) => ({
-    key: `cell-${index}`,
-    header: column.header,
-    align: column.numeric ? 'end' : 'start',
-    width: column.grow ? proportional(1) : pixel(column.numeric ? 88 : 120),
-    renderCell: (row) => (
-      <span className={column.numeric ? 'settingsUsageNumericCell' : undefined}>
-        {row.cells[index]}
-      </span>
-    ),
+  const data: UsageTableRow[] = props.rows.map((cells, id) => ({
+    id,
+    ...Object.fromEntries(cells.map((cell, index) => [`cell-${index}`, cell])),
   }));
+  const columns: Array<TableColumn<UsageTableRow>> = props.columns.map((column, index) => {
+    const key = `cell-${index}`;
+    const needsCustomRenderer = props.rows.some((row) => usageCellNeedsCustomRenderer(row[index]));
+    return {
+      key,
+      header: column.header,
+      align: column.numeric ? 'end' : 'start',
+      width: column.width !== undefined
+        ? pixel(column.width)
+        : column.grow
+          ? proportional(1)
+          : pixel(column.numeric ? 88 : 120),
+      ...(needsCustomRenderer ? { renderCell: (row) => row[key] as ReactNode } : {}),
+    };
+  });
 
   return (
     <Card className="settingsUsageTable" padding={3}>

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -58,6 +58,7 @@ import type {
 } from '../../src/preload/bridge-contract.js';
 import { withScopedMakaBridge } from '../maka-bridge';
 import { getDailyReviewSettingsCopy } from '../../src/renderer/locales/settings-daily-review-copy';
+import { getUsageSettingsCopy } from '../../src/renderer/locales/settings-usage-copy';
 
 /**
  * Read from the copy table, not typed out again. This selector matched a
@@ -1346,6 +1347,43 @@ export const UsageMultiModel: Story = {
 export const UsageLongTail: Story = {
   decorators: [withUsageLongTailBridge],
   render: () => <SettingsStory section="usage" />,
+  play: async ({ canvasElement, globals }) => {
+    const canvas = within(canvasElement);
+    const usageCopy = getUsageSettingsCopy(globals.locale === 'en' ? 'en' : 'zh');
+    await waitForStoryCondition(
+      () => canvas.queryByRole('table', { name: usageCopy.tables.requestsAria }) !== null
+        || canvas.queryByRole('button', { name: usageCopy.showDetails }) !== null,
+      'Usage request details did not become available',
+    );
+    const showDetails = canvas.queryByRole('button', { name: usageCopy.showDetails });
+    if (showDetails) await userEvent.click(showDetails);
+
+    const table = await canvas.findByRole('table', { name: usageCopy.tables.requestsAria });
+    const timeCell = table.querySelector<HTMLTableCellElement>('tbody tr td:first-child');
+    expect(timeCell).not.toBeNull();
+    const timeText = timeCell?.firstElementChild;
+    expect(timeText).toBeInstanceOf(HTMLElement);
+    const timeRange = document.createRange();
+    timeRange.selectNodeContents(timeText!);
+    const timeCellStyle = getComputedStyle(timeCell!);
+    const requiredWidth = timeRange.getBoundingClientRect().width
+      + Number.parseFloat(timeCellStyle.paddingLeft)
+      + Number.parseFloat(timeCellStyle.paddingRight);
+    expect(requiredWidth).toBeLessThanOrEqual(timeCell!.clientWidth);
+
+    const longTarget = 'anthropic/claude-sonnet-4-5-20250929-preview-extended-thinking';
+    const targetCellText = within(table).getByText(longTarget);
+    await waitFor(() => expect(targetCellText).toHaveAttribute('title', longTarget));
+    await userEvent.hover(targetCellText);
+    await waitFor(() => {
+      const tooltipId = targetCellText.getAttribute('aria-describedby');
+      expect(tooltipId).toBeTruthy();
+      const tooltip = document.getElementById(tooltipId!);
+      expect(tooltip).toHaveAttribute('role', 'tooltip');
+      expect(tooltip).toHaveTextContent(longTarget);
+    });
+    await userEvent.unhover(targetCellText);
+  },
 };
 // Real path: the same long-content Usage page at the minimum supported window width.
 export const UsageNarrow: Story = {


### PR DESCRIPTION
## Summary

- widen the usage request timestamp column so full localized date/time values remain visible in Chinese and English
- let primitive table cells use Astryx Table's default overflow handling, restoring full-value tooltips for truncated model and tool names
- preserve custom rendering for interactive session buttons and numeric alignment
- add a `UsageLongTail` Storybook interaction covering full timestamps and overflow tooltips

Fixes #3675

## Verification

- `npm --workspace @maka/desktop run typecheck`
- `npx biome check apps/desktop/src/renderer/settings/usage-settings-page.tsx apps/desktop/stories/settings/settings-pages.stories.tsx`
- `npm --workspace @maka/desktop run build:renderer`
- `git show --check HEAD`
- manually verified the `UsageLongTail` story in Chinese and English
- manually checked wide and narrow viewports; the narrow table remains horizontally scrollable

before
<img width="937" height="510" alt="image" src="https://github.com/user-attachments/assets/5f31ee6f-957f-400a-9c64-e3460dc0af83" />
after
<img width="903" height="366" alt="image" src="https://github.com/user-attachments/assets/bdc5d9bb-9203-4d6f-899b-dd8552b6d7dc" />


## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the table rendering issue, implemented the fix and regression coverage, ran verification, and drafted the issue and PR text. The human contributor of record reviewed and owns the contribution.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
