### PR TITLE
fix(desktop): keep transcript lifecycle registry-owned

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -1134,7 +1134,7 @@ test('does not let one backpressured transcript consumer block another', async (
   await observer.close();
 });
 
-test('releases an idle session when transcript delivery fails', async () => {
+test('keeps a transcript consumer available after a delivery fails', async () => {
   const events = new AsyncFrameQueue();
   let closeCount = 0;
   const observer = new RuntimeHostSessionObserver({
@@ -1176,12 +1176,18 @@ test('releases an idle session when transcript delivery fails', async () => {
     },
     emitSessionsChanged() {},
   });
-  let opened = false;
+  let failDelivery = false;
+  let failedDeliveries = 0;
+  let successfulDeliveries = 0;
   const consumerId = 'consumer-failing';
-  await observer.openTranscript('session-1', consumerId, {
+  const opened = await observer.openTranscript('session-1', consumerId, {
     id: 25,
     send(_channel, batch) {
-      if (opened) throw new Error('renderer unavailable');
+      if (failDelivery) {
+        failedDeliveries += 1;
+        throw new Error('renderer unavailable');
+      }
+      successfulDeliveries += 1;
       queueMicrotask(() =>
         observer.acknowledgeTranscript(
           consumerId,
@@ -1194,7 +1200,7 @@ test('releases an idle session when transcript delivery fails', async () => {
     once() {},
     off() {},
   });
-  opened = true;
+  failDelivery = true;
   events.push({
     kind: 'subscription.transcript_advanced',
     hostEpoch: 'host-1',
@@ -1204,6 +1210,22 @@ test('releases an idle session when transcript delivery fails', async () => {
     throughSequence: 0,
   });
 
+  await waitFor(() => failedDeliveries === 1);
+  failDelivery = false;
+  await assert.doesNotReject(
+    observer.loadTranscriptAround(
+      {
+        consumerId,
+        generation: opened.generation,
+        anchorSequence: 0,
+        maxBytes: DESKTOP_TRANSCRIPT_FRAGMENT_MAX_BYTES,
+      },
+      25,
+    ),
+  );
+  assert.ok(successfulDeliveries > 1);
+  assert.equal(closeCount, 0);
+  await observer.closeTranscript(consumerId, 25);
   await waitFor(() => closeCount === 1);
   await observer.close();
 });

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -124,7 +124,6 @@ interface ObservedSessionState {
 interface TranscriptConsumer {
   readonly consumerId: string;
   readonly target: RuntimeHostTranscriptTarget;
-  readonly destroyedListener: () => void;
   generation: string;
   deliverySequence: number;
   deliveryBytes: number;
@@ -281,13 +280,9 @@ export class RuntimeHostSessionObserver {
         void this.#closeIfIdle(state);
       }
     }
-    const destroyedListener = () => {
-      void this.closeTranscript(consumerId);
-    };
     const consumer: TranscriptConsumer = {
       consumerId,
       target,
-      destroyedListener,
       generation: replica.generation,
       deliverySequence: 0,
       deliveryBytes: 0,
@@ -296,7 +291,6 @@ export class RuntimeHostSessionObserver {
     };
     state.transcriptConsumers.set(consumerId, consumer);
     this.#transcriptConsumers.set(consumerId, state);
-    target.once('destroyed', destroyedListener);
     try {
       consumer.resetRequested = true;
       await this.#scheduleTranscriptDelivery(state, consumer);
@@ -1081,8 +1075,7 @@ export class RuntimeHostSessionObserver {
       if (consumer.generation !== replica.generation) {
         this.#requestTranscriptReset(state, consumer);
       } else if (!this.#mergeTranscriptChange(consumer, change)) {
-        this.#detachTranscriptConsumer(state, consumer);
-        void this.#closeIfIdle(state);
+        this.#requestTranscriptReset(state, consumer);
       } else {
         void this.#scheduleTranscriptDelivery(state, consumer).catch(() => undefined);
       }
@@ -1156,8 +1149,9 @@ export class RuntimeHostSessionObserver {
           }
         }
       } catch (error) {
-        this.#detachTranscriptConsumer(state, consumer);
-        void this.#closeIfIdle(state);
+        if (state.transcriptConsumers.get(consumer.consumerId) === consumer) {
+          consumer.resetRequested = true;
+        }
         throw error;
       }
     })().finally(() => {
@@ -1362,7 +1356,6 @@ export class RuntimeHostSessionObserver {
       pending.reject(new Error('Desktop transcript consumer was closed'));
     }
     consumer.pendingDeliveries.clear();
-    consumer.target.off('destroyed', consumer.destroyedListener);
   }
 
   #touchReplica(state: ObservedSessionState, protectedState?: ObservedSessionState): boolean {


### PR DESCRIPTION
## Summary

- keep transcript consumers registered when a delivery send, acknowledgement, or capacity attempt fails
- make the next delivery reset the existing consumer projection instead of silently detaching it
- keep `RuntimeHostSessionObservationRegistry` as the sole transcript lifecycle authority and remove the Observer duplicate renderer-destruction listener

The production diff is `+4 / -11`. The earlier Renderer close/reopen retry has been removed; this repair adds no retry protocol, recovery state, or second consumer identity.

## Root cause

`RuntimeHostSessionObserver` treated delivery work failure as consumer termination and removed the physical consumer from its indexes. `RuntimeHostSessionObservationRegistry` still retained the renderer logical registration because it owns continuity across Runtime Host replacement. Every later range request therefore passed the Registry and failed in the Observer with `Desktop transcript consumer does not exist`.

The diagnostic report cannot distinguish whether the original detach was triggered by a send failure, acknowledgement timeout, or delivery-capacity protection. All three entered the same silent-detach path.

## Architecture

The lifecycle is now one-way:

- the Registry owns whether the renderer transcript intent exists, including renderer destruction and Host replacement
- the Observer owns bounded replica and delivery work, but a failed delivery is non-terminal; it marks the same consumer for a reset on the next attempt
- the Renderer owns its materialized range and retains only its existing explicit user-facing reload action

This removes the conflicting Observer termination authority. Explicit close, renderer destruction, and Registry shutdown still release the consumer and idle Session normally.

## Verification

- RED: the new Observer regression failed on the old behavior with `Desktop transcript consumer does not exist`
- `node --test apps/desktop/dist/main/__tests__/runtime-host-session-observer.test.js apps/desktop/dist/main/__tests__/desktop-transcript-range-store.test.js` — 51 passed
- `npm --workspace @maka/desktop run typecheck`
- `npx biome check apps/desktop/src/main/runtime-host-session-observer.ts apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts`
- `npm run check:asf-headers`
- real Electron fixture with temporary fault injection: forced a delivery failure, then observed the same consumer ID recover on the next transcript projection; no error toast or ErrorBoundary appeared. The probe, Electron window, fixture Runtime Host, installed Maka process, and residual Runtime Host were removed or stopped afterward.
- full repository tests were not run locally

The previous CI failure was inherited from five missing ASF headers on the old base. #3708 fixed that baseline failure; this branch is rebased onto current green `main` and the new exact-head CI is running.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the lifecycle mismatch, performed the simplification audit, authored the Observer repair and regression coverage, and ran the focused automated and real-window verification. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No