### PR TITLE
fix(ui): stop tool-well copy button colliding with long first lines and titles

### DIFF
--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -697,12 +697,16 @@
    Ellipsize it inside the title slot the header already sizes (flex: 1,
    min-width: 0). display: block because a flex container will not ellipsize
    its anonymous text; tool wells never render the collapsible chevron that
-   the flex display exists for. */
+   the flex display exists for. white-space stays `pre`, not nowrap: both
+   satisfy text-overflow's no-wrap requirement, but nowrap would collapse
+   runs of spaces — and a title is often a literal path or command where
+   `report  final.txt` and `report final.txt` are different names, with the
+   title as their only display (the copy button copies the body). */
 .maka-tool-call-detail .astryx-codeblock-header .astryx-codeblock-title {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: pre;
 }
 .maka-tool-output-chunk { display: contents; }
 .maka-tool-output-chunk-stderr { color: var(--destructive); }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -689,6 +689,21 @@
   width: 28px;
   height: 24px;
 }
+/* The headered variant has the same collision inside its header row: the
+   title (often a long unbroken maka://archive URI headline) is a flex span
+   with white-space: pre and visible overflow, so it runs straight under the
+   header's copy button — and headerCompact draws no divider, so the title
+   reads as the well's first content line while colliding like an overlay.
+   Ellipsize it inside the title slot the header already sizes (flex: 1,
+   min-width: 0). display: block because a flex container will not ellipsize
+   its anonymous text; tool wells never render the collapsible chevron that
+   the flex display exists for. */
+.maka-tool-call-detail .astryx-codeblock-header .astryx-codeblock-title {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .maka-tool-output-chunk { display: contents; }
 .maka-tool-output-chunk-stderr { color: var(--destructive); }
 .maka-tool-output-chunk-redacted { opacity: 0.65; }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -670,6 +670,25 @@
      a rhythm no other row in the panel has. */
   --text-supporting-leading: var(--text-code-leading);
 }
+/* A headerless CodeBlock floats its copy button over the viewport's top-right
+   corner, and a long unbroken first line — a maka://archive URI, a long
+   command — runs straight under it (markdown avoids this by always giving the
+   block a header toolbar; tool wells stay quiet on purpose). Reserve the
+   button's footprint with a float on the first line so wrapped text flows
+   around the corner instead of colliding. On the line div, not <code>: 100+
+   line blocks wrap lines in content-visibility chunks whose layout containment
+   would keep an outer float from shortening their line boxes. The lengths are
+   the button's geometry, not tunables: the 28px button inset spacing-2 (8px)
+   ends 20px past the code's spacing-4 (16px) inline padding — plus an 8px gap
+   — and its bottom edge sits 36px − spacing-3 (12px) = 24px below the first
+   line's top. Tool wells never enable line numbers, so the numbered-gutter
+   ::before cannot collide here. */
+.maka-tool-call-detail .astryx-codeblock:not(:has(.astryx-codeblock-header)) [data-line="1"]::before {
+  content: '';
+  float: inline-end;
+  width: 28px;
+  height: 24px;
+}
 .maka-tool-output-chunk { display: contents; }
 .maka-tool-output-chunk-stderr { color: var(--destructive); }
 .maka-tool-output-chunk-redacted { opacity: 0.65; }


### PR DESCRIPTION
## Problem

In tool-call detail wells, a long unbroken line — typically a `maka://archive/tool-result-archive-…` URI — collides with the well's copy button. Two distinct layouts produce the same visual overlap:

1. **Headered wells** (the reported case): the result headline becomes the Astryx CodeBlock header title, a flex span with `white-space: pre` and visible overflow. The compact header draws no divider, so the title reads as the well's first content line — and runs straight under the header's copy button, then hard-clips at the container edge.
2. **Headerless wells** (same collision, different mechanism): Astryx floats the copy button absolutely over the scroll viewport's top-right (`copyButtonAbsolute`), and wrapped content's first line passes under it — the wrap point is the container edge, not the button edge.

### Before
![before](https://raw.githubusercontent.com/GabrielDrapor/maka-agent/42c9d6335947fb9b568f149be7d01278cf52ea52/tool-well-before.png)

### After
![after](https://raw.githubusercontent.com/GabrielDrapor/maka-agent/42c9d6335947fb9b568f149be7d01278cf52ea52/tool-well-after.png)

## Fix (CSS only, scoped to `.maka-tool-call-detail`)

- **Headered**: ellipsize the title inside the flex slot the header already sizes (`flex: 1` / `min-width: 0` on its wrapper). `display: block` because a flex container will not ellipsize its anonymous text; tool wells never render the collapsible chevron that the flex display exists for. `white-space` stays `pre` — both `pre` and `nowrap` satisfy `text-overflow`'s no-wrap requirement, but `nowrap` would collapse runs of spaces, and a title is often a literal path where `report  final.txt` and `report final.txt` are different names (this was a review finding, see below).
- **Headerless**: reserve the floating button's footprint with a 28×24px `float: inline-end` `::before` on the first line, so wrapped text flows around the corner. The lengths are the button's geometry, not tunables: the 28px sm IconButton inset `spacing-2` ends 20px past the code's `spacing-4` inline padding (+8px gap), and its bottom edge sits 36px − `spacing-3` = 24px below the first line's top. Anchored on the line div rather than `<code>` because 100+-line blocks wrap lines in `content-visibility` chunks whose layout containment would keep an outer float from shortening their line boxes. Logical properties throughout, so RTL follows the button (`inset-inline-end`).

This mirrors the doctrine already recorded for markdown code blocks (styles.css: markdown always gives CodeBlock a structural header "instead of overlaying the horizontal scroll viewport") while keeping tool wells quiet — no added header chrome.

## Verification

- Verified live against the packaged app via devtools on the reported well: title ellipsizes exactly at the button's edge (boundary 1031/1031, zero overlap); before/after screenshots above are from that app.
- An adversarial review pass (Codex) over the diff confirmed the geometry against the Astryx tokens (`--size-element-sm`, `spacing-2/3/4`), the header-class guard, RTL, consumer scope, and cascade order; its one P2 — `nowrap` collapsing literal spaces in path-like titles — is fixed in the third commit by keeping `white-space: pre`.
- `npm run format:check` clean.

Known trade-off: an ellipsized title's full value is no longer fully visible; it was not readable before either (hard clip + button overlap), it is excluded from the copy button's payload in both states (`pickHeadline` consumes it out of the body), and text selection still yields the full string. If the full headline should be hover-recoverable, a native `title` tooltip needs a small `ToolCodeBlock` component change — happy to follow up if preferred.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01VqBZ8cP7wMpy1mXTrn3VDg