### PR TITLE
test(ui): pin the humanized provider retry banner copy across locales and scales

### DIFF
--- a/packages/ui/src/__tests__/conversation-copy.test.ts
+++ b/packages/ui/src/__tests__/conversation-copy.test.ts
@@ -24,3 +24,35 @@ import { getConversationCopy } from '../conversation-copy.js';
 test('labels the Chinese default thinking level as default', () => {
   assert.equal(getConversationCopy('zh').model.defaultLevel, '默认');
 });
+
+/**
+ * A subscription quota window can hand the runtime an hour-scale Retry-After;
+ * the banner must count down in humanized d/h/m/s units rather than a raw
+ * five-digit second count that reads as a frozen hang (#3401).
+ */
+test('providerRetryScheduled humanizes hour-scale delays in both locales', () => {
+  const zh = getConversationCopy('zh').messages.providerRetryScheduled;
+  const en = getConversationCopy('en').messages.providerRetryScheduled;
+
+  // Sub-second and zero inputs still read as one second (never "0秒后重试").
+  assert.equal(zh(0, 2, 10), '1秒后重试（2/10）');
+  assert.equal(en(0, 2, 10), 'Retrying in 1s (2/10)');
+
+  // Short delays keep the compact seconds-only form.
+  assert.equal(zh(1, 2, 10), '1秒后重试（2/10）');
+  assert.equal(en(1, 2, 10), 'Retrying in 1s (2/10)');
+  assert.equal(zh(45, 2, 10), '45秒后重试（2/10）');
+  assert.equal(en(45, 2, 10), 'Retrying in 45s (2/10)');
+
+  // Minute-, hour-, and day-scale delays spell out the units.
+  assert.equal(zh(75, 2, 10), '1分 15秒后重试（2/10）');
+  assert.equal(en(75, 2, 10), 'Retrying in 1m 15s (2/10)');
+  assert.equal(zh(16_083, 2, 10), '4小时 28分 3秒后重试（2/10）');
+  assert.equal(en(16_083, 2, 10), 'Retrying in 4h 28m 3s (2/10)');
+  assert.equal(zh(90_061, 2, 10), '1天 1小时 1分 1秒后重试（2/10）');
+  assert.equal(en(90_061, 2, 10), 'Retrying in 1d 1h 1m 1s (2/10)');
+
+  // Zero-order units are skipped, not rendered as "0分".
+  assert.equal(zh(3_600, 2, 10), '1小时后重试（2/10）');
+  assert.equal(en(86_400, 2, 10), 'Retrying in 1d (2/10)');
+});


### PR DESCRIPTION
Follow-up to #3611 (and the closed #3402): @Astro-Han asked for the unit-test cases from #3402 to be sent standalone, since #3611 shipped the formatter without tests.

This adds one focused test pinning `providerRetryScheduled` in both locales:

- second/minute/hour/day scales (`45秒`, `1分 15秒`, `4小时 28分 3秒`, `1天 1小时 1分 1秒` — and the en equivalents)
- the ceil-to-one-second floor, so a zero-length wait reads `1秒后重试` / `Retrying in 1s` and never `0秒后重试`
- zero-order units are skipped rather than rendered as `0分` / `0m`

Also documents (per Astro-Han's note on #3402) that the zh short-delay string intentionally changed shape: `45 秒后重试` → `45秒后重试` (space dropped).

Generated-by: maka
