### PR TITLE
fix(runtime): retry transport failures the AI SDK marks retryable

### DIFF
--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -239,6 +239,46 @@ describe('Provider error classification', () => {
     });
   });
 
+  test('retries an AI SDK transport failure without an HTTP response', () => {
+    const failure = Object.assign(
+      new Error(
+        'Cannot connect to API: 80E1BDF601000000:error:0A000119:SSL routines:tls_get_more_records:decryption failed or bad record mac:../deps/openssl/openssl/ssl/record/methods/tls_common.c:869:',
+      ),
+      {
+        name: 'AI_APICallError',
+        isRetryable: true,
+        cause: Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('decryption failed or bad record mac'), {
+            code: 'ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC',
+          }),
+        }),
+      },
+    );
+
+    assert.equal(classifyError(failure), 'Network');
+    assert.deepEqual(providerRetryMetadata(failure), { retryable: true });
+    assert.equal(providerFailureDiagnostic(failure).retryable, true);
+  });
+
+  test('retries a transport failure identified only by a cause code', () => {
+    const failure = Object.assign(new Error('request failed'), {
+      cause: { code: 'ECONNRESET' },
+    });
+
+    assert.equal(classifyError(failure), 'Network');
+    assert.deepEqual(providerRetryMetadata(failure), { retryable: true });
+  });
+
+  test('does not retry a bare rate limit marked retryable by the AI SDK', () => {
+    const rateLimit = Object.assign(new Error('Rate limit exceeded'), {
+      name: 'AI_APICallError',
+      isRetryable: true,
+      statusCode: 429,
+    });
+
+    assert.deepEqual(providerRetryMetadata(rateLimit), { retryable: false });
+  });
+
   test('retries a rate limit only when the provider names a retry delay', () => {
     const bareRateLimit = Object.assign(new Error('Rate limit exceeded'), {
       name: 'AI_APICallError',

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -36,6 +36,19 @@ const PROVIDER_UNAVAILABLE_PROVIDER_CODES: ReadonlySet<string> = new Set([
   'server_error', // OpenAI-compatible stream errors can omit the HTTP status.
 ]);
 
+// Node, TLS, and undici codes that identify transport failures before an HTTP response.
+const TRANSPORT_FAILURE_CODES: ReadonlySet<string> = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EPIPE',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNABORTED',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+]);
+
 /**
  * xAI emits this code for transient model capacity failures, including when
  * the same payload is relayed through an OpenAI-compatible gateway. Do not
@@ -94,6 +107,8 @@ interface ProviderErrorEvidence {
   code: string;
   /** Structured provider identifiers (code/type), lowercased. */
   structuredCodes: string[];
+  /** Structured pre-response transport evidence from SDK metadata or cause codes. */
+  transportFailure: boolean;
 }
 
 interface ProviderErrorFacts {
@@ -137,6 +152,39 @@ function providerErrorTarget(error: unknown): unknown {
   return RetryError.isInstance(error) && error.lastError !== undefined && error.lastError !== error
     ? error.lastError
     : error;
+}
+
+function isTransportFailure(target: unknown, statusCode: string): boolean {
+  if (statusCode) return false;
+  const record = objectRecord(target);
+  if (!record) return false;
+  if (
+    target instanceof Error &&
+    target.name === 'AI_APICallError' &&
+    safeField(record, 'isRetryable') === true
+  ) {
+    return true;
+  }
+
+  let current: unknown = target;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 5 && current !== undefined && !seen.has(current); depth += 1) {
+    seen.add(current);
+    const currentRecord = objectRecord(current);
+    if (!currentRecord) return false;
+    const code = safeField(currentRecord, 'code');
+    if (
+      typeof code === 'string' &&
+      (TRANSPORT_FAILURE_CODES.has(code) ||
+        code.startsWith('ERR_SSL_') ||
+        code.startsWith('ERR_TLS_') ||
+        code.startsWith('UND_ERR_'))
+    ) {
+      return true;
+    }
+    current = safeField(currentRecord, 'cause');
+  }
+  return false;
 }
 
 function responseHeadersFromError(error: unknown): Record<string, string> | undefined {
@@ -224,13 +272,13 @@ function normalizeProviderError(error: unknown): ProviderErrorFacts | undefined 
   const target = providerErrorTarget(error);
   if (target instanceof Error) {
     const responseHeaders = responseHeadersFromError(target);
-    const code = 'code' in target ? String((target as { code?: unknown }).code) : '';
-    const statusCode =
-      'statusCode' in target
-        ? String((target as { statusCode?: unknown }).statusCode)
-        : 'status' in target
-          ? String((target as { status?: unknown }).status)
-          : '';
+    const record = target as unknown as Record<string, unknown>;
+    const field = (key: string): string => {
+      const value = safeField(record, key);
+      return typeof value === 'string' || typeof value === 'number' ? String(value) : '';
+    };
+    const code = field('code');
+    const statusCode = field('statusCode') || field('status');
     const rawBody = (target as { responseBody?: unknown }).responseBody;
     const body = typeof rawBody === 'string' ? rawBody : '';
     const structuredCodes: string[] = [];
@@ -256,6 +304,7 @@ function normalizeProviderError(error: unknown): ProviderErrorFacts | undefined 
         statusCode,
         code,
         structuredCodes,
+        transportFailure: isTransportFailure(target, statusCode),
       },
       summarySources: providerFailureSources(target),
       ...(responseHeaders ? { responseHeaders } : {}),
@@ -267,7 +316,13 @@ function normalizeProviderError(error: unknown): ProviderErrorFacts | undefined 
     if (parsed !== undefined) collectStructuredCodes(parsed, structuredCodes);
     return {
       target,
-      evidence: { text: target.toLowerCase(), statusCode: '', code: '', structuredCodes },
+      evidence: {
+        text: target.toLowerCase(),
+        statusCode: '',
+        code: '',
+        structuredCodes,
+        transportFailure: false,
+      },
       summarySources: providerFailureSources(parsed),
       ...(parsed === undefined
         ? { bareMessage: target }
@@ -285,6 +340,7 @@ function normalizeProviderError(error: unknown): ProviderErrorFacts | undefined 
     };
     const structuredCodes: string[] = [];
     collectStructuredCodes(record, structuredCodes);
+    const statusCode = field('statusCode') || field('status');
     let text: string;
     try {
       // Serialize the whole value so message/code text is evidence no matter
@@ -297,9 +353,10 @@ function normalizeProviderError(error: unknown): ProviderErrorFacts | undefined 
       target,
       evidence: {
         text,
-        statusCode: field('statusCode') || field('status'),
+        statusCode,
         code: field('code'),
         structuredCodes,
+        transportFailure: isTransportFailure(target, statusCode),
       },
       summarySources: providerFailureSources(target),
       ...(responseHeaders ? { responseHeaders } : {}),
@@ -686,6 +743,7 @@ function classifyProviderFacts(facts: ProviderErrorFacts): string {
   if (structuredCodes.some((c) => PROVIDER_UNAVAILABLE_PROVIDER_CODES.has(c)))
     return 'ProviderUnavailable';
   if (/^5\d\d$/.test(statusCode) || /^5\d\d$/.test(code)) return 'ProviderUnavailable';
+  if (evidence.transportFailure) return 'Network';
   // Weak word heuristics, last: they only catch errors that carried no
   // stronger evidence for any other class. `rate` must be word-shaped
   // ("generate"/"separate" are not rate limits) while still matching the


### PR DESCRIPTION
## Summary

Maka classified status-less transport failures wrapped by the AI SDK as terminal when their messages lacked weak network keywords. This change records structured pre-response transport evidence from the SDK retry flag and a bounded cause-code walk, then classifies that evidence as `Network`. Status and provider-code rules still run first, so bare 429 and status-less `server_error` behavior remain unchanged.

Fixes #3756

## Verification

- `npm --workspace @maka/runtime test`: pass, 3036 passed and 0 failed.
- Same suite with the classifier source stashed: the two new transport cases fail (`ℹ fail 2`, `ℹ pass 3034`); the bare 429 guard passes without the change.
- `npm run lint`: pass.
- `npm run format:check`: pass.
- `npm run typecheck`: pass.

## Review focus

`normalizeProviderError` now reads `code`, `statusCode`, and `status` through one `field()` helper that treats a present-but-undefined property as absent. The SDK constructs the fetch-failure `APICallError` without a status, so the old `'statusCode' in target` check produced the string `"undefined"` and would have blocked the new no-response rule. Composite text evidence therefore no longer contains a literal `undefined` token; the existing suite is unchanged by that.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (gpt-5.6-sol) authored the classifier change and tests; Claude Code (Fable 5) planned the boundary and reviewed

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
