### PR TITLE
refactor(windows): reuse packaged verifier for rollback

### DIFF
--- a/scripts/verify-windows-harness.test.mjs
+++ b/scripts/verify-windows-harness.test.mjs
@@ -287,27 +287,40 @@ it('uses the product SemVer contract throughout Windows release verification', (
   );
 });
 
-it('delegates restored-installation checks to the current packaged-app verifier', async () => {
+it('reuses the packaged renderer smoke without widening rollback verification', async () => {
   const calls = [];
-  const run = async () => ({ stdout: '', stderr: '' });
-  const verifyApp = async (appDirectory, options) => {
-    calls.push({ appDirectory, options });
+  const installDirectory = 'C:\\fixture\\installed';
+  const workingDirectory = 'C:\\fixture\\smoke';
+  const executable = join(installDirectory, 'Maka.exe');
+  const run = async (command, args, options) => {
+    calls.push({ command, args, options });
+    return { stdout: '1.2.3.0', stderr: '' };
+  };
+  const smokeRenderer = async (executable, options) => {
+    calls.push({ executable, options });
   };
 
-  await verifyRestoredWindowsInstallation('C:\\fixture\\installed', 'C:\\fixture\\smoke', '1.2.3', {
+  await verifyRestoredWindowsInstallation(installDirectory, workingDirectory, '1.2.3', {
     run,
-    verifyApp,
+    smokeRenderer,
   });
 
   assert.deepEqual(calls, [
     {
-      appDirectory: 'C:\\fixture\\installed',
+      executable,
       options: {
-        artifactContract: 'current',
-        expectedVersion: '1.2.3',
-        run,
-        workingDirectory: 'C:\\fixture\\smoke',
+        workingDirectory,
       },
+    },
+    {
+      command: 'powershell',
+      args: [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `(Get-Item '${executable}').VersionInfo.ProductVersion`,
+      ],
+      options: { timeoutMs: 30_000 },
     },
   ]);
 });

--- a/scripts/verify-windows-harness.test.mjs
+++ b/scripts/verify-windows-harness.test.mjs
@@ -45,6 +45,7 @@ import {
 import {
   deleteUninstallRegistrationForInstall,
   readUninstallDisplayVersionsForInstall,
+  verifyRestoredWindowsInstallation,
 } from './verify-windows-installer-rollback.mjs';
 import {
   completeInstalledApplicationUninstall,
@@ -284,6 +285,31 @@ it('uses the product SemVer contract throughout Windows release verification', (
     () => validateWindowsUpgradeBaseline(baseline, '1.2.3-alpha.1'),
     /must be older than the candidate/u,
   );
+});
+
+it('delegates restored-installation checks to the legacy packaged-app verifier', async () => {
+  const calls = [];
+  const run = async () => ({ stdout: '', stderr: '' });
+  const verifyApp = async (appDirectory, options) => {
+    calls.push({ appDirectory, options });
+  };
+
+  await verifyRestoredWindowsInstallation('C:\\fixture\\installed', 'C:\\fixture\\smoke', '1.2.3', {
+    run,
+    verifyApp,
+  });
+
+  assert.deepEqual(calls, [
+    {
+      appDirectory: 'C:\\fixture\\installed',
+      options: {
+        artifactContract: 'legacy-baseline',
+        expectedVersion: '1.2.3',
+        run,
+        workingDirectory: 'C:\\fixture\\smoke',
+      },
+    },
+  ]);
 });
 
 async function makeTree(shape) {

--- a/scripts/verify-windows-harness.test.mjs
+++ b/scripts/verify-windows-harness.test.mjs
@@ -287,7 +287,7 @@ it('uses the product SemVer contract throughout Windows release verification', (
   );
 });
 
-it('delegates restored-installation checks to the legacy packaged-app verifier', async () => {
+it('delegates restored-installation checks to the current packaged-app verifier', async () => {
   const calls = [];
   const run = async () => ({ stdout: '', stderr: '' });
   const verifyApp = async (appDirectory, options) => {
@@ -303,7 +303,7 @@ it('delegates restored-installation checks to the legacy packaged-app verifier',
     {
       appDirectory: 'C:\\fixture\\installed',
       options: {
-        artifactContract: 'legacy-baseline',
+        artifactContract: 'current',
         expectedVersion: '1.2.3',
         run,
         workingDirectory: 'C:\\fixture\\smoke',

--- a/scripts/verify-windows-installer-rollback.mjs
+++ b/scripts/verify-windows-installer-rollback.mjs
@@ -175,7 +175,10 @@ export async function verifyRestoredWindowsInstallation(
   { verifyApp = verifyPackagedWindowsApp, run } = {},
 ) {
   const options = {
-    artifactContract: 'legacy-baseline',
+    // The rollback verifier restores the candidate installer, not the pinned
+    // upgrade baseline. The candidate is built from the current tree and must
+    // therefore satisfy the current packaged-artifact contract.
+    artifactContract: 'current',
     expectedVersion,
     workingDirectory,
   };

--- a/scripts/verify-windows-installer-rollback.mjs
+++ b/scripts/verify-windows-installer-rollback.mjs
@@ -22,18 +22,19 @@ import { access, cp, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/prom
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { diffTreeManifests, directoryTreeManifest, runCommand } from './verify-packaged-app.mjs';
+import {
+  diffTreeManifests,
+  directoryTreeManifest,
+  runCommand,
+  smokePackagedRenderer,
+} from './verify-packaged-app.mjs';
 import {
   installerVersion,
   waitForInstalledProcessesToExit,
   waitForUninstallRegistrationToClear,
   waitUntilMissing,
 } from './verify-windows-installer-lifecycle.mjs';
-import {
-  assertWindowsProductVersion,
-  powerShellLiteral,
-  verifyPackagedWindowsApp,
-} from './verify-windows-x64.mjs';
+import { assertWindowsProductVersion, powerShellLiteral } from './verify-windows-x64.mjs';
 
 const uninstallExecutableName = 'Uninstall Maka.exe';
 const executableName = 'Maka.exe';
@@ -172,19 +173,17 @@ export async function verifyRestoredWindowsInstallation(
   installDirectory,
   workingDirectory,
   expectedVersion,
-  { verifyApp = verifyPackagedWindowsApp, run } = {},
+  { smokeRenderer = smokePackagedRenderer, run } = {},
 ) {
   await mkdir(workingDirectory, { recursive: true });
-  const options = {
-    // The rollback verifier restores the candidate installer, not the pinned
-    // upgrade baseline. The candidate is built from the current tree and must
-    // therefore satisfy the current packaged-artifact contract.
-    artifactContract: 'current',
-    expectedVersion,
-    workingDirectory,
-  };
-  if (run) options.run = run;
-  await verifyApp(installDirectory, options);
+  const installedExecutable = join(installDirectory, executableName);
+  // The caller has already proved the restored tree byte-identical. Keep this
+  // gate focused on rollback-specific evidence: the restored candidate still
+  // launches and reports the expected version, while the package step owns the
+  // full artifact/sandbox contract.
+  await smokeRenderer(installedExecutable, { workingDirectory });
+  const actualVersion = await readInstalledProductVersion(installedExecutable, { run });
+  assertWindowsProductVersion(actualVersion, expectedVersion);
 }
 
 /**
@@ -215,7 +214,7 @@ export async function verifyWindowsInstallerRollback(
     platform = process.platform,
     makeTemporaryDirectory = () => mkdtemp(join(tmpdir(), 'maka-rollback-')),
     run = runCommand,
-    verifyApp = verifyPackagedWindowsApp,
+    smokeRenderer = smokePackagedRenderer,
   } = {},
 ) {
   if (platform !== 'win32') {
@@ -344,7 +343,7 @@ export async function verifyWindowsInstallerRollback(
       installDirectory,
       join(temporaryDirectory, 'restored-smoke'),
       candidateVersion,
-      { run, verifyApp },
+      { run, smokeRenderer },
     );
     await waitForInstalledProcessesToExit(installDirectory);
 

--- a/scripts/verify-windows-installer-rollback.mjs
+++ b/scripts/verify-windows-installer-rollback.mjs
@@ -18,27 +18,22 @@
  */
 
 import { spawn } from 'node:child_process';
-import { access, cp, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { access, cp, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import {
-  diffTreeManifests,
-  directoryTreeManifest,
-  findRendererTarget,
-  isolatedUserEnv,
-  waitForDevToolsPort,
-  waitForUsableRenderer,
-  runCommand,
-  stopChild,
-} from './verify-packaged-app.mjs';
+import { diffTreeManifests, directoryTreeManifest, runCommand } from './verify-packaged-app.mjs';
 import {
   installerVersion,
   waitForInstalledProcessesToExit,
   waitForUninstallRegistrationToClear,
   waitUntilMissing,
 } from './verify-windows-installer-lifecycle.mjs';
-import { assertWindowsProductVersion, powerShellLiteral } from './verify-windows-x64.mjs';
+import {
+  assertWindowsProductVersion,
+  powerShellLiteral,
+  verifyPackagedWindowsApp,
+} from './verify-windows-x64.mjs';
 
 const uninstallExecutableName = 'Uninstall Maka.exe';
 const executableName = 'Maka.exe';
@@ -173,43 +168,19 @@ $entries | ForEach-Object { Remove-Item -LiteralPath $_.Path -Recurse -Force }
   });
 }
 
-async function assertLaunchable(installedExecutable, workingDirectory, expectedVersion) {
-  const home = join(workingDirectory, 'home');
-  const userData = join(workingDirectory, 'user-data');
-  const userEnv = isolatedUserEnv(home);
-  await mkdir(home, { recursive: true });
-  await mkdir(userData, { recursive: true });
-  await mkdir(userEnv.APPDATA, { recursive: true });
-  await mkdir(userEnv.LOCALAPPDATA, { recursive: true });
-  const child = spawn(
-    installedExecutable,
-    ['--remote-debugging-port=0', `--user-data-dir=${userData}`, '--enable-logging=stderr'],
-    {
-      cwd: workingDirectory,
-      env: { ...process.env, MAKA_SKIP_SHELL_ENV: '1', ...userEnv },
-      stdio: ['ignore', 'ignore', 'pipe'],
-    },
-  );
-  let stderr = '';
-  child.stderr.setEncoding('utf8');
-  child.stderr.on('data', (chunk) => {
-    stderr = `${stderr}${chunk}`.slice(-16_384);
-  });
-  try {
-    const cdpPort = await waitForDevToolsPort(child);
-    const target = await findRendererTarget(cdpPort, child);
-    await waitForUsableRenderer(target.webSocketDebuggerUrl, child, {
-      description: 'Restored app renderer',
-    }).catch((error) => {
-      throw new Error(`${error.message}${stderr.trim() ? `\n${stderr.trim()}` : ''}`, {
-        cause: error,
-      });
-    });
-    const productVersion = await readInstalledProductVersion(installedExecutable);
-    assertWindowsProductVersion(productVersion, expectedVersion);
-  } finally {
-    await stopChild(child);
-  }
+export async function verifyRestoredWindowsInstallation(
+  installDirectory,
+  workingDirectory,
+  expectedVersion,
+  { verifyApp = verifyPackagedWindowsApp, run } = {},
+) {
+  const options = {
+    artifactContract: 'legacy-baseline',
+    expectedVersion,
+    workingDirectory,
+  };
+  if (run) options.run = run;
+  await verifyApp(installDirectory, options);
 }
 
 /**
@@ -240,6 +211,7 @@ export async function verifyWindowsInstallerRollback(
     platform = process.platform,
     makeTemporaryDirectory = () => mkdtemp(join(tmpdir(), 'maka-rollback-')),
     run = runCommand,
+    verifyApp = verifyPackagedWindowsApp,
   } = {},
 ) {
   if (platform !== 'win32') {
@@ -364,10 +336,11 @@ export async function verifyWindowsInstallerRollback(
     }
 
     step('asserting the restored installation launches');
-    await assertLaunchable(
-      installedExecutable,
+    await verifyRestoredWindowsInstallation(
+      installDirectory,
       join(temporaryDirectory, 'restored-smoke'),
       candidateVersion,
+      { run, verifyApp },
     );
     await waitForInstalledProcessesToExit(installDirectory);
 

--- a/scripts/verify-windows-installer-rollback.mjs
+++ b/scripts/verify-windows-installer-rollback.mjs
@@ -18,7 +18,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { access, cp, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { access, cp, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -174,6 +174,7 @@ export async function verifyRestoredWindowsInstallation(
   expectedVersion,
   { verifyApp = verifyPackagedWindowsApp, run } = {},
 ) {
+  await mkdir(workingDirectory, { recursive: true });
   const options = {
     // The rollback verifier restores the candidate installer, not the pinned
     // upgrade baseline. The candidate is built from the current tree and must


### PR DESCRIPTION
## Summary

Replace the rollback verifier's private `assertLaunchable` CDP wrapper with the existing `smokePackagedRenderer` helper and the shared Windows product-version assertion.

The rollback path now checks only the restored candidate's launchability and version after its filesystem and uninstall-registration state have been restored. It does not rerun the full packaged-app contract (sandbox worker, stdio relay, node-pty, and dependency checks); those checks remain owned by the release verification step earlier in the same package job.

The rollback-specific filesystem, registry, backup, recovery, fail-closed, and `.onInstFailed` assertions are unchanged. The duplicate process/renderer/version plumbing is removed, and a focused harness test pins the narrow delegation contract.

Fixes #3575

## Verification

- `node --test scripts/verify-windows-harness.test.mjs` — 42 passed
- `npm run lint` — passed
- `npx biome check scripts/verify-windows-installer-rollback.mjs scripts/verify-windows-harness.test.mjs` — passed
- `node --check` for both changed scripts and `git diff --check` — passed
- The real Windows installer rollback gate was not run locally because this workspace is macOS; it remains the authoritative Windows CI check.
- The broader product-release test set requires built workspace artifacts in this fresh worktree; the focused rollback harness is green.

### 中文摘要

本 PR 复用已有的 renderer smoke 和 Windows 产品版本校验来验证回滚后的候选安装，不再重复执行完整 packaged-app contract；文件树、注册表、备份、恢复、fail-closed 和 `.onInstFailed` 行为保持不变，并补充了有界委托回归测试。

## AI use

- [x] Generative tooling made a substantive contribution

Tool: OpenAI Codex assisted with issue analysis, implementation, tests, and verification.
