### PR TITLE
fix(runtime): end Grep options before the pattern in the sandboxed worker

### DIFF
--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -243,6 +243,40 @@ describe('filesystem worker operations', () => {
     });
   });
 
+  test('ends Grep options before the pattern so an option-like pattern still searches', async () => {
+    const root = await temporaryDirectory('maka-worker-grep-separator-');
+    const target = join(root, 'style.css');
+    await writeFile(target, 'a { display: -webkit-box; }', 'utf8');
+    let grepArgs: readonly string[] | undefined;
+
+    const response = await executeFilesystemWorkerRequest(
+      await requestFor(
+        {
+          kind: 'grep',
+          cwd: root,
+          path: target,
+          pattern: '-webkit-box',
+          maxCountPerFile: 50,
+          limit: 200,
+          timeoutMs: 1_000,
+        },
+        { enforcementPath: target, access: 'read', scope: 'exact', targetType: 'file' },
+      ),
+      {
+        grepExecutable: '/usr/bin/rg',
+        runGrep: async (input) => {
+          grepArgs = input.args;
+          return { exitCode: 0, stdout: '1:a { display: -webkit-box; }\n', stderrTail: '' };
+        },
+      },
+    );
+
+    // Without the separator ripgrep reads `-webkit-box` as flags: it exits 1,
+    // which this worker reports as "no matches" for a string that is present.
+    assert.deepEqual(grepArgs?.slice(-3), ['--', '-webkit-box', target]);
+    assert.equal(response.ok, true);
+  });
+
   test('returns no Grep matches for exit code 1 and surfaces bounded stderr for failures', async () => {
     const root = await temporaryDirectory('maka-worker-grep-result-');
     const target = join(root, 'file.ts');

--- a/packages/runtime/src/filesystem-worker/operations.ts
+++ b/packages/runtime/src/filesystem-worker/operations.ts
@@ -413,7 +413,7 @@ export async function executeFilesystemOperation(
         throw operationError('grep_unavailable', 'Grep is unavailable in this runtime.');
       const args = ['-n', '--no-heading', `--max-count=${operation.maxCountPerFile}`];
       if (operation.glob) args.push('--glob', operation.glob);
-      args.push(operation.pattern, path);
+      args.push('--', operation.pattern, path);
       const result = await (dependencies.runGrep ?? runRipgrep)({
         executable: dependencies.grepExecutable,
         args,


### PR DESCRIPTION
fix(runtime): end Grep options before the pattern in the sandboxed worker

## Summary

The filesystem worker appended the model-supplied Grep pattern as a bare
positional, so ripgrep parsed a pattern starting with `-` as flags.
`-webkit-box` exits 1, and `packages/runtime/src/filesystem-worker/operations.ts:425`
maps exit 1 to `{ kind: 'grep', matches: [] }` — the model is told the string is
absent from a file that contains it, silently.

The host-local sibling already passes `--` first
(`packages/runtime/src/workspace-executor.ts:455`). That separator arrived in
#2961, which edited this worker's grep case in the same commit but left its argv
unchanged, so the two search paths have disagreed since. This propagates it.

Fixes #3733

## Verification

Ran locally on macOS 26.5.1 (25F80), Node v26.7.0, ripgrep 15.1.0:

- `npm --workspace @maka/runtime run test:dist` — 3090 tests, 0 failures
  (baseline on `main` was 3089/0; the delta is the new case).
- Negative control: restored `operations.ts` from `origin/main` and rebuilt — the
  new test fails (`actual [… '--max-count=50', '-webkit-box', …]` vs expected
  `['--', '-webkit-box', …]`) while the other 20 cases in the file still pass.
- `npm run lint`, `npm run format:check`, `npm run typecheck`,
  `npm run check:asf-headers` — all clean.

Not run: Windows and Linux sandbox surfaces.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — located the divergence, drafted the one-line fix
and the regression test. Reviewed, reproduced and verified by me before submitting.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
