### PR TITLE
fix(runtime): separate dash-prefixed Grep patterns with -- in sandbox worker

### DIFF
--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -243,6 +243,49 @@ describe('filesystem worker operations', () => {
     });
   });
 
+  test('separates dash-prefixed patterns from flags with the -- argv separator', async () => {
+    const root = await temporaryDirectory('maka-worker-grep-dash-pattern-');
+    const target = join(root, 'style.css');
+    await writeFile(target, 'a { display: -webkit-box; }', 'utf8');
+    let grepArgs: readonly string[] | undefined;
+
+    const response = await executeFilesystemWorkerRequest(
+      await requestFor(
+        {
+          kind: 'grep',
+          cwd: root,
+          path: target,
+          // Without `--`, ripgrep parses a leading `-` as flags and exits 1,
+          // which this worker maps to "no matches" — reporting a present
+          // string as absent. Mirrors workspace-executor's pinned behavior.
+          pattern: '-webkit-box',
+          maxCountPerFile: 50,
+          limit: 200,
+          timeoutMs: 1_000,
+        },
+        { enforcementPath: target, access: 'read', scope: 'exact', targetType: 'file' },
+      ),
+      {
+        grepExecutable: '/usr/bin/rg',
+        runGrep: async (input) => {
+          grepArgs = input.args;
+          return { exitCode: 0, stdout: '1:a { display: -webkit-box; }\n', stderrTail: '' };
+        },
+      },
+    );
+
+    assert.ok(grepArgs, 'grep must be invoked');
+    const separator = grepArgs.indexOf('--');
+    assert.notEqual(separator, -1, 'argv must contain a -- separator before the pattern');
+    assert.equal(grepArgs[separator + 1], '-webkit-box');
+    assert.deepEqual(response, {
+      version: FILESYSTEM_WORKER_PROTOCOL_VERSION,
+      requestId: 'request-1',
+      ok: true,
+      result: { kind: 'grep', matches: ['1:a { display: -webkit-box; }'] },
+    });
+  });
+
   test('returns no Grep matches for exit code 1 and surfaces bounded stderr for failures', async () => {
     const root = await temporaryDirectory('maka-worker-grep-result-');
     const target = join(root, 'file.ts');

--- a/packages/runtime/src/filesystem-worker/operations.ts
+++ b/packages/runtime/src/filesystem-worker/operations.ts
@@ -413,7 +413,9 @@ export async function executeFilesystemOperation(
         throw operationError('grep_unavailable', 'Grep is unavailable in this runtime.');
       const args = ['-n', '--no-heading', `--max-count=${operation.maxCountPerFile}`];
       if (operation.glob) args.push('--glob', operation.glob);
-      args.push(operation.pattern, path);
+      // `--` keeps ripgrep from parsing a dash-prefixed pattern as flags
+      // (a flag-like pattern exits 1, which maps to "no matches" below).
+      args.push('--', operation.pattern, path);
       const result = await (dependencies.runGrep ?? runRipgrep)({
         executable: dependencies.grepExecutable,
         args,


### PR DESCRIPTION
## Summary

- The sandboxed filesystem worker appended the Grep pattern as a bare positional, so ripgrep parsed a dash-prefixed pattern as flags. A leading flag exits 1, and this worker maps exit 1 to an empty match set - so the model was told a present string was absent, with no error.
- Adds the `--` argv separator the host-local workspace executor already pins (`workspace-executor.ts`, from #2961), plus a regression test asserting the separator position and a successful `-webkit-box` search.

## Test plan

- [x] New regression test fails without the fix (asserts `--` precedes the pattern in the spawned argv) and passes with it
- [x] Reproduced against real ripgrep 15.1.0: `rg -n --no-heading --max-count=5 -webkit-box style.css` exits 1; with `--` it matches
- [x] Full runtime suite locally: 3059/3068 pass; the 2 failures are pre-existing root-user permission tests (`chmod`-restricted files are readable by root, CI runs non-root) - untouched by this diff

Fixes #3733
