### PR TITLE
fix(core): include 'low' effort for deepseek-v4-flash

### DIFF
--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -432,7 +432,8 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
   deepseek: {
     'deepseek-v4-flash': {
       capabilities: { ...REASONING_FUNCTION_CALLING, webSearch: true },
-      thinkingOptions: { efforts: ['high', 'max'], toggle: true },
+      lastUpdated: '2026-08-24',
+      thinkingOptions: { efforts: ['low', 'high', 'max'], toggle: true },
     },
     'deepseek-v4-pro': {
       capabilities: { ...REASONING_FUNCTION_CALLING, webSearch: true },

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -301,18 +301,21 @@ describe('buildProviderOptions: thinking level', () => {
     );
     assert.deepEqual(
       [...thinkingVariantsForModel('deepseek', 'deepseek-v4-flash')],
-      ['high', 'max'],
+      ['low', 'high', 'max'],
     );
     // DeepSeek V4 uses the generic Open Responses adapter, which passes a
     // provider-native reasoningEffort through verbatim: `max` stays `max`
     // (DeepSeek's documented mapping sends `xhigh` to high, not max).
+    assert.deepEqual(buildProviderOptions(conn('deepseek'), 'deepseek-v4-flash', 'low'), {
+      deepseek: { reasoningEffort: 'low' },
+    });
     assert.deepEqual(buildProviderOptions(conn('deepseek'), 'deepseek-v4-flash', 'high'), {
       deepseek: { reasoningEffort: 'high' },
     });
     assert.deepEqual(buildProviderOptions(conn('deepseek'), 'deepseek-v4-flash', 'max'), {
       deepseek: { reasoningEffort: 'max' },
     });
-    for (const unsupported of ['off', 'low', 'medium', 'minimal'] as const) {
+    for (const unsupported of ['off', 'medium', 'minimal'] as const) {
       assert.deepEqual(
         buildProviderOptions(conn('deepseek'), 'deepseek-v4-flash', unsupported),
         {},


### PR DESCRIPTION
## Summary

- Adds `'low'` to `deepseek-v4-flash` thinking efforts: `['high', 'max']` -> `['low', 'high', 'max']`, with `lastUpdated: '2026-08-24'`.

This surfaced during review of #3605: the vision-exp entry inherited its pinned set from this sibling, whose value predates the model's 0731 refresh.

## Evidence

1. Official Thinking Mode guide accepts `reasoning_effort` of `low/high/max` and states the effort mapping table is "identical for deepseek-v4-flash and deepseek-v4-pro": https://api-docs.deepseek.com/guides/thinking_mode/
2. The in-repo `deepseek-v4-pro` entry directly below already pins `['low', 'high', 'max']`.
3. models.dev's entry for this model was refreshed on its 0731 release date.

## Test plan

- [x] biome check clean on the touched file
- [ ] CI `test`
