### PR TITLE
fix(ui): abbreviate sidebar timestamps

### DIFF
--- a/packages/core/src/__tests__/relative-time.test.ts
+++ b/packages/core/src/__tests__/relative-time.test.ts
@@ -22,7 +22,9 @@ import { describe, it } from 'node:test';
 import {
   formatCompactTimestamp,
   formatRelativeTimestamp,
+  formatSidebarTimestamp,
   nextRelativeRefreshDelay,
+  nextSidebarRefreshDelay,
   resetRelativeTimeFormatters,
 } from '../relative-time.js';
 
@@ -37,6 +39,7 @@ describe('relative timestamp labels', () => {
       assert.equal(formatRelativeTimestamp(NOW - ageMs, NOW, 'zh'), '刚刚');
       assert.equal(formatRelativeTimestamp(NOW - ageMs, NOW, 'en'), 'just now');
       assert.equal(formatCompactTimestamp(NOW - ageMs, NOW, 'zh'), '刚刚');
+      assert.equal(formatSidebarTimestamp(NOW - ageMs, NOW, 'zh'), '刚刚');
     }
 
     assert.equal(formatRelativeTimestamp(NOW - 60_000, NOW, 'zh'), '1分钟前');
@@ -49,6 +52,44 @@ describe('relative timestamp labels', () => {
     assert.equal(nextRelativeRefreshDelay(NOW - 60_000, NOW), 60_000);
   });
 
+  it('uses scan-friendly units for sidebar timestamps', () => {
+    for (const locale of ['zh', 'en'] as const) {
+      for (const [ageMs, expected] of [
+        [60_000, '1min'],
+        [46 * 60_000, '46min'],
+        [13 * 60 * 60_000, '13h'],
+        [3 * 24 * 60 * 60_000, '3d'],
+        [17 * 24 * 60 * 60_000, '17d'],
+        [29 * 24 * 60 * 60_000, '29d'],
+        [30 * 24 * 60 * 60_000, '1mo'],
+        [60 * 24 * 60 * 60_000, '2mo'],
+        [365 * 24 * 60 * 60_000, '1y'],
+      ] as const) {
+        assert.equal(formatSidebarTimestamp(NOW - ageMs, NOW, locale), expected);
+      }
+    }
+  });
+
+  it('keeps the existing compact date fallback outside the sidebar', () => {
+    const ts = NOW - 17 * 24 * 60 * 60_000;
+    const expected = new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(ts));
+
+    assert.equal(formatCompactTimestamp(ts, NOW, 'en'), expected);
+  });
+
+  it('refreshes sidebar timestamps at the next visible bucket', () => {
+    const nearRoundedDayBucketBoundary = NOW - (17 * 24 * 60 + 11 * 60 + 58) * 60_000;
+
+    assert.equal(formatSidebarTimestamp(nearRoundedDayBucketBoundary, NOW, 'en'), '17d');
+    assert.equal(nextSidebarRefreshDelay(nearRoundedDayBucketBoundary, NOW), 2 * 60_000);
+    assert.equal(nextSidebarRefreshDelay(NOW - 17 * 24 * 60 * 60_000, NOW), 12 * 60 * 60_000);
+    assert.equal(nextSidebarRefreshDelay(NOW - THIRTY_DAYS_MS, NOW), 15 * 24 * 60 * 60_000);
+    assert.equal(nextSidebarRefreshDelay(NOW - 365 * 24 * 60 * 60_000, NOW), 24 * 24 * 60 * 60_000);
+  });
+
   it('treats a finite future timestamp as just now and schedules recovery', () => {
     const futureTs = NOW + THIRTY_DAYS_MS;
     const delay = nextRelativeRefreshDelay(futureTs, NOW);
@@ -56,6 +97,7 @@ describe('relative timestamp labels', () => {
     assert.equal(delay, 60_000);
     assert.equal(formatRelativeTimestamp(futureTs, NOW, 'en'), 'just now');
     assert.equal(formatCompactTimestamp(futureTs, NOW, 'en'), 'just now');
+    assert.equal(formatSidebarTimestamp(futureTs, NOW, 'en'), 'just now');
   });
 
   it('keeps timestamp refresh delays within the scheduler bound', () => {

--- a/packages/core/src/relative-time.ts
+++ b/packages/core/src/relative-time.ts
@@ -32,6 +32,20 @@ const RELATIVE_HORIZON_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Age below this stays on one just-now label instead of counting seconds. */
 const JUST_NOW_MS = 60_000;
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const MONTH_MS = 30 * DAY_MS;
+const YEAR_MS = 12 * MONTH_MS;
+/** Stays below the browser timer ceiling while avoiding needless daily wakes. */
+const MAX_SIDEBAR_REFRESH_MS = 24 * DAY_MS;
+const SIDEBAR_TIME_BUCKETS = [
+  { unitMs: MINUTE_MS, maxValue: 60, suffix: 'min' },
+  { unitMs: HOUR_MS, maxValue: 24, suffix: 'h' },
+  { unitMs: DAY_MS, maxValue: 30, suffix: 'd' },
+  { unitMs: MONTH_MS, maxValue: 12, suffix: 'mo' },
+  { unitMs: YEAR_MS, maxValue: Number.POSITIVE_INFINITY, suffix: 'y' },
+] as const;
 
 const JUST_NOW: UiCatalog<string> = {
   zh: '刚刚',
@@ -125,10 +139,8 @@ function getCompactFormats(uiLocale: UiLocale): {
 }
 
 /**
- * Compact variant for space-starved rows (sidebar session list): same relative
- * buckets inside the horizon, then a date-only label ("6月20日" within the
- * current year, "2025年6月20日" across years) instead of the wide
- * medium-date-plus-time fallback.
+ * Compact variant for wider list rows: relative inside the seven-day horizon,
+ * then a localized date-only label.
  */
 export function formatCompactTimestamp(
   ts: number,
@@ -143,6 +155,22 @@ export function formatCompactTimestamp(
   return date.getFullYear() === nowDate.getFullYear()
     ? sameYear.format(date)
     : otherYear.format(date);
+}
+
+/**
+ * Scan-friendly relative label for space-starved rows (sidebar session list).
+ * Unit tokens stay deliberately locale-neutral so the trailing column remains
+ * stable across UI languages: "46min", "13h", "17d", "1mo", "1y".
+ */
+export function formatSidebarTimestamp(
+  ts: number,
+  now: number = Date.now(),
+  locale: UiLocale = 'zh',
+): string {
+  const diffMs = relativeAgeMs(ts, now);
+  if (diffMs < JUST_NOW_MS) return JUST_NOW[locale];
+  const bucket = sidebarTimeBucket(diffMs);
+  return `${bucket.value}${bucket.suffix}`;
 }
 
 /**
@@ -169,4 +197,32 @@ export function nextRelativeRefreshDelay(ts: number, now: number = Date.now()): 
   if (ageMs < JUST_NOW_MS) return JUST_NOW_MS - ageMs;
   if (ageMs < 60 * 60_000) return 60_000;
   return 10 * 60_000;
+}
+
+function nextRoundedBoundaryDelay(ageMs: number, unitMs: number, value: number): number {
+  return Math.max(1, Math.ceil((value + 0.5) * unitMs - ageMs));
+}
+
+function sidebarTimeBucket(ageMs: number): {
+  value: number;
+  unitMs: number;
+  suffix: (typeof SIDEBAR_TIME_BUCKETS)[number]['suffix'];
+} {
+  for (const bucket of SIDEBAR_TIME_BUCKETS) {
+    const value = Math.round(ageMs / bucket.unitMs);
+    if (value < bucket.maxValue) return { value, unitMs: bucket.unitMs, suffix: bucket.suffix };
+  }
+  throw new Error('Sidebar time buckets must end with an unbounded bucket');
+}
+
+/** Refreshes at the next visible sidebar bucket, capped below the timer ceiling. */
+export function nextSidebarRefreshDelay(ts: number, now: number = Date.now()): number | null {
+  const ageMs = relativeAgeMs(ts, now);
+  if (!Number.isFinite(ageMs)) return null;
+  if (ageMs < JUST_NOW_MS) return JUST_NOW_MS - ageMs;
+  const bucket = sidebarTimeBucket(ageMs);
+  return Math.min(
+    nextRoundedBoundaryDelay(ageMs, bucket.unitMs, bucket.value),
+    MAX_SIDEBAR_REFRESH_MS,
+  );
 }

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -106,6 +106,27 @@ test('renders session navigation and row actions as sibling controls', () => {
   assertNoNestedButtons(markup);
 });
 
+test('renders a scan-friendly compact timestamp in the session rail', () => {
+  const now = Date.UTC(2026, 7, 24, 12, 0, 0);
+  const originalDateNow = Date.now;
+  Date.now = () => now;
+  try {
+    const markup = renderToStaticMarkup(
+      <LocaleProvider locale="en">
+        <SessionHistoryList
+          sessions={[{ ...session, lastMessageAt: now - 46 * 60_000 }]}
+          onSelectSession={() => undefined}
+        />
+      </LocaleProvider>,
+    );
+    const { document } = parseHTML(markup);
+
+    assert.equal(document.querySelector('.maka-session-row-time-label')?.textContent, '46min');
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test('renders Runtime Host live runs without requiring renderer-local streaming', () => {
   const hostRunning = { ...session, runningTurnIds: ['turn-live'] };
   const markup = renderToStaticMarkup(

--- a/packages/ui/src/relative-time.tsx
+++ b/packages/ui/src/relative-time.tsx
@@ -20,9 +20,10 @@
 import { useEffect, useState } from 'react';
 import { formatAbsoluteTimestamp } from './chat-display-helpers.js';
 import {
-  formatCompactTimestamp,
   formatRelativeTimestamp,
   nextRelativeRefreshDelay,
+  formatSidebarTimestamp,
+  nextSidebarRefreshDelay,
 } from '@maka/core/relative-time';
 import { cn } from './utils.js';
 import { useUiLocale } from './locale-context.js';
@@ -31,24 +32,27 @@ import { useUiLocale } from './locale-context.js';
  * Self-refreshing relative-time label: stays on the just-now label for the
  * first minute, then ticks every minute, then every 10 minutes (see
  * `nextRelativeRefreshDelay`), stopping past the 7-day horizon to show the
- * absolute date. `variant="compact"` uses the date-only fallback
- * (`formatCompactTimestamp`) that fits space-starved sidebar rows.
+ * absolute date. `variant="sidebar"` uses abbreviated relative units and
+ * refreshes at the next visible bucket for space-starved sidebar rows.
  */
 export function RelativeTime(props: {
   ts: number;
   className?: string;
   suppressTitle?: boolean;
-  variant?: 'relative' | 'compact';
+  variant?: 'relative' | 'sidebar';
 }) {
   const locale = useUiLocale();
   const [, setTick] = useState(0);
   useEffect(() => {
-    const delay = nextRelativeRefreshDelay(props.ts);
+    const delay =
+      props.variant === 'sidebar'
+        ? nextSidebarRefreshDelay(props.ts)
+        : nextRelativeRefreshDelay(props.ts);
     if (delay === null) return;
     const id = setTimeout(() => setTick((n) => n + 1), delay);
     return () => clearTimeout(id);
   });
-  const format = props.variant === 'compact' ? formatCompactTimestamp : formatRelativeTimestamp;
+  const format = props.variant === 'sidebar' ? formatSidebarTimestamp : formatRelativeTimestamp;
   return (
     <small
       className={cn('tabular-nums', props.className ?? 'maka-message-time')}

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -466,7 +466,7 @@ const SessionNavRow = memo(function SessionNavRow(props: {
               {props.session.lastMessageAt ? (
                 <RelativeTime
                   ts={props.session.lastMessageAt}
-                  variant="compact"
+                  variant="sidebar"
                   className="maka-session-row-time-label"
                   suppressTitle
                 />


### PR DESCRIPTION
## Summary

- Abbreviate session-sidebar timestamps as `min`, `h`, `d`, `mo`, and `y`, matching the compact Codex-style display.
- Keep the localized “just now” state and preserve the existing compact date format used outside the sidebar.
- Refresh each timestamp at the next visible rounding boundary so labels do not become stale.

## Verification

- `npm --workspace @maka/core test`
- `npm --workspace @maka/ui test`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- Storybook: `Product/Sidebar Session List / Long Titles and Narrow` rendered `52min`, `6min`, and `31min`.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex assisted with diagnosis, implementation, tests, and adversarial review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
