### PR TITLE
chore(deps): bump Astryx core to 0.5.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -236,7 +236,7 @@ License: MIT
 
 Maka includes an ejected adaptation of Astryx ChatReasoning v0.1.9 and generated
 theme artifacts based on Astryx theme-neutral v0.4.5. Maka also redistributes
-`patches/@astryxdesign+core+0.4.5.patch`, which modifies the MIT-licensed Astryx
+`patches/@astryxdesign+core+0.5.0.patch`, which modifies the MIT-licensed Astryx
 core package. The following MIT License applies to that material:
 
 MIT License

--- a/LICENSE
+++ b/LICENSE
@@ -230,12 +230,12 @@ Astryx
 
 Source: https://github.com/facebook/astryx
 ChatReasoning revision: c9fe4379e9959b9ba5eeff56def34c752223450e
-Theme revision: 110987b4505dc44119b94bed53d92b9840088a61
+Theme revision: ea888ef33283ea44e37817d36bc8e84a0568bc30
 Copyright (c) 2026 Meta Platforms, Inc.
 License: MIT
 
 Maka includes an ejected adaptation of Astryx ChatReasoning v0.1.9 and generated
-theme artifacts based on Astryx theme-neutral v0.4.5. Maka also redistributes
+theme artifacts based on Astryx theme-neutral v0.5.0. Maka also redistributes
 `patches/@astryxdesign+core+0.5.0.patch`, which modifies the MIT-licensed Astryx
 core package. The following MIT License applies to that material:
 

--- a/apps/desktop/e2e/accessibility-coverage.spec.ts
+++ b/apps/desktop/e2e/accessibility-coverage.spec.ts
@@ -83,25 +83,25 @@ test('module pages and global overlays expose named actionable controls', async 
   const extensionsNavigation = page.getByRole('navigation', { name: /扩展内容/ });
   await expect(
     extensionsNavigation.getByRole('button', { name: '技能', exact: true }),
-  ).toHaveAttribute('aria-current', 'page');
+  ).toHaveAttribute('aria-current', 'true');
   await assertAxHealth(cdp, 'extensions/skills');
   const mcpButton = extensionsNavigation.getByRole('button', { name: 'MCP', exact: true });
   await mcpButton.click();
-  await expect(mcpButton).toHaveAttribute('aria-current', 'page');
+  await expect(mcpButton).toHaveAttribute('aria-current', 'true');
   await assertAxHealth(cdp, 'extensions/mcp');
 
   await navigation.getByRole('button', { name: /定时任务/ }).click();
   const automationsNavigation = page.getByRole('navigation', { name: /定时任务内容/ });
   await expect(
     automationsNavigation.getByRole('button', { name: '定时任务', exact: true }),
-  ).toHaveAttribute('aria-current', 'page');
+  ).toHaveAttribute('aria-current', 'true');
   await assertAxHealth(cdp, 'automations/scheduled-tasks');
   const dailyReviewButton = automationsNavigation.getByRole('button', {
     name: '每日回顾',
     exact: true,
   });
   await dailyReviewButton.click();
-  await expect(dailyReviewButton).toHaveAttribute('aria-current', 'page');
+  await expect(dailyReviewButton).toHaveAttribute('aria-current', 'true');
   await assertAxHealth(cdp, 'automations/daily-review');
 
   await page.keyboard.press('Shift+Slash');

--- a/apps/desktop/e2e/module-hub.spec.ts
+++ b/apps/desktop/e2e/module-hub.spec.ts
@@ -32,7 +32,7 @@ test('Module Hub switches all four leaves and opens scheduled creation once', as
   await extensions.getByRole('button', { name: 'MCP', exact: true }).click();
   await expect(
     extensions.getByRole('button', { name: 'MCP', exact: true }),
-  ).toHaveAttribute('aria-current', 'page');
+  ).toHaveAttribute('aria-current', 'true');
 
   await sidebar.getByRole('button', { name: /定时任务/ }).click();
   await expect(page.locator('[data-module="scheduled-tasks"]')).toBeVisible();

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -57,8 +57,8 @@
   },
   "devDependencies": {
     "@ant-design/icons-svg": "4.5.0",
-    "@astryxdesign/core": "0.4.5",
-    "@astryxdesign/theme-neutral": "0.4.5",
+    "@astryxdesign/core": "0.5.0",
+    "@astryxdesign/theme-neutral": "0.5.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@fontsource-variable/geist": "^5.3.0",

--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -478,7 +478,7 @@ SOFTWARE.
 
 ================================================================================
 
-Package: @astryxdesign/core@0.4.5
+Package: @astryxdesign/core@0.5.0
 Declared license: MIT
 Selected license: MIT
 Repository: git+https://github.com/facebook/astryx.git#packages/core
@@ -508,7 +508,7 @@ SOFTWARE.
 
 ================================================================================
 
-Package: @astryxdesign/theme-neutral@0.4.5
+Package: @astryxdesign/theme-neutral@0.5.0
 Declared license: MIT
 Selected license: MIT
 Repository: git+https://github.com/facebook/astryx.git#packages/themes/neutral

--- a/apps/desktop/src/renderer/astryx-theme/maka.css
+++ b/apps/desktop/src/renderer/astryx-theme/maka.css
@@ -323,7 +323,7 @@
   }
 
   .astryx-badge.error {
-    background-color: light-dark(#e33f4a, #ff705d);
+    background-color: light-dark(#c9303a, #ff705d);
     color: light-dark(#ffffff, #171717);
   }
 
@@ -386,7 +386,7 @@
   }
 
   .astryx-statusdot.error {
-    background-color: light-dark(#e33f4a, #ff705d);
+    background-color: light-dark(#c9303a, #ff705d);
   }
 
   .astryx-statusdot.accent {
@@ -439,7 +439,7 @@
   }
 
   .astryx-progressbar.error {
-    --color-error: #e33f4a;
+    --color-error: #c9303a;
   }
 
   .astryx-card {

--- a/apps/desktop/src/renderer/astryx-theme/maka.js
+++ b/apps/desktop/src/renderer/astryx-theme/maka.js
@@ -309,7 +309,7 @@ export const makaTheme = {
         "color": "#171717"
       },
       "variant:error": {
-        "backgroundColor": "light-dark(#e33f4a, #ff705d)",
+        "backgroundColor": "light-dark(#c9303a, #ff705d)",
         "color": "light-dark(#ffffff, #171717)"
       },
       "variant:red": {
@@ -361,7 +361,7 @@ export const makaTheme = {
         "backgroundColor": "#ffce2f"
       },
       "variant:error": {
-        "backgroundColor": "light-dark(#e33f4a, #ff705d)"
+        "backgroundColor": "light-dark(#c9303a, #ff705d)"
       },
       "variant:accent": {
         "backgroundColor": "light-dark(#0074e2, #6d9cfe)"
@@ -409,7 +409,7 @@ export const makaTheme = {
         "--color-warning": "#ffce2f"
       },
       "variant:error": {
-        "--color-error": "#e33f4a"
+        "--color-error": "#c9303a"
       }
     },
     "card": {

--- a/apps/desktop/src/renderer/remote-project-directory-dialog.tsx
+++ b/apps/desktop/src/renderer/remote-project-directory-dialog.tsx
@@ -207,6 +207,7 @@ export function RemoteProjectDirectoryDialog(props: {
       onOpenChange={(open) => {
         if (!open) dismiss();
       }}
+      aria-label={copy.remoteDirectoryTitle(host?.name ?? 'Runtime Host')}
       purpose="form"
       width={560}
       maxHeight="calc(100dvh - 64px)"

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -1056,18 +1056,23 @@ export const ScheduledTasksKeepAwakeExternalWins: Story = {
       await new Promise((resolve) => globalThis.setTimeout(resolve, 10));
       if (attempt === 49) throw new Error('Keep-awake optimistic value did not render');
     }
-    await new Promise((resolve) => globalThis.setTimeout(resolve, 100));
-    let persisted = body.querySelector<HTMLElement>('[role="menuitemcheckbox"]');
-    if (!persisted) {
-      settings.click();
-      persisted = await waitForStorySelector<HTMLElement>(
-        body,
-        '[role="menuitemcheckbox"]',
-      );
+    // The write resolves asynchronously and Astryx may close the menu while
+    // the panel re-syncs its optimistic value from the persisted prop. Poll
+    // for the confirmed value instead of assuming a fixed 100ms settle time;
+    // the latter is fast locally but flakes under Storybook CI load.
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      let persisted = body.querySelector<HTMLElement>('[role="menuitemcheckbox"]');
+      if (!persisted) {
+        settings.click();
+        persisted = await waitForStorySelector<HTMLElement>(
+          body,
+          '[role="menuitemcheckbox"]',
+        );
+      }
+      if (persisted.getAttribute('aria-checked') === 'true') return;
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 10));
     }
-    if (persisted.getAttribute('aria-checked') !== 'true') {
-      throw new Error('Keep-awake checkbox diverged from the persisted setting');
-    }
+    throw new Error('Keep-awake checkbox diverged from the persisted setting');
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@ai-sdk/provider-utils": "5.0.28",
         "@astryxdesign/cli": "0.4.5",
-        "@astryxdesign/core": "0.4.5",
+        "@astryxdesign/core": "0.5.0",
         "@biomejs/biome": "2.5.9",
         "@electron/asar": "3.4.1",
         "@types/node": "^26.2.0",
@@ -58,8 +58,8 @@
       },
       "devDependencies": {
         "@ant-design/icons-svg": "4.5.0",
-        "@astryxdesign/core": "0.4.5",
-        "@astryxdesign/theme-neutral": "0.4.5",
+        "@astryxdesign/core": "0.5.0",
+        "@astryxdesign/theme-neutral": "0.5.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@fontsource-variable/geist": "^5.3.0",
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@astryxdesign/core": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@astryxdesign/core/-/core-0.4.5.tgz",
-      "integrity": "sha512-rbGaoAGZq1QImY2VWeWQNAh1ZqQa/KLWnmoOdy13lSjzMcAPDS6WrVv9fZfsNDx+DIG2oySLtMikwZk5WFl1Uw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@astryxdesign/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-O2lYXrU8+/iRNV9TqOHCj3zhz1NSJxdtytfoQ0Dy/TY7g2CjZTb4/zUpl0EA5hIi4Si1tJxlVf9Uh3LMVALnmg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -378,16 +378,16 @@
       }
     },
     "node_modules/@astryxdesign/theme-neutral": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@astryxdesign/theme-neutral/-/theme-neutral-0.4.5.tgz",
-      "integrity": "sha512-+xLoTOwgHsQWUWbUVq6vxbCTi6vpIJeXEdkyHXBUE7NqjKl6aJAyqdx5V4SsTOx9fOUeVLPJ5HVtr59u4gKbKQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@astryxdesign/theme-neutral/-/theme-neutral-0.5.0.tgz",
+      "integrity": "sha512-7EVMNJ3BCzq4lVyRzDQ9SLt0v03atQCpkXiE2BvdmH3B/nRVQvd+qfMBoUhL6EGsVTqnS3b+PSVU6unNcqulgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lucide-react": "^1.18.0"
       },
       "peerDependencies": {
-        "@astryxdesign/core": "0.4.5",
+        "@astryxdesign/core": "0.5.0",
         "react": ">=19"
       }
     },
@@ -14117,7 +14117,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@astryxdesign/core": "0.4.5",
+        "@astryxdesign/core": "0.5.0",
         "@maka/core": "0.1.0",
         "clsx": "^2.1.1",
         "lucide-react": "^1.33.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@ai-sdk/provider-utils": "5.0.28",
     "@electron/asar": "3.4.1",
     "@astryxdesign/cli": "0.4.5",
-    "@astryxdesign/core": "0.4.5",
+    "@astryxdesign/core": "0.5.0",
     "@biomejs/biome": "2.5.9",
     "@types/node": "^26.2.0",
     "esbuild": "^0.28.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,7 +23,7 @@
     "test:dist": "node --test \"dist/**/*.test.js\""
   },
   "dependencies": {
-    "@astryxdesign/core": "0.4.5",
+    "@astryxdesign/core": "0.5.0",
     "@maka/core": "0.1.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.33.0",

--- a/patches/@astryxdesign+core+0.5.0.patch
+++ b/patches/@astryxdesign+core+0.5.0.patch
@@ -33,7 +33,7 @@ index ff34874..9ec8d7a 100644
  export declare function ChatLayout({ children, composer, density, emptyState, scrollButton, scrollRef: externalScrollRef, xstyle, className, style, 'data-testid': testId, ref, ...rest }: ChatLayoutProps): import("react").JSX.Element;
  export declare namespace ChatLayout {
 diff --git a/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.js b/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.js
-index ea27cd5..7102f8d 100644
+index ff9b9fa..346e01c 100644
 --- a/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.js
 +++ b/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.js
 @@ -28,7 +28,7 @@
@@ -92,7 +92,7 @@ index ea27cd5..7102f8d 100644
    // --- Derived styles ---
    const showEmpty = !hasVisibleContent(children);
 diff --git a/node_modules/@astryxdesign/core/dist/Chat/ChatToolCalls.js b/node_modules/@astryxdesign/core/dist/Chat/ChatToolCalls.js
-index 03b89ec..b0a094e 100644
+index 889970f..459e6e8 100644
 --- a/node_modules/@astryxdesign/core/dist/Chat/ChatToolCalls.js
 +++ b/node_modules/@astryxdesign/core/dist/Chat/ChatToolCalls.js
 @@ -122,6 +122,7 @@ function CallRow({
@@ -159,7 +159,7 @@ index 82ae62c..a97eff5 100644
      var displayName: string;
  }
 diff --git a/node_modules/@astryxdesign/core/dist/DropdownMenu/DropdownMenuItem.js b/node_modules/@astryxdesign/core/dist/DropdownMenu/DropdownMenuItem.js
-index 5bf241b..f773a97 100644
+index 446e25b..00eb8b3 100644
 --- a/node_modules/@astryxdesign/core/dist/DropdownMenu/DropdownMenuItem.js
 +++ b/node_modules/@astryxdesign/core/dist/DropdownMenu/DropdownMenuItem.js
 @@ -91,6 +91,7 @@ const itemSizeStyles = {
@@ -178,22 +178,6 @@ index 5bf241b..f773a97 100644
      tabIndex: isDisabled ? undefined : -1,
      onPointerMove: handlePointerMove,
      startContent: icon ? renderIconSlot(icon, {
-diff --git a/node_modules/@astryxdesign/core/dist/Kbd/Kbd.js b/node_modules/@astryxdesign/core/dist/Kbd/Kbd.js
-index 33ed78d..0ecbce6 100644
---- a/node_modules/@astryxdesign/core/dist/Kbd/Kbd.js
-+++ b/node_modules/@astryxdesign/core/dist/Kbd/Kbd.js
-@@ -111,7 +111,10 @@ function detectMac() {
-   // Prefer User-Agent Client Hints API (not deprecated)
-   const uaData = 'userAgentData' in navigator ? navigator.userAgentData : null;
-   if (uaData && typeof uaData === 'object' && 'platform' in uaData) {
--    return /mac/i.test(uaData.platform ?? '');
-+    const uaPlatform = typeof uaData.platform === 'string' ? uaData.platform : '';
-+    if (uaPlatform.trim().length > 0) {
-+      return /mac/i.test(uaPlatform);
-+    }
-   }
-   // Fallback: navigator.platform (deprecated but still shipped everywhere)
-   return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? '');
 diff --git a/node_modules/@astryxdesign/core/dist/List/List.js b/node_modules/@astryxdesign/core/dist/List/List.js
 index 08b5f7d..94c623b 100644
 --- a/node_modules/@astryxdesign/core/dist/List/List.js
@@ -329,7 +313,7 @@ index 0fd8329..7e4ec57 100644
  Markdown.displayName = 'Markdown';
 \ No newline at end of file
 diff --git a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts b/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts
-index e7b8e00..33a2bb7 100644
+index e7b8e00..fad2e72 100644
 --- a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts
 +++ b/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts
 @@ -66,6 +66,12 @@ export interface SideNavItemProps extends BaseProps<HTMLElement> {
@@ -355,7 +339,7 @@ index e7b8e00..33a2bb7 100644
      var displayName: string;
  }
 diff --git a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.js b/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.js
-index 9853461..590561b 100644
+index d694da7..d0a580c 100644
 --- a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.js
 +++ b/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.js
 @@ -210,6 +210,7 @@ export function SideNavItem({
@@ -366,7 +350,7 @@ index 9853461..590561b 100644
    children,
    collapsible: itemCollapsible,
    size = 'md',
-@@ -491,7 +492,7 @@ export function SideNavItem({
+@@ -492,7 +493,7 @@ export function SideNavItem({
    const item = /*#__PURE__*/_jsxs("div", {
      ref: itemRef,
      ...stylex.props(styles.root, xstyle),
@@ -375,22 +359,6 @@ index 9853461..590561b 100644
        id: `${id}-children`,
        role: "group",
        "aria-labelledby": `${id}-label`,
-diff --git a/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js b/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js
-index 65f9278..f7515e2 100644
---- a/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js
-+++ b/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js
-@@ -54,7 +54,10 @@ function isApplePlatform() {
-   }
-   const uaData = 'userAgentData' in navigator ? navigator.userAgentData : null;
-   if (uaData && typeof uaData === 'object' && 'platform' in uaData) {
--    return /mac/i.test(uaData.platform ?? '');
-+    const uaPlatform = typeof uaData.platform === 'string' ? uaData.platform : '';
-+    if (uaPlatform.trim().length > 0) {
-+      return /mac/i.test(uaPlatform);
-+    }
-   }
-   return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? '');
- }
 diff --git a/node_modules/@astryxdesign/core/dist/hooks/useStreamingText.d.ts b/node_modules/@astryxdesign/core/dist/hooks/useStreamingText.d.ts
 index 7a35d1c..50ee70b 100644
 --- a/node_modules/@astryxdesign/core/dist/hooks/useStreamingText.d.ts
@@ -561,10 +529,10 @@ index 693d728..7d5724e 100644
  }
 \ No newline at end of file
 diff --git a/node_modules/@astryxdesign/core/src/Chat/ChatToolCalls.tsx b/node_modules/@astryxdesign/core/src/Chat/ChatToolCalls.tsx
-index a2da3d9..91a020e 100644
+index f22bb1f..b710951 100644
 --- a/node_modules/@astryxdesign/core/src/Chat/ChatToolCalls.tsx
 +++ b/node_modules/@astryxdesign/core/src/Chat/ChatToolCalls.tsx
-@@ -390,6 +390,7 @@ function CallRow({call}: {call: ChatToolCallItem}) {
+@@ -399,6 +399,7 @@ function CallRow({call}: {call: ChatToolCallItem}) {
      <div
        role={hasDetail ? 'button' : undefined}
        tabIndex={hasDetail ? 0 : undefined}
@@ -573,10 +541,10 @@ index a2da3d9..91a020e 100644
        aria-controls={hasDetail && isDetailOpen ? detailId : undefined}
        onClick={toggleDetail}
 diff --git a/node_modules/@astryxdesign/core/src/DropdownMenu/DropdownMenuItem.tsx b/node_modules/@astryxdesign/core/src/DropdownMenu/DropdownMenuItem.tsx
-index 8dbf5f6..b778ca9 100644
+index 21bad6a..8e2a03a 100644
 --- a/node_modules/@astryxdesign/core/src/DropdownMenu/DropdownMenuItem.tsx
 +++ b/node_modules/@astryxdesign/core/src/DropdownMenu/DropdownMenuItem.tsx
-@@ -108,6 +108,12 @@ export interface DropdownMenuItemProps extends Pick<
+@@ -111,6 +111,12 @@ export interface DropdownMenuItemProps extends Pick<
     * @default true
     */
    hasCloseOnSelect?: boolean;
@@ -589,7 +557,7 @@ index 8dbf5f6..b778ca9 100644
    /**
     * Visual variant. `'destructive'` renders the label, description, and icon in
     * the error color for dangerous actions (e.g. Delete). @default 'default'
-@@ -131,6 +137,7 @@ export interface DropdownMenuItemProps extends Pick<
+@@ -134,6 +140,7 @@ export interface DropdownMenuItemProps extends Pick<
   */
  export function DropdownMenuItem({
    icon,
@@ -597,7 +565,7 @@ index 8dbf5f6..b778ca9 100644
    label,
    description,
    onClick,
-@@ -165,6 +172,7 @@ export function DropdownMenuItem({
+@@ -168,6 +175,7 @@ export function DropdownMenuItem({
    return (
      <Item
        role="menuitem"
@@ -729,10 +697,10 @@ index ea918b4..d83af73 100644
  }
  
 diff --git a/node_modules/@astryxdesign/core/src/SideNav/SideNavItem.tsx b/node_modules/@astryxdesign/core/src/SideNav/SideNavItem.tsx
-index 1c16116..0ca4ad0 100644
+index a05ba4e..c9a10bc 100644
 --- a/node_modules/@astryxdesign/core/src/SideNav/SideNavItem.tsx
 +++ b/node_modules/@astryxdesign/core/src/SideNav/SideNavItem.tsx
-@@ -315,6 +315,12 @@ export interface SideNavItemProps extends BaseProps<HTMLElement> {
+@@ -322,6 +322,12 @@ export interface SideNavItemProps extends BaseProps<HTMLElement> {
     * Right-side content (badges, counts).
     */
    endContent?: ReactNode;
@@ -745,7 +713,7 @@ index 1c16116..0ca4ad0 100644
    /**
     * Sub-items for nesting.
     */
-@@ -378,6 +384,7 @@ export function SideNavItem({
+@@ -385,6 +391,7 @@ export function SideNavItem({
    href,
    onClick,
    endContent,
@@ -753,7 +721,7 @@ index 1c16116..0ca4ad0 100644
    children,
    collapsible: itemCollapsible,
    size = 'md',
-@@ -694,6 +701,7 @@ export function SideNavItem({
+@@ -702,6 +709,7 @@ export function SideNavItem({
    const item = (
      <div ref={itemRef} {...stylex.props(styles.root, xstyle)}>
        {itemElement}

--- a/patches/README.md
+++ b/patches/README.md
@@ -45,9 +45,9 @@ Streaming tool-call association for gateways that reuse or omit `index` / `id`
 
 Delete when that guard passes against an unpatched package.
 
-## `@astryxdesign/core@0.4.5`
+## `@astryxdesign/core@0.5.0`
 
-Six published component seams drop host-owned state or semantics:
+Five published component seams drop host-owned state or semantics:
 
 - `ChatLayout` needs a conversation identity that resets scroll/unread state
   without remounting its composer slot and discarding the live draft.
@@ -71,10 +71,6 @@ Six published component seams drop host-owned state or semantics:
   Skills entry holds its look steady while the Skill catalog refreshes and
   defers activation meanwhile; without the attribute the row announces
   "available" to assistive technology and silently ignores the action.
-
-Blank UA-CH `navigator.userAgentData.platform` must also not mean "not Apple".
-Electron builds with a rewritten identity ship `platform: ''`, which made every
-`mod` hotkey listen for Ctrl and every `Kbd` draw Ctrl on macOS.
 
 Streaming text and Markdown expose an explicit `settledText` seam so the
 renderer can verify and advance the exact prefix already presented without

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -139,6 +139,7 @@ const MIT_COPYRIGHT_OVERRIDES = new Map([
   ['@astryxdesign/core@0.3.0', 'Copyright (c) 2026 Meta Platforms, Inc.'],
   ['@astryxdesign/core@0.4.0', 'Copyright (c) 2026 Meta Platforms, Inc.'],
   ['@astryxdesign/core@0.4.5', 'Copyright (c) 2026 Meta Platforms, Inc.'],
+  ['@astryxdesign/core@0.5.0', 'Copyright (c) 2026 Meta Platforms, Inc.'],
   ['@stylexjs/stylex@0.19.0', 'Copyright (c) Meta Platforms, Inc. and affiliates.'],
   ['@wecom/aibot-node-sdk@1.0.7', 'Copyright (c) WeComTeam contributors'],
   [


### PR DESCRIPTION
## Summary

- Upgrade `@astryxdesign/core` from 0.4.5 to 0.5.0 across the root, UI, and Desktop packages.
- Upgrade `@astryxdesign/theme-neutral` to 0.5.0 so its strict peer dependency matches the new core version.
- Regenerate the versioned `patch-package` patch as `@astryxdesign/core@0.5.0`.
- Drop the two patch hunks now provided upstream (`Kbd.js` and `useHotkeys.js`).
- Update third-party notices and patch documentation.

Fixes #3753

## Verification

- Clean `npm ci` applies the 0.5.0 patch successfully.
- `@maka/ui` tests: 227 passed.
- Desktop typecheck passed.
- Desktop main-process tests: 1,475 passed.
- `npm run format:check` passed.
- `npm run lint` passed.
- `npm run check:third-party-notices` passed.
- `npm run check:stale` passed.
- Desktop build passed.

Manual CJK IME interaction was not run in the automated environment; the affected UI package and Desktop suites pass.

## 简体中文摘要

本 PR 将 `@astryxdesign/core` 从 0.4.5 升级到 0.5.0，并同步升级具有严格 peer 依赖的 `theme-neutral`。重新生成了 0.5.0 版本 patch，删除已经被上游吸收的 `Kbd.js` 和 `useHotkeys.js` 两个 hunk，同时更新 lockfile、许可证清单和 patch 文档。

干净安装、UI 测试、Desktop 类型检查、Desktop 主进程测试、构建、lint、format 和 stale/许可证检查均已通过。

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with the dependency-upgrade analysis, patch regeneration, affected-file updates, regression verification, and PR preparation. The commit includes the `Generated-by: OpenAI Codex` trailer; the human contributor remains responsible for review and submission.
