### PR TITLE
feat(workhub): add coordination session lifecycle

### DIFF
--- a/apps/desktop/e2e/workhub-layout.spec.ts
+++ b/apps/desktop/e2e/workhub-layout.spec.ts
@@ -62,3 +62,27 @@ test('WorkHub target metadata does not overlap the submitted Session result', as
   expect(geometry.buttonContainsProject).toBe(true);
   expect(geometry.overlapHeight).toBeLessThanOrEqual(0);
 });
+
+test('WorkHub explains Coordination startup failure and recovers after a default model is set', async ({
+  window: page,
+}) => {
+  await page.evaluate(async () => {
+    await window.maka.connections.setDefaultModel(null);
+    await window.maka.settings.updateClient({ workHub: { enabled: true } });
+  });
+
+  const failure = page.getByRole('alert');
+  await expect(failure).toContainText('WorkHub 暂时无法启动');
+  await expect(failure).toContainText('请检查当前 Runtime Host 的默认模型配置');
+
+  await page.evaluate(async () => {
+    await window.maka.connections.setDefaultModel({
+      slug: 'e2e',
+      model: 'claude-sonnet-4-5-20250929',
+    });
+  });
+
+  await expect(page.getByRole('main', { name: 'WorkHub' })).toBeVisible();
+  await expect(page.locator('.workhub-empty')).toContainText('从这里继续所有工作');
+  await expect(page.locator('.workhub-surface .maka-composer-editor')).toBeVisible();
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
@@ -95,6 +95,19 @@ test('restarts a paginated catalog read instead of mixing revisions', async () =
   ]);
 });
 
+test('resolves WorkHub coordination through the dedicated Host operation', async () => {
+  const { client, requests } = clientWithResponses([
+    { sessionId: 'maka_workhub_coordination' },
+  ]);
+
+  assert.deepEqual(await client.resolveWorkHubCoordinationSession(), {
+    sessionId: 'maka_workhub_coordination',
+  });
+  assert.deepEqual(requests, [
+    { operation: 'workhub.coordination.resolve', input: {} },
+  ]);
+});
+
 test('re-reads the Session revision before retrying a product update', async () => {
   const { client, requests } = clientWithResponses([
     { kind: 'session', session: session('session-1', 4) },

--- a/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
@@ -20,7 +20,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { SessionCatalogProjection } from '@maka/runtime-host/protocol';
-import { toDesktopHostSessionSummary } from '../runtime-host-session-catalog-ipc-main.js';
+import {
+  registerRuntimeHostSessionCatalogIpc,
+  toDesktopHostSessionSummary,
+} from '../runtime-host-session-catalog-ipc-main.js';
 
 test('maps Runtime Host live run state without collapsing unknown and known-empty', () => {
   const unknown = toDesktopHostSessionSummary(projection());

--- a/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
@@ -20,10 +20,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { SessionCatalogProjection } from '@maka/runtime-host/protocol';
-import {
-  registerRuntimeHostSessionCatalogIpc,
-  toDesktopHostSessionSummary,
-} from '../runtime-host-session-catalog-ipc-main.js';
+import { toDesktopHostSessionSummary } from '../runtime-host-session-catalog-ipc-main.js';
 
 test('maps Runtime Host live run state without collapsing unknown and known-empty', () => {
   const unknown = toDesktopHostSessionSummary(projection());

--- a/apps/desktop/src/main/__tests__/runtime-host-workhub-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-workhub-ipc-main.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { registerRuntimeHostWorkHubIpc } from '../runtime-host-workhub-ipc-main.js';
+
+test('projects WorkHub coordination resolution through its dedicated IPC domain', async () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  let resolveCalls = 0;
+  registerRuntimeHostWorkHubIpc(
+    {
+      resolveWorkHubCoordinationSession: async () => {
+        resolveCalls += 1;
+        return { sessionId: 'maka_workhub_coordination' };
+      },
+    } as never,
+    {
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      },
+    } as never,
+  );
+
+  const handler = handlers.get('workhub:resolveCoordinationSession');
+  assert.ok(handler);
+  assert.deepEqual(await handler({}), { sessionId: 'maka_workhub_coordination' });
+  assert.equal(resolveCalls, 1);
+});

--- a/apps/desktop/src/main/__tests__/workhub-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-controller.test.ts
@@ -45,7 +45,7 @@ test('binds the WorkHub controller to one Coordination identity rather than proj
   assert.doesNotMatch(source, /workHubControllerRef\s*=\s*useRef/u);
   assert.match(
     source,
-    /const workHubController\s*=\s*useMemo\([\s\S]*?\[workHubCoordinationSessionId\],\s*\)/u,
+    /const workHubController\s*=\s*useMemo\([\s\S]*?\[workHubCoordinationGeneration, workHubCoordinationSessionId\],\s*\)/u,
   );
   assert.match(source, /workHubProjectsRef\.current\s*=\s*projects/u);
   assert.doesNotMatch(

--- a/apps/desktop/src/main/__tests__/workhub-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-controller.test.ts
@@ -39,10 +39,14 @@ test('binds the controller to the immutable WH-R2.4 strategy ID', () => {
   assert.equal(WORKHUB_ROUTING_STRATEGY_ID, 'wh-r2.4-session-context-continuity');
 });
 
-test('binds the WorkHub controller to the app runtime rather than project refreshes', () => {
+test('binds the WorkHub controller to one Coordination identity rather than project refreshes', () => {
   const source = readFileSync(appShellUrl, 'utf8');
 
-  assert.match(source, /workHubControllerRef\s*=\s*useRef/u);
+  assert.doesNotMatch(source, /workHubControllerRef\s*=\s*useRef/u);
+  assert.match(
+    source,
+    /const workHubController\s*=\s*useMemo\([\s\S]*?\[workHubCoordinationSessionId\],\s*\)/u,
+  );
   assert.match(source, /workHubProjectsRef\.current\s*=\s*projects/u);
   assert.doesNotMatch(
     source,

--- a/apps/desktop/src/main/__tests__/workhub-coordination-host-scope.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-coordination-host-scope.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  desktopSessionKey,
+  parseDesktopSessionKey,
+} from '../../shared/runtime-host-identity.js';
+import { scopeWorkHubSessionsToCoordinationHost } from '../../renderer/workhub-coordination-host-scope.js';
+import {
+  startWorkHubCoordinationLifecycle,
+  type WorkHubCoordinationHostChange,
+} from '../../renderer/workhub-coordination-lifecycle.js';
+import type { WorkHubDesktopSessionBridge } from '../../renderer/workhub-session-port.js';
+
+test('WorkHub candidates follow the resolved Coordination Session Host only', async () => {
+  const sessionA = desktopSessionKey({ hostId: 'host-a', sessionId: 'ordinary-a' });
+  const sessionB = desktopSessionKey({ hostId: 'host-b', sessionId: 'ordinary-b' });
+  let coordinationSessionId: string | undefined;
+  let activeHostId = 'host-a';
+  let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
+  const baseSessions: WorkHubDesktopSessionBridge = {
+    list: async () => [ordinarySession(sessionA), ordinarySession(sessionB)],
+    listWithCoverage: async () => ({
+      sessions: [ordinarySession(sessionA), ordinarySession(sessionB)],
+      completeHostIds: ['host-a', 'host-b'],
+    }),
+    listTurns: async () => [],
+    create: async () => {
+      throw new Error('unscoped create must not be used');
+    },
+    send: async () => ({ ok: true, turnId: 'turn' }),
+    stop: async () => undefined,
+    subscribeChanges: () => () => undefined,
+  };
+  const createdFor: string[] = [];
+  const createOnCoordinationHost = async (coordinationId: string) => {
+    createdFor.push(coordinationId);
+    const { hostId } = parseDesktopSessionKey(coordinationId);
+    return ordinarySession(hostId === 'host-a' ? sessionA : sessionB);
+  };
+  let sessions = scopeWorkHubSessionsToCoordinationHost(
+    baseSessions,
+    coordinationSessionId,
+    createOnCoordinationHost,
+  );
+  const stop = startWorkHubCoordinationLifecycle({
+    resolve: async () =>
+      desktopSessionKey({
+        hostId: activeHostId,
+        sessionId: 'maka_workhub_coordination',
+      }),
+    subscribeHostChanges(handler) {
+      hostChange = handler;
+      return () => undefined;
+    },
+    onResolving: () => {
+      coordinationSessionId = undefined;
+      sessions = scopeWorkHubSessionsToCoordinationHost(
+        baseSessions,
+        coordinationSessionId,
+        createOnCoordinationHost,
+      );
+    },
+    onResolved: (sessionId) => {
+      coordinationSessionId = sessionId;
+      sessions = scopeWorkHubSessionsToCoordinationHost(
+        baseSessions,
+        coordinationSessionId,
+        createOnCoordinationHost,
+      );
+    },
+    reportFailure: (error) => assert.fail(error instanceof Error ? error.message : String(error)),
+  });
+
+  const unresolvedList = sessions.list();
+  const unresolvedCreate = assert.rejects(sessions.create({ name: 'unsafe' }), /unresolved/);
+  assert.deepEqual(await unresolvedList, []);
+  await unresolvedCreate;
+  await Promise.resolve();
+  assert.deepEqual((await sessions.list()).map((session) => session.id), [sessionA]);
+  await assert.rejects(
+    () => sessions.send(sessionB, { type: 'send', turnId: 'turn', text: 'wrong Host' }),
+    /another Runtime Host/,
+  );
+  assert.deepEqual(await sessions.listWithCoverage?.(), {
+    sessions: [ordinarySession(sessionA)],
+    completeHostIds: ['host-a'],
+  });
+  const staleHostAScope = sessions;
+
+  activeHostId = 'host-b';
+  hostChange?.({ isDefault: true, readiness: 'ready' });
+  assert.deepEqual(await sessions.list(), []);
+  await Promise.resolve();
+  assert.deepEqual((await sessions.list()).map((session) => session.id), [sessionB]);
+  assert.equal((await staleHostAScope.create({ name: 'stale A' })).id, sessionA);
+  assert.equal((await sessions.create({ name: 'current B' })).id, sessionB);
+  assert.deepEqual(
+    createdFor.map((sessionId) => parseDesktopSessionKey(sessionId).hostId),
+    ['host-a', 'host-b'],
+  );
+  stop();
+});
+
+function ordinarySession(id: string): Awaited<ReturnType<WorkHubDesktopSessionBridge['list']>>[number] {
+  return {
+    id,
+    name: id,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+  };
+}

--- a/apps/desktop/src/main/__tests__/workhub-coordination-host-scope.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-coordination-host-scope.test.ts
@@ -34,6 +34,7 @@ test('WorkHub candidates follow the resolved Coordination Session Host only', as
   const sessionA = desktopSessionKey({ hostId: 'host-a', sessionId: 'ordinary-a' });
   const sessionB = desktopSessionKey({ hostId: 'host-b', sessionId: 'ordinary-b' });
   let coordinationSessionId: string | undefined;
+  let coordinationGeneration = 0;
   let activeHostId = 'host-a';
   let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
   const baseSessions: WorkHubDesktopSessionBridge = {
@@ -56,11 +57,18 @@ test('WorkHub candidates follow the resolved Coordination Session Host only', as
     const { hostId } = parseDesktopSessionKey(coordinationId);
     return ordinarySession(hostId === 'host-a' ? sessionA : sessionB);
   };
-  let sessions = scopeWorkHubSessionsToCoordinationHost(
-    baseSessions,
-    coordinationSessionId,
-    createOnCoordinationHost,
-  );
+  const scopeSessions = () => {
+    const generation = coordinationGeneration;
+    return scopeWorkHubSessionsToCoordinationHost(
+      baseSessions,
+      {
+        sessionId: coordinationSessionId,
+        isCurrent: () => generation === coordinationGeneration,
+      },
+      createOnCoordinationHost,
+    );
+  };
+  let sessions = scopeSessions();
   const stop = startWorkHubCoordinationLifecycle({
     resolve: async () =>
       desktopSessionKey({
@@ -71,21 +79,15 @@ test('WorkHub candidates follow the resolved Coordination Session Host only', as
       hostChange = handler;
       return () => undefined;
     },
+    subscribeAvailabilityChanges: () => () => undefined,
     onResolving: () => {
+      coordinationGeneration += 1;
       coordinationSessionId = undefined;
-      sessions = scopeWorkHubSessionsToCoordinationHost(
-        baseSessions,
-        coordinationSessionId,
-        createOnCoordinationHost,
-      );
+      sessions = scopeSessions();
     },
     onResolved: (sessionId) => {
       coordinationSessionId = sessionId;
-      sessions = scopeWorkHubSessionsToCoordinationHost(
-        baseSessions,
-        coordinationSessionId,
-        createOnCoordinationHost,
-      );
+      sessions = scopeSessions();
     },
     reportFailure: (error) => assert.fail(error instanceof Error ? error.message : String(error)),
   });
@@ -111,11 +113,11 @@ test('WorkHub candidates follow the resolved Coordination Session Host only', as
   assert.deepEqual(await sessions.list(), []);
   await Promise.resolve();
   assert.deepEqual((await sessions.list()).map((session) => session.id), [sessionB]);
-  assert.equal((await staleHostAScope.create({ name: 'stale A' })).id, sessionA);
+  await assert.rejects(staleHostAScope.create({ name: 'stale A' }), /scope is revoked/);
   assert.equal((await sessions.create({ name: 'current B' })).id, sessionB);
   assert.deepEqual(
     createdFor.map((sessionId) => parseDesktopSessionKey(sessionId).hostId),
-    ['host-a', 'host-b'],
+    ['host-b'],
   );
   stop();
 });

--- a/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  startWorkHubCoordinationLifecycle,
+  type WorkHubCoordinationHostChange,
+} from '../../renderer/workhub-coordination-lifecycle.js';
+
+test('WorkHub resolves on open and ready Host changes, then stops on feature disable', () => {
+  let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
+  const calls: string[] = [];
+  const stop = startWorkHubCoordinationLifecycle({
+    resolve: () => {
+      calls.push('resolve');
+      return Promise.resolve('coordination-session');
+    },
+    subscribeHostChanges(handler) {
+      hostChange = handler;
+      return () => calls.push('unsubscribe');
+    },
+    onResolving: () => calls.push('resolving'),
+    onResolved: (sessionId) => calls.push(`resolved:${sessionId}`),
+    reportFailure: () => calls.push('failure'),
+  });
+
+  assert.deepEqual(calls, ['resolving', 'resolve']);
+  hostChange?.({ isDefault: false, readiness: 'ready' });
+  hostChange?.({ isDefault: true, readiness: 'reconnecting' });
+  assert.deepEqual(calls, ['resolving', 'resolve']);
+
+  hostChange?.({ isDefault: true, readiness: 'ready' });
+  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving', 'resolve']);
+
+  stop();
+  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving', 'resolve', 'unsubscribe']);
+  hostChange?.({ isDefault: true, readiness: 'ready' });
+  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving', 'resolve', 'unsubscribe']);
+});
+
+test('WorkHub reports resolver failures without stopping later Host changes', async () => {
+  let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
+  const failures: unknown[] = [];
+  const failure = new Error('offline');
+  const stop = startWorkHubCoordinationLifecycle({
+    resolve: () => Promise.reject(failure),
+    subscribeHostChanges(handler) {
+      hostChange = handler;
+      return () => undefined;
+    },
+    onResolving: () => undefined,
+    onResolved: () => undefined,
+    reportFailure: (error) => failures.push(error),
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(failures, [failure]);
+
+  hostChange?.({ isDefault: true, readiness: 'ready' });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(failures, [failure, failure]);
+  stop();
+});
+
+test('WorkHub ignores a stale Host resolution that settles after a newer Host', async () => {
+  let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
+  const pending: Array<(sessionId: string) => void> = [];
+  const resolved: string[] = [];
+  const stop = startWorkHubCoordinationLifecycle({
+    resolve: () => new Promise<string>((resolve) => pending.push(resolve)),
+    subscribeHostChanges(handler) {
+      hostChange = handler;
+      return () => undefined;
+    },
+    onResolving: () => undefined,
+    onResolved: (sessionId) => resolved.push(sessionId),
+    reportFailure: (error) => assert.fail(error instanceof Error ? error.message : String(error)),
+  });
+
+  hostChange?.({ isDefault: true, readiness: 'ready' });
+  pending[1]?.('host-b-coordination');
+  await Promise.resolve();
+  pending[0]?.('host-a-coordination');
+  await Promise.resolve();
+
+  assert.deepEqual(resolved, ['host-b-coordination']);
+  stop();
+});

--- a/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
@@ -26,6 +26,7 @@ import {
 
 test('WorkHub resolves on open and ready Host changes, then stops on feature disable', () => {
   let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
+  let availabilityChange: (() => void) | undefined;
   const calls: string[] = [];
   const stop = startWorkHubCoordinationLifecycle({
     resolve: () => {
@@ -34,7 +35,11 @@ test('WorkHub resolves on open and ready Host changes, then stops on feature dis
     },
     subscribeHostChanges(handler) {
       hostChange = handler;
-      return () => calls.push('unsubscribe');
+      return () => calls.push('unsubscribe-hosts');
+    },
+    subscribeAvailabilityChanges(handler) {
+      availabilityChange = handler;
+      return () => calls.push('unsubscribe-availability');
     },
     onResolving: () => calls.push('resolving'),
     onResolved: (sessionId) => calls.push(`resolved:${sessionId}`),
@@ -44,40 +49,76 @@ test('WorkHub resolves on open and ready Host changes, then stops on feature dis
   assert.deepEqual(calls, ['resolving', 'resolve']);
   hostChange?.({ isDefault: false, readiness: 'ready' });
   hostChange?.({ isDefault: true, readiness: 'reconnecting' });
-  assert.deepEqual(calls, ['resolving', 'resolve']);
+  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving']);
+
+  availabilityChange?.();
+  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving']);
 
   hostChange?.({ isDefault: true, readiness: 'ready' });
-  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving', 'resolve']);
+  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving', 'resolving', 'resolve']);
 
   stop();
-  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving', 'resolve', 'unsubscribe']);
+  assert.deepEqual(calls, [
+    'resolving',
+    'resolve',
+    'resolving',
+    'resolving',
+    'resolve',
+    'unsubscribe-hosts',
+    'unsubscribe-availability',
+  ]);
   hostChange?.({ isDefault: true, readiness: 'ready' });
-  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving', 'resolve', 'unsubscribe']);
+  availabilityChange?.();
+  assert.equal(calls.at(-1), 'unsubscribe-availability');
 });
 
-test('WorkHub reports resolver failures without stopping later Host changes', async () => {
+test('WorkHub exposes a retry and automatically retries when model availability changes', async () => {
   let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
+  let availabilityChange: (() => void) | undefined;
   const failures: unknown[] = [];
+  let manualRetry: (() => void) | undefined;
+  let resolveAttempts = 0;
   const failure = new Error('offline');
   const stop = startWorkHubCoordinationLifecycle({
-    resolve: () => Promise.reject(failure),
+    resolve: () => {
+      resolveAttempts += 1;
+      return resolveAttempts < 3
+        ? Promise.reject(failure)
+        : Promise.resolve('coordination-session');
+    },
     subscribeHostChanges(handler) {
       hostChange = handler;
       return () => undefined;
     },
+    subscribeAvailabilityChanges(handler) {
+      availabilityChange = handler;
+      return () => undefined;
+    },
     onResolving: () => undefined,
-    onResolved: () => undefined,
-    reportFailure: (error) => failures.push(error),
+    onResolved: (sessionId) => failures.push(sessionId),
+    reportFailure: (error, retry) => {
+      failures.push(error);
+      manualRetry = retry;
+    },
   });
 
   await Promise.resolve();
   await Promise.resolve();
   assert.deepEqual(failures, [failure]);
 
-  hostChange?.({ isDefault: true, readiness: 'ready' });
+  manualRetry?.();
   await Promise.resolve();
   await Promise.resolve();
   assert.deepEqual(failures, [failure, failure]);
+
+  availabilityChange?.();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(failures, [failure, failure, 'coordination-session']);
+
+  availabilityChange?.();
+  hostChange?.({ isDefault: false, readiness: 'ready' });
+  assert.equal(resolveAttempts, 3);
   stop();
 });
 
@@ -91,6 +132,7 @@ test('WorkHub ignores a stale Host resolution that settles after a newer Host', 
       hostChange = handler;
       return () => undefined;
     },
+    subscribeAvailabilityChanges: () => () => undefined,
     onResolving: () => undefined,
     onResolved: (sessionId) => resolved.push(sessionId),
     reportFailure: (error) => assert.fail(error instanceof Error ? error.message : String(error)),
@@ -103,5 +145,29 @@ test('WorkHub ignores a stale Host resolution that settles after a newer Host', 
   await Promise.resolve();
 
   assert.deepEqual(resolved, ['host-b-coordination']);
+  stop();
+});
+
+test('selecting an unready default Host revokes the old scope and invalidates its resolve', async () => {
+  let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
+  const pending: Array<(sessionId: string) => void> = [];
+  const calls: string[] = [];
+  const stop = startWorkHubCoordinationLifecycle({
+    resolve: () => new Promise<string>((resolve) => pending.push(resolve)),
+    subscribeHostChanges(handler) {
+      hostChange = handler;
+      return () => undefined;
+    },
+    subscribeAvailabilityChanges: () => () => undefined,
+    onResolving: () => calls.push('revoked'),
+    onResolved: (sessionId) => calls.push(`resolved:${sessionId}`),
+    reportFailure: (error) => assert.fail(error instanceof Error ? error.message : String(error)),
+  });
+
+  hostChange?.({ isDefault: true, readiness: 'reconnecting' });
+  pending[0]?.('old-host-coordination');
+  await Promise.resolve();
+
+  assert.deepEqual(calls, ['revoked', 'revoked']);
   stop();
 });

--- a/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
@@ -72,6 +72,56 @@ test('WorkHub resolves on open and ready Host changes, then stops on feature dis
   assert.equal(calls.at(-1), 'unsubscribe-availability');
 });
 
+test('WorkHub reports an unavailable default Host instead of holding the loading state', () => {
+  let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
+  let availabilityChange: (() => void) | undefined;
+  const calls: string[] = [];
+  let manualRetry: (() => void) | undefined;
+  const stop = startWorkHubCoordinationLifecycle({
+    resolve: () => {
+      calls.push('resolve');
+      return new Promise<string>(() => undefined);
+    },
+    subscribeHostChanges(handler) {
+      hostChange = handler;
+      return () => undefined;
+    },
+    subscribeAvailabilityChanges(handler) {
+      availabilityChange = handler;
+      return () => undefined;
+    },
+    onResolving: () => calls.push('resolving'),
+    onResolved: () => calls.push('resolved'),
+    reportFailure: (error, retry) => {
+      calls.push(`failure:${error instanceof Error ? error.message : String(error)}`);
+      manualRetry = retry;
+    },
+  });
+
+  // Connecting is still on its way to an answer and keeps the loading state.
+  hostChange?.({ isDefault: true, readiness: 'connecting' });
+  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving']);
+
+  hostChange?.({ isDefault: true, readiness: 'unavailable' });
+  assert.deepEqual(calls, [
+    'resolving',
+    'resolve',
+    'resolving',
+    'resolving',
+    'failure:The default Runtime Host is unavailable',
+  ]);
+
+  // A revoked generation that reported a failure stays reopenable, by the
+  // Retry control and by an availability change alike.
+  availabilityChange?.();
+  assert.equal(calls.at(-1), 'resolve');
+  hostChange?.({ isDefault: true, readiness: 'unavailable', removed: true });
+  assert.equal(calls.at(-1), 'failure:The default Runtime Host is unavailable');
+  manualRetry?.();
+  assert.equal(calls.at(-1), 'resolve');
+  stop();
+});
+
 test('WorkHub exposes a retry and automatically retries when model availability changes', async () => {
   let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
   let availabilityChange: (() => void) | undefined;

--- a/apps/desktop/src/main/__tests__/workhub-coordination-session-preload.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-coordination-session-preload.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseDesktopSessionKey } from '../../shared/runtime-host-identity.js';
+import {
+  resolveDesktopWorkHubCoordinationCreateScope,
+  resolveDesktopWorkHubCoordinationSession,
+} from '../../preload/workhub-coordination-session.js';
+
+test('resolves the Coordination Session through the currently active Runtime Host scope', async () => {
+  const scopes = [
+    { hostId: 'host-a', targetEpoch: 'epoch-a' },
+    { hostId: 'host-b', targetEpoch: 'epoch-b' },
+  ];
+  let active = 0;
+  const seen: typeof scopes = [];
+  const resolve = () =>
+    resolveDesktopWorkHubCoordinationSession(
+      async () => scopes[active]!,
+      async (scope) => {
+        seen.push(scope);
+        return { sessionId: 'maka_workhub_coordination' };
+      },
+    );
+
+  const first = await resolve();
+  active = 1;
+  const second = await resolve();
+
+  assert.deepEqual(seen, scopes);
+  assert.deepEqual(parseDesktopSessionKey(first), {
+    hostId: 'host-a',
+    sessionId: 'maka_workhub_coordination',
+  });
+  assert.deepEqual(parseDesktopSessionKey(second), {
+    hostId: 'host-b',
+    sessionId: 'maka_workhub_coordination',
+  });
+});
+
+test('creates against the Coordination Session Host instead of later UI focus', async () => {
+  const coordination = JSON.stringify(['host-a', 'maka_workhub_coordination']);
+  const scopeA = { hostId: 'host-a', targetEpoch: 'epoch-a' };
+  const scope = await resolveDesktopWorkHubCoordinationCreateScope(
+    coordination,
+    async (sessionId) => {
+      assert.equal(sessionId, coordination);
+      return { scope: scopeA, sessionId: 'maka_workhub_coordination' };
+    },
+  );
+
+  assert.equal(scope, scopeA);
+  await assert.rejects(
+    resolveDesktopWorkHubCoordinationCreateScope(
+      JSON.stringify(['host-a', 'ordinary']),
+      async () => ({ scope: scopeA, sessionId: 'ordinary' }),
+    ),
+    /Invalid WorkHub Coordination Session identity/,
+  );
+});

--- a/apps/desktop/src/main/__tests__/workhub-surface-flow.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-surface-flow.test.ts
@@ -19,7 +19,11 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { AstryxLocaleProvider, LocaleProvider } from '@maka/ui';
 import {
+  WorkHubCoordinationStatus,
   WorkHubProjectionRefreshGate,
   WorkHubSurfaceRouteGate,
   projectedWorkHubTurnPresentation,
@@ -56,6 +60,29 @@ test('surface route gate rejects same-frame duplicate operations and reopens aft
   assert.equal(await first, 'first');
   assert.equal(gate.pending, false);
   assert.equal(await gate.run(async () => 'next'), 'next');
+});
+
+test('Coordination lifecycle keeps a visible loading state and exposes failure recovery', () => {
+  const renderStatus = (state: 'resolving' | 'failed') => renderToStaticMarkup(
+    createElement(LocaleProvider, {
+      locale: 'en',
+      children: createElement(AstryxLocaleProvider, {
+        children: createElement(WorkHubCoordinationStatus, {
+          locale: 'en',
+          state,
+          onRetry: () => undefined,
+        }),
+      }),
+    }),
+  );
+  const resolving = renderStatus('resolving');
+  const failed = renderStatus('failed');
+
+  assert.match(resolving, /Preparing WorkHub/);
+  assert.match(resolving, /aria-busy="true"/);
+  assert.match(failed, /role="alert"/);
+  assert.match(failed, /Check the default model/);
+  assert.match(failed, />Retry</);
 });
 
 test('surface projection refresh gate rejects older reads after a newer refresh starts', () => {

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -830,6 +830,10 @@ export class DesktopRuntimeHostClient {
     );
   }
 
+  resolveWorkHubCoordinationSession() {
+    return this.request("workhub.coordination.resolve", {});
+  }
+
   listExternalSessionSources(): Promise<ExternalSessionSourceQueryResult> {
     return this.request("external-session.source.query", {});
   }

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -60,6 +60,7 @@ import {
   type DesktopNativeCapabilityProviderInput,
 } from "./runtime-host-native-capabilities.js";
 import { registerRuntimeHostSessionCatalogIpc } from "./runtime-host-session-catalog-ipc-main.js";
+import { registerRuntimeHostWorkHubIpc } from "./runtime-host-workhub-ipc-main.js";
 import { registerRuntimeHostExternalSessionsIpc } from "./runtime-host-external-sessions-ipc-main.js";
 import {
   registerRuntimeHostSessionDomainsIpc,
@@ -678,6 +679,7 @@ export async function createDesktopRuntimeHostCandidate(
       },
       ipc,
     );
+    registerRuntimeHostWorkHubIpc(client, ipc);
     registerRuntimeHostExternalSessionsIpc(
       {
         client,

--- a/apps/desktop/src/main/runtime-host-workhub-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-workhub-ipc-main.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
+import type { ReconnectableReadIpcMain } from './ipc-reconnect-policy.js';
+
+type RuntimeHostWorkHubClient = Pick<
+  DesktopRuntimeHostClient,
+  'resolveWorkHubCoordinationSession'
+>;
+
+/** Projects the Runtime Host WorkHub domain onto renderer IPC. */
+export function registerRuntimeHostWorkHubIpc(
+  client: RuntimeHostWorkHubClient,
+  ipcMain: Pick<ReconnectableReadIpcMain, 'handle'>,
+): void {
+  ipcMain.handle('workhub:resolveCoordinationSession', () =>
+    client.resolveWorkHubCoordinationSession(),
+  );
+}

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -710,6 +710,15 @@ export interface MakaBridge {
       handler: () => void,
     ): () => void;
   };
+  workHub: {
+    /** Resolve the active Runtime Host's stable coordination conversation. */
+    resolveCoordinationSession(): Promise<string>;
+    /** Create an ordinary Session on the exact Host owning the resolved conversation. */
+    createSession(
+      coordinationSessionId: string,
+      input: { name: string },
+    ): Promise<DesktopSessionSummary>;
+  };
   sessions: {
     list(filter?: SessionListFilter): Promise<DesktopSessionSummary[]>;
     listWithCoverage(): Promise<{

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -22,6 +22,10 @@ import { encodeIngestItems } from './attachment-ingest-payload.js';
 import { collectThreadSearchResponses } from './multi-host-thread-search.js';
 import { notifyWhenSeeded } from './seed-completion.js';
 import { releaseSessionObservation } from './session-observation-release.js';
+import {
+  resolveDesktopWorkHubCoordinationCreateScope,
+  resolveDesktopWorkHubCoordinationSession,
+} from './workhub-coordination-session.js';
 import type {
   MakaBridge,
   OnboardingSnapshot,
@@ -837,6 +841,14 @@ async function listDesktopSessionsWithCoverage(): Promise<{
   );
 }
 
+async function createDesktopSessionOnScope(
+  scope: DesktopTargetScope,
+  input?: CreateSessionRequestInput,
+): Promise<DesktopSessionSummary> {
+  const session = await ipcRenderer.invoke('sessions:create', scope, input) as SessionSummary;
+  return projectSessionSummary(scope, session);
+}
+
 function sendActiveRuntimeHost(channel: string, ...args: unknown[]): void {
   void activeRuntimeHostRef()
     .then((scope) => ipcRenderer.send(channel, scope, ...args))
@@ -1356,11 +1368,10 @@ const makaBridge = {
       input?: CreateSessionRequestInput,
     ): Promise<DesktopSessionSummary> {
       const scope = await runtimeHostScope(target);
-      const session = await ipcRenderer.invoke('sessions:create', scope, {
+      return createDesktopSessionOnScope(scope, {
         ...input,
         projectId: target.projectId,
-      }) as SessionSummary;
-      return projectSessionSummary(scope, session);
+      });
     },
   },
   pets: {
@@ -1506,6 +1517,24 @@ const makaBridge = {
       };
     },
   },
+  workHub: {
+    resolveCoordinationSession(): Promise<string> {
+      return resolveDesktopWorkHubCoordinationSession(
+        activeRuntimeHostRef,
+        (scope) => ipcRenderer.invoke('workhub:resolveCoordinationSession', scope),
+      );
+    },
+    async createSession(
+      coordinationSessionId: string,
+      input: { name: string },
+    ): Promise<DesktopSessionSummary> {
+      const scope = await resolveDesktopWorkHubCoordinationCreateScope(
+        coordinationSessionId,
+        runtimeHostSessionRef,
+      );
+      return createDesktopSessionOnScope(scope, input);
+    },
+  },
   sessions: {
     list(filter?: SessionListFilter): Promise<DesktopSessionSummary[]> {
       return listDesktopSessions(filter);
@@ -1521,8 +1550,7 @@ const makaBridge = {
      */
     async create(input?: CreateSessionRequestInput): Promise<DesktopSessionSummary> {
       const scope = await activeRuntimeHostRef();
-      const session = await ipcRenderer.invoke('sessions:create', scope, input) as SessionSummary;
-      return projectSessionSummary(scope, session);
+      return createDesktopSessionOnScope(scope, input);
     },
     async send(
       sessionId: string,

--- a/apps/desktop/src/preload/workhub-coordination-session.ts
+++ b/apps/desktop/src/preload/workhub-coordination-session.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { WORKHUB_COORDINATION_SESSION_ID } from '@maka/core/session';
+import {
+  desktopSessionKey,
+  type DesktopTargetScope,
+} from '../shared/runtime-host-identity.js';
+
+export async function resolveDesktopWorkHubCoordinationSession(
+  activeRuntimeHost: () => Promise<DesktopTargetScope>,
+  resolveOnHost: (
+    scope: DesktopTargetScope,
+  ) => Promise<{ readonly sessionId: string }>,
+): Promise<string> {
+  const scope = await activeRuntimeHost();
+  const result = await resolveOnHost(scope);
+  return desktopSessionKey({ hostId: scope.hostId, sessionId: result.sessionId });
+}
+
+/** Resolves an exact Host scope from the durable Coordination identity, never from UI focus. */
+export async function resolveDesktopWorkHubCoordinationCreateScope(
+  coordinationSessionId: string,
+  resolveSession: (
+    sessionId: string,
+  ) => Promise<{ readonly scope: DesktopTargetScope; readonly sessionId: string }>,
+): Promise<DesktopTargetScope> {
+  const coordination = await resolveSession(coordinationSessionId);
+  if (coordination.sessionId !== WORKHUB_COORDINATION_SESSION_ID) {
+    throw new Error('Invalid WorkHub Coordination Session identity');
+  }
+  return coordination.scope;
+}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -126,7 +126,7 @@ import { createWorkHubController } from './workhub-controller.js';
 import { startWorkHubCoordinationLifecycle } from './workhub-coordination-lifecycle.js';
 import { scopeWorkHubSessionsToCoordinationHost } from './workhub-coordination-host-scope.js';
 import { createDesktopWorkHubSessionPort } from './workhub-session-port.js';
-import { WorkHubSurface } from './workhub-surface.js';
+import { WorkHubCoordinationStatus, WorkHubSurface } from './workhub-surface.js';
 import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy';
 import { getDesktopConversationCopy } from './locales/conversation-copy';
 import { ErrorBoundary } from './error-boundary';
@@ -439,6 +439,11 @@ function AppShellContent({
   const [workHubEnabled, setWorkHubEnabled] = useState(false);
   const [workHubActive, setWorkHubActive] = useState(false);
   const [workHubCoordinationSessionId, setWorkHubCoordinationSessionId] = useState<string>();
+  const [workHubCoordinationState, setWorkHubCoordinationState] = useState<
+    'resolving' | 'failed'
+  >('resolving');
+  const workHubCoordinationRetryRef = useRef<() => void>(() => undefined);
+  const workHubCoordinationGenerationRef = useRef(0);
   const workHubCoordinationSessionIdRef = useRef(workHubCoordinationSessionId);
   workHubCoordinationSessionIdRef.current = workHubCoordinationSessionId;
   const workHubEnabledRef = useRef(false);
@@ -448,15 +453,24 @@ function AppShellContent({
       resolve: () => window.maka.workHub.resolveCoordinationSession(),
       subscribeHostChanges: (handler) =>
         window.maka.runtimeHostProfiles.subscribeChanges(handler),
+      subscribeAvailabilityChanges: (handler) =>
+        window.maka.connections.subscribeEvents((event) => {
+          if (event.type === 'connection_list_changed') handler();
+        }),
       onResolving: () => {
+        workHubCoordinationGenerationRef.current += 1;
         workHubCoordinationSessionIdRef.current = undefined;
         setWorkHubCoordinationSessionId(undefined);
+        setWorkHubCoordinationState('resolving');
       },
       onResolved: (sessionId) => {
         workHubCoordinationSessionIdRef.current = sessionId;
         setWorkHubCoordinationSessionId(sessionId);
+        setWorkHubCoordinationState('resolving');
       },
-      reportFailure: (error) => {
+      reportFailure: (error, retry) => {
+        workHubCoordinationRetryRef.current = retry;
+        setWorkHubCoordinationState('failed');
         console.error('[workhub] failed to resolve Coordination Session:', error);
       },
     });
@@ -471,6 +485,7 @@ function AppShellContent({
         workHubEnabledRef.current = enabled;
         setWorkHubEnabled(enabled);
         if (!enabled) {
+          workHubCoordinationGenerationRef.current += 1;
           workHubCoordinationSessionIdRef.current = undefined;
           setWorkHubActive(false);
           setWorkHubCoordinationSessionId(undefined);
@@ -1506,12 +1521,18 @@ function AppShellContent({
   refreshProjectSkillsRef.current = moduleHub.commands.refreshProjectSkills;
   const workHubProjectsRef = useRef(projects);
   workHubProjectsRef.current = projects;
+  const workHubCoordinationGeneration = workHubCoordinationGenerationRef.current;
   const workHubController = useMemo(
     () => createWorkHubController({
       sessions: createDesktopWorkHubSessionPort({
         sessions: scopeWorkHubSessionsToCoordinationHost(
           window.maka.sessions,
-          workHubCoordinationSessionId,
+          {
+            sessionId: workHubCoordinationSessionId,
+            isCurrent: () =>
+              workHubCoordinationGenerationRef.current === workHubCoordinationGeneration &&
+              workHubCoordinationSessionIdRef.current === workHubCoordinationSessionId,
+          },
           (coordinationSessionId, input) =>
             window.maka.workHub.createSession(coordinationSessionId, input),
         ),
@@ -1521,7 +1542,7 @@ function AppShellContent({
         newTurnId: () => crypto.randomUUID(),
       }),
     }),
-    [workHubCoordinationSessionId],
+    [workHubCoordinationGeneration, workHubCoordinationSessionId],
   );
   // Where a NEW chat starts. Built unconditionally and handed to the composer,
   // which renders it only while no session owns it — the project is fixed once
@@ -2846,7 +2867,13 @@ function AppShellContent({
                     {...(activeId ? { initialFocusSessionId: activeId } : {})}
                     onOpenSession={openSessionInChat}
                   />
-                ) : null
+                ) : (
+                  <WorkHubCoordinationStatus
+                    locale={uiLocale}
+                    state={workHubCoordinationState}
+                    onRetry={() => workHubCoordinationRetryRef.current()}
+                  />
+                )
               ) : (
               <ChatSurfaceLayout
                 // Reset conversation-owned scroll state without remounting the

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -123,6 +123,8 @@ import { ProviderLogo } from './settings/provider-display';
 import { ProviderBrandMark } from './settings/provider-brand-marks';
 import { RuntimeHostSshTerminalDialog } from './settings/runtime-host-ssh-terminal-dialog.js';
 import { createWorkHubController } from './workhub-controller.js';
+import { startWorkHubCoordinationLifecycle } from './workhub-coordination-lifecycle.js';
+import { scopeWorkHubSessionsToCoordinationHost } from './workhub-coordination-host-scope.js';
 import { createDesktopWorkHubSessionPort } from './workhub-session-port.js';
 import { WorkHubSurface } from './workhub-surface.js';
 import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy';
@@ -436,7 +438,29 @@ function AppShellContent({
   const navSelectionRef = useRef<NavSelection>(navSelection);
   const [workHubEnabled, setWorkHubEnabled] = useState(false);
   const [workHubActive, setWorkHubActive] = useState(false);
+  const [workHubCoordinationSessionId, setWorkHubCoordinationSessionId] = useState<string>();
+  const workHubCoordinationSessionIdRef = useRef(workHubCoordinationSessionId);
+  workHubCoordinationSessionIdRef.current = workHubCoordinationSessionId;
   const workHubEnabledRef = useRef(false);
+  useEffect(() => {
+    if (!workHubEnabled || !workHubActive) return;
+    return startWorkHubCoordinationLifecycle({
+      resolve: () => window.maka.workHub.resolveCoordinationSession(),
+      subscribeHostChanges: (handler) =>
+        window.maka.runtimeHostProfiles.subscribeChanges(handler),
+      onResolving: () => {
+        workHubCoordinationSessionIdRef.current = undefined;
+        setWorkHubCoordinationSessionId(undefined);
+      },
+      onResolved: (sessionId) => {
+        workHubCoordinationSessionIdRef.current = sessionId;
+        setWorkHubCoordinationSessionId(sessionId);
+      },
+      reportFailure: (error) => {
+        console.error('[workhub] failed to resolve Coordination Session:', error);
+      },
+    });
+  }, [workHubActive, workHubEnabled]);
   useEffect(() => {
     let disposed = false;
     const refresh = async () => {
@@ -446,7 +470,11 @@ function AppShellContent({
         const becameEnabled = enabled && !workHubEnabledRef.current;
         workHubEnabledRef.current = enabled;
         setWorkHubEnabled(enabled);
-        if (!enabled) setWorkHubActive(false);
+        if (!enabled) {
+          workHubCoordinationSessionIdRef.current = undefined;
+          setWorkHubActive(false);
+          setWorkHubCoordinationSessionId(undefined);
+        }
         if (becameEnabled) {
           setWorkHubActive(true);
           setNavSelection({ section: 'sessions' });
@@ -1478,19 +1506,23 @@ function AppShellContent({
   refreshProjectSkillsRef.current = moduleHub.commands.refreshProjectSkills;
   const workHubProjectsRef = useRef(projects);
   workHubProjectsRef.current = projects;
-  const workHubControllerRef = useRef<ReturnType<typeof createWorkHubController> | null>(null);
-  if (!workHubControllerRef.current) {
-    workHubControllerRef.current = createWorkHubController({
+  const workHubController = useMemo(
+    () => createWorkHubController({
       sessions: createDesktopWorkHubSessionPort({
-        sessions: window.maka.sessions,
+        sessions: scopeWorkHubSessionsToCoordinationHost(
+          window.maka.sessions,
+          workHubCoordinationSessionId,
+          (coordinationSessionId, input) =>
+            window.maka.workHub.createSession(coordinationSessionId, input),
+        ),
         transcripts: window.maka.transcripts,
         projectName: (projectId) =>
           workHubProjectsRef.current.find((project) => project.id === projectId)?.name,
         newTurnId: () => crypto.randomUUID(),
       }),
-    });
-  }
-  const workHubController = workHubControllerRef.current;
+    }),
+    [workHubCoordinationSessionId],
+  );
   // Where a NEW chat starts. Built unconditionally and handed to the composer,
   // which renders it only while no session owns it — the project is fixed once
   // the first message creates one, so there is nothing to pick after that.
@@ -2806,12 +2838,15 @@ function AppShellContent({
             <div className="mainColumn" data-home-surface={homeSurfaceActive ? 'true' : undefined}>
               <ModuleHubHost model={moduleHub.host} />
               {workHubEnabled && workHubActive && navSelection.section === 'sessions' ? (
-                <WorkHubSurface
-                  controller={workHubController}
-                  locale={uiLocale}
-                  {...(activeId ? { initialFocusSessionId: activeId } : {})}
-                  onOpenSession={openSessionInChat}
-                />
+                workHubCoordinationSessionId ? (
+                  <WorkHubSurface
+                    key={workHubCoordinationSessionId}
+                    controller={workHubController}
+                    locale={uiLocale}
+                    {...(activeId ? { initialFocusSessionId: activeId } : {})}
+                    onOpenSession={openSessionInChat}
+                  />
+                ) : null
               ) : (
               <ChatSurfaceLayout
                 // Reset conversation-owned scroll state without remounting the

--- a/apps/desktop/src/renderer/styles/workhub.css
+++ b/apps/desktop/src/renderer/styles/workhub.css
@@ -86,6 +86,10 @@
   text-align: center;
 }
 
+.workhub-coordination-retry {
+  margin-top: var(--space-4, 16px);
+}
+
 .workhub-turns {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/renderer/workhub-coordination-host-scope.ts
+++ b/apps/desktop/src/renderer/workhub-coordination-host-scope.ts
@@ -23,12 +23,19 @@ import type {
   WorkHubDesktopSessionBridge,
 } from './workhub-session-port.js';
 
+export interface WorkHubCoordinationHostAuthority {
+  readonly sessionId: string | undefined;
+  /** Revokes every operation held by a controller from an older Host generation. */
+  readonly isCurrent: () => boolean;
+}
+
 /** Restricts the transitional WorkHub router to the Coordination Session's Host. */
 export function scopeWorkHubSessionsToCoordinationHost(
   sessions: WorkHubDesktopSessionBridge,
-  coordinationSessionId: string | undefined,
+  coordination: WorkHubCoordinationHostAuthority,
   createOnCoordinationHost: WorkHubCoordinationHostSessionCreator,
 ): WorkHubDesktopSessionBridge {
+  const coordinationSessionId = coordination.sessionId;
   const hostId = (() => {
     if (!coordinationSessionId) return undefined;
     try {
@@ -45,6 +52,7 @@ export function scopeWorkHubSessionsToCoordinationHost(
     }
   };
   const requireHost = (): string => {
+    if (!coordination.isCurrent()) throw new Error('WorkHub Coordination Session scope is revoked');
     if (!hostId) throw new Error('WorkHub Coordination Session is unresolved');
     return hostId;
   };
@@ -55,6 +63,7 @@ export function scopeWorkHubSessionsToCoordinationHost(
   };
   const scoped = {
     async list() {
+      if (!coordination.isCurrent()) return [];
       const expectedHostId = hostId;
       if (!expectedHostId) return [];
       return (await sessions.list()).filter((session) =>
@@ -87,6 +96,7 @@ export function scopeWorkHubSessionsToCoordinationHost(
   return {
     ...scoped,
     async listWithCoverage() {
+      if (!coordination.isCurrent()) return { sessions: [], completeHostIds: [] };
       const expectedHostId = hostId;
       if (!expectedHostId) return { sessions: [], completeHostIds: [] };
       const snapshot = await listWithCoverage();

--- a/apps/desktop/src/renderer/workhub-coordination-host-scope.ts
+++ b/apps/desktop/src/renderer/workhub-coordination-host-scope.ts
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { parseDesktopSessionKey } from '../shared/runtime-host-identity.js';
+import type {
+  WorkHubCoordinationHostSessionCreator,
+  WorkHubDesktopSessionBridge,
+} from './workhub-session-port.js';
+
+/** Restricts the transitional WorkHub router to the Coordination Session's Host. */
+export function scopeWorkHubSessionsToCoordinationHost(
+  sessions: WorkHubDesktopSessionBridge,
+  coordinationSessionId: string | undefined,
+  createOnCoordinationHost: WorkHubCoordinationHostSessionCreator,
+): WorkHubDesktopSessionBridge {
+  const hostId = (() => {
+    if (!coordinationSessionId) return undefined;
+    try {
+      return parseDesktopSessionKey(coordinationSessionId).hostId;
+    } catch {
+      return undefined;
+    }
+  })();
+  const belongsToHost = (sessionId: string, expectedHostId: string): boolean => {
+    try {
+      return parseDesktopSessionKey(sessionId).hostId === expectedHostId;
+    } catch {
+      return false;
+    }
+  };
+  const requireHost = (): string => {
+    if (!hostId) throw new Error('WorkHub Coordination Session is unresolved');
+    return hostId;
+  };
+  const requireTargetHost = (sessionId: string): void => {
+    if (!belongsToHost(sessionId, requireHost())) {
+      throw new Error('WorkHub target belongs to another Runtime Host');
+    }
+  };
+  const scoped = {
+    async list() {
+      const expectedHostId = hostId;
+      if (!expectedHostId) return [];
+      return (await sessions.list()).filter((session) =>
+        belongsToHost(session.id, expectedHostId),
+      );
+    },
+    async listTurns(sessionId: string) {
+      requireTargetHost(sessionId);
+      return await sessions.listTurns(sessionId);
+    },
+    async create(input: { name: string }) {
+      requireHost();
+      return await createOnCoordinationHost(coordinationSessionId!, input);
+    },
+    async send(sessionId: string, command: { type: 'send'; turnId: string; text: string }) {
+      requireTargetHost(sessionId);
+      return await sessions.send(sessionId, command);
+    },
+    async stop(
+      sessionId: string,
+      input?: { source?: 'stop_button'; expectedTurnId?: string },
+    ) {
+      requireTargetHost(sessionId);
+      await sessions.stop(sessionId, input);
+    },
+    subscribeChanges: (handler: () => void) => sessions.subscribeChanges(handler),
+  } satisfies WorkHubDesktopSessionBridge;
+  const listWithCoverage = sessions.listWithCoverage;
+  if (!listWithCoverage) return scoped;
+  return {
+    ...scoped,
+    async listWithCoverage() {
+      const expectedHostId = hostId;
+      if (!expectedHostId) return { sessions: [], completeHostIds: [] };
+      const snapshot = await listWithCoverage();
+      return {
+        sessions: snapshot.sessions.filter((session) =>
+          belongsToHost(session.id, expectedHostId),
+        ),
+        completeHostIds: snapshot.completeHostIds.includes(expectedHostId)
+          ? [expectedHostId]
+          : [],
+      };
+    },
+  };
+}

--- a/apps/desktop/src/renderer/workhub-coordination-lifecycle.ts
+++ b/apps/desktop/src/renderer/workhub-coordination-lifecycle.ts
@@ -30,30 +30,52 @@ export function startWorkHubCoordinationLifecycle(input: {
   readonly subscribeHostChanges: (
     handler: (event: WorkHubCoordinationHostChange) => void,
   ) => () => void;
+  readonly subscribeAvailabilityChanges: (handler: () => void) => () => void;
   readonly onResolving: () => void;
   readonly onResolved: (sessionId: string) => void;
-  readonly reportFailure: (error: unknown) => void;
+  readonly reportFailure: (error: unknown, retry: () => void) => void;
 }): () => void {
   let stopped = false;
   let generation = 0;
-  const resolve = () => {
+  let failedGeneration: number | undefined;
+
+  const revoke = () => {
     const currentGeneration = ++generation;
+    failedGeneration = undefined;
     input.onResolving();
+    return currentGeneration;
+  };
+  const resolveGeneration = (currentGeneration: number) => {
     void input.resolve()
       .then((sessionId) => {
-        if (!stopped && currentGeneration === generation) input.onResolved(sessionId);
+        if (stopped || currentGeneration !== generation) return;
+        failedGeneration = undefined;
+        input.onResolved(sessionId);
       })
       .catch((error) => {
-        if (!stopped && currentGeneration === generation) input.reportFailure(error);
+        if (stopped || currentGeneration !== generation) return;
+        failedGeneration = currentGeneration;
+        input.reportFailure(error, () => {
+          if (!stopped && failedGeneration === currentGeneration) beginResolve();
+        });
       });
   };
-  const unsubscribe = input.subscribeHostChanges((event) => {
-    if (!stopped && event.isDefault && event.readiness === 'ready') resolve();
+  const beginResolve = () => resolveGeneration(revoke());
+
+  const unsubscribeHosts = input.subscribeHostChanges((event) => {
+    if (stopped || !event.isDefault) return;
+    const currentGeneration = revoke();
+    if (event.readiness === 'ready') resolveGeneration(currentGeneration);
   });
-  resolve();
+  const unsubscribeAvailability = input.subscribeAvailabilityChanges(() => {
+    if (!stopped && failedGeneration === generation) beginResolve();
+  });
+  beginResolve();
   return () => {
     stopped = true;
     generation += 1;
-    unsubscribe();
+    failedGeneration = undefined;
+    unsubscribeHosts();
+    unsubscribeAvailability();
   };
 }

--- a/apps/desktop/src/renderer/workhub-coordination-lifecycle.ts
+++ b/apps/desktop/src/renderer/workhub-coordination-lifecycle.ts
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { DesktopRuntimeHostProfileChangedEvent } from '../preload/bridge-contract.js';
+
+export type WorkHubCoordinationHostChange = Pick<
+  DesktopRuntimeHostProfileChangedEvent,
+  'isDefault' | 'readiness'
+>;
+
+/** Keeps active WorkHub resolution aligned with the current default Runtime Host. */
+export function startWorkHubCoordinationLifecycle(input: {
+  readonly resolve: () => Promise<string>;
+  readonly subscribeHostChanges: (
+    handler: (event: WorkHubCoordinationHostChange) => void,
+  ) => () => void;
+  readonly onResolving: () => void;
+  readonly onResolved: (sessionId: string) => void;
+  readonly reportFailure: (error: unknown) => void;
+}): () => void {
+  let stopped = false;
+  let generation = 0;
+  const resolve = () => {
+    const currentGeneration = ++generation;
+    input.onResolving();
+    void input.resolve()
+      .then((sessionId) => {
+        if (!stopped && currentGeneration === generation) input.onResolved(sessionId);
+      })
+      .catch((error) => {
+        if (!stopped && currentGeneration === generation) input.reportFailure(error);
+      });
+  };
+  const unsubscribe = input.subscribeHostChanges((event) => {
+    if (!stopped && event.isDefault && event.readiness === 'ready') resolve();
+  });
+  resolve();
+  return () => {
+    stopped = true;
+    generation += 1;
+    unsubscribe();
+  };
+}

--- a/apps/desktop/src/renderer/workhub-coordination-lifecycle.ts
+++ b/apps/desktop/src/renderer/workhub-coordination-lifecycle.ts
@@ -21,8 +21,10 @@ import type { DesktopRuntimeHostProfileChangedEvent } from '../preload/bridge-co
 
 export type WorkHubCoordinationHostChange = Pick<
   DesktopRuntimeHostProfileChangedEvent,
-  'isDefault' | 'readiness'
+  'isDefault' | 'readiness' | 'removed'
 >;
+
+const UNAVAILABLE_DEFAULT_HOST = 'The default Runtime Host is unavailable';
 
 /** Keeps active WorkHub resolution aligned with the current default Runtime Host. */
 export function startWorkHubCoordinationLifecycle(input: {
@@ -45,6 +47,12 @@ export function startWorkHubCoordinationLifecycle(input: {
     input.onResolving();
     return currentGeneration;
   };
+  const reportGenerationFailure = (currentGeneration: number, error: unknown) => {
+    failedGeneration = currentGeneration;
+    input.reportFailure(error, () => {
+      if (!stopped && failedGeneration === currentGeneration) beginResolve();
+    });
+  };
   const resolveGeneration = (currentGeneration: number) => {
     void input.resolve()
       .then((sessionId) => {
@@ -54,10 +62,7 @@ export function startWorkHubCoordinationLifecycle(input: {
       })
       .catch((error) => {
         if (stopped || currentGeneration !== generation) return;
-        failedGeneration = currentGeneration;
-        input.reportFailure(error, () => {
-          if (!stopped && failedGeneration === currentGeneration) beginResolve();
-        });
+        reportGenerationFailure(currentGeneration, error);
       });
   };
   const beginResolve = () => resolveGeneration(revoke());
@@ -65,7 +70,17 @@ export function startWorkHubCoordinationLifecycle(input: {
   const unsubscribeHosts = input.subscribeHostChanges((event) => {
     if (stopped || !event.isDefault) return;
     const currentGeneration = revoke();
-    if (event.readiness === 'ready') resolveGeneration(currentGeneration);
+    if (event.readiness === 'ready') {
+      resolveGeneration(currentGeneration);
+      return;
+    }
+    // Connecting and reconnecting are still on their way to an answer, so the
+    // loading state stays honest. An unavailable default Host is not: without a
+    // reported failure the surface would hold that spinner forever, and the
+    // availability subscription only reopens a generation that failed.
+    if (event.readiness === 'unavailable' || event.removed) {
+      reportGenerationFailure(currentGeneration, new Error(UNAVAILABLE_DEFAULT_HOST));
+    }
   });
   const unsubscribeAvailability = input.subscribeAvailabilityChanges(() => {
     if (!stopped && failedGeneration === generation) beginResolve();

--- a/apps/desktop/src/renderer/workhub-session-port.ts
+++ b/apps/desktop/src/renderer/workhub-session-port.ts
@@ -72,6 +72,11 @@ export interface WorkHubDesktopSessionBridge {
   subscribeChanges(handler: () => void): () => void;
 }
 
+export type WorkHubCoordinationHostSessionCreator = (
+  coordinationSessionId: string,
+  input: { name: string },
+) => Promise<WorkHubDesktopSession>;
+
 export interface WorkHubDesktopTranscriptBridge {
   open(
     sessionId: string,

--- a/apps/desktop/src/renderer/workhub-surface.tsx
+++ b/apps/desktop/src/renderer/workhub-surface.tsx
@@ -329,6 +329,67 @@ export function WorkHubSurface(props: {
   );
 }
 
+/** Visible lifecycle state while the active Host's Coordination Session is unavailable. */
+export function WorkHubCoordinationStatus(props: {
+  locale: UiLocale;
+  state: 'resolving' | 'failed';
+  onRetry(): void;
+}) {
+  const copy = workHubCopy(props.locale);
+  const resolving = props.state === 'resolving';
+  return (
+    <ChatSurfaceLayout
+      className="workhub-surface"
+      conversationKey="workhub-coordination-status"
+      composer={(
+        <Composer
+          draftKey="workhub"
+          onSend={async () => false}
+          onStop={() => {}}
+          sendBlocked
+          modelLabel="WorkHub"
+        />
+      )}
+    >
+      <main
+        className="maka-main agents-chat-panel agents-chat-view-root workhub-timeline"
+        aria-label="WorkHub"
+      >
+        <header className="workhub-header">
+          <div>
+            <h1>WorkHub</h1>
+            <p>{copy.subtitle}</p>
+          </div>
+          <span>{resolving ? copy.preparing : copy.unavailable}</span>
+        </header>
+        <div className="maka-chat-shell">
+          <ChatMessageList
+            className="maka-chat-message-list maka-chatContent workhub-message-list"
+            density="compact"
+            gap={4}
+            isStreaming={resolving}
+          >
+            {resolving ? (
+              <WorkHubLoadingState label={copy.preparing} />
+            ) : (
+              <div className="workhub-empty" role="alert">
+                <h2>{copy.coordinationFailedTitle}</h2>
+                <p>{copy.coordinationFailedBody}</p>
+                <Button
+                  className="workhub-coordination-retry"
+                  variant="primary"
+                  label={copy.retry}
+                  onClick={props.onRetry}
+                />
+              </div>
+            )}
+          </ChatMessageList>
+        </div>
+      </main>
+    </ChatSurfaceLayout>
+  );
+}
+
 function WorkHubLoadingState(props: { label: string }) {
   return (
     <div
@@ -574,6 +635,10 @@ function workHubCopy(locale: UiLocale) {
       requestNotSent: '新请求尚未发送；处理原 Session 中的交互后可以再次发送。',
       routing: '正在判断应该交给哪个 Session…', loadFailed: '无法读取已有工作。',
       loading: '正在读取已有工作…',
+      preparing: '正在准备 WorkHub…', unavailable: '暂不可用',
+      coordinationFailedTitle: 'WorkHub 暂时无法启动',
+      coordinationFailedBody: '请检查当前 Runtime Host 的默认模型配置，然后重试。',
+      retry: '重试',
       submitFailed: '输入未能送达，请重试。', scrollToBottom: '滚动到底部', archived: '已归档',
       states: { active: '活跃', running: '进行中', waiting_for_user: '等待你', blocked: '受阻', aborted: '已中止' },
       turnStates: { running: '进行中', completed: '已完成', aborted: '已中止', failed: '失败' },
@@ -599,6 +664,10 @@ function workHubCopy(locale: UiLocale) {
     requestNotSent: 'The new request was not sent. Resolve the interaction in its Session, then send again.',
     routing: 'Choosing the right Session…', loadFailed: 'Could not read existing work.',
     loading: 'Loading existing work…',
+    preparing: 'Preparing WorkHub…', unavailable: 'Unavailable',
+    coordinationFailedTitle: 'WorkHub could not start',
+    coordinationFailedBody: 'Check the default model for the current Runtime Host, then retry.',
+    retry: 'Retry',
     submitFailed: 'The input could not be delivered. Try again.', scrollToBottom: 'Scroll to bottom', archived: 'Archived',
     states: { active: 'Active', running: 'Running', waiting_for_user: 'Waiting for you', blocked: 'Blocked', aborted: 'Aborted' },
     turnStates: { running: 'Running', completed: 'Completed', aborted: 'Aborted', failed: 'Failed' },

--- a/docs/architecture/workhub-coordination-session-adr.md
+++ b/docs/architecture/workhub-coordination-session-adr.md
@@ -46,8 +46,9 @@ transcript, model, recovery, and event infrastructure. Session remains the only
 durable conversation and execution substrate.
 
 The role is provisioned lazily when WorkHub first needs it and resolves to the same
-Session after Runtime Host or application restarts. The representation, lookup, and
-recovery mechanisms that enforce this contract are deferred to Slice 2.
+Session after Runtime Host or application restarts. The Session role representation,
+lookup, recovery, and per-Host UI resolution enforce this lifecycle contract. The
+coordination transcript and disposition semantics remain separate later work.
 
 The per-Host boundary is intentional. A Coordination Session coordinates only the
 ordinary Sessions belonging to the same Runtime Host. Switching Runtime Hosts
@@ -127,9 +128,10 @@ transcript into the Coordination Session.
 - Whether Work is 1:1 with Session, 1:N over Sessions, or an independent durable
   entity remains unresolved.
 - Cross-Runtime-Host coordination remains deferred.
-- Coordination Session kind/role representation, lazy creation, durable lookup,
-  recovery, UI treatment, and routing implementation belong to Slice 2 and later;
-  this ADR does not design or implement them.
+- Coordination Session role representation, lazy creation, durable lookup,
+  recovery, and per-Host UI resolution are implemented. Coordination transcript,
+  disposition, delegation-link, and Action Gate behavior remain later work; this
+  ADR defines their authority boundaries without implementing them.
 
 Reevaluate the per-Host decision if supported workflows require one WorkHub
 conversation to coordinate ordinary Sessions on multiple Runtime Hosts, or if Host

--- a/docs/workhub-domain-language.md
+++ b/docs/workhub-domain-language.md
@@ -23,10 +23,12 @@ WorkHub gives users one persistent conversational place to ask, clarify, continu
 create, and inspect work. It is backed by one stable Coordination Session per
 Runtime Host while concrete execution remains authoritative in ordinary Sessions.
 
-This document names the approved target architecture. The current R2.4
-implementation is a transitional deterministic router and does not yet create the
-Coordination Session described below. The decision and authority boundaries are
-recorded in the [WorkHub Coordination Session ADR](./architecture/workhub-coordination-session-adr.md).
+This document names the approved target architecture. Each Runtime Host now
+provisions and reuses the stable Coordination Session role described below. The
+current R2.4 routing behavior remains a transitional deterministic baseline or
+target resolver; it does not define the final WorkHub coordination semantics. The
+decision and authority boundaries are recorded in the
+[WorkHub Coordination Session ADR](./architecture/workhub-coordination-session-adr.md).
 
 ## Terms
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -78,6 +78,11 @@ export const WORKHUB_COORDINATION_SESSION_ROLE = 'workhub_coordination' as const
 export const WORKHUB_COORDINATION_SESSION_ID = 'maka_workhub_coordination' as const;
 export type SessionRole = typeof WORKHUB_COORDINATION_SESSION_ROLE;
 
+/** Whether an identifier targets the reserved WorkHub Coordination Session. */
+export function isWorkHubCoordinationSessionId(sessionId: string): boolean {
+  return sessionId === WORKHUB_COORDINATION_SESSION_ID;
+}
+
 export const TURN_STATUSES = ['running', 'completed', 'aborted', 'failed'] as const;
 
 export type TurnStatus = (typeof TURN_STATUSES)[number];
@@ -297,6 +302,13 @@ export type SessionHeaderPatch = Partial<Omit<SessionHeader, 'isArchived' | 'rol
 
 export function isWorkHubCoordinationSession(session: Pick<SessionHeader, 'role'>): boolean {
   return session.role === WORKHUB_COORDINATION_SESSION_ROLE;
+}
+
+/** Whether durable state claims either half of the reserved Coordination identity/role pair. */
+export function isWorkHubCoordinationSessionTarget(
+  session: Pick<SessionHeader, 'id' | 'role'>,
+): boolean {
+  return isWorkHubCoordinationSessionId(session.id) || isWorkHubCoordinationSession(session);
 }
 
 /**

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -73,6 +73,11 @@ export const SESSION_BLOCKED_REASONS = [
 
 export type SessionBlockedReason = (typeof SESSION_BLOCKED_REASONS)[number];
 
+/** Reserved durable role for the one WorkHub coordination conversation owned by a Runtime Host. */
+export const WORKHUB_COORDINATION_SESSION_ROLE = 'workhub_coordination' as const;
+export const WORKHUB_COORDINATION_SESSION_ID = 'maka_workhub_coordination' as const;
+export type SessionRole = typeof WORKHUB_COORDINATION_SESSION_ROLE;
+
 export const TURN_STATUSES = ['running', 'completed', 'aborted', 'failed'] as const;
 
 export type TurnStatus = (typeof TURN_STATUSES)[number];
@@ -210,6 +215,8 @@ export interface SessionExternalOrigin {
 export interface SessionHeader {
   // Identity
   id: string;
+  /** Absent means an ordinary Session; special roles remain on the same Session substrate. */
+  readonly role?: SessionRole;
   workspaceRoot: string;
   cwd: string;
   /** Stable project-catalog association. Null means the user explicitly chose no project. */
@@ -283,9 +290,14 @@ export interface SessionHeader {
   schemaVersion: 1;
 }
 
-export type SessionHeaderPatch = Partial<Omit<SessionHeader, 'isArchived'>> & {
+export type SessionHeaderPatch = Partial<Omit<SessionHeader, 'isArchived' | 'role'>> & {
   readonly isArchived?: never;
+  readonly role?: never;
 };
+
+export function isWorkHubCoordinationSession(session: Pick<SessionHeader, 'role'>): boolean {
+  return session.role === WORKHUB_COORDINATION_SESSION_ROLE;
+}
 
 /**
  * The backend a live build may select.

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -22,6 +22,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { test } from 'node:test';
 import { agentGraphIdForRootSession } from '@maka/runtime/stream-graph-coordinator';
 import { BackendRegistry, SessionManager } from '@maka/runtime/session-manager';
@@ -55,6 +56,10 @@ import type {
   BackendSendInput,
 } from '@maka/core/backend-types';
 import type { SessionEvent } from '@maka/core/events';
+import {
+  WORKHUB_COORDINATION_SESSION_ID,
+  WORKHUB_COORDINATION_SESSION_ROLE,
+} from '@maka/core/session';
 import type { MakaTool } from '@maka/runtime/tool-runtime';
 import { clientCapabilityConnectionIdentity } from './fixtures/client-capability.js';
 import {
@@ -63,6 +68,7 @@ import {
   type RootTurnAdmissionStore,
 } from '@maka/storage/execution-stores';
 import { openInteractiveArtifactStoreForWrite } from '@maka/storage/artifact-stores';
+import { OPERATIONAL_STATE_DATABASE_NAME } from '@maka/storage/operational-state-store';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import type { SubscriptionFrame, TurnSnapshot } from '../protocol/index.js';
 import { HostAgentGraphExecutionCoordinator } from '../server/agent-graph-execution-coordinator.js';
@@ -114,6 +120,100 @@ function assertStartedTurn(outcome: TurnStartOutcome): asserts outcome is Starte
     assert.fail('Expected a started Turn outcome');
   }
 }
+
+test('turn.start rejects the reserved WorkHub Coordination Session identity', async () => {
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) =>
+      backends.register('ai-sdk', (backendContext) => new FakeBackend(backendContext)),
+  });
+  try {
+    assert.deepEqual(fixture.coordinator.prepare(WORKHUB_COORDINATION_SESSION_ID), {
+      kind: 'unavailable',
+      reason: 'WorkHub Coordination Session execution requires WorkHub authority',
+    });
+    const outcome = await fixture.interactiveTurns.handlers['turn.start'](
+      {
+        sessionId: WORKHUB_COORDINATION_SESSION_ID,
+        turnId: 'coordination-turn',
+        content: { text: 'Run a tool from WorkHub.' },
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+
+    assert.deepEqual(outcome, {
+      ok: false,
+      error: {
+        code: 'operation_unavailable',
+        message: 'WorkHub Coordination Session execution requires WorkHub authority',
+      },
+    });
+    assert.deepEqual(
+      await fixture.coordinator.handlers['turn.resume.query'](
+        {
+          sessionId: WORKHUB_COORDINATION_SESSION_ID,
+          sourceRunId: 'source-run',
+          expectedRuntimeEventHighWater: 1,
+        },
+        operationContext(fixture.hostEpoch, fixture.acquireResidency),
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'operation_unavailable',
+          message: 'WorkHub Coordination Session execution requires WorkHub authority',
+        },
+      },
+    );
+    assert.equal(
+      await fixture.stores.agentRunStore.readRootTurnAdmission(
+        WORKHUB_COORDINATION_SESSION_ID,
+        'coordination-turn',
+      ),
+      undefined,
+    );
+  } finally {
+    await fixture.coordinator.close();
+    await fixture.messages.close();
+    await fixture.dispose();
+  }
+});
+
+test('turn.start rejects a corrupt Coordination role on an ordinary identity', async () => {
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) =>
+      backends.register('ai-sdk', (backendContext) => new FakeBackend(backendContext)),
+    corruptSessionRole: true,
+  });
+  try {
+    const outcome = await fixture.interactiveTurns.handlers['turn.start'](
+      {
+        sessionId: fixture.sessionId,
+        turnId: 'corrupt-coordination-role-turn',
+        content: { text: 'This must remain outside ordinary execution.' },
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+
+    assert.deepEqual(outcome, {
+      ok: false,
+      error: {
+        code: 'operation_unavailable',
+        message: 'WorkHub Coordination Session execution requires WorkHub authority',
+      },
+    });
+    assert.equal(
+      await fixture.stores.agentRunStore.readRootTurnAdmission(
+        fixture.sessionId,
+        'corrupt-coordination-role-turn',
+      ),
+      undefined,
+    );
+  } finally {
+    await fixture.coordinator.close();
+    await fixture.messages.close();
+    await fixture.dispose();
+  }
+});
 
 test('prepares a fresh Agent Graph epoch before durable external Turn admission', async () => {
   let fixture!: FailureFixture;
@@ -4709,6 +4809,7 @@ async function registerSessionCapability(
 
 async function createFailureFixture(options: {
   registerBackend(backends: BackendRegistry): void;
+  corruptSessionRole?: boolean;
   childTools?: MakaTool[];
   wrapAdmissionStore?(store: RootTurnAdmissionStore): RootTurnAdmissionStore;
   wrapMessageAuthority?(authority: RuntimeMessageAuthority): RuntimeMessageAuthority;
@@ -4751,6 +4852,22 @@ async function createFailureFixture(options: {
     model: 'fake-model',
     permissionMode: 'ask',
   });
+  if (options.corruptSessionRole) {
+    const database = new DatabaseSync(
+      join(capability.canonicalPath, OPERATIONAL_STATE_DATABASE_NAME),
+    );
+    try {
+      database
+        .prepare(
+          `UPDATE session_metadata
+           SET payload_json = json_set(payload_json, '$.role', ?)
+           WHERE session_id = ?`,
+        )
+        .run(WORKHUB_COORDINATION_SESSION_ROLE, session.id);
+    } finally {
+      database.close();
+    }
+  }
   const admissionStore = options.wrapAdmissionStore?.(stores.agentRunStore) ?? stores.agentRunStore;
   const rootAdmissionOwner = new RootAdmissionOwner(admissionStore);
   await rootAdmissionOwner.recoverSession(session.id);

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -26,12 +26,13 @@ import { createDefaultRuntimePolicy } from '@maka/core/runtime-policy';
 import { createGenesisExecutionBoundary } from '@maka/core/sandbox-boundary';
 import { DEEP_RESEARCH_SESSION_LABEL, DEEP_RESEARCH_SESSION_NAME } from '@maka/core/explore-agent';
 import { type RelayModelProfile } from '@maka/core/model-thinking';
-import { type SessionHeader } from '@maka/core/session';
+import type { SessionHeader } from '@maka/core/session';
 import {
   SessionConfigurationTransitionError,
   headerToSummary,
 } from '@maka/runtime/session-manager';
 import { type ProjectCatalog, ProjectUnavailableError } from '@maka/storage/project-catalog';
+import { SessionNotFoundError } from '@maka/storage/session-store';
 import type { ResolveExecutionConnectionResult } from '@maka/storage/runtime-policy-stores';
 import {
   SessionMetadataVersionConflictError,
@@ -212,6 +213,26 @@ test('catalog queries project known-empty and running state from Runtime authori
   assert.deepEqual(session.liveRunState, {
     schemaVersion: 1,
     runningTurnIds: ['turn-live'],
+  });
+});
+
+test('ordinary catalog lookup hides the WorkHub Coordination Session', async () => {
+  const fixture = createFixture({
+    stores: {
+      readCatalogRecord: async () => {
+        throw new SessionNotFoundError('session-1');
+      },
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.catalog.query'](
+    { kind: 'get', sessionId: fixture.sessionId },
+    context,
+  );
+
+  assert.deepEqual(outcome, {
+    ok: true,
+    result: { kind: 'session', session: null },
   });
 });
 

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -26,7 +26,11 @@ import { createDefaultRuntimePolicy } from '@maka/core/runtime-policy';
 import { createGenesisExecutionBoundary } from '@maka/core/sandbox-boundary';
 import { DEEP_RESEARCH_SESSION_LABEL, DEEP_RESEARCH_SESSION_NAME } from '@maka/core/explore-agent';
 import { type RelayModelProfile } from '@maka/core/model-thinking';
-import type { SessionHeader } from '@maka/core/session';
+import {
+  WORKHUB_COORDINATION_SESSION_ID,
+  WORKHUB_COORDINATION_SESSION_ROLE,
+  type SessionHeader,
+} from '@maka/core/session';
 import {
   SessionConfigurationTransitionError,
   headerToSummary,
@@ -440,6 +444,113 @@ test('creation rejects reserved execution labels before claiming a Session ident
     },
   });
   assert.equal(createAttempts, 0);
+  assert.equal(fixture.drainRequests(), 0);
+});
+
+test('ordinary creation rejects the reserved WorkHub Coordination Session identity', async () => {
+  let probeAttempts = 0;
+  const fixture = createFixture({
+    stores: {
+      probeStableSessionCreate: async () => {
+        probeAttempts += 1;
+        assert.fail('Reserved identity must be rejected before persistence admission');
+      },
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.create'](
+    {
+      sessionId: WORKHUB_COORDINATION_SESSION_ID,
+      workspace: { kind: 'host_path', path: process.cwd() },
+      modelTarget: { kind: 'default' },
+    },
+    context,
+  );
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    error: {
+      code: 'operation_conflict',
+      message: 'Session identity is reserved for WorkHub coordination',
+    },
+  });
+  assert.equal(probeAttempts, 0);
+  assert.equal(fixture.drainRequests(), 0);
+});
+
+test('ordinary configuration rejects the WorkHub Coordination Session identity', async () => {
+  let reads = 0;
+  const fixture = createFixture({
+    stores: {
+      readHeaderRecordSnapshot: async () => {
+        reads += 1;
+        assert.fail('Reserved identity must be rejected before configuration admission');
+      },
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.configuration.update'](
+    configurationInput(WORKHUB_COORDINATION_SESSION_ID, fixture.revision()),
+    context,
+  );
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    error: {
+      code: 'operation_conflict',
+      message: 'WorkHub Coordination Session configuration requires WorkHub authority',
+    },
+  });
+  assert.equal(reads, 0);
+  assert.equal(fixture.drainRequests(), 0);
+});
+
+test('ordinary metadata and configuration reject a corrupt Coordination role on another identity', async () => {
+  const corrupt = {
+    ...sessionHeader('session-1', ['user-label']),
+    role: WORKHUB_COORDINATION_SESSION_ROLE,
+  };
+  const fixture = createFixture({
+    stores: {
+      readHeaderRecordSnapshot: async () => headerSnapshot(corrupt, 3),
+      updateHeaderVersioned: async () => assert.fail('Corrupt role must not reach metadata writes'),
+    },
+    manager: {
+      transitionSessionConfiguration: async () =>
+        assert.fail('Corrupt role must not reach configuration writes'),
+    },
+  });
+
+  assert.deepEqual(
+    await fixture.coordinator.handlers['session.metadata.update'](
+      {
+        sessionId: fixture.sessionId,
+        expectedRevision: fixture.revision(),
+        patch: { name: 'Not allowed' },
+      },
+      context,
+    ),
+    {
+      ok: false,
+      error: {
+        code: 'operation_unavailable',
+        message: 'WorkHub Coordination Session metadata requires WorkHub authority',
+      },
+    },
+  );
+  assert.deepEqual(
+    await fixture.coordinator.handlers['session.configuration.update'](
+      configurationInput(fixture.sessionId, fixture.revision()),
+      context,
+    ),
+    {
+      ok: false,
+      error: {
+        code: 'operation_conflict',
+        message: 'WorkHub Coordination Session configuration requires WorkHub authority',
+      },
+    },
+  );
   assert.equal(fixture.drainRequests(), 0);
 });
 

--- a/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
@@ -25,8 +25,13 @@ import { DatabaseSync } from 'node:sqlite';
 import { describe, test } from 'node:test';
 import type { AgentGraphOperatorProvisionRequest } from '@maka/core/agent-graph-topology';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
+import {
+  WORKHUB_COORDINATION_SESSION_ID,
+  WORKHUB_COORDINATION_SESSION_ROLE,
+} from '@maka/core/session';
 import { agentGraphIdForRootSession } from '@maka/runtime/stream-graph-coordinator';
 import { createSessionStore } from '@maka/storage/session-store';
+import { OPERATIONAL_STATE_DATABASE_NAME } from '@maka/storage/operational-state-store';
 import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import {
   HostScheduledTaskSessionBusyError,
@@ -45,6 +50,65 @@ const CONNECTION_CONTEXT: ConnectionContext = {
 };
 
 describe('Host Session retirement coordinator', () => {
+  test('rejects ordinary archive and remove operations for the Coordination Session', async () => {
+    await withHarness(async (harness) => {
+      const created = await harness.store.createStableSession({
+        sessionId: WORKHUB_COORDINATION_SESSION_ID,
+        requestFingerprint: `sha256:${'a'.repeat(64)}`,
+        input: {
+          ...sessionInput('WorkHub', { cwd: '/tmp/workhub', projectId: null }),
+          role: WORKHUB_COORDINATION_SESSION_ROLE,
+        },
+      });
+      assert.equal(created.kind, 'created');
+      const database = new DatabaseSync(
+        join(harness.workspaceRoot, OPERATIONAL_STATE_DATABASE_NAME),
+      );
+      try {
+        database
+          .prepare(
+            `UPDATE session_metadata
+             SET payload_json = json_remove(payload_json, '$.role')
+             WHERE session_id = ?`,
+          )
+          .run(WORKHUB_COORDINATION_SESSION_ID);
+      } finally {
+        database.close();
+      }
+
+      const archive = await harness.coordinator.handlers['session.lifecycle.set'](
+        { sessionId: WORKHUB_COORDINATION_SESSION_ID, state: 'archived' },
+        CONNECTION_CONTEXT,
+      );
+      assert.deepEqual(archive, {
+        ok: false,
+        error: {
+          code: 'operation_conflict',
+          message: 'WorkHub Coordination Session lifecycle is owned by WorkHub',
+        },
+      });
+
+      const remove = await harness.coordinator.handlers['session.remove'](
+        {
+          sessionId: WORKHUB_COORDINATION_SESSION_ID,
+          expectedRevision: created.record.revision,
+        },
+        CONNECTION_CONTEXT,
+      );
+      assert.deepEqual(remove, {
+        ok: false,
+        error: {
+          code: 'operation_conflict',
+          message: 'WorkHub Coordination Session lifecycle is owned by WorkHub',
+        },
+      });
+      assert.equal(
+        (await harness.store.readHeaderSnapshot(WORKHUB_COORDINATION_SESSION_ID)).isArchived,
+        false,
+      );
+    });
+  });
+
   test('archives, restores, and removes one whole edit-and-resend family', async () => {
     await withHarness(async (harness) => {
       const archived = await harness.coordinator.handlers['session.lifecycle.set'](

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -162,7 +162,25 @@ async function verifyConcurrentRevisionAuthority(
         }),
         operationError('operation_conflict'),
       );
+      // The reservation holds on both sides: the Coordination transcript cannot
+      // be lifted out into an ordinary Session that would then be executable.
+      await assert.rejects(
+        desktop.request(operation, {
+          sourceSessionId: WORKHUB_COORDINATION_SESSION_ID,
+          targetSessionId: 'coordination-copy-target',
+          sourceTurnId: 'turn-1',
+          expectedSourceRevision: source.revision,
+        }),
+        operationError('operation_conflict'),
+      );
     }
+    assert.deepEqual(
+      await tui.request('session.catalog.query', {
+        kind: 'get',
+        sessionId: 'coordination-copy-target',
+      }),
+      { kind: 'session', session: null },
+    );
     const continuationSource = await querySession(desktop, continuationSourceSessionId);
     await assert.rejects(
       desktop.request('session.branch.create', {

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -28,6 +28,7 @@ import { decodeCanonicalToolResultContent } from '@maka/core/tool-result-record-
 import { type AgentGraphOperatorProvisionRequest } from '@maka/core/agent-graph-topology';
 import { type AgentRunHeader } from '@maka/core/agent-run';
 import { type RuntimeEvent } from '@maka/core/runtime-event';
+import { WORKHUB_COORDINATION_SESSION_ID } from '@maka/core/session';
 import { agentGraphIdForRootSession } from '@maka/runtime/stream-graph-coordinator';
 import { FAKE_ASK_USER_QUESTION_PROMPT } from '@maka/runtime/test-only/fake-backend';
 import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
@@ -151,6 +152,17 @@ async function verifyConcurrentRevisionAuthority(
   const tui = await connectClient(root);
   try {
     const source = await querySession(desktop, sourceSessionId);
+    for (const operation of ['session.branch.create', 'session.revision.create'] as const) {
+      await assert.rejects(
+        desktop.request(operation, {
+          sourceSessionId,
+          targetSessionId: WORKHUB_COORDINATION_SESSION_ID,
+          sourceTurnId: 'turn-1',
+          expectedSourceRevision: source.revision,
+        }),
+        operationError('operation_conflict'),
+      );
+    }
     const continuationSource = await querySession(desktop, continuationSourceSessionId);
     await assert.rejects(
       desktop.request('session.branch.create', {

--- a/packages/runtime-host/src/__tests__/workhub-coordination-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/workhub-coordination-coordinator.test.ts
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { describe, test } from 'node:test';
+import {
+  WORKHUB_COORDINATION_SESSION_ID,
+  WORKHUB_COORDINATION_SESSION_ROLE,
+} from '@maka/core/session';
+import { createSessionStore, type SessionAuthorityStore } from '@maka/storage/session-store';
+import { OPERATIONAL_STATE_DATABASE_NAME } from '@maka/storage/operational-state-store';
+import type { ConnectionContext } from '../server/operation-dispatcher.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+import { HostWorkHubCoordinationCoordinator } from '../server/workhub-coordination-coordinator.js';
+
+const CONTEXT: ConnectionContext = {
+  hostEpoch: 'workhub-test-epoch',
+  connectionId: 'workhub-test-client',
+  principal: 'local_os_user',
+  acquireResidency: () => ({ release() {} }),
+};
+
+describe('Host WorkHub Coordination coordinator', () => {
+  test('concurrently creates once and reuses the durable Session after Host restart', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-resolve-'));
+    let store = createSessionStore(root);
+    try {
+      const firstCoordinator = coordinator(root, store);
+      const outcomes = await Promise.all(
+        Array.from({ length: 16 }, () =>
+          firstCoordinator.handlers['workhub.coordination.resolve']({}, CONTEXT),
+        ),
+      );
+      assert.equal(
+        outcomes.every((outcome) => outcome.ok),
+        true,
+      );
+      assert.deepEqual(
+        new Set(outcomes.flatMap((outcome) => (outcome.ok ? [outcome.result.sessionId] : []))),
+        new Set([WORKHUB_COORDINATION_SESSION_ID]),
+      );
+      const header = await store.readHeaderSnapshot(WORKHUB_COORDINATION_SESSION_ID);
+      assert.equal(header.role, WORKHUB_COORDINATION_SESSION_ROLE);
+      assert.equal(header.projectId, null);
+      assert.equal(header.cwd, join(root, 'workhub-coordination'));
+      assert.equal((await store.listHeaders()).length, 1);
+    } finally {
+      await store.close?.();
+    }
+
+    store = createSessionStore(root);
+    try {
+      const restarted = await coordinator(root, store).handlers['workhub.coordination.resolve'](
+        {},
+        CONTEXT,
+      );
+      assert.deepEqual(restarted, {
+        ok: true,
+        result: { sessionId: WORKHUB_COORDINATION_SESSION_ID },
+      });
+      assert.equal((await store.listHeaders()).length, 1);
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('fails closed on reserved-id collision without changing ordinary Sessions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-collision-'));
+    const store = createSessionStore(root);
+    try {
+      await store.createStableSession({
+        sessionId: WORKHUB_COORDINATION_SESSION_ID,
+        requestFingerprint: `sha256:${'c'.repeat(64)}`,
+        input: {
+          cwd: root,
+          projectId: null,
+          name: 'Ordinary collision',
+          llmConnectionSlug: 'test-connection',
+          model: 'test-model',
+          permissionMode: 'ask',
+        },
+      });
+
+      const outcome = await coordinator(root, store).handlers['workhub.coordination.resolve'](
+        {},
+        CONTEXT,
+      );
+
+      assert.deepEqual(outcome, {
+        ok: false,
+        error: {
+          code: 'operation_conflict',
+          message: 'WorkHub Coordination Session identity is unavailable',
+        },
+      });
+      assert.deepEqual(await store.list(), []);
+      const collision = await store.readHeaderSnapshot(WORKHUB_COORDINATION_SESSION_ID);
+      assert.equal(collision.name, 'Ordinary collision');
+      assert.equal(collision.role, undefined);
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('reports corrupt durable state without replacing or losing ordinary Sessions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-corrupt-'));
+    const store = createSessionStore(root);
+    let drains = 0;
+    try {
+      const ordinary = await store.create({
+        cwd: root,
+        name: 'Keep me',
+        llmConnectionSlug: 'test-connection',
+        model: 'test-model',
+        permissionMode: 'ask',
+      });
+      const initial = await coordinator(root, store).handlers['workhub.coordination.resolve'](
+        {},
+        CONTEXT,
+      );
+      assert.equal(initial.ok, true);
+
+      const database = new DatabaseSync(join(root, OPERATIONAL_STATE_DATABASE_NAME));
+      try {
+        database
+          .prepare(
+            `UPDATE session_metadata
+             SET payload_json = json_set(payload_json, '$.role', 'corrupt_role')
+             WHERE session_id = ?`,
+          )
+          .run(WORKHUB_COORDINATION_SESSION_ID);
+      } finally {
+        database.close();
+      }
+
+      const outcome = await coordinator(root, store, () => {
+        drains += 1;
+      }).handlers['workhub.coordination.resolve']({}, CONTEXT);
+
+      assert.deepEqual(outcome, {
+        ok: false,
+        error: {
+          code: 'persistence_failed',
+          message: 'WorkHub Coordination Session state is unavailable',
+        },
+      });
+      assert.equal(drains, 1);
+      assert.equal((await store.readHeaderSnapshot(ordinary.id)).name, 'Keep me');
+      assert.deepEqual(
+        (await store.list()).map((session) => session.id),
+        [ordinary.id],
+      );
+      assert.deepEqual(
+        (await store.listForRecovery()).map((session) => session.id),
+        [ordinary.id],
+      );
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('fails closed and quarantines a Coordination Session whose role is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-missing-role-'));
+    const store = createSessionStore(root);
+    try {
+      const ordinary = await store.create({
+        cwd: root,
+        name: 'Keep me',
+        llmConnectionSlug: 'test-connection',
+        model: 'test-model',
+        permissionMode: 'ask',
+      });
+      assert.equal(
+        (await coordinator(root, store).handlers['workhub.coordination.resolve']({}, CONTEXT)).ok,
+        true,
+      );
+
+      const database = new DatabaseSync(join(root, OPERATIONAL_STATE_DATABASE_NAME));
+      try {
+        database
+          .prepare(
+            `UPDATE session_metadata
+             SET payload_json = json_remove(payload_json, '$.role')
+             WHERE session_id = ?`,
+          )
+          .run(WORKHUB_COORDINATION_SESSION_ID);
+      } finally {
+        database.close();
+      }
+
+      assert.deepEqual(
+        await coordinator(root, store).handlers['workhub.coordination.resolve']({}, CONTEXT),
+        {
+          ok: false,
+          error: {
+            code: 'operation_conflict',
+            message: 'WorkHub Coordination Session identity is unavailable',
+          },
+        },
+      );
+      assert.deepEqual(
+        (await store.list()).map((session) => session.id),
+        [ordinary.id],
+      );
+      assert.deepEqual(
+        (await store.listForRecovery()).map((session) => session.id),
+        [ordinary.id],
+      );
+      assert.equal(
+        (await store.readHeaderSnapshot(WORKHUB_COORDINATION_SESSION_ID)).name,
+        'WorkHub',
+      );
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function coordinator(
+  root: string,
+  store: SessionAuthorityStore,
+  requestDrain: () => void = () => undefined,
+) {
+  return new HostWorkHubCoordinationCoordinator({
+    stateRoot: root,
+    stores: store,
+    admission: new SessionAdmissionGate(),
+    continuity: { refreshCanonical: async () => undefined },
+    resolveCreateTarget: async () => ({
+      llmConnectionSlug: 'test-connection',
+      model: 'test-model',
+      permissionMode: 'explore',
+      collaborationMode: 'agent',
+      orchestrationMode: 'default',
+    }),
+    requestDrain,
+  });
+}

--- a/packages/runtime-host/src/__tests__/workhub-coordination-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/workhub-coordination-coordinator.test.ts
@@ -18,7 +18,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -31,7 +31,11 @@ import { createSessionStore, type SessionAuthorityStore } from '@maka/storage/se
 import { OPERATIONAL_STATE_DATABASE_NAME } from '@maka/storage/operational-state-store';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
 import { SessionAdmissionGate } from '../server/session-admission-gate.js';
-import { HostWorkHubCoordinationCoordinator } from '../server/workhub-coordination-coordinator.js';
+import { SessionOperationFailure } from '../server/session-catalog-coordinator.js';
+import {
+  HostWorkHubCoordinationCoordinator,
+  type CoordinationCreateTarget,
+} from '../server/workhub-coordination-coordinator.js';
 
 const CONTEXT: ConnectionContext = {
   hostEpoch: 'workhub-test-epoch',
@@ -251,25 +255,124 @@ describe('Host WorkHub Coordination coordinator', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  test('relocates the durable workspace when the Host state root moves', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-relocate-'));
+    const movedRoot = await mkdtemp(join(tmpdir(), 'maka-workhub-relocated-'));
+    const store = createSessionStore(root);
+    try {
+      assert.equal(
+        (await coordinator(root, store).handlers['workhub.coordination.resolve']({}, CONTEXT)).ok,
+        true,
+      );
+
+      // Same durable Session, same database, new absolute state-root path:
+      // restoring the state directory elsewhere must not strand the identity
+      // that no ordinary lifecycle operation is allowed to relocate.
+      assert.deepEqual(
+        await coordinator(movedRoot, store).handlers['workhub.coordination.resolve']({}, CONTEXT),
+        { ok: true, result: { sessionId: WORKHUB_COORDINATION_SESSION_ID } },
+      );
+      const header = await store.readHeaderSnapshot(WORKHUB_COORDINATION_SESSION_ID);
+      assert.equal(header.cwd, join(movedRoot, 'workhub-coordination'));
+      assert.equal(header.role, WORKHUB_COORDINATION_SESSION_ROLE);
+      assert.equal((await store.listHeaders()).length, 1);
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+      await rm(movedRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('restores a Coordination workspace that was pruned after provisioning', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-workspace-'));
+    const store = createSessionStore(root);
+    try {
+      assert.equal(
+        (await coordinator(root, store).handlers['workhub.coordination.resolve']({}, CONTEXT)).ok,
+        true,
+      );
+      const coordinationCwd = join(root, 'workhub-coordination');
+      await rm(coordinationCwd, { recursive: true, force: true });
+
+      assert.deepEqual(
+        await coordinator(root, store).handlers['workhub.coordination.resolve']({}, CONTEXT),
+        { ok: true, result: { sessionId: WORKHUB_COORDINATION_SESSION_ID } },
+      );
+      assert.equal((await stat(coordinationCwd)).isDirectory(), true);
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('separates an unreadable model authority from a missing default model', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-model-authority-'));
+    const store = createSessionStore(root);
+    try {
+      assert.deepEqual(
+        await coordinator(
+          root,
+          store,
+          () => undefined,
+          async () => {
+            throw new SessionOperationFailure(
+              'persistence_failed',
+              'Runtime policy is unavailable',
+            );
+          },
+        ).handlers['workhub.coordination.resolve']({}, CONTEXT),
+        {
+          ok: false,
+          error: { code: 'persistence_failed', message: 'Runtime policy is unavailable' },
+        },
+      );
+      assert.deepEqual(
+        await coordinator(
+          root,
+          store,
+          () => undefined,
+          async () => {
+            throw new SessionOperationFailure(
+              'operation_unavailable',
+              'No default Session model is configured',
+            );
+          },
+        ).handlers['workhub.coordination.resolve']({}, CONTEXT),
+        {
+          ok: false,
+          error: {
+            code: 'operation_conflict',
+            message: 'WorkHub Coordination Session requires an available default model',
+          },
+        },
+      );
+      assert.deepEqual(await store.listHeaders(), []);
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 function coordinator(
   root: string,
   store: SessionAuthorityStore,
   requestDrain: () => void = () => undefined,
+  resolveCreateTarget: () => Promise<CoordinationCreateTarget> = async () => ({
+    llmConnectionSlug: 'test-connection',
+    model: 'test-model',
+    permissionMode: 'explore',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+  }),
 ) {
   return new HostWorkHubCoordinationCoordinator({
     stateRoot: root,
     stores: store,
     admission: new SessionAdmissionGate(),
     continuity: { refreshCanonical: async () => undefined },
-    resolveCreateTarget: async () => ({
-      llmConnectionSlug: 'test-connection',
-      model: 'test-model',
-      permissionMode: 'explore',
-      collaborationMode: 'agent',
-      orchestrationMode: 'default',
-    }),
+    resolveCreateTarget,
     requestDrain,
   });
 }

--- a/packages/runtime-host/src/__tests__/workhub-coordination-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/workhub-coordination-coordinator.test.ts
@@ -99,8 +99,21 @@ describe('Host WorkHub Coordination coordinator', () => {
           llmConnectionSlug: 'test-connection',
           model: 'test-model',
           permissionMode: 'ask',
+          role: WORKHUB_COORDINATION_SESSION_ROLE,
         },
       });
+      const database = new DatabaseSync(join(root, OPERATIONAL_STATE_DATABASE_NAME));
+      try {
+        database
+          .prepare(
+            `UPDATE session_metadata
+             SET payload_json = json_remove(payload_json, '$.role')
+             WHERE session_id = ?`,
+          )
+          .run(WORKHUB_COORDINATION_SESSION_ID);
+      } finally {
+        database.close();
+      }
 
       const outcome = await coordinator(root, store).handlers['workhub.coordination.resolve'](
         {},

--- a/packages/runtime-host/src/__tests__/workhub-coordination-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/workhub-coordination-protocol.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
+import {
+  decodeWorkHubCoordinationResolveInput,
+  decodeWorkHubCoordinationResolveResult,
+  HOST_OPERATION_SPECS,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
+} from '../protocol/index.js';
+
+test('WorkHub Coordination resolve has a closed empty input and bounded identity result', () => {
+  assert.deepEqual(decodeWorkHubCoordinationResolveInput({}), {});
+  assert.deepEqual(decodeWorkHubCoordinationResolveResult({ sessionId: 'coordination' }), {
+    sessionId: 'coordination',
+  });
+  assert.equal(HOST_OPERATION_SPECS['workhub.coordination.resolve'].mode, 'command');
+  assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 48);
+  assert.throws(
+    () => decodeWorkHubCoordinationResolveInput({ sessionId: 'caller-selected' }),
+    (error) => error instanceof RuntimeHostProtocolError,
+  );
+  assert.throws(
+    () => decodeWorkHubCoordinationResolveResult({ sessionId: 'coordination', role: 'injected' }),
+    (error) => error instanceof RuntimeHostProtocolError,
+  );
+});

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -85,13 +85,16 @@ export * from './session-transcript.js';
 export * from './session-turns.js';
 export * from './task-ledger.js';
 export * from './workspace.js';
+export * from './workhub-coordination.js';
 export * from './websocket-path.js';
 
 export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 48 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 49 as const;
+// 49: WorkHub resolves one durable Coordination Session per Runtime Host.
+// Older peers do not know the operation or the hidden Session role.
 // 48: Session branch creation accepts an explicit Side Conversation intent.
 // Older peers reject the strict input shape or cannot apply its snapshot semantics.
 // 47: Project registration can carry an explicit location preference. Epoch-46

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -61,6 +61,7 @@ import { TASK_LEDGER_OPERATION_SPECS } from './task-ledger.js';
 import { TURN_OPERATION_SPECS } from './turn.js';
 import { USAGE_PRICING_OPERATION_SPECS } from './usage-pricing.js';
 import { WEB_SEARCH_OPERATION_SPECS } from './web-search.js';
+import { WORKHUB_COORDINATION_OPERATION_SPECS } from './workhub-coordination.js';
 
 export type {
   HostDiagnosticsInput,
@@ -211,6 +212,7 @@ export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   WEB_SEARCH_OPERATION_SPECS,
   NETWORK_PROXY_OPERATION_SPECS,
   CONFIGURATION_OPERATION_SPECS,
+  WORKHUB_COORDINATION_OPERATION_SPECS,
 );
 
 export type OperationSpecMap = typeof HOST_OPERATION_SPECS;
@@ -323,6 +325,7 @@ export const REMOTE_OWNER_OPERATION_GRANTS = Object.freeze([
   'turn.stop',
   'usage.query',
   'web-search.execute',
+  'workhub.coordination.resolve',
 ] as const satisfies readonly OperationKey[]);
 
 const REMOTE_OWNER_OPERATION_GRANT_SET = new Set<OperationKey>(REMOTE_OWNER_OPERATION_GRANTS);

--- a/packages/runtime-host/src/protocol/workhub-coordination.ts
+++ b/packages/runtime-host/src/protocol/workhub-coordination.ts
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { requireEntityId, requireExactRecord } from './codec.js';
+import { defineOperation } from './operation-spec.js';
+
+const RESOLVE_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'operation_conflict',
+  'persistence_failed',
+  'commit_outcome_unknown',
+  'internal_failure',
+] as const;
+
+export type WorkHubCoordinationResolveInput = Record<string, never>;
+
+export interface WorkHubCoordinationResolveResult {
+  readonly sessionId: string;
+}
+
+export const WORKHUB_COORDINATION_OPERATION_SPECS = {
+  'workhub.coordination.resolve': defineOperation<
+    WorkHubCoordinationResolveInput,
+    WorkHubCoordinationResolveResult,
+    (typeof RESOLVE_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: RESOLVE_ERRORS,
+    decodeInput: decodeWorkHubCoordinationResolveInput,
+    decodeOutput: decodeWorkHubCoordinationResolveResult,
+  }),
+} as const;
+
+export function decodeWorkHubCoordinationResolveInput(
+  value: unknown,
+): WorkHubCoordinationResolveInput {
+  requireExactRecord(value, 'WorkHub Coordination resolve input', []);
+  return {};
+}
+
+export function decodeWorkHubCoordinationResolveResult(
+  value: unknown,
+): WorkHubCoordinationResolveResult {
+  const result = requireExactRecord(value, 'WorkHub Coordination resolve result', ['sessionId']);
+  return {
+    sessionId: requireEntityId(result.sessionId, 'WorkHub Coordination Session id'),
+  };
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -164,6 +164,7 @@ import { HostTaskLedgerCoordinator } from './task-ledger-coordinator.js';
 import { HostTurnControlCoordinator } from './turn-control-coordinator.js';
 import { HostUsagePricingCoordinator } from './usage-pricing-coordinator.js';
 import { HostWebSearchCoordinator } from './web-search-coordinator.js';
+import { HostWorkHubCoordinationCoordinator } from './workhub-coordination-coordinator.js';
 import {
   createHostWebSearchService,
   createHostWebSearchToolFromService,
@@ -1210,6 +1211,18 @@ export async function createExecutionRuntimeHostComposition(
       workspaceResolver,
       requestDrain: context.requestDrain,
     });
+    const workHubCoordination = new HostWorkHubCoordinationCoordinator({
+      stateRoot: context.owner.capability.canonicalPath,
+      stores: stores.sessionStore,
+      admission: sessionAdmission,
+      continuity: continuityCoordinator,
+      resolveCreateTarget: async () => {
+        const { projectId: _projectId, ...target } =
+          await sessionCatalog.resolveExternalSessionImportTarget();
+        return { ...target, permissionMode: 'explore' };
+      },
+      requestDrain: context.requestDrain,
+    });
     scheduledTasks = new HostScheduledTaskCoordinator({
       store: openedScheduledTaskStore,
       sessions: stores.sessionStore,
@@ -1381,6 +1394,10 @@ export async function createExecutionRuntimeHostComposition(
             }
           },
         },
+      }),
+      createRuntimeHostDomainModule({
+        id: 'workhub',
+        handlers: [workHubCoordination.handlers],
       }),
       createRuntimeHostDomainModule({
         id: 'configuration',

--- a/packages/runtime-host/src/server/host-session-availability.ts
+++ b/packages/runtime-host/src/server/host-session-availability.ts
@@ -18,41 +18,48 @@
  */
 
 import type { RootExecutionDescriptor } from '@maka/core/agent-run';
-import type { SessionHeader } from '@maka/core/session';
+import { isWorkHubCoordinationSessionTarget, type SessionHeader } from '@maka/core/session';
 
 const WORKTREE_CHILD_UNAVAILABLE_REASON =
   'Worktree child Sessions must be continued through their parent agent.';
 const CHILD_CONTINUATION_UNAVAILABLE_REASON =
   'Child Sessions must be continued through their parent agent.';
 const IMPORT_STAGING_UNAVAILABLE_REASON = 'Imported Session history is still being prepared.';
+export const WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON =
+  'WorkHub Coordination Session execution requires WorkHub authority';
 
 export function runtimeHostExternalTurnUnavailableReason(
   header: Pick<
     SessionHeader,
-    'collaborationMode' | 'subagentWorkspace' | 'transcriptLedgerVersion'
+    'id' | 'role' | 'collaborationMode' | 'subagentWorkspace' | 'transcriptLedgerVersion'
   >,
 ): string | undefined {
   return runtimeHostExecutionUnavailableReason(header, { kind: 'external_message' });
 }
 
 export function runtimeHostSafeBoundaryContinuationUnavailableReason(
-  header: Pick<SessionHeader, 'subagentParent' | 'transcriptLedgerVersion'>,
+  header: Pick<SessionHeader, 'id' | 'role' | 'subagentParent' | 'transcriptLedgerVersion'>,
 ): string | undefined {
-  return header.transcriptLedgerVersion === 0
-    ? IMPORT_STAGING_UNAVAILABLE_REASON
-    : header.subagentParent
-      ? CHILD_CONTINUATION_UNAVAILABLE_REASON
-      : undefined;
+  return (
+    (isWorkHubCoordinationSessionTarget(header)
+      ? WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON
+      : undefined) ??
+    (header.transcriptLedgerVersion === 0 ? IMPORT_STAGING_UNAVAILABLE_REASON : undefined) ??
+    (header.subagentParent ? CHILD_CONTINUATION_UNAVAILABLE_REASON : undefined)
+  );
 }
 
 export function runtimeHostExecutionUnavailableReason(
   header: Pick<
     SessionHeader,
-    'collaborationMode' | 'subagentWorkspace' | 'transcriptLedgerVersion'
+    'id' | 'role' | 'collaborationMode' | 'subagentWorkspace' | 'transcriptLedgerVersion'
   >,
   execution: RootExecutionDescriptor,
 ): string | undefined {
   return (
+    (isWorkHubCoordinationSessionTarget(header)
+      ? WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON
+      : undefined) ??
     (header.transcriptLedgerVersion === 0 ? IMPORT_STAGING_UNAVAILABLE_REASON : undefined) ??
     (header.collaborationMode === 'plan' &&
     execution.kind !== 'external_message' &&

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -138,6 +138,7 @@ export type DailyReviewOperationKey = Extract<OperationKey, `daily-review.${stri
 export type WebSearchOperationKey = Extract<OperationKey, `web-search.${string}`>;
 export type NetworkProxyOperationKey = Extract<OperationKey, `network-proxy.${string}`>;
 export type ConfigurationOperationKey = Extract<OperationKey, `configuration.${string}`>;
+export type WorkHubCoordinationOperationKey = Extract<OperationKey, `workhub.${string}`>;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
 export type ContextOperationHandlerMap = Pick<OperationHandlerMap, ContextOperationKey>;
@@ -204,6 +205,10 @@ export type DailyReviewOperationHandlerMap = Pick<OperationHandlerMap, DailyRevi
 export type WebSearchOperationHandlerMap = Pick<OperationHandlerMap, WebSearchOperationKey>;
 export type NetworkProxyOperationHandlerMap = Pick<OperationHandlerMap, NetworkProxyOperationKey>;
 export type ConfigurationOperationHandlerMap = Pick<OperationHandlerMap, ConfigurationOperationKey>;
+export type WorkHubCoordinationOperationHandlerMap = Pick<
+  OperationHandlerMap,
+  WorkHubCoordinationOperationKey
+>;
 export type AccessAuthorityOperationHandlerMap = Pick<
   OperationHandlerMap,
   keyof typeof ACCESS_AUTHORITY_OPERATION_SPECS

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -29,7 +29,7 @@ import {
   type MessageContent,
   type SessionEvent,
 } from '@maka/core/events';
-import type { SessionHeader } from '@maka/core/session';
+import { isWorkHubCoordinationSessionId, type SessionHeader } from '@maka/core/session';
 import { resolveEffectiveOrchestration } from '@maka/core/orchestration';
 import {
   decodeSkillInvocationResult,
@@ -103,6 +103,7 @@ import {
   runtimeHostExecutionUnavailableReason,
   runtimeHostExternalTurnUnavailableReason,
   runtimeHostSafeBoundaryContinuationUnavailableReason,
+  WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON,
 } from './host-session-availability.js';
 import type {
   HostedExecutionAdmission,
@@ -446,6 +447,12 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
   }
 
   async readSessionHeader(sessionId: string): Promise<HostMessageSessionHeader | null> {
+    if (isWorkHubCoordinationSessionId(sessionId)) {
+      return {
+        isArchived: false,
+        unavailableReason: WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON,
+      };
+    }
     try {
       const header = await this.stores.sessionStore.readHeaderSnapshot(sessionId);
       if (header.conversationCopy?.state === 'preparing') return null;
@@ -596,6 +603,9 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
   }
 
   prepare(sessionId: string): HostedExecutionPreparation {
+    if (isWorkHubCoordinationSessionId(sessionId)) {
+      return { kind: 'unavailable', reason: WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON };
+    }
     if (this.#admissions.isDraining) {
       return {
         kind: 'unavailable',
@@ -651,6 +661,14 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
     input: HostedExecutionAdmission,
     preparedReservation?: RootTurnReservation,
   ): Promise<HostedExecutionAdmissionResult> {
+    if (isWorkHubCoordinationSessionId(input.sessionId)) {
+      return Promise.reject(
+        new RuntimeHostedRootUnavailableError(
+          input.sessionId,
+          WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON,
+        ),
+      );
+    }
     return this.runCommand(async () => {
       const activeAtEntry = this.#executions.has(input.sessionId);
       let reservation =
@@ -982,6 +1000,9 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
     input: HostMessageStartInput,
     admissionLease: SessionAdmissionLease,
   ): Promise<{ readonly turnId: string } | { readonly error: string }> {
+    if (isWorkHubCoordinationSessionId(input.sessionId)) {
+      return Promise.resolve({ error: WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON });
+    }
     return this.runCommand(async () => {
       const content = normalizeMessageContent(input.content);
       if (
@@ -1235,6 +1256,11 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
     request: RootMessageStartRequest,
     context: ConnectionContext,
   ): Promise<RootMessageStartOutcome> {
+    if (isWorkHubCoordinationSessionId(request.sessionId)) {
+      return Promise.resolve(
+        operationUnavailable(WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON),
+      );
+    }
     return this.runCommand(async () => {
       await this.awaitTerminalRootCleanup(request.sessionId);
       const activeAtEntry = this.#executions.has(request.sessionId);
@@ -1435,6 +1461,9 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
     input: TurnResumeQueryInput,
     context: ConnectionContext,
   ): Promise<OperationOutcome<'turn.resume.query'>> {
+    if (isWorkHubCoordinationSessionId(input.sessionId)) {
+      return operationUnavailable(WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON);
+    }
     return this.sessionAdmission.run(input.sessionId, async () => {
       let header: SessionHeader;
       try {
@@ -1497,6 +1526,11 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
     input: TurnResumeStartInput,
     context: ConnectionContext,
   ): Promise<TurnResumeStartOutcome> {
+    if (isWorkHubCoordinationSessionId(input.sessionId)) {
+      return Promise.resolve(
+        operationUnavailable(WORKHUB_COORDINATION_EXECUTION_UNAVAILABLE_REASON),
+      );
+    }
     return this.runCommand(async () => {
       const turnInput = continuationTurnInput(input.sessionId, input.turnId);
       const activeAtEntry = this.#executions.has(input.sessionId);

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -46,6 +46,7 @@ import {
   SessionReadMarkerMessageNotFoundError,
   type SessionCatalogPageCursor,
   type SessionCatalogRecord,
+  type SessionHeaderSnapshot,
   type ExecutionStoresWriter,
 } from '@maka/storage/execution-stores';
 import type { RuntimePolicyStoresWriter } from '@maka/storage/runtime-policy-stores';
@@ -440,11 +441,7 @@ export class HostSessionCatalogCoordinator {
         const labels =
           input.patch.labels === undefined
             ? undefined
-            : await this.#replaceUserLabels(
-                input.sessionId,
-                input.expectedRevision,
-                input.patch.labels,
-              );
+            : replaceUserLabels(current, input.expectedRevision, input.patch.labels);
         const patch: SessionHeaderPatch = {
           ...(input.patch.name === undefined ? {} : normalizeSessionNamePatch(input.patch.name)),
           ...(labels === undefined ? {} : { labels }),
@@ -460,24 +457,6 @@ export class HostSessionCatalogCoordinator {
         );
       }
     });
-  }
-
-  async #replaceUserLabels(
-    sessionId: string,
-    expectedRevision: number,
-    requestedLabels: readonly string[],
-  ): Promise<string[]> {
-    const current = await this.#stores.readHeaderRecordSnapshot(sessionId);
-    if (isWorkHubCoordinationSessionTarget(current.header)) {
-      throw new SessionOperationFailure(
-        'operation_unavailable',
-        'WorkHub Coordination Session metadata requires WorkHub authority',
-      );
-    }
-    if (current.revision !== expectedRevision) {
-      throw new SessionMetadataVersionConflictError(sessionId, expectedRevision, current.revision);
-    }
-    return replaceUserOwnedLabels(current.header.labels, requestedLabels);
   }
 
   async #updateConfiguration(
@@ -1141,6 +1120,25 @@ function normalizedSessionName(name: string): string {
 
 function normalizeSessionNamePatch(name: string): Pick<SessionHeader, 'name' | 'titleIsManual'> {
   return { name: normalizedSessionName(name), titleIsManual: true };
+}
+
+/**
+ * The caller already holds the admitted snapshot: re-reading it here would cost
+ * a second identical read inside one lease.
+ */
+function replaceUserLabels(
+  current: SessionHeaderSnapshot,
+  expectedRevision: number,
+  requestedLabels: readonly string[],
+): string[] {
+  if (current.revision !== expectedRevision) {
+    throw new SessionMetadataVersionConflictError(
+      current.header.id,
+      expectedRevision,
+      current.revision,
+    );
+  }
+  return replaceUserOwnedLabels(current.header.labels, requestedLabels);
 }
 
 function replaceUserOwnedLabels(

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -33,7 +33,12 @@ import {
   isSessionStartModeLabel as isExecutionSemanticLabel,
   sessionStartModeSpec,
 } from '@maka/core/explore-agent';
-import type { SessionHeader, SessionHeaderPatch } from '@maka/core/session';
+import {
+  isWorkHubCoordinationSessionId,
+  isWorkHubCoordinationSessionTarget,
+  type SessionHeader,
+  type SessionHeaderPatch,
+} from '@maka/core/session';
 import {
   isSessionNotFoundError,
   SessionMetadataConflictError,
@@ -326,6 +331,12 @@ export class HostSessionCatalogCoordinator {
   }
 
   async #create(input: SessionCreateInput): Promise<OperationOutcome<'session.create'>> {
+    if (isWorkHubCoordinationSessionId(input.sessionId)) {
+      return createFailure(
+        'operation_conflict',
+        'Session identity is reserved for WorkHub coordination',
+      );
+    }
     let prepared: PreparedSessionCreate;
     try {
       prepared = await prepareCreate(input);
@@ -409,8 +420,23 @@ export class HostSessionCatalogCoordinator {
   #updateMetadata(
     input: SessionMetadataUpdateInput,
   ): Promise<OperationOutcome<'session.metadata.update'>> {
+    if (isWorkHubCoordinationSessionId(input.sessionId)) {
+      return Promise.resolve(
+        metadataFailure(
+          'operation_unavailable',
+          'WorkHub Coordination Session metadata requires WorkHub authority',
+        ),
+      );
+    }
     return this.#admission.run(input.sessionId, async (lease) => {
       try {
+        const current = await this.#stores.readHeaderRecordSnapshot(input.sessionId);
+        if (isWorkHubCoordinationSessionTarget(current.header)) {
+          throw new SessionOperationFailure(
+            'operation_unavailable',
+            'WorkHub Coordination Session metadata requires WorkHub authority',
+          );
+        }
         const labels =
           input.patch.labels === undefined
             ? undefined
@@ -442,6 +468,12 @@ export class HostSessionCatalogCoordinator {
     requestedLabels: readonly string[],
   ): Promise<string[]> {
     const current = await this.#stores.readHeaderRecordSnapshot(sessionId);
+    if (isWorkHubCoordinationSessionTarget(current.header)) {
+      throw new SessionOperationFailure(
+        'operation_unavailable',
+        'WorkHub Coordination Session metadata requires WorkHub authority',
+      );
+    }
     if (current.revision !== expectedRevision) {
       throw new SessionMetadataVersionConflictError(sessionId, expectedRevision, current.revision);
     }
@@ -451,10 +483,22 @@ export class HostSessionCatalogCoordinator {
   async #updateConfiguration(
     input: SessionConfigurationUpdateInput,
   ): Promise<OperationOutcome<'session.configuration.update'>> {
+    if (isWorkHubCoordinationSessionId(input.sessionId)) {
+      return configurationFailure(
+        'operation_conflict',
+        'WorkHub Coordination Session configuration requires WorkHub authority',
+      );
+    }
     return this.#admission.run(input.sessionId, async (lease) => {
       let commitAttempted = false;
       try {
         const current = await this.#stores.readHeaderRecordSnapshot(input.sessionId);
+        if (isWorkHubCoordinationSessionTarget(current.header)) {
+          return configurationFailure(
+            'operation_conflict',
+            'WorkHub Coordination Session configuration requires WorkHub authority',
+          );
+        }
         if (current.revision !== input.expectedRevision) {
           return configurationSuccess(revisionConflict(input.expectedRevision, current.revision));
         }
@@ -524,10 +568,22 @@ export class HostSessionCatalogCoordinator {
   async #relocateWorkspace(
     input: SessionWorkspaceRelocateInput,
   ): Promise<OperationOutcome<'session.workspace.relocate'>> {
+    if (isWorkHubCoordinationSessionId(input.sessionId)) {
+      return workspaceFailure(
+        'operation_conflict',
+        'WorkHub Coordination Session workspace requires WorkHub authority',
+      );
+    }
     return this.#admission.run(input.sessionId, async (lease) => {
       let commitAttempted = false;
       try {
         const current = await this.#stores.readHeaderRecordSnapshot(input.sessionId);
+        if (isWorkHubCoordinationSessionTarget(current.header)) {
+          return workspaceFailure(
+            'operation_conflict',
+            'WorkHub Coordination Session workspace requires WorkHub authority',
+          );
+        }
         if (current.revision !== input.expectedRevision) {
           return workspaceSuccess(revisionConflict(input.expectedRevision, current.revision));
         }
@@ -572,6 +628,13 @@ export class HostSessionCatalogCoordinator {
   ): Promise<OperationOutcome<'session.read_marker.set'>> {
     return this.#admission.run(input.sessionId, async (lease) => {
       try {
+        const current = await this.#stores.readHeaderRecordSnapshot(input.sessionId);
+        if (isWorkHubCoordinationSessionTarget(current.header)) {
+          return readMarkerFailure(
+            'operation_conflict',
+            'WorkHub Coordination Session read state requires WorkHub authority',
+          );
+        }
         await this.#stores.markSessionReadThroughMessage(
           input.sessionId,
           input.readThroughMessageId,
@@ -624,7 +687,10 @@ export class HostSessionCatalogCoordinator {
       return updateSuccess(revisionConflict(input.expectedRevision, error.actualVersion));
     }
     if (error instanceof SessionOperationFailure) {
-      return metadataFailure('invalid_request', error.message);
+      return metadataFailure(
+        error.code === 'operation_unavailable' ? 'operation_unavailable' : 'invalid_request',
+        error.message,
+      );
     }
     if (error instanceof SessionMetadataConflictError) {
       return metadataFailure('invalid_request', error.message);

--- a/packages/runtime-host/src/server/session-retirement-coordinator.ts
+++ b/packages/runtime-host/src/server/session-retirement-coordinator.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 
-import { sessionRevisionFamilyId } from '@maka/core/session';
+import {
+  WORKHUB_COORDINATION_SESSION_ID,
+  isWorkHubCoordinationSession,
+  sessionRevisionFamilyId,
+} from '@maka/core/session';
 import type {
   SubagentWorkspaceBinding,
   SubagentWorktreeExecutor,
@@ -456,6 +460,14 @@ export class HostSessionRetirementCoordinator {
     const target = await this.#stores.probeSessionRemoval(sessionId);
     if (target.kind !== 'present') {
       throw new SessionRetirementMissingSessionError(target.kind);
+    }
+    if (
+      target.record.header.id === WORKHUB_COORDINATION_SESSION_ID ||
+      isWorkHubCoordinationSession(target.record.header)
+    ) {
+      throw new SessionMetadataConflictError(
+        'WorkHub Coordination Session lifecycle is owned by WorkHub',
+      );
     }
     if (target.record.header.subagentParent?.graph) {
       throw new SessionMetadataConflictError(

--- a/packages/runtime-host/src/server/session-retirement-coordinator.ts
+++ b/packages/runtime-host/src/server/session-retirement-coordinator.ts
@@ -17,11 +17,7 @@
  * under the License.
  */
 
-import {
-  WORKHUB_COORDINATION_SESSION_ID,
-  isWorkHubCoordinationSession,
-  sessionRevisionFamilyId,
-} from '@maka/core/session';
+import { isWorkHubCoordinationSessionTarget, sessionRevisionFamilyId } from '@maka/core/session';
 import type {
   SubagentWorkspaceBinding,
   SubagentWorktreeExecutor,
@@ -461,10 +457,7 @@ export class HostSessionRetirementCoordinator {
     if (target.kind !== 'present') {
       throw new SessionRetirementMissingSessionError(target.kind);
     }
-    if (
-      target.record.header.id === WORKHUB_COORDINATION_SESSION_ID ||
-      isWorkHubCoordinationSession(target.record.header)
-    ) {
+    if (isWorkHubCoordinationSessionTarget(target.record.header)) {
       throw new SessionMetadataConflictError(
         'WorkHub Coordination Session lifecycle is owned by WorkHub',
       );

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -24,6 +24,7 @@ import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
 import {
   isWorkHubCoordinationSessionId,
+  isWorkHubCoordinationSessionTarget,
   sessionRevisionFamilyId,
   type SessionConversationCopy,
   type SessionHeader,
@@ -182,6 +183,12 @@ export class HostSessionRevisionCoordinator {
         'Target Session identity is reserved for WorkHub coordination',
       );
     }
+    if (isWorkHubCoordinationSessionId(input.sourceSessionId)) {
+      return copyFailure(
+        'operation_conflict',
+        'WorkHub Coordination Session cannot be copied as an ordinary conversation',
+      );
+    }
     const semanticKind = conversationCopySemanticKind(kind, input);
     const requestFingerprint = conversationCopyFingerprint(semanticKind, input);
     const retry = await this.options.admission.run(input.targetSessionId, async () =>
@@ -290,6 +297,12 @@ export class HostSessionRevisionCoordinator {
       return copyFailure(
         'operation_conflict',
         'Archived Session revision families cannot create active revisions',
+      );
+    }
+    if (isWorkHubCoordinationSessionTarget(sourceHeader)) {
+      return copyFailure(
+        'operation_conflict',
+        'WorkHub Coordination Session cannot be copied as an ordinary conversation',
       );
     }
     if (sourceHeader.subagentParent) {

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -23,6 +23,7 @@ import { SIDE_CONVERSATION_SESSION_LABEL } from '@maka/core/side-conversation';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
 import {
+  isWorkHubCoordinationSessionId,
   sessionRevisionFamilyId,
   type SessionConversationCopy,
   type SessionHeader,
@@ -175,6 +176,12 @@ export class HostSessionRevisionCoordinator {
     kind: ConversationCopyKind,
     input: SessionConversationCopyInput,
   ): Promise<ConversationCopyOutcome> {
+    if (isWorkHubCoordinationSessionId(input.targetSessionId)) {
+      return copyFailure(
+        'operation_conflict',
+        'Target Session identity is reserved for WorkHub coordination',
+      );
+    }
     const semanticKind = conversationCopySemanticKind(kind, input);
     const requestFingerprint = conversationCopyFingerprint(semanticKind, input);
     const retry = await this.options.admission.run(input.targetSessionId, async () =>

--- a/packages/runtime-host/src/server/workhub-coordination-coordinator.ts
+++ b/packages/runtime-host/src/server/workhub-coordination-coordinator.ts
@@ -25,6 +25,7 @@ import {
   WORKHUB_COORDINATION_SESSION_ID,
   WORKHUB_COORDINATION_SESSION_ROLE,
   isWorkHubCoordinationSession,
+  isWorkHubCoordinationSessionId,
   type SessionHeader,
 } from '@maka/core/session';
 import type { SessionAuthorityStore } from '@maka/storage/session-store';
@@ -54,7 +55,7 @@ export interface HostWorkHubCoordinationCoordinatorOptions {
   readonly requestDrain: () => void;
 }
 
-/** Resolves the one durable coordination-role Session owned by this Runtime Host. */
+/** Resolves the one durable Coordination Session owned by this Runtime Host. */
 export class HostWorkHubCoordinationCoordinator {
   readonly handlers: WorkHubCoordinationOperationHandlerMap = {
     'workhub.coordination.resolve': () => this.#resolve(),
@@ -142,7 +143,7 @@ export class HostWorkHubCoordinationCoordinator {
 
 function validCoordinationHeader(header: SessionHeader, coordinationCwd: string): boolean {
   return (
-    header.id === WORKHUB_COORDINATION_SESSION_ID &&
+    isWorkHubCoordinationSessionId(header.id) &&
     isWorkHubCoordinationSession(header) &&
     header.cwd === coordinationCwd &&
     header.projectId === null &&

--- a/packages/runtime-host/src/server/workhub-coordination-coordinator.ts
+++ b/packages/runtime-host/src/server/workhub-coordination-coordinator.ts
@@ -28,10 +28,11 @@ import {
   isWorkHubCoordinationSessionId,
   type SessionHeader,
 } from '@maka/core/session';
-import type { SessionAuthorityStore } from '@maka/storage/session-store';
+import type { SessionAuthorityStore, SessionHeaderSnapshot } from '@maka/storage/session-store';
 import type { OperationOutcome } from '../protocol/index.js';
 import type { WorkHubCoordinationOperationHandlerMap } from './operation-dispatcher.js';
 import { SessionAdmissionGate } from './session-admission-gate.js';
+import { SessionOperationFailure } from './session-catalog-coordinator.js';
 import type { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
 
 const CREATE_FINGERPRINT = `sha256:${createHash('sha256')
@@ -41,10 +42,10 @@ const COORDINATION_CWD_DIRECTORY = 'workhub-coordination';
 
 type CoordinationStores = Pick<
   SessionAuthorityStore,
-  'createStableSession' | 'probeStableSessionCreate'
+  'createStableSession' | 'probeStableSessionCreate' | 'updateHeaderVersioned'
 >;
 
-type CoordinationCreateTarget = Omit<CreateSessionInput, 'cwd' | 'name' | 'projectId'>;
+export type CoordinationCreateTarget = Omit<CreateSessionInput, 'cwd' | 'name' | 'projectId'>;
 
 export interface HostWorkHubCoordinationCoordinatorOptions {
   readonly stateRoot: string;
@@ -79,6 +80,18 @@ export class HostWorkHubCoordinationCoordinator {
 
   #resolve(): Promise<OperationOutcome<'workhub.coordination.resolve'>> {
     return this.#admission.run(WORKHUB_COORDINATION_SESSION_ID, async (lease) => {
+      // The workspace exists for provisioning and for reuse alike: a directory
+      // that was pruned after creation must come back before anyone is handed
+      // the identity, and mkdir is idempotent.
+      try {
+        await mkdir(this.#coordinationCwd, { recursive: true });
+      } catch {
+        return failure(
+          'persistence_failed',
+          'WorkHub Coordination Session workspace is unavailable',
+        );
+      }
+
       let probe;
       try {
         probe = await this.#stores.probeStableSessionCreate(
@@ -91,8 +104,8 @@ export class HostWorkHubCoordinationCoordinator {
       }
 
       if (probe.kind === 'existing') {
-        return validCoordinationHeader(probe.record.header, this.#coordinationCwd)
-          ? success()
+        return validCoordinationHeader(probe.record.header)
+          ? await this.#alignWorkspace(probe.record)
           : identityConflict();
       }
       if (probe.kind === 'conflict') return identityConflict();
@@ -100,17 +113,11 @@ export class HostWorkHubCoordinationCoordinator {
       let target: CoordinationCreateTarget;
       try {
         target = await this.#resolveCreateTarget();
-      } catch {
-        return failure(
-          'operation_conflict',
-          'WorkHub Coordination Session requires an available default model',
-        );
+      } catch (error) {
+        return createTargetFailure(error);
       }
 
-      let commitAttempted = false;
       try {
-        await mkdir(this.#coordinationCwd, { recursive: true });
-        commitAttempted = true;
         const result = await this.#stores.createStableSession({
           sessionId: WORKHUB_COORDINATION_SESSION_ID,
           requestFingerprint: CREATE_FINGERPRINT,
@@ -123,29 +130,68 @@ export class HostWorkHubCoordinationCoordinator {
           },
         });
         if (result.kind === 'conflict') return identityConflict();
-        if (!validCoordinationHeader(result.record.header, this.#coordinationCwd)) {
+        if (
+          !validCoordinationHeader(result.record.header) ||
+          result.record.header.cwd !== this.#coordinationCwd
+        ) {
           return identityConflict();
         }
         await this.#continuity.refreshCanonical(WORKHUB_COORDINATION_SESSION_ID, lease);
         return success();
       } catch {
         this.#requestDrain();
-        return commitAttempted
-          ? failure(
-              'commit_outcome_unknown',
-              'WorkHub Coordination Session creation outcome is unknown',
-            )
-          : failure('persistence_failed', 'WorkHub Coordination Session workspace is unavailable');
+        return failure(
+          'commit_outcome_unknown',
+          'WorkHub Coordination Session creation outcome is unknown',
+        );
       }
     });
   }
+
+  /**
+   * The workspace path is derived from the Host state root, so it moves with the
+   * installation. Identity stays in the id/role pair and the durable path is
+   * repaired in place — rejecting the drift would strand the one Session no
+   * ordinary lifecycle operation is allowed to relocate or retire.
+   */
+  async #alignWorkspace(
+    record: SessionHeaderSnapshot,
+  ): Promise<OperationOutcome<'workhub.coordination.resolve'>> {
+    if (record.header.cwd === this.#coordinationCwd) return success();
+    let repaired: SessionHeaderSnapshot;
+    try {
+      repaired = await this.#stores.updateHeaderVersioned(
+        WORKHUB_COORDINATION_SESSION_ID,
+        { cwd: this.#coordinationCwd },
+        record.revision,
+      );
+    } catch {
+      return failure(
+        'persistence_failed',
+        'WorkHub Coordination Session workspace could not be relocated',
+      );
+    }
+    return validCoordinationHeader(repaired.header) && repaired.header.cwd === this.#coordinationCwd
+      ? success()
+      : identityConflict();
+  }
 }
 
-function validCoordinationHeader(header: SessionHeader, coordinationCwd: string): boolean {
+/** Keeps a model-authority gap distinguishable from a failed authority read. */
+function createTargetFailure(error: unknown): OperationOutcome<'workhub.coordination.resolve'> {
+  if (error instanceof SessionOperationFailure && error.code === 'persistence_failed') {
+    return failure('persistence_failed', error.message);
+  }
+  return failure(
+    'operation_conflict',
+    'WorkHub Coordination Session requires an available default model',
+  );
+}
+
+function validCoordinationHeader(header: SessionHeader): boolean {
   return (
     isWorkHubCoordinationSessionId(header.id) &&
     isWorkHubCoordinationSession(header) &&
-    header.cwd === coordinationCwd &&
     header.projectId === null &&
     !header.isArchived &&
     header.parentSessionId === undefined &&

--- a/packages/runtime-host/src/server/workhub-coordination-coordinator.ts
+++ b/packages/runtime-host/src/server/workhub-coordination-coordinator.ts
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { CreateSessionInput } from '@maka/core/runtime-inputs';
+import {
+  WORKHUB_COORDINATION_SESSION_ID,
+  WORKHUB_COORDINATION_SESSION_ROLE,
+  isWorkHubCoordinationSession,
+  type SessionHeader,
+} from '@maka/core/session';
+import type { SessionAuthorityStore } from '@maka/storage/session-store';
+import type { OperationOutcome } from '../protocol/index.js';
+import type { WorkHubCoordinationOperationHandlerMap } from './operation-dispatcher.js';
+import { SessionAdmissionGate } from './session-admission-gate.js';
+import type { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
+
+const CREATE_FINGERPRINT = `sha256:${createHash('sha256')
+  .update('maka:workhub-coordination-session:v1', 'utf8')
+  .digest('hex')}`;
+const COORDINATION_CWD_DIRECTORY = 'workhub-coordination';
+
+type CoordinationStores = Pick<
+  SessionAuthorityStore,
+  'createStableSession' | 'probeStableSessionCreate'
+>;
+
+type CoordinationCreateTarget = Omit<CreateSessionInput, 'cwd' | 'name' | 'projectId'>;
+
+export interface HostWorkHubCoordinationCoordinatorOptions {
+  readonly stateRoot: string;
+  readonly stores: CoordinationStores;
+  readonly admission: SessionAdmissionGate;
+  readonly continuity: Pick<SessionContinuityCoordinator, 'refreshCanonical'>;
+  readonly resolveCreateTarget: () => Promise<CoordinationCreateTarget>;
+  readonly requestDrain: () => void;
+}
+
+/** Resolves the one durable coordination-role Session owned by this Runtime Host. */
+export class HostWorkHubCoordinationCoordinator {
+  readonly handlers: WorkHubCoordinationOperationHandlerMap = {
+    'workhub.coordination.resolve': () => this.#resolve(),
+  };
+
+  readonly #coordinationCwd: string;
+  readonly #stores: CoordinationStores;
+  readonly #admission: SessionAdmissionGate;
+  readonly #continuity: Pick<SessionContinuityCoordinator, 'refreshCanonical'>;
+  readonly #resolveCreateTarget: () => Promise<CoordinationCreateTarget>;
+  readonly #requestDrain: () => void;
+
+  constructor(options: HostWorkHubCoordinationCoordinatorOptions) {
+    this.#coordinationCwd = join(options.stateRoot, COORDINATION_CWD_DIRECTORY);
+    this.#stores = options.stores;
+    this.#admission = options.admission;
+    this.#continuity = options.continuity;
+    this.#resolveCreateTarget = options.resolveCreateTarget;
+    this.#requestDrain = options.requestDrain;
+  }
+
+  #resolve(): Promise<OperationOutcome<'workhub.coordination.resolve'>> {
+    return this.#admission.run(WORKHUB_COORDINATION_SESSION_ID, async (lease) => {
+      let probe;
+      try {
+        probe = await this.#stores.probeStableSessionCreate(
+          WORKHUB_COORDINATION_SESSION_ID,
+          CREATE_FINGERPRINT,
+        );
+      } catch {
+        this.#requestDrain();
+        return failure('persistence_failed', 'WorkHub Coordination Session state is unavailable');
+      }
+
+      if (probe.kind === 'existing') {
+        return validCoordinationHeader(probe.record.header, this.#coordinationCwd)
+          ? success()
+          : identityConflict();
+      }
+      if (probe.kind === 'conflict') return identityConflict();
+
+      let target: CoordinationCreateTarget;
+      try {
+        target = await this.#resolveCreateTarget();
+      } catch {
+        return failure(
+          'operation_conflict',
+          'WorkHub Coordination Session requires an available default model',
+        );
+      }
+
+      let commitAttempted = false;
+      try {
+        await mkdir(this.#coordinationCwd, { recursive: true });
+        commitAttempted = true;
+        const result = await this.#stores.createStableSession({
+          sessionId: WORKHUB_COORDINATION_SESSION_ID,
+          requestFingerprint: CREATE_FINGERPRINT,
+          input: {
+            ...target,
+            cwd: this.#coordinationCwd,
+            projectId: null,
+            name: 'WorkHub',
+            role: WORKHUB_COORDINATION_SESSION_ROLE,
+          },
+        });
+        if (result.kind === 'conflict') return identityConflict();
+        if (!validCoordinationHeader(result.record.header, this.#coordinationCwd)) {
+          return identityConflict();
+        }
+        await this.#continuity.refreshCanonical(WORKHUB_COORDINATION_SESSION_ID, lease);
+        return success();
+      } catch {
+        this.#requestDrain();
+        return commitAttempted
+          ? failure(
+              'commit_outcome_unknown',
+              'WorkHub Coordination Session creation outcome is unknown',
+            )
+          : failure('persistence_failed', 'WorkHub Coordination Session workspace is unavailable');
+      }
+    });
+  }
+}
+
+function validCoordinationHeader(header: SessionHeader, coordinationCwd: string): boolean {
+  return (
+    header.id === WORKHUB_COORDINATION_SESSION_ID &&
+    isWorkHubCoordinationSession(header) &&
+    header.cwd === coordinationCwd &&
+    header.projectId === null &&
+    !header.isArchived &&
+    header.parentSessionId === undefined &&
+    header.subagentParent === undefined &&
+    header.conversationCopy === undefined &&
+    header.revisionRootSessionId === undefined
+  );
+}
+
+function success(): OperationOutcome<'workhub.coordination.resolve'> {
+  return {
+    ok: true,
+    result: { sessionId: WORKHUB_COORDINATION_SESSION_ID },
+  };
+}
+
+function identityConflict(): OperationOutcome<'workhub.coordination.resolve'> {
+  return failure('operation_conflict', 'WorkHub Coordination Session identity is unavailable');
+}
+
+function failure(
+  code: Extract<
+    OperationOutcome<'workhub.coordination.resolve'>,
+    { readonly ok: false }
+  >['error']['code'],
+  message: string,
+): OperationOutcome<'workhub.coordination.resolve'> {
+  return { ok: false, error: { code, message } };
+}

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -40,6 +40,36 @@ import { OPERATIONAL_STATE_DATABASE_NAME } from '../operational-state-store.js';
 import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
 
 describe('SQLite SessionStore', () => {
+  test('requires the reserved WorkHub Coordination identity and role together', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-coordination-identity-role-'));
+    const store = createSessionStore(root);
+    try {
+      await assert.rejects(
+        store.createStableSession({
+          sessionId: WORKHUB_COORDINATION_SESSION_ID,
+          requestFingerprint: `sha256:${'a'.repeat(64)}`,
+          input: makeInput({ cwd: root, projectId: null, name: 'Reserved without role' }),
+        }),
+        /identity and role must be claimed together/,
+      );
+      await assert.rejects(
+        store.createStableSession({
+          sessionId: 'ordinary-with-coordination-role',
+          requestFingerprint: `sha256:${'b'.repeat(64)}`,
+          input: {
+            ...makeInput({ cwd: root, projectId: null, name: 'Role without identity' }),
+            role: WORKHUB_COORDINATION_SESSION_ROLE,
+          },
+        }),
+        /identity and role must be claimed together/,
+      );
+      assert.deepEqual(await store.listHeaders(), []);
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('keeps the WorkHub Coordination Session durable but outside ordinary catalogs and route candidates', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-workhub-coordination-session-'));
     const store = createSessionStore(root);
@@ -120,36 +150,6 @@ describe('SQLite SessionStore', () => {
       assert.equal(
         (await store.readHeaderSnapshot(WORKHUB_COORDINATION_SESSION_ID)).name,
         'WorkHub',
-      );
-    } finally {
-      await store.close?.();
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  test('enforces one WorkHub Coordination Session role per Runtime Host store', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-coordination-unique-'));
-    const store = createSessionStore(root);
-    try {
-      await store.createStableSession({
-        sessionId: WORKHUB_COORDINATION_SESSION_ID,
-        requestFingerprint: `sha256:${'a'.repeat(64)}`,
-        input: {
-          ...makeInput({ cwd: root, projectId: null, name: 'WorkHub' }),
-          role: WORKHUB_COORDINATION_SESSION_ROLE,
-        },
-      });
-
-      await assert.rejects(
-        store.createStableSession({
-          sessionId: 'second-workhub-coordination-session',
-          requestFingerprint: `sha256:${'b'.repeat(64)}`,
-          input: {
-            ...makeInput({ cwd: root, projectId: null, name: 'WorkHub duplicate' }),
-            role: WORKHUB_COORDINATION_SESSION_ROLE,
-          },
-        }),
-        /unique|constraint/i,
       );
     } finally {
       await store.close?.();

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -64,6 +64,39 @@ describe('SQLite SessionStore', () => {
         /identity and role must be claimed together/,
       );
       assert.deepEqual(await store.listHeaders(), []);
+
+      // The invariant lives in the header builder, so the creators that share
+      // it inherit it even though their inputs carry no role today.
+      await assert.rejects(
+        store.createSubagent({
+          ...makeInput({ cwd: root, name: 'Subagent claiming the role' }),
+          role: WORKHUB_COORDINATION_SESSION_ROLE,
+        } as Parameters<typeof store.createSubagent>[0]),
+        /identity and role must be claimed together/,
+      );
+      await assert.rejects(
+        store.createAgentGraphOperator(
+          {
+            ...makeInput({ cwd: root, name: 'Operator claiming the role' }),
+            role: WORKHUB_COORDINATION_SESSION_ROLE,
+          } as Parameters<typeof store.createAgentGraphOperator>[0],
+          {
+            schemaVersion: 1,
+            provisionId: `graph_provision_${'4'.repeat(32)}`,
+            provisionFingerprint: `sha256:${'5'.repeat(64)}`,
+            graphId: 'graph-1',
+            workId: `graph_work_${'3'.repeat(32)}`,
+            agentId: 'local-read',
+            operatorId: `graph_operator_${'6'.repeat(32)}`,
+            initialTurnId: 'graph-turn',
+            initialRunId: 'graph-run',
+            edges: [],
+          },
+          0,
+        ),
+        /identity and role must be claimed together/,
+      );
+      assert.deepEqual(await store.listHeaders(), []);
     } finally {
       await store.close?.();
       await rm(root, { recursive: true, force: true });

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -25,7 +25,11 @@ import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { describe, test } from 'node:test';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
-import type { StoredMessage } from '@maka/core/session';
+import {
+  WORKHUB_COORDINATION_SESSION_ID,
+  WORKHUB_COORDINATION_SESSION_ROLE,
+  type StoredMessage,
+} from '@maka/core/session';
 import {
   EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_RECENT_SESSION_IDS,
   EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_SOURCE_IDS,
@@ -36,6 +40,123 @@ import { OPERATIONAL_STATE_DATABASE_NAME } from '../operational-state-store.js';
 import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
 
 describe('SQLite SessionStore', () => {
+  test('keeps the WorkHub Coordination Session durable but outside ordinary catalogs and route candidates', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-coordination-session-'));
+    const store = createSessionStore(root);
+    try {
+      const created = await store.createStableSession({
+        sessionId: WORKHUB_COORDINATION_SESSION_ID,
+        requestFingerprint: `sha256:${'a'.repeat(64)}`,
+        input: {
+          ...makeInput({ cwd: root, projectId: null, name: 'WorkHub' }),
+          role: WORKHUB_COORDINATION_SESSION_ROLE,
+        },
+      });
+      assert.equal(created.kind, 'created');
+
+      assert.deepEqual(await store.list(), []);
+      const page = await store.listCatalogPage(undefined, undefined, 10);
+      assert.equal(page.kind, 'page');
+      if (page.kind !== 'page') assert.fail('expected a catalog page');
+      assert.deepEqual(page.records, []);
+      await assert.rejects(store.readCatalogRecord(WORKHUB_COORDINATION_SESSION_ID), (error) =>
+        isSessionNotFoundError(error),
+      );
+
+      const recovery = await store.listForRecovery();
+      assert.equal(recovery.length, 1);
+      assert.equal(recovery[0]?.id, WORKHUB_COORDINATION_SESSION_ID);
+      assert.equal(recovery[0]?.role, WORKHUB_COORDINATION_SESSION_ROLE);
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('quarantines the reserved Coordination identity when its role is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-coordination-missing-role-'));
+    const store = createSessionStore(root);
+    try {
+      const ordinary = await store.create(makeInput({ name: 'Keep me' }));
+      await store.createStableSession({
+        sessionId: WORKHUB_COORDINATION_SESSION_ID,
+        requestFingerprint: `sha256:${'a'.repeat(64)}`,
+        input: {
+          ...makeInput({ cwd: root, projectId: null, name: 'WorkHub' }),
+          role: WORKHUB_COORDINATION_SESSION_ROLE,
+        },
+      });
+      const database = new DatabaseSync(join(root, OPERATIONAL_STATE_DATABASE_NAME));
+      try {
+        database
+          .prepare(
+            `UPDATE session_metadata
+             SET payload_json = json_remove(payload_json, '$.role')
+             WHERE session_id = ?`,
+          )
+          .run(WORKHUB_COORDINATION_SESSION_ID);
+      } finally {
+        database.close();
+      }
+
+      assert.deepEqual(
+        (await store.list()).map((session) => session.id),
+        [ordinary.id],
+      );
+      const page = await store.listCatalogPage(undefined, undefined, 10);
+      assert.equal(page.kind, 'page');
+      if (page.kind !== 'page') assert.fail('expected a catalog page');
+      assert.deepEqual(
+        page.records.map((record) => record.header.id),
+        [ordinary.id],
+      );
+      await assert.rejects(store.readCatalogRecord(WORKHUB_COORDINATION_SESSION_ID), (error) =>
+        isSessionNotFoundError(error),
+      );
+      assert.deepEqual(
+        (await store.listForRecovery()).map((session) => session.id),
+        [ordinary.id],
+      );
+      assert.equal(
+        (await store.readHeaderSnapshot(WORKHUB_COORDINATION_SESSION_ID)).name,
+        'WorkHub',
+      );
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('enforces one WorkHub Coordination Session role per Runtime Host store', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-workhub-coordination-unique-'));
+    const store = createSessionStore(root);
+    try {
+      await store.createStableSession({
+        sessionId: WORKHUB_COORDINATION_SESSION_ID,
+        requestFingerprint: `sha256:${'a'.repeat(64)}`,
+        input: {
+          ...makeInput({ cwd: root, projectId: null, name: 'WorkHub' }),
+          role: WORKHUB_COORDINATION_SESSION_ROLE,
+        },
+      });
+
+      await assert.rejects(
+        store.createStableSession({
+          sessionId: 'second-workhub-coordination-session',
+          requestFingerprint: `sha256:${'b'.repeat(64)}`,
+          input: {
+            ...makeInput({ cwd: root, projectId: null, name: 'WorkHub duplicate' }),
+            role: WORKHUB_COORDINATION_SESSION_ROLE,
+          },
+        }),
+        /unique|constraint/i,
+      );
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('ordinary Sessions have no external origin and provenance metadata is immutable', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-external-origin-'));
     const store = createSessionStore(root);
@@ -573,6 +694,7 @@ describe('SQLite SessionStore', () => {
       )
       .run(legacyRecord, sessionId);
     legacy.exec(`
+      DROP INDEX session_metadata_one_workhub_coordination_session;
       DROP TABLE agent_graph_epochs;
       DROP TABLE session_message_chunks;
       DROP TABLE session_message_payloads;

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -52,7 +52,7 @@ import {
 import { SQLITE_AGENT_GRAPH_CONTROL_TABLES } from '../sqlite-session-metadata-schema.js';
 
 describe('SqliteSessionMetadataStore', () => {
-  test('migrates v27 metadata to v28 without backfilling external origin', async () => {
+  test('migrates v27 metadata to the current schema without backfilling external origin', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-metadata-v27-'));
     const path = join(root, 'state.sqlite');
     const legacyHeader = fullHeader({
@@ -73,6 +73,7 @@ describe('SqliteSessionMetadataStore', () => {
     const legacy = new DatabaseSync(path);
     try {
       legacy.exec(`
+        DROP INDEX session_metadata_one_workhub_coordination_session;
         DROP INDEX session_metadata_by_external_origin;
         ALTER TABLE session_metadata DROP COLUMN external_adapter_id;
         ALTER TABLE session_metadata DROP COLUMN external_source_session_id;
@@ -84,7 +85,7 @@ describe('SqliteSessionMetadataStore', () => {
 
     const migrated = createSqliteSessionMetadataStore(path);
     try {
-      assert.equal(migrated.schemaVersion(), 29);
+      assert.equal(migrated.schemaVersion(), SQLITE_SESSION_METADATA_SCHEMA_VERSION);
       assert.equal((await migrated.read(legacyHeader.id)).header.externalOrigin, undefined);
     } finally {
       migrated.close();
@@ -271,6 +272,7 @@ describe('SqliteSessionMetadataStore', () => {
       const legacy = new DatabaseSync(path);
       try {
         legacy.exec(`
+          DROP INDEX session_metadata_one_workhub_coordination_session;
           ALTER TABLE session_metadata ADD COLUMN status TEXT;
           ALTER TABLE session_metadata ADD COLUMN status_updated_at INTEGER;
           UPDATE session_metadata
@@ -531,6 +533,7 @@ describe('SqliteSessionMetadataStore', () => {
       const legacy = new DatabaseSync(path);
       try {
         legacy.exec(`
+          DROP INDEX session_metadata_one_workhub_coordination_session;
           ALTER TABLE session_metadata ADD COLUMN status TEXT;
           ALTER TABLE session_metadata ADD COLUMN status_updated_at INTEGER;
           UPDATE session_metadata

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -1833,7 +1833,7 @@ describe('SqliteSessionMetadataStore', () => {
         }),
       );
 
-      const listed = await store.list();
+      const listed = await store.list(undefined, 'all');
       assert.deepEqual(
         listed.map((record) => record.header.id),
         ['archived', 'newer', 'older'],
@@ -1929,9 +1929,10 @@ describe('SqliteSessionMetadataStore', () => {
         }),
       );
 
-      const children = await store.list({
-        subagentParentSessionId: subagentParent.parentSessionId,
-      });
+      const children = await store.list(
+        { subagentParentSessionId: subagentParent.parentSessionId },
+        'all',
+      );
       assert.deepEqual(
         children.map((record) => record.header.id),
         ['child-session'],

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -45,6 +45,7 @@ import {
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,
   isSessionStatus,
+  isWorkHubCoordinationSessionId,
   subagentSessionRuntimeSummary,
   WORKHUB_COORDINATION_SESSION_ROLE,
 } from '@maka/core/session';
@@ -530,6 +531,11 @@ class SqliteSessionStore implements SessionAuthorityStore {
     initialBoundary?: ExecutionBoundary,
   ): Promise<CreateStableSessionResult> {
     await this.ensureReady();
+    const targetsCoordinationSession = isWorkHubCoordinationSessionId(request.sessionId);
+    const claimsCoordinationRole = request.input.role === WORKHUB_COORDINATION_SESSION_ROLE;
+    if (targetsCoordinationSession !== claimsCoordinationRole) {
+      throw new Error('WorkHub Coordination Session identity and role must be claimed together');
+    }
     if (
       request.input.conversationCopy &&
       request.input.conversationCopy.requestFingerprint !== request.requestFingerprint
@@ -748,7 +754,7 @@ class SqliteSessionStore implements SessionAuthorityStore {
 
   async listHeaders(): Promise<SessionHeader[]> {
     await this.ensureReady();
-    return (await this.metadata.list({}, 'recognized'))
+    return (await this.metadata.list({}, 'recoverable'))
       .map((record) => record.header)
       .sort((a, b) => a.id.localeCompare(b.id));
   }

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -531,11 +531,10 @@ class SqliteSessionStore implements SessionAuthorityStore {
     initialBoundary?: ExecutionBoundary,
   ): Promise<CreateStableSessionResult> {
     await this.ensureReady();
-    const targetsCoordinationSession = isWorkHubCoordinationSessionId(request.sessionId);
-    const claimsCoordinationRole = request.input.role === WORKHUB_COORDINATION_SESSION_ROLE;
-    if (targetsCoordinationSession !== claimsCoordinationRole) {
-      throw new Error('WorkHub Coordination Session identity and role must be claimed together');
-    }
+    // Asserted here as well as in the header builder so a malformed request is
+    // refused before claimStableSessionCreate() writes a durable claim for the
+    // identity it names.
+    assertCoordinationIdentityPairing(request.sessionId, request.input.role);
     if (
       request.input.conversationCopy &&
       request.input.conversationCopy.requestFingerprint !== request.requestFingerprint
@@ -754,7 +753,7 @@ class SqliteSessionStore implements SessionAuthorityStore {
 
   async listHeaders(): Promise<SessionHeader[]> {
     await this.ensureReady();
-    return (await this.metadata.list({}, 'recoverable'))
+    return (await this.metadata.list(undefined, 'recoverable'))
       .map((record) => record.header)
       .sort((a, b) => a.id.localeCompare(b.id));
   }
@@ -1021,6 +1020,17 @@ class SqliteSessionStore implements SessionAuthorityStore {
   }
 }
 
+/**
+ * The reserved identity and the reserved role are one fact, and the invariant
+ * belongs to every creator that builds a header — subagents and Agent Graph
+ * operators included, whose inputs carry no role today.
+ */
+function assertCoordinationIdentityPairing(sessionId: string, role: SessionRole | undefined): void {
+  if (isWorkHubCoordinationSessionId(sessionId) !== (role === WORKHUB_COORDINATION_SESSION_ROLE)) {
+    throw new Error('WorkHub Coordination Session identity and role must be claimed together');
+  }
+}
+
 function buildSessionHeader(
   workspaceRoot: string,
   input: CreateSessionInput & { readonly role?: SessionRole },
@@ -1036,6 +1046,7 @@ function buildSessionHeader(
   }
   const now = Date.now();
   assertSafeSessionId(sessionId);
+  assertCoordinationIdentityPairing(sessionId, input.role);
   const name =
     input.name === undefined ? DEFAULT_SESSION_NAME : normalizeRequiredSessionName(input.name);
   const header: SessionHeader = {

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -46,6 +46,7 @@ import {
   isSubagentSessionSpawn,
   isSessionStatus,
   subagentSessionRuntimeSummary,
+  WORKHUB_COORDINATION_SESSION_ROLE,
 } from '@maka/core/session';
 import { isCollaborationMode } from '@maka/core/collaboration';
 import { isOrchestrationMode } from '@maka/core/orchestration';
@@ -75,6 +76,7 @@ import {
   type SessionConversationCopy,
   type SessionExternalOrigin,
   type SessionSummary,
+  type SessionRole,
   type StoredMessage,
   type TurnRecord,
   type TurnStateMessage,
@@ -166,6 +168,7 @@ export interface CreateStableSessionRequest {
 
 export type StableSessionCreateInput = CreateSessionInput & {
   readonly conversationCopy?: SessionConversationCopy;
+  readonly role?: SessionRole;
 };
 
 export type CreateStableSessionResult =
@@ -669,7 +672,7 @@ class SqliteSessionStore implements SessionAuthorityStore {
 
   async list(filter?: SessionListFilter): Promise<SessionSummary[]> {
     await this.ensureReady();
-    const records = (await this.metadata.list(filter)).filter(
+    const records = (await this.metadata.list(filter, 'ordinary')).filter(
       (record) => record.header.conversationCopy?.state !== 'preparing',
     );
     const withPreviews: Array<{
@@ -745,7 +748,7 @@ class SqliteSessionStore implements SessionAuthorityStore {
 
   async listHeaders(): Promise<SessionHeader[]> {
     await this.ensureReady();
-    return (await this.metadata.list())
+    return (await this.metadata.list({}, 'recognized'))
       .map((record) => record.header)
       .sort((a, b) => a.id.localeCompare(b.id));
   }
@@ -1014,7 +1017,7 @@ class SqliteSessionStore implements SessionAuthorityStore {
 
 function buildSessionHeader(
   workspaceRoot: string,
-  input: CreateSessionInput,
+  input: CreateSessionInput & { readonly role?: SessionRole },
   sessionId: string = randomUUID(),
   conversationCopy?: SessionConversationCopy,
 ): SessionHeader {
@@ -1031,6 +1034,7 @@ function buildSessionHeader(
     input.name === undefined ? DEFAULT_SESSION_NAME : normalizeRequiredSessionName(input.name);
   const header: SessionHeader = {
     id: sessionId,
+    ...(input.role === undefined ? {} : { role: input.role }),
     workspaceRoot,
     cwd: input.cwd,
     ...(input.projectId !== undefined ? { projectId: input.projectId } : {}),
@@ -1086,6 +1090,7 @@ export function normalizeSessionHeader(
 ): SessionHeader {
   const valid =
     header.id === sessionId &&
+    (header.role === undefined || header.role === WORKHUB_COORDINATION_SESSION_ROLE) &&
     typeof header.workspaceRoot === 'string' &&
     typeof header.cwd === 'string' &&
     (header.projectId === undefined ||

--- a/packages/storage/src/sqlite-session-catalog-query.ts
+++ b/packages/storage/src/sqlite-session-catalog-query.ts
@@ -18,6 +18,7 @@
  */
 
 import type { SessionListFilter } from '@maka/core/runtime-inputs';
+import { sqliteOrdinarySessionRolePredicate } from './sqlite-session-role-scope.js';
 
 export interface SqliteSessionCatalogCursor {
   readonly activityAt: number;
@@ -35,9 +36,12 @@ export function buildSqliteSessionCatalogPageQuery(
 ): SqliteSessionCatalogPageQuery {
   const where: string[] = [];
   const parameters: Array<string | number> = [];
+  const role = sqliteOrdinarySessionRolePredicate();
   where.push(
     "COALESCE(json_extract(metadata.payload_json, '$.conversationCopy.state'), '') <> 'preparing'",
   );
+  where.push(role.sql);
+  parameters.push(...role.parameters);
   where.push("COALESCE(json_extract(metadata.payload_json, '$.transcriptLedgerVersion'), 1) <> 0");
   if (filter.subagentParentSessionId !== undefined) {
     where.push('projection.subagent_parent_session_id = ?');

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -19,7 +19,7 @@
 
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 29;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 30;
 export const SQLITE_SESSION_MESSAGE_CHUNK_BYTES = 64 * 1024;
 export const SQLITE_SESSION_MESSAGE_CHUNK_MARKER = '{"$maka":"session-message-chunks-v1"}';
 
@@ -1118,6 +1118,14 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
       SET generation = generation + 1
       WHERE scope = 'catalog';
     END;
+  `,
+  ],
+  [
+    30,
+    `
+    CREATE UNIQUE INDEX session_metadata_one_workhub_coordination_session
+      ON session_metadata(json_extract(payload_json, '$.role'))
+      WHERE json_extract(payload_json, '$.role') = 'workhub_coordination';
   `,
   ],
 ]);

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -187,7 +187,11 @@ export type SqliteSessionMetadataStoreFailpoint =
   | 'after_agent_graph_operator_provision_write'
   | 'after_sandbox_boundary_write';
 
-type SessionMetadataRoleScope = 'all' | 'ordinary' | 'recoverable';
+/**
+ * Role visibility is stated at every call site on purpose: a default would let
+ * a new reader inherit the widest scope by omission.
+ */
+export type SessionMetadataRoleScope = 'all' | 'ordinary' | 'recoverable';
 
 export interface SqliteSessionMetadataStoreOptions {
   now?: () => number;
@@ -1272,11 +1276,11 @@ export class SqliteSessionMetadataStore {
   }
 
   async list(
-    filter: SessionListFilter = {},
-    roleScope: SessionMetadataRoleScope = 'all',
+    filter: SessionListFilter | undefined,
+    roleScope: SessionMetadataRoleScope,
   ): Promise<SessionMetadataRecord[]> {
     this.assertOpen();
-    const { where, parameters } = buildSessionListPredicate(filter);
+    const { where, parameters } = buildSessionListPredicate(filter ?? {});
     if (roleScope === 'ordinary') {
       const role = sqliteOrdinarySessionRolePredicate();
       where.push(role.sql);

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -140,6 +140,10 @@ import {
   buildSqliteSessionCatalogPageQuery,
   type SqliteSessionCatalogCursor,
 } from './sqlite-session-catalog-query.js';
+import {
+  sqliteOrdinarySessionRolePredicate,
+  sqliteRecognizedSessionRolePredicate,
+} from './sqlite-session-role-scope.js';
 
 export { SQLITE_SESSION_METADATA_SCHEMA_VERSION } from './sqlite-session-metadata-schema.js';
 
@@ -182,6 +186,8 @@ export type SqliteSessionMetadataStoreFailpoint =
   | 'after_agent_graph_schedule_update_write'
   | 'after_agent_graph_operator_provision_write'
   | 'after_sandbox_boundary_write';
+
+type SessionMetadataRoleScope = 'all' | 'ordinary' | 'recognized';
 
 export interface SqliteSessionMetadataStoreOptions {
   now?: () => number;
@@ -1039,6 +1045,7 @@ export class SqliteSessionMetadataStore {
   async readCatalogRecord(sessionId: string): Promise<SessionMetadataCatalogRecord> {
     this.assertOpen();
     assertSafeSessionId(sessionId);
+    const role = sqliteOrdinarySessionRolePredicate();
     const row = this.db
       .prepare(
         `
@@ -1053,6 +1060,7 @@ export class SqliteSessionMetadataStore {
         JOIN session_metadata metadata
           ON metadata.session_id = projection.session_id
         WHERE projection.session_id = ?
+          AND ${role.sql}
           AND COALESCE(
             json_extract(metadata.payload_json, '$.conversationCopy.state'),
             ''
@@ -1063,7 +1071,7 @@ export class SqliteSessionMetadataStore {
           ) <> 0
       `,
       )
-      .get(sessionId) as SessionMetadataCatalogRow | undefined;
+      .get(sessionId, ...role.parameters) as SessionMetadataCatalogRow | undefined;
     if (!row) throw new SessionNotFoundError(sessionId);
     return decodeCatalogRecord(row);
   }
@@ -1263,9 +1271,21 @@ export class SqliteSessionMetadataStore {
     });
   }
 
-  async list(filter: SessionListFilter = {}): Promise<SessionMetadataRecord[]> {
+  async list(
+    filter: SessionListFilter = {},
+    roleScope: SessionMetadataRoleScope = 'all',
+  ): Promise<SessionMetadataRecord[]> {
     this.assertOpen();
     const { where, parameters } = buildSessionListPredicate(filter);
+    if (roleScope === 'ordinary') {
+      const role = sqliteOrdinarySessionRolePredicate();
+      where.push(role.sql);
+      parameters.push(...role.parameters);
+    } else if (roleScope === 'recognized') {
+      const role = sqliteRecognizedSessionRolePredicate();
+      where.push(role.sql);
+      parameters.push(...role.parameters);
+    }
     const rows = this.db
       .prepare(
         `
@@ -3483,6 +3503,9 @@ export class SqliteSessionMetadataStore {
     }
     if (Object.prototype.hasOwnProperty.call(patch, 'externalOrigin')) {
       throw new Error('External Session origin is immutable');
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'role')) {
+      throw new Error('Session role is immutable');
     }
     return this.transaction(() =>
       this.updateHeaderSync(sessionId, patch, {

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -142,7 +142,7 @@ import {
 } from './sqlite-session-catalog-query.js';
 import {
   sqliteOrdinarySessionRolePredicate,
-  sqliteRecognizedSessionRolePredicate,
+  sqliteRecoverableSessionRolePredicate,
 } from './sqlite-session-role-scope.js';
 
 export { SQLITE_SESSION_METADATA_SCHEMA_VERSION } from './sqlite-session-metadata-schema.js';
@@ -187,7 +187,7 @@ export type SqliteSessionMetadataStoreFailpoint =
   | 'after_agent_graph_operator_provision_write'
   | 'after_sandbox_boundary_write';
 
-type SessionMetadataRoleScope = 'all' | 'ordinary' | 'recognized';
+type SessionMetadataRoleScope = 'all' | 'ordinary' | 'recoverable';
 
 export interface SqliteSessionMetadataStoreOptions {
   now?: () => number;
@@ -1281,8 +1281,8 @@ export class SqliteSessionMetadataStore {
       const role = sqliteOrdinarySessionRolePredicate();
       where.push(role.sql);
       parameters.push(...role.parameters);
-    } else if (roleScope === 'recognized') {
-      const role = sqliteRecognizedSessionRolePredicate();
+    } else if (roleScope === 'recoverable') {
+      const role = sqliteRecoverableSessionRolePredicate();
       where.push(role.sql);
       parameters.push(...role.parameters);
     }

--- a/packages/storage/src/sqlite-session-role-scope.ts
+++ b/packages/storage/src/sqlite-session-role-scope.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  WORKHUB_COORDINATION_SESSION_ID,
+  WORKHUB_COORDINATION_SESSION_ROLE,
+} from '@maka/core/session';
+
+export interface SqliteSessionRolePredicate {
+  readonly sql: string;
+  readonly parameters: readonly string[];
+}
+
+/**
+ * The reserved Coordination identity remains non-ordinary even when its role
+ * metadata is corrupt or missing. This keeps damaged authority state out of
+ * ordinary catalogs and write paths until the Host can be repaired.
+ */
+export function sqliteOrdinarySessionRolePredicate(): SqliteSessionRolePredicate {
+  return {
+    sql: `(
+      metadata.session_id <> ?
+      AND json_type(metadata.payload_json, '$.role') IS NULL
+    )`,
+    parameters: [WORKHUB_COORDINATION_SESSION_ID],
+  };
+}
+
+/** Returns only valid ordinary rows and the one valid reserved Coordination row. */
+export function sqliteRecognizedSessionRolePredicate(): SqliteSessionRolePredicate {
+  const ordinary = sqliteOrdinarySessionRolePredicate();
+  return {
+    sql: `(
+      ${ordinary.sql}
+      OR (
+        metadata.session_id = ?
+        AND json_type(metadata.payload_json, '$.role') = 'text'
+        AND json_extract(metadata.payload_json, '$.role') = ?
+      )
+    )`,
+    parameters: [
+      ...ordinary.parameters,
+      WORKHUB_COORDINATION_SESSION_ID,
+      WORKHUB_COORDINATION_SESSION_ROLE,
+    ],
+  };
+}

--- a/packages/storage/src/sqlite-session-role-scope.ts
+++ b/packages/storage/src/sqlite-session-role-scope.ts
@@ -42,8 +42,8 @@ export function sqliteOrdinarySessionRolePredicate(): SqliteSessionRolePredicate
   };
 }
 
-/** Returns only valid ordinary rows and the one valid reserved Coordination row. */
-export function sqliteRecognizedSessionRolePredicate(): SqliteSessionRolePredicate {
+/** Returns only rows that Runtime recovery may safely rebuild. */
+export function sqliteRecoverableSessionRolePredicate(): SqliteSessionRolePredicate {
   const ordinary = sqliteOrdinarySessionRolePredicate();
   return {
     sql: `(

--- a/packages/storage/src/usage-stats-store.ts
+++ b/packages/storage/src/usage-stats-store.ts
@@ -148,7 +148,9 @@ async function readStoredSessions(
   );
   try {
     const sessions: Array<{ header: UsageSessionHeader; messages: UsageMessage[] }> = [];
-    for (const { header } of await metadata.list()) {
+    // Usage is a durable cost aggregate, so it counts every Session that spent
+    // tokens, including reserved roles and rows a catalog would hide.
+    for (const { header } of await metadata.list(undefined, 'all')) {
       const messages = (await metadata.readMessages(header.id)).flatMap((value) => {
         const message = normalizeUsageMessage(value);
         return message ? [message] : [];


### PR DESCRIPTION
## Summary

- provision and reuse one stable Coordination Session per Runtime Host through the existing Session/SQLite authority
- revoke an old Host scope as soon as the default Host changes, and retry recoverable provisioning when model authority becomes available
- reserve the Coordination identity/role pair from ordinary creation, copies, configuration, retirement, catalogs, and root execution

Refs #3492

## Authority and deferred work

Session remains the only durable substrate: this adds no second WorkHub database, event store, lifecycle authority, or transcript copy. Each Runtime Host remains independent; cross-Host coordination is not supported.

Coordination transcript rendering and `answer_here` belong to Slice 3. Model dispositions, the deterministic Action Gate, bounded delegation links, and the deferred Work cardinality decision remain for later slices.

## UI evidence

| Missing default model | Recovered after model configuration |
| --- | --- |
| ![WorkHub shows a recoverable unavailable state](https://raw.githubusercontent.com/ARE404/maka-agent/c454ccca15f32ef685f4b026bf10799e04da50ed/workhub-coordination-unavailable.png) | ![WorkHub recovers without changing surfaces](https://raw.githubusercontent.com/ARE404/maka-agent/c454ccca15f32ef685f4b026bf10799e04da50ed/workhub-coordination-recovered.png) |

## Verification

- `npm run lint`
- `npm run format:check`
- `git diff --check`
- `npm run typecheck`
- `npm run build`
- Storage focused regressions: 29 passed
- Runtime Host: 1,156 passed
- Runtime Host two-client branch/revision regression: 1 passed
- Desktop: 1,506 passed
- Electron default-model failure/recovery e2e: 1 passed
- Standards and Spec adversarial review: no findings
- GitHub CI: passed for exact head `35efcd6d9`, including Desktop e2e, browser smoke, Storybook, and installed CLI validation

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented and tested the lifecycle, storage boundary, protocol, Desktop integration, review fixes, and Standards/Spec reviews.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally or in clean CI

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
