### PR TITLE
fix(desktop): own Settings Escape before paint

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -19,6 +19,13 @@
 
 import { test, expect, COMPOSER_INPUT } from './fixtures';
 
+interface SettingsChunkLatchWindow extends Window {
+  makaE2eLatch?: {
+    arm(key: 'settings.chunk'): void;
+    release(key: 'settings.chunk'): void;
+  };
+}
+
 async function choiceContentGeometry(card: import('@playwright/test').Locator) {
   return card.evaluate((element) => {
     const content = Array.from(element.children).find((child) => child.tagName !== 'INPUT');
@@ -35,6 +42,54 @@ async function choiceContentGeometry(card: import('@playwright/test').Locator) {
     };
   });
 }
+
+test('Settings loading surface owns unmodified Escape', async ({ window: page }) => {
+  const latchInstalled = await page.evaluate(() => {
+    const e2eLatch = (window as unknown as SettingsChunkLatchWindow).makaE2eLatch;
+    e2eLatch?.arm('settings.chunk');
+    return e2eLatch !== undefined;
+  });
+  expect(latchInstalled, 'the preload E2E latch is installed').toBe(true);
+
+  try {
+    await page.getByRole('button', { name: '设置' }).click();
+
+    const loadingSurface = page.locator('.maka-lazy-fallback');
+    await expect(loadingSurface).toBeVisible();
+
+    for (const modifier of ['ctrlKey', 'metaKey', 'altKey'] as const) {
+      const wasNotPrevented = await page.evaluate((key) =>
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Escape',
+            [key]: true,
+            bubbles: true,
+            cancelable: true,
+          }),
+        ), modifier);
+      expect(wasNotPrevented).toBe(true);
+      await expect(loadingSurface).toBeVisible();
+    }
+
+    const wasNotPrevented = await page.evaluate(() =>
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
+    );
+    expect(wasNotPrevented).toBe(false);
+    await expect(page.locator('.settingsModal')).toHaveCount(0);
+  } finally {
+    await page.evaluate(() =>
+      (window as unknown as SettingsChunkLatchWindow).makaE2eLatch?.release(
+        'settings.chunk',
+      ),
+    );
+  }
+});
 
 test('opening settings commits an active titlebar rename', async ({ window: page }) => {
   const composer = page.locator(COMPOSER_INPUT);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3144,27 +3144,29 @@ const makaBridge = {
   },
 } satisfies MakaBridge;
 
-// E2E-only IPC latches. Real users never get these: the preload mirrors the
+// E2E-only async latches. Real users never get these: the preload mirrors the
 // main process's isolated-E2E gate (startup-context.ts) — MAKA_E2E alone is
 // not enough without the throwaway profile dir. An armed latch holds the next
-// call (or every call) to one bridge method until the test releases it, so
-// Playwright gets a deterministic in-flight window instead of racing the fake
-// backend's near-instant replies. The wrappers must be installed BEFORE
+// bridge call or an explicitly gated renderer boundary until the test releases
+// it, so Playwright gets a deterministic in-flight window instead of racing
+// near-instant work. The wrappers must be installed BEFORE
 // exposeInMainWorld: the bridge is cloned into the main world at expose time,
 // and the exposed clone is sealed against later patching.
 if (process.env.MAKA_E2E === '1' && process.env.MAKA_E2E_USER_DATA_DIR) {
-  type LatchKey = 'newTasks.listInvocableSkills' | 'sessions.list';
+  type LatchKey = 'newTasks.listInvocableSkills' | 'sessions.list' | 'settings.chunk';
   const gates = new Map<LatchKey, { promise: Promise<void>; oneShot: boolean }>();
   const releases = new Map<LatchKey, { resolve: () => void; reject: (error: Error) => void }>();
+  const waitForLatch = async (key: LatchKey): Promise<void> => {
+    const gate = gates.get(key);
+    if (!gate) return;
+    if (gate.oneShot) gates.delete(key);
+    await gate.promise;
+  };
   const wrapLatched = <Args extends unknown[], Result>(
     call: (...args: Args) => Promise<Result>,
     key: LatchKey,
   ) => async (...args: Args): Promise<Result> => {
-    const gate = gates.get(key);
-    if (gate) {
-      if (gate.oneShot) gates.delete(key);
-      await gate.promise;
-    }
+    await waitForLatch(key);
     return call(...args);
   };
   makaBridge.newTasks.listInvocableSkills = wrapLatched(
@@ -3185,6 +3187,9 @@ if (process.env.MAKA_E2E === '1' && process.env.MAKA_E2E_USER_DATA_DIR) {
       });
       gates.set(key, { promise, oneShot: options?.oneShot === true });
       releases.set(key, { resolve, reject });
+    },
+    wait(key: 'settings.chunk') {
+      return waitForLatch(key);
     },
     release(key: LatchKey) {
       releases.get(key)?.resolve();

--- a/apps/desktop/src/renderer/app-shell-overlays.tsx
+++ b/apps/desktop/src/renderer/app-shell-overlays.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useLayoutEffect, useRef } from 'react';
 import type { ChatDefaultPermissionMode, SettingsSection, ThemePalette, ThemePreference } from '@maka/core/settings';
 import type { ProviderType } from '@maka/core/llm-connections';
 import type { DesktopSessionSummary } from '../preload/bridge-contract.js';
@@ -32,7 +32,17 @@ import type { ArchivedTasksBridge } from './settings/tasks-settings-page';
 import type { UiLocaleUpdateGate } from './settings/ui-locale-update-gate';
 import { getShellRemainingCopy } from './locales/shell-remaining-copy.js';
 
-const SettingsModal = lazy(() => import('./settings/settings-modal').then((m) => ({ default: m.SettingsModal })));
+const SettingsModal = lazy(async () => {
+  const e2eLatch = (
+    window as typeof window & {
+      makaE2eLatch?: { wait(key: 'settings.chunk'): Promise<void> };
+    }
+  ).makaE2eLatch;
+  await e2eLatch?.wait('settings.chunk');
+  return import('./settings/settings-modal').then((module) => ({
+    default: module.SettingsModal,
+  }));
+});
 
 type SearchModalProps = Parameters<typeof SearchModal>[0];
 
@@ -117,6 +127,36 @@ export function AppShellOverlays(props: {
     themePref,
     onExternalSessionImported,
   } = props;
+
+  const closeSettingsRef = useRef(closeSettings);
+  useLayoutEffect(() => {
+    closeSettingsRef.current = closeSettings;
+  });
+
+  // The overlay boundary, rather than the lazy Settings chunk, owns Escape.
+  // That keeps one owner installed before paint for both the Suspense loading
+  // surface and the resolved Settings surface. Keep the listener stable while
+  // Settings is open, but read the latest shell callback after every commit.
+  useLayoutEffect(() => {
+    if (!settingsOpen) return;
+
+    function onKeyDown(event: globalThis.KeyboardEvent) {
+      if (
+        event.key.toLowerCase() !== 'escape' ||
+        event.defaultPrevented ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      event.preventDefault();
+      closeSettingsRef.current();
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [settingsOpen]);
 
   // #1045: base commands freeze per open/close; session rows stay live on
   // visibleSessions/activeId. run() closures read latest options via ref.

--- a/apps/desktop/src/renderer/settings/settings-modal.tsx
+++ b/apps/desktop/src/renderer/settings/settings-modal.tsx
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-import { useRef } from 'react';
-import { useHotkeys } from '@astryxdesign/core/hooks';
+import { useLayoutEffect, useRef } from 'react';
 import type { ChatDefaultPermissionMode, SettingsSection, ThemePalette, ThemePreference } from '@maka/core/settings';
 import type { ProviderType } from '@maka/core/llm-connections';
 import type { DesktopSessionSummary } from '../../preload/bridge-contract.js';
@@ -87,20 +86,27 @@ export function SettingsModal(props: {
   // happens per streamed token), and a focus side effect keyed on it yanks
   // focus away from anything open inside Settings while a session streams.
   const activeNavRef = useRef<HTMLButtonElement>(null);
+  const onCloseRef = useRef(props.onClose);
+  useLayoutEffect(() => {
+    onCloseRef.current = props.onClose;
+  });
 
-  // useHotkeys keeps its entries in a ref it refreshes every render, so Escape
-  // always calls the current `onClose` without the listener churning on that
-  // prop's identity (it is recreated on every AppShell render, i.e. per
-  // streamed token). It also skips defaultPrevented events, which is what the
-  // old `!event.defaultPrevented` check bought: a nested dialog that already
-  // consumed Escape closes itself, not the whole Settings surface.
-  //
-  // `allowInInputs` because Escape must close Settings from inside its own
-  // fields — the hook's default would have made Escape dead in every text box
-  // on the page.
-  useHotkeys([
-    { keys: 'escape', allowInInputs: true, onPress: () => props.onClose() },
-  ]);
+  // Settings owns Escape from the same committed frame that makes its surface
+  // observable. A passive-effect subscription leaves a window where the DOM
+  // is visible but the first Escape has no owner; Playwright can reach that
+  // window, and so can an input event already queued during the transition.
+  // Keep the listener stable across streamed-token renders while reading the
+  // current close callback from the render-updated ref.
+  useLayoutEffect(() => {
+    function onKeyDown(event: globalThis.KeyboardEvent) {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      event.preventDefault();
+      onCloseRef.current();
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
 
   return (
     <div

--- a/apps/desktop/src/renderer/settings/settings-modal.tsx
+++ b/apps/desktop/src/renderer/settings/settings-modal.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { useLayoutEffect, useRef } from 'react';
+import { useRef } from 'react';
 import type { ChatDefaultPermissionMode, SettingsSection, ThemePalette, ThemePreference } from '@maka/core/settings';
 import type { ProviderType } from '@maka/core/llm-connections';
 import type { DesktopSessionSummary } from '../../preload/bridge-contract.js';
@@ -86,27 +86,6 @@ export function SettingsModal(props: {
   // happens per streamed token), and a focus side effect keyed on it yanks
   // focus away from anything open inside Settings while a session streams.
   const activeNavRef = useRef<HTMLButtonElement>(null);
-  const onCloseRef = useRef(props.onClose);
-  useLayoutEffect(() => {
-    onCloseRef.current = props.onClose;
-  });
-
-  // Settings owns Escape from the same committed frame that makes its surface
-  // observable. A passive-effect subscription leaves a window where the DOM
-  // is visible but the first Escape has no owner; Playwright can reach that
-  // window, and so can an input event already queued during the transition.
-  // Keep the listener stable across streamed-token renders while reading the
-  // current close callback from the render-updated ref.
-  useLayoutEffect(() => {
-    function onKeyDown(event: globalThis.KeyboardEvent) {
-      if (event.key !== 'Escape' || event.defaultPrevented) return;
-      event.preventDefault();
-      onCloseRef.current();
-    }
-
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
 
   return (
     <div

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -5,7 +5,7 @@ Each row is one on-disk product surface file. Regenerated inventory must stay in
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 209 files — blocker 0, polish 1, aligned 208.
+**Totals:** 211 files — blocker 0, polish 1, aligned 210.
 
 ## Exclusions (explicit)
 


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

The Settings overlay now installs its Escape owner during the layout phase, above the lazy-loaded Settings component. The same owner therefore covers both the visible Suspense loading surface and the resolved Settings surface from their first observable frame.

The listener remains stable across shell re-renders and reads the current close callback from a ref. It preserves the existing keyboard contract: nested layers that already prevented Escape keep priority, Ctrl/Cmd/Alt+Escape remain untouched, and unmodified or Shift+Escape close Settings even from an input.

Fixes #3728

## Root cause

The previous `useHotkeys` subscription lived inside the lazy Settings component and attached its global listener from a passive effect. This left two intervals with no Escape owner:

1. the visible Suspense fallback while the Settings chunk was still loading; and
2. the interval after the resolved Settings DOM committed but before its passive effect ran.

The existing titlebar-rename E2E waited for the resolved Settings main region before pressing Escape, so it could expose the second race intermittently but could not exercise the loading fallback at all.

## Verification

- `npm --workspace @maka/desktop run build:with-deps`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 1,436 passed
- Full Desktop Electron E2E suite — 64 passed, 1 skipped
- Full Settings E2E spec — 6 passed
- A new deterministic E2E latch holds the Settings chunk while the loading surface is visible; Ctrl/Cmd/Alt+Escape keep it open and one unmodified Escape closes it
- The targeted titlebar-rename/Settings test passed 25 consecutive runs across stress and final-head verification
- `npx biome check` on all changed source and E2E files
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented and verified the event-lifecycle fix. The affected commits include a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — Settings owns Escape from its first observable loading or resolved frame
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## 摘要

Settings overlay 现在会在布局阶段、lazy Settings 组件之外安装 Escape 的唯一处理者。因此从可见的 Suspense 加载界面到解析完成的 Settings 界面，两段都从各自首次可观察的帧开始拥有同一个处理者。

监听器在 shell 重渲染期间保持稳定，并通过 ref 读取当前的关闭回调。现有键盘契约保持不变：已经阻止 Escape 的内层界面优先处理；Ctrl/Cmd/Alt+Escape 不受影响；裸 Escape 或 Shift+Escape 即使在输入框中也会关闭 Settings。

修复 #3728

## 根因

原来的 `useHotkeys` 订阅位于 lazy Settings 组件内部，并在被动 effect 中安装全局监听器。这会留下两个没有 Escape 处理者的时间窗：

1. Settings chunk 仍在加载时已经可见的 Suspense fallback；
2. 真正的 Settings DOM 已提交、但被动 effect 尚未运行的时间窗。

原有标题栏重命名 E2E 会先等待解析完成的 Settings main 区域再按 Escape，因此它可能间歇性暴露第二个竞态，但完全无法覆盖 loading fallback。

## 验证

- `npm --workspace @maka/desktop run build:with-deps`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 1,436 条通过
- 完整 Desktop Electron E2E — 64 条通过，1 条跳过
- 完整 Settings E2E — 6 条通过
- 新增确定性 E2E latch：在 loading 界面可见时挂住 Settings chunk，验证 Ctrl/Cmd/Alt+Escape 保持打开，单次裸 Escape 关闭
- 标题栏重命名/Settings 定向测试在压力与最终 head 验证中连续通过 25 次
- 对所有变更源码和 E2E 文件执行 `npx biome check`
- `git diff --check`

## AI 使用

- [ ] 没有生成式工具做出实质贡献
- [x] 生成式工具做出了实质贡献

工具与范围：Codex 实现并验证了事件生命周期修复。相关提交包含 `Generated-by: Codex` trailer。

## 检查清单

- [x] 测试覆盖该改动，并且在未修复时会失败
- [x] lint、format、typecheck 与受影响测试套件均在本地通过

此 PR 是否改变行为？

- [x] 是 — Settings 从首次可观察的 loading 或解析完成帧起即拥有 Escape
- [ ] 否

</details>
