### PR TITLE
fix(desktop): recover stale transcript subscriptions

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -28,7 +28,10 @@ import {
   type SessionTranscriptPage,
   type SubscriptionFrame,
 } from "@maka/runtime-host/protocol";
-import { RuntimeHostSubscriptionError } from "@maka/runtime-host/client";
+import {
+  RuntimeHostOperationError,
+  RuntimeHostSubscriptionError,
+} from "@maka/runtime-host/client";
 import type { DesktopRuntimeHostSession } from "../runtime-host-client.js";
 import {
   DESKTOP_TRANSCRIPT_FRAGMENT_MAX_BYTES,
@@ -1619,6 +1622,66 @@ test("reopens an evicted active subscription without a renderer resubscribe", as
   );
 
   await observer.unobserve("observer-1");
+  await observer.close();
+});
+
+test("recovers when transcript paging loses the active subscription", async () => {
+  const firstEvents = new AsyncFrameQueue();
+  const secondEvents = new AsyncFrameQueue();
+  const target = eventTarget(12);
+  let openCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        openCount += 1;
+        const first = openCount === 1;
+        const events = first ? firstEvents : secondEvents;
+        return runtimeHostSessionFixture({
+          snapshot: continuitySnapshot(),
+          transcript: Promise.resolve([]),
+          events,
+          loadTranscriptPage: async () => {
+            if (first) {
+              throw new RuntimeHostOperationError(
+                "session.transcript.page",
+                "not_found",
+                "Session subscription was not found",
+              );
+            }
+            return {
+              kind: "page",
+              sessionId: "session-1",
+              source: "durable",
+              direction: "newer",
+              throughSequence: 0,
+              rawBytes: 0,
+              fragments: [],
+              nextCursor: null,
+            };
+          },
+          async close() {
+            events.end();
+          },
+        });
+      },
+    },
+    emitSessionsChanged() {},
+  });
+
+  await observer.observe("session-1", "observer-1", target);
+  firstEvents.push({
+    kind: "subscription.transcript_advanced",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-session-1",
+    sessionId: "session-1",
+    sequence: 1,
+    throughSequence: 0,
+  });
+  await waitFor(() => openCount === 2);
+
+  secondEvents.push(deltaFrame(1, 0, "recovered"));
+  await waitFor(() => target.events.some((event) => event.type === "text_delta"));
+  assert.equal(target.events.some((event) => event.type === "error"), false);
   await observer.close();
 });
 

--- a/apps/desktop/src/main/runtime-host-session-subscription-owner.ts
+++ b/apps/desktop/src/main/runtime-host-session-subscription-owner.ts
@@ -17,7 +17,10 @@
  * under the License.
  */
 
-import { RuntimeHostSubscriptionError } from "@maka/runtime-host/client";
+import {
+  RuntimeHostOperationError,
+  RuntimeHostSubscriptionError,
+} from "@maka/runtime-host/client";
 import type {
   SessionAssistantStreamIdentity,
   SessionContinuitySnapshot,
@@ -414,6 +417,9 @@ function subscriptionClosedError(
 }
 
 function isRecoverableSubscriptionFailure(error: unknown): boolean {
+  if (error instanceof RuntimeHostOperationError) {
+    return error.operation === "session.transcript.page" && error.code === "not_found";
+  }
   if (!(error instanceof RuntimeHostSubscriptionError)) return false;
   return (
     error.reason === "slow_consumer" ||


### PR DESCRIPTION
## Summary

- Treat only `session.transcript.page` + `not_found` as a recoverable subscription failure.
- Reuse the existing subscription replacement and snapshot/transcript reconciliation path.
- Add a deterministic observer regression test proving that live frames continue after the stale subscription is replaced.
- Keep other `not_found` operations and `session_removed` terminal.

Fixes #3748

## Verification

- Desktop typecheck passes.
- Focused Runtime Host session observer suite passes (37 tests).
- Full Desktop main-process suite passes (1,476 tests).

## 简体中文摘要

当旧 Session subscription 在 transcript 分页期间失效时，Runtime Host 返回的是 `RuntimeHostOperationError("session.transcript.page", "not_found")`。Desktop 之前没有把它识别为可恢复错误，导致后台任务继续运行但界面停止接收实时更新。

本 PR 只放行这一组精确错误，复用现有的重新订阅、snapshot/transcript reconcile 和后续 frame 处理流程；其他 `not_found` 和 `session_removed` 行为保持不变，并增加确定性回归测试。
