### PR TITLE
fix(runtime): add the missing ASF headers to the plugin modules

### DIFF
--- a/packages/runtime/src/__tests__/plugin-composition-loader.test.ts
+++ b/packages/runtime/src/__tests__/plugin-composition-loader.test.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { Context, type Plugin } from '../plugin-kernel.js';

--- a/packages/runtime/src/__tests__/plugin-kernel.test.ts
+++ b/packages/runtime/src/__tests__/plugin-kernel.test.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { Context, FiberState, Service, type Plugin } from '../plugin-kernel.js';

--- a/packages/runtime/src/plugin-composition-loader.ts
+++ b/packages/runtime/src/plugin-composition-loader.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { Context, type Fiber, type Inject, type Plugin } from './plugin-kernel.js';
 import {
   fiberStateName,

--- a/packages/runtime/src/plugin-kernel.ts
+++ b/packages/runtime/src/plugin-kernel.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 export type Awaitable<T> = T | PromiseLike<T>;
 
 export type Disposable<T = void | Promise<void>> = () => T;

--- a/packages/runtime/src/plugin-runtime.ts
+++ b/packages/runtime/src/plugin-runtime.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import type { Context, FiberState, Plugin } from './plugin-kernel.js';
 
 const ID_PATTERN = /^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$/u;


### PR DESCRIPTION
`Check ASF source headers` is failing on `main`, so `main` and every branch built on it currently report a red CI run for a reason unrelated to their own changes.

Five files added by #3250 carry no license header:

```
packages/runtime/src/plugin-kernel.ts
packages/runtime/src/plugin-runtime.ts
packages/runtime/src/plugin-composition-loader.ts
packages/runtime/src/__tests__/plugin-kernel.test.ts
packages/runtime/src/__tests__/plugin-composition-loader.test.ts
```

#3250's own commit was already red for this, so the failure arrived with that merge rather than with anything after it.

This change is the output of `node scripts/asf-license-headers.mjs write` and nothing else — the standard header the script emits, added to those five files, `+95` lines and no logic change. After it, `node scripts/asf-license-headers.mjs check` reports all 2819 covered files clean, which I verified on a clean checkout of current `main`.

@likun666661 — you own #3250, so if you would rather land this yourself, please say so and I will close this. I opened it because `main` being red makes every other PR's CI harder to read, and this seemed worth unblocking quickly rather than waiting.

<details><summary>简体中文</summary>

`main` 上的 `Check ASF source headers` 正在失败，因此 `main` 以及所有基于它的分支，当前都会因为与自身改动无关的原因报出一次红色 CI。

#3250 新增的五个文件没有版权头：

```
packages/runtime/src/plugin-kernel.ts
packages/runtime/src/plugin-runtime.ts
packages/runtime/src/plugin-composition-loader.ts
packages/runtime/src/__tests__/plugin-kernel.test.ts
packages/runtime/src/__tests__/plugin-composition-loader.test.ts
```

#3250 自己那个提交上的 CI 就已经是红的，所以这个失败是随那次合并到来的，不是之后的改动引入的。

本次改动就是 `node scripts/asf-license-headers.mjs write` 的输出，除此之外没有别的内容——把脚本生成的标准版权头加到这五个文件上，`+95` 行，零逻辑改动。之后 `node scripts/asf-license-headers.mjs check` 报告 2819 个受覆盖文件全部通过，我在当前 `main` 的干净检出上验证过。

@likun666661 —— #3250 是你的，如果你更希望自己来修，说一声我就把这个关掉。我开这个 PR 是因为 `main` 红着会让其他所有 PR 的 CI 结果难以判读，觉得值得尽快解开，而不是等。

</details>
