### PR TITLE
fix(desktop): retire the owned local Host on full quit

### DIFF
--- a/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
@@ -26,8 +26,10 @@ describe('app quit coordinator', () => {
     let resumeQuitCount = 0;
     let preventedCount = 0;
     const coordinator = createAppQuitCoordinator({
+      prepareToQuit: async () => {},
       cleanup: async () => {},
       focusOrCreateWindow: () => {},
+      onPreparationError: () => {},
       onCleanupError: () => {},
       onWindowCreationError: () => {},
       resumeQuit: () => {
@@ -48,7 +50,7 @@ describe('app quit coordinator', () => {
     assert.equal(resumeQuitCount, 0);
     assert.equal(preventedCount, 2);
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await flushQuitCoordinator();
 
     assert.equal(resumeQuitCount, 1);
   });
@@ -62,6 +64,7 @@ describe('app quit coordinator', () => {
       releaseCleanup = resolve;
     });
     const coordinator = createAppQuitCoordinator({
+      prepareToQuit: async () => {},
       cleanup: async () => {
         cleanupCount += 1;
         await cleanupPending;
@@ -69,6 +72,7 @@ describe('app quit coordinator', () => {
       focusOrCreateWindow: () => {
         focusOrCreateCount += 1;
       },
+      onPreparationError: () => {},
       onCleanupError: () => {},
       onWindowCreationError: () => {},
       resumeQuit: () => {
@@ -84,6 +88,7 @@ describe('app quit coordinator', () => {
 
     coordinator.handleBeforeQuit(event);
     coordinator.handleBeforeQuit(event);
+    await flushQuitCoordinator();
     assert.equal(cleanupCount, 1);
     assert.equal(preventedCount, 2);
     assert.equal(resumeQuitCount, 0);
@@ -91,7 +96,7 @@ describe('app quit coordinator', () => {
     releaseCleanup();
     await cleanupPending;
     await Promise.resolve();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await flushQuitCoordinator();
 
     assert.equal(resumeQuitCount, 1);
 
@@ -108,11 +113,13 @@ describe('app quit coordinator', () => {
     let focusOrCreateCount = 0;
     let windowCreationSignal: AbortSignal | undefined;
     const coordinator = createAppQuitCoordinator({
+      prepareToQuit: async () => {},
       cleanup: () => new Promise<void>(() => {}),
       focusOrCreateWindow: (signal) => {
         focusOrCreateCount += 1;
         windowCreationSignal = signal;
       },
+      onPreparationError: () => {},
       onCleanupError: () => {},
       onWindowCreationError: () => {},
       resumeQuit: () => {},
@@ -130,10 +137,12 @@ describe('app quit coordinator', () => {
     const failure = new Error('window load failed');
     const reportedErrors: unknown[] = [];
     const coordinator = createAppQuitCoordinator({
+      prepareToQuit: async () => {},
       cleanup: async () => {},
       focusOrCreateWindow: async () => {
         throw failure;
       },
+      onPreparationError: () => {},
       onCleanupError: () => {},
       onWindowCreationError: (error) => reportedErrors.push(error),
       resumeQuit: () => {},
@@ -146,18 +155,62 @@ describe('app quit coordinator', () => {
     assert.deepEqual(reportedErrors, [failure]);
   });
 
+  it('cancels quit without closing resources when Host retirement preparation fails', async () => {
+    const preparationError = new Error('retirement failed');
+    const reportedErrors: unknown[] = [];
+    let preparationCount = 0;
+    let cleanupCount = 0;
+    let focusOrCreateCount = 0;
+    let resumeQuitCount = 0;
+    const coordinator = createAppQuitCoordinator({
+      prepareToQuit: async () => {
+        preparationCount += 1;
+        if (preparationCount === 1) throw preparationError;
+      },
+      cleanup: async () => {
+        cleanupCount += 1;
+      },
+      focusOrCreateWindow: () => {
+        focusOrCreateCount += 1;
+      },
+      onPreparationError: (error) => reportedErrors.push(error),
+      onCleanupError: () => {},
+      onWindowCreationError: () => {},
+      resumeQuit: () => {
+        resumeQuitCount += 1;
+      },
+    });
+
+    coordinator.handleBeforeQuit({ preventDefault: () => {} });
+    await flushQuitCoordinator();
+
+    assert.deepEqual(reportedErrors, [preparationError]);
+    assert.equal(cleanupCount, 0);
+    assert.equal(resumeQuitCount, 0);
+    assert.equal(focusOrCreateCount, 1);
+
+    coordinator.handleBeforeQuit({ preventDefault: () => {} });
+    await flushQuitCoordinator();
+
+    assert.equal(preparationCount, 2);
+    assert.equal(cleanupCount, 1);
+    assert.equal(resumeQuitCount, 1);
+  });
+
   it('reports cleanup failure without leaking an unhandled rejection', async () => {
     const cleanupError = new Error('close failed');
     const reportedErrors: unknown[] = [];
     let focusOrCreateCount = 0;
     let resumeQuitCount = 0;
     const deps = {
+      prepareToQuit: async () => {},
       cleanup: async () => {
         throw cleanupError;
       },
       focusOrCreateWindow: () => {
         focusOrCreateCount += 1;
       },
+      onPreparationError: () => {},
       onCleanupError: (error: unknown) => {
         reportedErrors.push(error);
       },
@@ -169,8 +222,7 @@ describe('app quit coordinator', () => {
     const coordinator = createAppQuitCoordinator(deps);
 
     coordinator.handleBeforeQuit({ preventDefault: () => {} });
-    await Promise.resolve();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await flushQuitCoordinator();
     let secondQuitPrevented = false;
     coordinator.focusOrCreateWindow();
     coordinator.handleBeforeQuit({
@@ -185,3 +237,8 @@ describe('app quit coordinator', () => {
     assert.equal(secondQuitPrevented, false);
   });
 });
+
+async function flushQuitCoordinator(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -219,11 +219,51 @@ test('coalesces concurrent retirement intents onto one exact Host request', asyn
   const update = owner.retireOwnedLocalHost('refuse_active_work');
   await exitWaitStarted;
   const quit = owner.retireOwnedLocalHost('interrupt_active_work');
-  assert.equal(quit, update);
   releaseExitWait();
-  await Promise.all([update, quit]);
+  assert.deepEqual(
+    (await Promise.all([update, quit])).map(({ kind }) => kind),
+    ['retired', 'retired'],
+  );
 
   assert.equal(current.prepareRetirementCalls, 1);
+  assert.deepEqual(current.retirementModes, ['refuse_active_work']);
+  await owner.close();
+});
+
+test('reissues a concurrent strong retirement when weak retirement is refused', async () => {
+  let reportWeakPrepare!: () => void;
+  let releaseWeakPrepare!: () => void;
+  const weakPrepareStarted = new Promise<void>((resolve) => {
+    reportWeakPrepare = resolve;
+  });
+  const weakPrepareGate = new Promise<void>((resolve) => {
+    releaseWeakPrepare = resolve;
+  });
+  const current = candidateHarness({
+    activeTasks: true,
+    disconnectOnPrepare: true,
+    onPrepare: async (mode) => {
+      if (mode !== 'refuse_active_work') return;
+      reportWeakPrepare();
+      await weakPrepareGate;
+    },
+  });
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async () => ready(current.candidate),
+    waitForHostExit: async () => {},
+  });
+
+  const update = owner.retireOwnedLocalHost('refuse_active_work');
+  await weakPrepareStarted;
+  const quit = owner.retireOwnedLocalHost('interrupt_active_work');
+  releaseWeakPrepare();
+
+  assert.deepEqual(await update, { kind: 'active_tasks' });
+  assert.equal((await quit).kind, 'retired');
+  assert.deepEqual(current.retirementModes, [
+    'refuse_active_work',
+    'interrupt_active_work',
+  ]);
   await owner.close();
 });
 
@@ -287,6 +327,28 @@ test('resumes candidate launches when active tasks block the update', async () =
   assert.deepEqual(events, ['pause', 'retire', 'resume']);
   await owner.close();
   assert.equal(events.at(-1), 'release');
+});
+
+test('preserves Host facts when authorized retirement is refused', async () => {
+  const current = candidateHarness({ activeTasks: 'always' });
+  const owner = await startRuntimeHostDesktopManager({
+    rootPath: '/test-root',
+  } as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async () => ready(current.candidate),
+  });
+
+  await assert.rejects(
+    owner.retireOwnedLocalHost('interrupt_active_work'),
+    (error: unknown) =>
+      error instanceof DesktopLocalHostRetirementError &&
+      error.facts.hostId === 'test-host' &&
+      error.facts.hostEpoch === 'test-host-epoch' &&
+      error.facts.rootPath === '/test-root' &&
+      error.facts.pid === 42 &&
+      error.cause instanceof Error &&
+      error.cause.message === 'Runtime Host refused authorized retirement',
+  );
+  await owner.close();
 });
 
 test('resumes candidate launches when candidate retirement fails', async () => {
@@ -998,13 +1060,13 @@ function candidateHarness(
   options: {
     delayDisconnect?: boolean;
     disconnectOnPrepare?: boolean;
-    activeTasks?: boolean;
+    activeTasks?: boolean | 'always';
     lifecycleMode?: 'ephemeral' | 'service' | 'remote';
     hostId?: string;
     hostEpoch?: string;
     finalizeFailures?: Error[];
     disconnectOnFinalizeFailure?: boolean;
-    onPrepare?: () => void;
+    onPrepare?: (mode: string) => unknown | Promise<unknown>;
   } = {},
 ) {
   let resolveClosed: (() => void) | undefined;
@@ -1033,10 +1095,13 @@ function candidateHarness(
         return { pid: 42 };
       },
       async prepareHostRetirement(mode: string) {
-        options.onPrepare?.();
         prepareRetirementCalls += 1;
         retirementModes.push(mode);
-        if (options.activeTasks && mode === 'refuse_active_work') {
+        await options.onPrepare?.(mode);
+        if (
+          (options.activeTasks && mode === 'refuse_active_work') ||
+          options.activeTasks === 'always'
+        ) {
           return { kind: 'active_tasks' as const };
         }
         if (options.disconnectOnPrepare) {

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -35,6 +35,7 @@ import type {
   DesktopRuntimeHostCandidateStartResult,
 } from '../runtime-host-desktop-candidate.js';
 import {
+  DesktopLocalHostRetirementError,
   RuntimeHostPairingFinalizationInterruptedError,
   RuntimeHostUpgradeCancelledError,
   startRuntimeHostDesktopManager,
@@ -128,15 +129,101 @@ test('quiesces reconnect and waits for the Host process before update install', 
     },
   });
 
-  const preparation = await owner.prepareForUpdate(false);
-  assert.equal(preparation.kind, 'prepared');
-  assert.equal(current.prepareUpgradeCalls, 1);
-  assert.deepEqual(current.prepareUpgradeAuthorities, [false]);
+  const retirement = await owner.retireOwnedLocalHost('refuse_active_work');
+  assert.equal(retirement.kind, 'retired');
+  assert.equal(current.prepareRetirementCalls, 1);
+  assert.deepEqual(current.retirementModes, ['refuse_active_work']);
   assert.equal(waitedForPid, 42);
   assert.equal(starts, 1);
-  if (preparation.kind === 'prepared') preparation.rollback();
+  if (retirement.kind === 'retired') retirement.resume();
   await reconnected;
   assert.equal(starts, 2);
+  await owner.close();
+});
+
+test('retires the owned ephemeral Host before Desktop quit', async () => {
+  const events: string[] = [];
+  const current = candidateHarness({
+    activeTasks: true,
+    disconnectOnPrepare: true,
+    onPrepare: () => events.push('prepare-host'),
+  });
+  const owner = await startRuntimeHostDesktopManager({
+    candidateLaunchBarrier: {
+      connect: async () => assert.fail('mocked candidate startup bypasses the barrier'),
+      pause: () => events.push('pause-launches'),
+      retireExcept: async (pid: number) => {
+        events.push(`retire-except:${pid}`);
+      },
+      resume: () => events.push('resume-launches'),
+      release: () => events.push('release-launches'),
+    },
+  } as unknown as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async () => ready(current.candidate),
+    waitForHostExit: async (pid) => {
+      events.push(`wait:${pid}`);
+    },
+  });
+
+  await owner.retireOwnedLocalHost('interrupt_active_work');
+
+  assert.deepEqual(current.retirementModes, ['interrupt_active_work']);
+  assert.deepEqual(events, [
+    'pause-launches',
+    'retire-except:42',
+    'prepare-host',
+    'wait:42',
+  ]);
+  await owner.close();
+  assert.equal(events.at(-1), 'release-launches');
+  assert.ok(!events.includes('resume-launches'));
+});
+
+test('does not retire the local Host twice when an update handoff triggers quit', async () => {
+  const current = candidateHarness({ disconnectOnPrepare: true });
+  const waitedFor: number[] = [];
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async () => ready(current.candidate),
+    waitForHostExit: async (pid) => {
+      waitedFor.push(pid);
+    },
+  });
+
+  const update = await owner.retireOwnedLocalHost('refuse_active_work');
+  assert.equal(update.kind, 'retired');
+  await owner.retireOwnedLocalHost('interrupt_active_work');
+
+  assert.equal(current.prepareRetirementCalls, 1);
+  assert.deepEqual(waitedFor, [42]);
+  await owner.close();
+});
+
+test('coalesces concurrent retirement intents onto one exact Host request', async () => {
+  const current = candidateHarness({ disconnectOnPrepare: true });
+  let releaseExitWait!: () => void;
+  let reportExitWait!: () => void;
+  const exitWaitStarted = new Promise<void>((resolve) => {
+    reportExitWait = resolve;
+  });
+  const exitWait = new Promise<void>((resolve) => {
+    releaseExitWait = resolve;
+  });
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async () => ready(current.candidate),
+    waitForHostExit: async () => {
+      reportExitWait();
+      await exitWait;
+    },
+  });
+
+  const update = owner.retireOwnedLocalHost('refuse_active_work');
+  await exitWaitStarted;
+  const quit = owner.retireOwnedLocalHost('interrupt_active_work');
+  assert.equal(quit, update);
+  releaseExitWait();
+  await Promise.all([update, quit]);
+
+  assert.equal(current.prepareRetirementCalls, 1);
   await owner.close();
 });
 
@@ -163,15 +250,15 @@ test('retires unadopted candidates before draining the tracked Host', async () =
     },
   });
 
-  const preparation = await owner.prepareForUpdate(false);
-  assert.equal(preparation.kind, 'prepared');
+  const retirement = await owner.retireOwnedLocalHost('refuse_active_work');
+  assert.equal(retirement.kind, 'retired');
   assert.deepEqual(events, [
     'pause-launches',
     'retire-except:42',
     'prepare-host',
     'wait:42',
   ]);
-  if (preparation.kind === 'prepared') preparation.rollback();
+  if (retirement.kind === 'retired') retirement.resume();
   assert.equal(events.at(-1), 'resume-launches');
   await owner.close();
   assert.equal(events.at(-1), 'release-launches');
@@ -194,7 +281,9 @@ test('resumes candidate launches when active tasks block the update', async () =
     startCandidate: async () => ready(current.candidate),
   });
 
-  assert.deepEqual(await owner.prepareForUpdate(false), { kind: 'active_tasks' });
+  assert.deepEqual(await owner.retireOwnedLocalHost('refuse_active_work'), {
+    kind: 'active_tasks',
+  });
   assert.deepEqual(events, ['pause', 'retire', 'resume']);
   await owner.close();
   assert.equal(events.at(-1), 'release');
@@ -218,7 +307,14 @@ test('resumes candidate launches when candidate retirement fails', async () => {
     startCandidate: async () => ready(current.candidate),
   });
 
-  await assert.rejects(owner.prepareForUpdate(false), /retirement failed/);
+  await assert.rejects(
+    owner.retireOwnedLocalHost('refuse_active_work'),
+    (error: unknown) =>
+      error instanceof DesktopLocalHostRetirementError &&
+      error.facts.pid === 42 &&
+      error.cause instanceof Error &&
+      error.cause.message === 'retirement failed',
+  );
   assert.deepEqual(events, ['pause', 'retire', 'resume']);
   await owner.handleBotIncomingMessage({ text: 'still connected' } as BotIncomingMessage);
   assert.equal(current.botMessages, 1);
@@ -235,12 +331,14 @@ test('keeps active-task confirmation bound to the current Host', async () => {
     },
   });
 
-  assert.deepEqual(await owner.prepareForUpdate(false), { kind: 'active_tasks' });
+  assert.deepEqual(await owner.retireOwnedLocalHost('refuse_active_work'), {
+    kind: 'active_tasks',
+  });
   await owner.handleBotIncomingMessage({ text: 'still connected' } as BotIncomingMessage);
   assert.equal(current.botMessages, 1);
-  const authorized = await owner.prepareForUpdate(true);
-  assert.equal(authorized.kind, 'prepared');
-  assert.deepEqual(current.prepareUpgradeAuthorities, [false, true]);
+  const authorized = await owner.retireOwnedLocalHost('interrupt_active_work');
+  assert.equal(authorized.kind, 'retired');
+  assert.deepEqual(current.retirementModes, ['refuse_active_work', 'interrupt_active_work']);
   assert.deepEqual(waitedFor, [42]);
   await owner.close();
 });
@@ -253,10 +351,9 @@ for (const lifecycleMode of ['service', 'remote'] as const) {
       waitForHostExit: async () => assert.fail(`${lifecycleMode} Host exit must not be awaited`),
     });
 
-    const preparation = await owner.prepareForUpdate(false);
-    assert.equal(preparation.kind, 'prepared');
-    assert.equal(current.prepareUpgradeCalls, 0);
-    if (preparation.kind === 'prepared') preparation.rollback();
+    const retirement = await owner.retireOwnedLocalHost('refuse_active_work');
+    assert.equal(retirement.kind, 'not_owned');
+    assert.equal(current.prepareRetirementCalls, 0);
     await owner.handleBotIncomingMessage({ text: 'still connected' } as BotIncomingMessage);
     assert.equal(current.botMessages, 1);
     await owner.close();
@@ -918,13 +1015,14 @@ function candidateHarness(
   let botMessages = 0;
   const stoppedSessions: string[] = [];
   let lifecycleState: 'ready' | 'unavailable' = 'ready';
-  let prepareUpgradeCalls = 0;
+  let prepareRetirementCalls = 0;
   let finalizeCalls = 0;
   const finalizeTimeouts: number[] = [];
-  const prepareUpgradeAuthorities: boolean[] = [];
+  const retirementModes: string[] = [];
   const candidate = {
     closed,
     hostLifecycleMode: options.lifecycleMode ?? 'ephemeral',
+    hostPid: 42,
     client: {
       hostId: options.hostId ?? 'test-host',
       hostEpoch: options.hostEpoch ?? 'test-host-epoch',
@@ -934,11 +1032,11 @@ function candidateHarness(
       async queryHostDiagnostics() {
         return { pid: 42 };
       },
-      async prepareHostUpgrade(allowInterruptActiveTasks: boolean) {
+      async prepareHostRetirement(mode: string) {
         options.onPrepare?.();
-        prepareUpgradeCalls += 1;
-        prepareUpgradeAuthorities.push(allowInterruptActiveTasks);
-        if (options.activeTasks && !allowInterruptActiveTasks) {
+        prepareRetirementCalls += 1;
+        retirementModes.push(mode);
+        if (options.activeTasks && mode === 'refuse_active_work') {
           return { kind: 'active_tasks' as const };
         }
         if (options.disconnectOnPrepare) {
@@ -991,11 +1089,11 @@ function candidateHarness(
     get stoppedSessions() {
       return stoppedSessions;
     },
-    get prepareUpgradeCalls() {
-      return prepareUpgradeCalls;
+    get prepareRetirementCalls() {
+      return prepareRetirementCalls;
     },
-    get prepareUpgradeAuthorities() {
-      return prepareUpgradeAuthorities;
+    get retirementModes() {
+      return retirementModes;
     },
     get finalizeCalls() {
       return finalizeCalls;

--- a/apps/desktop/src/main/__tests__/runtime-host-quit-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-quit-copy.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DesktopLocalHostRetirementError } from '../runtime-host-desktop-manager.js';
+import { buildRuntimeHostQuitFailureDialog } from '../runtime-host-quit-copy.js';
+
+const failure = new DesktopLocalHostRetirementError(
+  {
+    hostId: 'root-id',
+    hostEpoch: 'host-epoch',
+    lifecycleMode: 'ephemeral',
+    rootPath: '/state/root',
+    pid: 4242,
+  },
+  { cause: new Error('writer release timed out') },
+);
+
+for (const locale of ['en', 'zh'] as const) {
+  test(`quit failure copy exposes actionable Host facts in ${locale}`, () => {
+    const dialog = buildRuntimeHostQuitFailureDialog(failure, locale);
+
+    assert.match(dialog.detail ?? '', /4242/);
+    assert.match(dialog.detail ?? '', /host-epoch/);
+    assert.match(dialog.detail ?? '', /\/state\/root/);
+    assert.match(dialog.detail ?? '', /writer release timed out/);
+  });
+}
+
+test('manual recovery copy names a cross-platform process-management concept', () => {
+  const english = buildRuntimeHostQuitFailureDialog(failure, 'en').detail ?? '';
+  const chinese = buildRuntimeHostQuitFailureDialog(failure, 'zh').detail ?? '';
+
+  assert.match(english, /operating system's process-management tool/);
+  assert.match(chinese, /操作系统的进程管理工具/);
+  assert.doesNotMatch(`${english}\n${chinese}`, /Activity Monitor|Task Manager|活动监视器|任务管理器/);
+});

--- a/apps/desktop/src/main/app-quit-coordinator.ts
+++ b/apps/desktop/src/main/app-quit-coordinator.ts
@@ -27,35 +27,39 @@ export interface AppQuitCoordinator {
 }
 
 export interface AppQuitCoordinatorDeps {
+  prepareToQuit(): Promise<void>;
   cleanup(): Promise<void>;
   focusOrCreateWindow(signal: AbortSignal): void | Promise<void>;
+  onPreparationError(error: unknown): void;
   onCleanupError(error: unknown): void;
   onWindowCreationError(error: unknown): void;
   resumeQuit(): void;
 }
 
-type AppQuitPhase = 'running' | 'cleaning' | 'ready-to-exit';
+type AppQuitPhase = 'running' | 'preparing' | 'cleaning' | 'ready-to-exit';
 
 export function createAppQuitCoordinator(deps: AppQuitCoordinatorDeps): AppQuitCoordinator {
   let phase: AppQuitPhase = 'running';
-  const windowCreationAbort = new AbortController();
+  let windowCreationAbort = new AbortController();
+
+  const focusOrCreateWindow = (): void => {
+    if (phase !== 'running') return;
+    try {
+      void Promise.resolve(deps.focusOrCreateWindow(windowCreationAbort.signal)).catch(
+        deps.onWindowCreationError,
+      );
+    } catch (error) {
+      deps.onWindowCreationError(error);
+    }
+  };
 
   return {
-    focusOrCreateWindow(): void {
-      if (phase !== 'running') return;
-      try {
-        void Promise.resolve(deps.focusOrCreateWindow(windowCreationAbort.signal)).catch(
-          deps.onWindowCreationError,
-        );
-      } catch (error) {
-        deps.onWindowCreationError(error);
-      }
-    },
+    focusOrCreateWindow,
     handleBeforeQuit(event): void {
       if (phase === 'ready-to-exit') return;
       event.preventDefault();
-      if (phase === 'cleaning') return;
-      phase = 'cleaning';
+      if (phase !== 'running') return;
+      phase = 'preparing';
       windowCreationAbort.abort();
       const finishCleanup = () => {
         // `before-quit` was cancelled inside Electron's native quit transaction.
@@ -68,10 +72,25 @@ export function createAppQuitCoordinator(deps: AppQuitCoordinatorDeps): AppQuitC
           deps.resumeQuit();
         });
       };
-      void deps.cleanup().then(finishCleanup, (error) => {
-        deps.onCleanupError(error);
-        finishCleanup();
-      });
+      void Promise.resolve()
+        .then(() => deps.prepareToQuit())
+        .then(
+          () => {
+            phase = 'cleaning';
+            return Promise.resolve()
+              .then(() => deps.cleanup())
+              .then(finishCleanup, (error) => {
+                deps.onCleanupError(error);
+                finishCleanup();
+              });
+          },
+          (error) => {
+            phase = 'running';
+            windowCreationAbort = new AbortController();
+            deps.onPreparationError(error);
+            focusOrCreateWindow();
+          },
+        );
     },
   };
 }

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -157,6 +157,7 @@ import {
   startRuntimeHostDesktopManager,
   type RuntimeHostDesktopManager,
 } from "./runtime-host-desktop-manager.js";
+import { buildRuntimeHostQuitFailureDialog } from "./runtime-host-quit-copy.js";
 import { createRuntimeHostUpgradePrompts } from "./runtime-host-upgrade-dialog.js";
 import { registerRuntimeHostMemoryIpc } from "./runtime-host-memory-ipc-main.js";
 import {
@@ -653,7 +654,14 @@ const updateService = createAppUpdateService({
     mainWindowController.send("app:updateStatusChanged", status),
   prepareInstall: async (input) => {
     if (!runtimeHostManager) throw new Error("Runtime Host manager is unavailable");
-    return runtimeHostManager.prepareForUpdate(input.allowInterruptActiveTasks);
+    const retirement = await runtimeHostManager.retireOwnedLocalHost(
+      input.allowInterruptActiveTasks ? "interrupt_active_work" : "refuse_active_work",
+    );
+    if (retirement.kind === "active_tasks") return retirement;
+    return {
+      kind: "prepared",
+      rollback: retirement.kind === "retired" ? retirement.resume : () => {},
+    };
   },
 });
 mcpManager.onChange(() => {
@@ -1521,10 +1529,17 @@ function emitSessionsChanged(
 
 function wireLifecycle(): void {
   const quitCoordinator = createAppQuitCoordinator({
+    prepareToQuit: prepareRuntimeHostDesktopQuit,
     cleanup: closeRuntimeHostDesktop,
     focusOrCreateWindow: (signal) => {
       if (mainWindowController.hasOpenWindows()) mainWindowController.focus();
       else return mainWindowController.createWindow(signal);
+    },
+    onPreparationError: (error) => {
+      console.error("[runtime-host] quit retirement failed:", error);
+      void showRuntimeHostQuitFailure(error).catch((dialogError) =>
+        console.error("[runtime-host] quit failure dialog failed:", dialogError),
+      );
     },
     onCleanupError: (error) =>
       console.error("[runtime-host] shutdown failed:", error),
@@ -1551,6 +1566,20 @@ function wireLifecycle(): void {
   });
   app.on("before-quit", quitCoordinator.handleBeforeQuit);
   quitCoordinator.focusOrCreateWindow();
+}
+
+async function prepareRuntimeHostDesktopQuit(): Promise<void> {
+  const retirement = await runtimeHostManager?.retireOwnedLocalHost(
+    "interrupt_active_work",
+  );
+  if (retirement?.kind === "active_tasks") {
+    throw new Error("Runtime Host refused authorized quit retirement");
+  }
+}
+
+async function showRuntimeHostQuitFailure(error: unknown): Promise<void> {
+  const locale = await desktopLocale.resolve();
+  await dialog.showMessageBox(buildRuntimeHostQuitFailureDialog(error, locale));
 }
 
 async function closeRuntimeHostDesktop(): Promise<void> {

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -46,9 +46,12 @@ import {
   type DecodedSessionTranscriptPage,
   type DirectRequestOperationKey,
   type RuntimeHostConnection,
+  type RuntimeHostRetirementMode,
+  type RuntimeHostRetirementPreparation,
   type RuntimeHostSessionSubscription,
   RuntimeHostCatalogReadError,
   RuntimeHostOperationError,
+  prepareConnectedRuntimeHostRetirement,
   readRuntimeHostAgentGraphEpochs,
   readRuntimeHostConnectionCatalog,
   readRuntimeHostInvocableSkills,
@@ -1150,13 +1153,10 @@ export class DesktopRuntimeHostClient {
     return this.connection.queryHostDiagnostics(2_000);
   }
 
-  prepareHostUpgrade(
-    allowInterruptActiveTasks: boolean,
-  ): Promise<OperationOutput<"host.upgrade.prepare">> {
-    return this.request("host.upgrade.prepare", {
-      expectedHostEpoch: this.connection.hostEpoch,
-      allowInterruptActiveTasks,
-    });
+  prepareHostRetirement(
+    mode: RuntimeHostRetirementMode,
+  ): Promise<RuntimeHostRetirementPreparation> {
+    return prepareConnectedRuntimeHostRetirement(this.connection, mode);
   }
 
   stopTurn(

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -185,6 +185,7 @@ export interface DesktopRuntimeHostCandidate {
   readonly client: DesktopRuntimeHostClient;
   readonly closed: Promise<void>;
   readonly hostLifecycleMode: HostRegistration["lifecycleMode"] | "remote";
+  readonly hostPid?: number;
   stopSession(sessionId: string): Promise<void>;
   close(): Promise<void>;
 }
@@ -194,6 +195,7 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
   readonly client: DesktopRuntimeHostClient;
   readonly closed: Promise<void>;
   readonly hostLifecycleMode: HostRegistration["lifecycleMode"] | "remote";
+  readonly hostPid: number | undefined;
   readonly #client: DesktopRuntimeHostClient;
   readonly #observer: RuntimeHostSessionObserver;
   readonly #ipc: ScopedIpcMain;
@@ -219,6 +221,7 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
     closeSessionObservations: () => Promise<void>;
     connectionClosed: Promise<void>;
     hostLifecycleMode: HostRegistration["lifecycleMode"] | "remote";
+    hostPid?: number;
     hasRegisteredCapabilities: () => boolean;
     stopSession: (sessionId: string) => Promise<void>;
   }) {
@@ -236,6 +239,7 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
     this.#stopSession = input.stopSession;
     this.botIncoming = input.botIncoming;
     this.hostLifecycleMode = input.hostLifecycleMode;
+    this.hostPid = input.hostPid;
     this.closed = input.connectionClosed.then(() => this.close());
   }
 
@@ -301,6 +305,7 @@ export async function startDesktopRuntimeHostCandidate(
         observationRegistry,
         connection.registration.lifecycleMode,
         "local",
+        connection.registration.pid,
       ),
     };
   } catch (error) {
@@ -403,6 +408,7 @@ export async function createDesktopRuntimeHostCandidate(
   observationRegistry: RuntimeHostSessionObservationRegistry | undefined,
   hostLifecycleMode: HostRegistration["lifecycleMode"] | "remote",
   targetKind: DesktopRuntimeHostTargetPolicy["kind"],
+  hostPid?: number,
 ): Promise<DesktopRuntimeHostCandidate> {
   const target: DesktopRuntimeHostTargetPolicy = {
     kind: targetKind,
@@ -724,6 +730,7 @@ export async function createDesktopRuntimeHostCandidate(
           : Promise.resolve(),
       connectionClosed: connection.closed,
       hostLifecycleMode,
+      ...(hostPid === undefined ? {} : { hostPid }),
       hasRegisteredCapabilities: () => capabilitiesRegistered,
       stopSession,
     });

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -30,6 +30,7 @@ import {
   type ResolvedRuntimeHostProfile,
   type RuntimeHostReconnectBackoff,
   type RuntimeHostReconnectLifecycle,
+  type RuntimeHostRetirementMode,
   type RuntimeHostSshInteraction,
 } from '@maka/runtime-host/client';
 import type { HostRegistration } from '@maka/runtime-host/protocol';
@@ -70,9 +71,7 @@ export interface RuntimeHostDesktopManager {
     signal?: AbortSignal,
   ): Promise<void>;
   setDefaultProfile(profileId: string): void;
-  prepareForUpdate(
-    allowInterruptActiveTasks: boolean,
-  ): Promise<RuntimeHostUpdatePreparation>;
+  retireOwnedLocalHost(mode: RuntimeHostRetirementMode): Promise<DesktopLocalHostRetirement>;
   close(): Promise<void>;
 }
 
@@ -105,9 +104,28 @@ export type RuntimeHostDesktopTargetState =
       readonly error: Error;
     };
 
-export type RuntimeHostUpdatePreparation =
+export type DesktopLocalHostRetirement =
   | { readonly kind: 'active_tasks' }
-  | { readonly kind: 'prepared'; rollback(): void };
+  | { readonly kind: 'not_owned' }
+  | { readonly kind: 'retired'; resume(): void };
+
+export interface DesktopLocalHostRetirementFacts {
+  readonly hostId: string;
+  readonly hostEpoch: string;
+  readonly lifecycleMode: 'ephemeral';
+  readonly rootPath: string;
+  readonly pid?: number;
+}
+
+export class DesktopLocalHostRetirementError extends Error {
+  constructor(
+    readonly facts: DesktopLocalHostRetirementFacts,
+    options: ErrorOptions,
+  ) {
+    super('Unable to retire the Desktop-owned local Runtime Host', options);
+    this.name = 'DesktopLocalHostRetirementError';
+  }
+}
 
 export type RuntimeHostRestartDecision = 'restart' | 'wait' | 'cancel';
 export type RuntimeHostWaitDecision = 'wait' | 'cancel';
@@ -206,6 +224,8 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
   readonly #baseInput: DesktopRuntimeHostCandidateStartInput;
   readonly #pairingFinalizationShutdown = new AbortController();
   #defaultProfileId: string = LOCAL_RUNTIME_HOST_PROFILE.id;
+  #localHostRetirement: Extract<DesktopLocalHostRetirement, { kind: 'retired' }> | undefined;
+  #localHostRetirementTask: Promise<DesktopLocalHostRetirement> | undefined;
   #closed = false;
   #closeTask: Promise<void> | undefined;
 
@@ -496,13 +516,28 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     this.onDefaultProfileChanged?.(profileId);
   }
 
-  async prepareForUpdate(
-    allowInterruptActiveTasks: boolean,
-  ): Promise<RuntimeHostUpdatePreparation> {
+  retireOwnedLocalHost(
+    mode: RuntimeHostRetirementMode,
+  ): Promise<DesktopLocalHostRetirement> {
+    if (this.#localHostRetirement) return Promise.resolve(this.#localHostRetirement);
+    if (this.#localHostRetirementTask) return this.#localHostRetirementTask;
+    const task = this.#retireOwnedLocalHost(mode).finally(() => {
+      if (this.#localHostRetirementTask === task) {
+        this.#localHostRetirementTask = undefined;
+      }
+    });
+    this.#localHostRetirementTask = task;
+    return task;
+  }
+
+  async #retireOwnedLocalHost(
+    mode: RuntimeHostRetirementMode,
+  ): Promise<DesktopLocalHostRetirement> {
     const lifecycle = this.#requireLifecycle(
       this.#requireTarget(LOCAL_RUNTIME_HOST_PROFILE.id),
     );
     const quiescence = lifecycle.quiesce();
+    let hostPid = quiescence.current.hostPid;
     let launchBarrierPaused = false;
     const resume = () => {
       if (launchBarrierPaused) {
@@ -516,27 +551,55 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
         quiescence.current.hostLifecycleMode === 'service' ||
         quiescence.current.hostLifecycleMode === 'remote'
       ) {
-        return { kind: 'prepared', rollback: resume };
+        resume();
+        return { kind: 'not_owned' };
       }
       this.#baseInput.candidateLaunchBarrier?.pause();
       launchBarrierPaused = this.#baseInput.candidateLaunchBarrier !== undefined;
       const diagnostics = await quiescence.current.client.queryHostDiagnostics();
+      hostPid = diagnostics.pid;
       // The adopted Host still owns the root here, so every other owned launch
       // can be settled without allowing it to become a late election winner.
       await this.#baseInput.candidateLaunchBarrier?.retireExcept(diagnostics.pid);
-      const result = await quiescence.current.client.prepareHostUpgrade(
-        allowInterruptActiveTasks,
-      );
+      const result = await quiescence.current.client.prepareHostRetirement(mode);
       if (result.kind === 'active_tasks') {
         resume();
         return result;
       }
       await this.waitForHostExit(result.pid);
-      return { kind: 'prepared', rollback: resume };
+      return this.#completeLocalHostRetirement(resume);
     } catch (error) {
       resume();
-      throw error;
+      throw new DesktopLocalHostRetirementError(
+        {
+          hostId: quiescence.current.client.hostId,
+          hostEpoch: quiescence.current.client.hostEpoch,
+          lifecycleMode: 'ephemeral',
+          rootPath: this.#baseInput.rootPath,
+          ...(hostPid === undefined ? {} : { pid: hostPid }),
+        },
+        { cause: error },
+      );
     }
+  }
+
+  #completeLocalHostRetirement(
+    resume: () => void,
+  ): Extract<DesktopLocalHostRetirement, { kind: 'retired' }> {
+    let active = true;
+    const retirement = {
+      kind: 'retired' as const,
+      resume: () => {
+        if (!active) return;
+        active = false;
+        if (this.#localHostRetirement !== retirement) return;
+        this.#localHostRetirement = undefined;
+        if (this.#closed) return;
+        resume();
+      },
+    };
+    this.#localHostRetirement = retirement;
+    return retirement;
   }
 
   close(): Promise<void> {

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -109,6 +109,11 @@ export type DesktopLocalHostRetirement =
   | { readonly kind: 'not_owned' }
   | { readonly kind: 'retired'; resume(): void };
 
+interface DesktopLocalHostRetirementTask {
+  readonly mode: RuntimeHostRetirementMode;
+  readonly result: Promise<DesktopLocalHostRetirement>;
+}
+
 export interface DesktopLocalHostRetirementFacts {
   readonly hostId: string;
   readonly hostEpoch: string;
@@ -225,7 +230,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
   readonly #pairingFinalizationShutdown = new AbortController();
   #defaultProfileId: string = LOCAL_RUNTIME_HOST_PROFILE.id;
   #localHostRetirement: Extract<DesktopLocalHostRetirement, { kind: 'retired' }> | undefined;
-  #localHostRetirementTask: Promise<DesktopLocalHostRetirement> | undefined;
+  #localHostRetirementTask: DesktopLocalHostRetirementTask | undefined;
   #closed = false;
   #closeTask: Promise<void> | undefined;
 
@@ -520,14 +525,29 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     mode: RuntimeHostRetirementMode,
   ): Promise<DesktopLocalHostRetirement> {
     if (this.#localHostRetirement) return Promise.resolve(this.#localHostRetirement);
-    if (this.#localHostRetirementTask) return this.#localHostRetirementTask;
-    const task = this.#retireOwnedLocalHost(mode).finally(() => {
-      if (this.#localHostRetirementTask === task) {
+
+    const activeTask = this.#localHostRetirementTask;
+    if (activeTask) {
+      if (
+        activeTask.mode === 'refuse_active_work' &&
+        mode === 'interrupt_active_work'
+      ) {
+        return activeTask.result.then((result) =>
+          result.kind === 'active_tasks'
+            ? this.retireOwnedLocalHost(mode)
+            : result,
+        );
+      }
+      return activeTask.result;
+    }
+
+    const result = this.#retireOwnedLocalHost(mode).finally(() => {
+      if (this.#localHostRetirementTask?.result === result) {
         this.#localHostRetirementTask = undefined;
       }
     });
-    this.#localHostRetirementTask = task;
-    return task;
+    this.#localHostRetirementTask = { mode, result };
+    return result;
   }
 
   async #retireOwnedLocalHost(
@@ -563,6 +583,9 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       await this.#baseInput.candidateLaunchBarrier?.retireExcept(diagnostics.pid);
       const result = await quiescence.current.client.prepareHostRetirement(mode);
       if (result.kind === 'active_tasks') {
+        if (mode === 'interrupt_active_work') {
+          throw new Error('Runtime Host refused authorized retirement');
+        }
         resume();
         return result;
       }
@@ -965,7 +988,7 @@ async function waitForProcessRetirement(
 async function waitForProcessExit(pid: number): Promise<void> {
   const deadline = Date.now() + 10_000;
   while (isProcessAlive(pid)) {
-    if (Date.now() >= deadline) throw new Error('Runtime Host did not exit before update');
+    if (Date.now() >= deadline) throw new Error('Runtime Host did not exit before retirement');
     await new Promise<void>((resolve) => setTimeout(resolve, 50));
   }
 }

--- a/apps/desktop/src/main/runtime-host-quit-copy.ts
+++ b/apps/desktop/src/main/runtime-host-quit-copy.ts
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { UiLocale } from '@maka/core/ui-locale';
+import type { MessageBoxOptions } from 'electron';
+import { DesktopLocalHostRetirementError } from './runtime-host-desktop-manager.js';
+
+export function buildRuntimeHostQuitFailureDialog(
+  error: unknown,
+  locale: UiLocale,
+): MessageBoxOptions {
+  const retirement = error instanceof DesktopLocalHostRetirementError ? error : undefined;
+  const copy = COPY[locale];
+  const details: string[] = [copy.detail];
+  if (retirement) {
+    details.push(`State Root: ${retirement.facts.rootPath}`);
+    details.push(`Host epoch: ${retirement.facts.hostEpoch}`);
+    if (retirement.facts.pid !== undefined) {
+      details.push(copy.process(retirement.facts.pid), copy.manual);
+    }
+  }
+  const cause = error instanceof Error && error.cause instanceof Error
+    ? error.cause.message
+    : error instanceof Error
+      ? error.message
+      : String(error);
+  details.push(`${copy.cause}: ${cause}`);
+  return {
+    type: 'error',
+    title: copy.title,
+    message: copy.message,
+    detail: details.join('\n'),
+    buttons: [copy.button],
+    defaultId: 0,
+    noLink: true,
+  };
+}
+
+const COPY = {
+  en: {
+    title: 'Unable to quit Maka safely',
+    message: 'The local Runtime Host could not stop safely. Maka is still running.',
+    detail: 'Quit was cancelled. Try again, or inspect diagnostics if the problem persists.',
+    process: (pid: number) => `Runtime Host process PID: ${pid}`,
+    manual:
+      "If retry still fails, confirm that no execution must be preserved before stopping this PID with the operating system's process-management tool.",
+    cause: 'Cause',
+    button: 'OK',
+  },
+  zh: {
+    title: '无法安全退出 Maka',
+    message: '本地 Runtime Host 未能安全停止，Maka 仍在运行。',
+    detail: '退出已取消。请重试；如果问题持续存在，请查看诊断信息。',
+    process: (pid: number) => `Runtime Host 进程 PID：${pid}`,
+    manual: '如果重试仍然失败，请先确认没有需要保留的执行，再通过操作系统的进程管理工具停止该 PID。',
+    cause: '原因',
+    button: '好',
+  },
+} as const;

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -29,7 +29,10 @@ import {
   PROJECT_DIRECTORY_ROOT_LABEL_MAX_BYTES,
   RUNTIME_HOST_PROTOCOL_VERSION,
 } from '@maka/runtime-host/protocol';
-import { connectExistingRuntimeHost } from '@maka/runtime-host/client';
+import {
+  connectExistingRuntimeHost,
+  prepareConnectedRuntimeHostRetirement,
+} from '@maka/runtime-host/client';
 import { RUNTIME_HOST_SERVICE_LOG_MAX_BYTES } from '@maka/runtime-host/operator';
 import {
   withLegacyFileUpdateLockLease,
@@ -1011,10 +1014,10 @@ async function prepareRuntimeHostRetirement(
         'The State Root is owned by a different Runtime Host process',
       );
     }
-    const prepared = await connected.connection.request('host.upgrade.prepare', {
-      expectedHostEpoch: hostEpoch,
-      allowInterruptActiveTasks,
-    });
+    const prepared = await prepareConnectedRuntimeHostRetirement(
+      connected.connection,
+      allowInterruptActiveTasks ? 'interrupt_active_work' : 'refuse_active_work',
+    );
     if (prepared.kind === 'active_tasks') return prepared;
     if (prepared.pid !== expectedPid) {
       throw new RuntimeHostServiceManagerError(

--- a/packages/runtime-host/src/__tests__/host-retirement.test.ts
+++ b/packages/runtime-host/src/__tests__/host-retirement.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { RuntimeHostConnection } from '../client/connection.js';
+import { prepareConnectedRuntimeHostRetirement } from '../client/host-retirement.js';
+
+test('retirement binds both interruption policy choices to the authenticated Host epoch', async () => {
+  const requests: unknown[] = [];
+  const connection = {
+    hostEpoch: 'authenticated-host',
+    request: async (operation: string, input: unknown) => {
+      requests.push({ operation, input });
+      return { kind: 'prepared', pid: 42 };
+    },
+  } as unknown as RuntimeHostConnection;
+
+  await prepareConnectedRuntimeHostRetirement(connection, 'refuse_active_work');
+  await prepareConnectedRuntimeHostRetirement(connection, 'interrupt_active_work');
+
+  assert.deepEqual(requests, [
+    {
+      operation: 'host.upgrade.prepare',
+      input: {
+        expectedHostEpoch: 'authenticated-host',
+        allowInterruptActiveTasks: false,
+      },
+    },
+    {
+      operation: 'host.upgrade.prepare',
+      input: {
+        expectedHostEpoch: 'authenticated-host',
+        allowInterruptActiveTasks: true,
+      },
+    },
+  ]);
+});

--- a/packages/runtime-host/src/client/host-retirement.ts
+++ b/packages/runtime-host/src/client/host-retirement.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { OperationOutput } from '../protocol/index.js';
+import type { RuntimeHostConnection } from './connection.js';
+
+export type RuntimeHostRetirementMode = 'refuse_active_work' | 'interrupt_active_work';
+export type RuntimeHostRetirementPreparation = OperationOutput<'host.upgrade.prepare'>;
+
+/**
+ * Requests retirement of the exact authenticated Host behind `connection`.
+ *
+ * `host.upgrade.prepare` is the current wire identifier. Keep that historical
+ * transport detail here so lifecycle owners can model the operation as
+ * retirement instead of spreading update-specific authority.
+ */
+export function prepareConnectedRuntimeHostRetirement(
+  connection: RuntimeHostConnection,
+  mode: RuntimeHostRetirementMode,
+): Promise<RuntimeHostRetirementPreparation> {
+  return connection.request('host.upgrade.prepare', {
+    expectedHostEpoch: connection.hostEpoch,
+    allowInterruptActiveTasks: mode === 'interrupt_active_work',
+  });
+}

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -27,6 +27,11 @@ export {
   type DirectRequestOperationKey,
 } from './connection.js';
 export {
+  prepareConnectedRuntimeHostRetirement,
+  type RuntimeHostRetirementMode,
+  type RuntimeHostRetirementPreparation,
+} from './host-retirement.js';
+export {
   LOCAL_RUNTIME_HOST_PROFILE,
   RUNTIME_HOST_ACCESS_CREDENTIAL_MAX_BYTES,
   createClientRuntimeHostCredentialStore,


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Fixes #3703

Treat a full Desktop application quit as an explicit retirement intent for the Desktop-owned ephemeral Runtime Host. Quit now waits for authenticated, exact-epoch Host retirement before closing Client resources; if retirement cannot be confirmed, quit is cancelled and Maka remains usable.

The retirement request is exposed as a shared Client contract instead of a Desktop-quit special case. Desktop Quit, Desktop Update, and managed service retirement now share the same epoch-bound adapter while the historical `host.upgrade.prepare` wire name remains isolated behind it. Service-mode and remote Hosts are explicitly outside Desktop ownership and are not retired.

When safe retirement fails, the dialog reports the State Root, Host epoch, underlying cause, and the authenticated Host PID when available. Manual recovery copy uses a cross-platform “operating system process-management tool” concept rather than naming a platform-specific utility.

## Verification

- `npm --workspace @maka/desktop run test:dist` — 1410 passed
- `npm --workspace @maka/desktop run build:main` — passed
- Runtime Host Desktop manager retirement tests — 32 passed
- `npm --workspace @maka/runtime-host run build` and the shared retirement test — passed
- `npm --workspace maka-agent run build` and `npm --workspace maka-agent run typecheck` — passed
- Managed Runtime Host service tests — 19 passed
- Repository formatting policy and `git diff --check` — passed (Desktop is excluded from Biome formatting)

`npm --workspace @maka/desktop run build:workspace-deps` remains blocked by pre-existing `@maka/ui` source/type-surface errors on current main (`settledText`, `conversationKey`, `unlockAutoFollow`, and `trailingAction`). The affected Desktop main build and full compiled test suite pass independently.

## Review focus

- This is the connected, compatible-Client retirement path. It is complementary to #3254, which addresses installation provenance and exact-generation takeover of an incompatible but truly idle ephemeral Host; it does not replace that bootstrap path.
- An incompatible Host with durable residency still cannot be safely retired by either change. That case needs the previous compatible owner or a future installation-management control primitive.
- Closing the last window remains Surface-only on macOS. On Windows and Linux, the existing `window-all-closed → app.quit()` mapping makes last-window close a full application quit, so it now retires the Desktop-owned ephemeral Host.
- Update handoff and quit share a successful in-flight retirement. If a refuse-mode update is blocked by active work, an authorized quit reissues retirement with interrupt authority instead of inheriting the refusal.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex investigated the lifecycle boundary, implemented the shared retirement adapter and Desktop quit coordination, added user-facing failure diagnostics and regression tests, and ran the listed verification. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## 摘要

修复 #3703

将 Desktop 应用完整退出建模为对 Desktop 所拥有的临时 Runtime Host 的显式退役意图。现在，退出会先等待经认证且绑定精确 Host epoch 的退役完成，再关闭 Client 资源；如果无法确认安全退役，退出会被取消，Maka 保持可用。

退役请求被提升为共享 Client 契约，而不是 Desktop Quit 的特例。Desktop Quit、Desktop Update 和托管 service 退役现在复用同一个绑定 epoch 的适配器，同时将历史遗留的 `host.upgrade.prepare` wire 名称隔离在适配器内部。service 模式和远端 Host 明确不属于 Desktop 的所有权范围，因此不会被 Desktop 退役。

安全退役失败时，弹窗会显示 State Root、Host epoch、底层原因，以及可获得时经认证的 Host PID。手动恢复文案使用跨平台的“操作系统进程管理工具”概念，不引用任何平台专有工具名称。

## 验证

- `npm --workspace @maka/desktop run test:dist` — 1410 项通过
- `npm --workspace @maka/desktop run build:main` — 通过
- Runtime Host Desktop manager 退役测试 — 32 项通过
- `npm --workspace @maka/runtime-host run build` 与共享退役测试 — 通过
- `npm --workspace maka-agent run build` 与 `npm --workspace maka-agent run typecheck` — 通过
- 托管 Runtime Host service 测试 — 19 项通过
- 仓库格式策略与 `git diff --check` — 通过（Desktop 不在 Biome 格式化范围内）

`npm --workspace @maka/desktop run build:workspace-deps` 仍被当前 main 上既有的 `@maka/ui` 源码/类型表面错误阻塞（`settledText`、`conversationKey`、`unlockAutoFollow` 和 `trailingAction`）。本次影响范围内的 Desktop main build 与完整编译后测试套件均可独立通过。

## 审查重点

- 本 PR 解决的是已连接、协议兼容 Client 的退役路径。它与 #3254 互补：#3254 处理安装来源和对“不兼容但真正空闲”的临时 Host 进行精确 generation 接管；本 PR 不取代该 bootstrap 路径。
- 对于不兼容且仍有 durable residency 的 Host，两项改动目前都不能安全退役。该场景仍需原兼容 owner，或未来的安装级管理控制原语。
- macOS 上关闭最后一个窗口仍然只是关闭 Surface。Windows 和 Linux 沿用现有的 `window-all-closed → app.quit()` 映射，因此关闭最后一个窗口属于完整应用退出，并会退役 Desktop 所拥有的临时 Host。
- 更新交接与退出会共享成功的在途退役；如果拒绝活跃工作的更新请求被阻塞，已获授权的退出会携带中断权限重新发起退役，而不会继承该拒绝结果。

## AI 使用

仅选择一项：

- [ ] 没有生成式工具作出实质性贡献
- [x] 生成式工具作出了实质性贡献

工具与范围：Codex 调查了生命周期边界，实现了共享退役适配器与 Desktop 退出协调，补充了用户可见的失败诊断和回归测试，并执行了上述验证。提交已包含所需的 `Generated-by: Codex` trailer。

## 检查清单

- [x] 测试覆盖本次变更，并且在没有该变更时会失败
- [x] lint、format、typecheck 和受影响测试套件均在本地通过

该 PR 是否包含行为变更？

- [x] 是 — 已在上方摘要中说明
- [ ] 否

</details>
