### PR TITLE
test(desktop): stabilize WorkHub correction E2E

### DIFF
--- a/apps/desktop/e2e/workhub-reconstruction.spec.ts
+++ b/apps/desktop/e2e/workhub-reconstruction.spec.ts
@@ -68,12 +68,18 @@ test('WorkHub rebuilds Session conversation after navigating away and back', asy
 test('WorkHub handles a first natural-language correction', async ({
   window: page,
 }) => {
+  const sourceSessionName = '检查支付回调重复投递时的幂等性';
   const composer = page.locator(COMPOSER_INPUT);
-  await composer.fill('检查支付回调重复投递时的幂等性');
+  await composer.fill(sourceSessionName);
   await composer.press('Enter');
   await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, {
     timeout: 20_000,
   });
+  await page.evaluate(async (name) => {
+    const sourceSession = (await window.maka.sessions.list())[0];
+    if (!sourceSession) throw new Error('Source Session was not found');
+    await window.maka.sessions.rename(sourceSession.id, name);
+  }, sourceSessionName);
   await page.evaluate(async () => {
     await window.maka.settings.updateClient({ workHub: { enabled: true } });
   });
@@ -93,7 +99,7 @@ test('WorkHub handles a first natural-language correction', async ({
   });
   await expect(
     continuedTurn.locator('.workhub-submitted-session strong'),
-  ).toHaveText('检查支付回调重复投递时的幂等性');
+  ).toHaveText(sourceSessionName);
 
   await workHubComposer.fill('不是这个，换成登录稳定性，补充刷新令牌失败判定。');
   await expect(


### PR DESCRIPTION
## Summary

- Make the WorkHub natural-language correction E2E independent of asynchronous automatic title generation.
- Explicitly rename the source Session through the existing Desktop session API before enabling WorkHub.
- Reuse the same deterministic Session name for input and assertions.
- This is a test-only change and does not modify production behavior.

Fixes #3762

## Verification

- Before the fix, the focused test failed 3 of 10 repeated runs because the Session was still named `New Chat`.
- After the fix, the same 10-run test was executed twice: 20/20 passed.
- WorkHub reconstruction E2E: 2/2 passed.
- WorkHub-related Desktop unit tests: 92/92 passed.
- Full Desktop E2E: 65 passed, 1 skipped.
- Desktop unit suite on the CI Node.js 24 runtime: passed.
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

OpenAI Codex analyzed the title-generation race, implemented the E2E-only change, ran local verification, and reviewed the diff. The human contributor reviewed the final change and owns the submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No