### PR TITLE
fix(desktop): preserve proxy auth intent in tests

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-settings-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-settings-ipc-main.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createDefaultRuntimePolicy,
+  type RuntimePolicy,
+} from "@maka/core/runtime-policy";
+import { registerRuntimeHostSettingsIpc } from "../runtime-host-settings-ipc-main.js";
+
+type TestCandidate = RuntimePolicy["networkProxy"];
+
+async function testCandidate(authEnabled: boolean): Promise<{
+  candidate: TestCandidate;
+  result: { ok: boolean; code: string };
+}> {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  const policy = createDefaultRuntimePolicy();
+  let candidate: TestCandidate | undefined;
+
+  registerRuntimeHostSettingsIpc({
+    ipcMain: {
+      handle(channel, listener) {
+        handlers.set(channel, listener as (...args: unknown[]) => unknown);
+      },
+    },
+    client: {
+      async queryRuntimePolicy() {
+        return { revision: 0, policy };
+      },
+      async testNetworkProxy(input: { networkProxy?: TestCandidate }) {
+        candidate = input.networkProxy;
+        return candidate?.authEnabled
+          ? {
+              ok: false,
+              latencyMs: 0,
+              error: "Proxy credential is not configured",
+            }
+          : { ok: true, latencyMs: 1, status: 200 };
+      },
+    } as never,
+    settingsStore: {} as never,
+    async applyClientSettings() {},
+  });
+
+  const handler = handlers.get("settings:testNetworkProxy");
+  assert.ok(handler);
+  const result = await handler({}, {
+    proxy: {
+      enabled: true,
+      type: "http",
+      host: "127.0.0.1",
+      port: 7897,
+      authEnabled,
+      bypassList: [],
+    },
+  });
+
+  assert.ok(candidate);
+  return {
+    candidate,
+    result: result as { ok: boolean; code: string },
+  };
+}
+
+test("proxy test preserves enabled authentication when credentials are empty", async () => {
+  const tested = await testCandidate(true);
+
+  assert.equal(tested.candidate.authEnabled, true);
+  assert.equal(tested.result.ok, false);
+  assert.equal(tested.result.code, "proxy_unreachable");
+});
+
+test("proxy test preserves disabled authentication for a local proxy", async () => {
+  const tested = await testCandidate(false);
+
+  assert.equal(tested.candidate.authEnabled, false);
+  assert.equal(tested.result.ok, true);
+  assert.equal(tested.result.code, "proxy_reachable");
+});

--- a/apps/desktop/src/main/runtime-host-settings-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-settings-ipc-main.ts
@@ -30,8 +30,8 @@ import type {
 } from "@maka/core/runtime-policy";
 import { SENSITIVE_PLACEHOLDER } from "@maka/core/settings/network-settings";
 import type {
-  ProxySettings,
   TestProxyInput,
+  TestProxySettings,
 } from "@maka/core/settings/network-settings";
 import type { SettingsStore } from "@maka/storage";
 import {
@@ -149,11 +149,12 @@ export async function updateRuntimeHostSettings(
 }
 
 function toRuntimeHostProxyPolicy(
-  proxy: ProxySettings,
+  proxy: TestProxySettings,
   autoBypassDomains: readonly string[],
 ): RuntimePolicy["networkProxy"] {
   const username = proxy.username?.trim() ?? "";
-  const authEnabled = Boolean(username || proxy.password);
+  const authEnabled =
+    proxy.authEnabled ?? Boolean(username || proxy.password);
   return {
     enabled: proxy.enabled,
     protocol: proxy.type,

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -793,6 +793,7 @@ function toProxyTestInput(proxy: NetworkProxySettings): TestProxyInput {
       type: proxy.protocol,
       host: proxy.host.trim(),
       port: proxy.port,
+      authEnabled: proxy.authEnabled,
       username:
         proxy.authEnabled && proxy.username.trim()
           ? proxy.username.trim()

--- a/packages/core/src/settings/network-settings.ts
+++ b/packages/core/src/settings/network-settings.ts
@@ -68,8 +68,12 @@ export const NETWORK_DEFAULTS: RuntimeNetworkSettings = {
   preferIpv4: false,
 };
 
+export interface TestProxySettings extends ProxySettings {
+  authEnabled?: boolean;
+}
+
 export interface TestProxyInput {
-  proxy?: ProxySettings;
+  proxy?: TestProxySettings;
   url?: string;
   timeoutMs?: number;
 }


### PR DESCRIPTION
## Summary

- carry the Settings draft's explicit proxy authentication state through the test-only proxy candidate
- make the Desktop IPC adapter prefer explicit authentication intent while retaining value-based inference for legacy callers
- add regression coverage proving missing credentials fail when authentication is enabled and unauthenticated local proxy tests remain unchanged

Fixes #3682

## Verification

- `npm run lint` — 2,672 files checked, no fixes required
- `npm run format:check` — 1,615 files checked, no fixes required
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build:workspace-deps`
- `npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/runtime-host-settings-ipc-main.test.js` — 2 passed, 0 failed
- `node --test --test-reporter=dot "apps/desktop/dist/main/**/*.test.js"`
- `git diff --check upstream/main...HEAD`

The regression test was run before the production change and failed on the enabled-authentication assertion (`false !== true`), then passed after the fix.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex reproduced and diagnosed the proxy-test inconsistency, implemented the contract and IPC fix, added regression coverage, ran verification, and drafted the issue and PR text. The human contributor of record reviewed the proposed behavior and owns the contribution.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
