### PR TITLE
refactor(runtime-host): share verified deployment identity

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
@@ -188,6 +188,7 @@ function updateSelection(
   outcome: RuntimeHostUpdateSelection['outcome'],
 ): RuntimeHostUpdateSelection {
   const candidate = {
+    kind: 'npm_registry' as const,
     version: '2.0.0',
     integrity: INTEGRITY,
     compatibility: 7,

--- a/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-update-discovery.test.ts
@@ -106,6 +106,7 @@ describe('managed Runtime Host update discovery', () => {
       'https://registry.npmjs.org/',
     ]);
     assert.deepEqual(candidate, {
+      kind: 'npm_registry',
       version: '2.0.0-beta.1',
       integrity: INTEGRITY,
       compatibility: 7,
@@ -142,6 +143,7 @@ describe('managed Runtime Host update discovery', () => {
 
   it('admits only exact current or compatible target identities', () => {
     const candidate = (version: string, compatibility?: number) => ({
+      kind: 'npm_registry' as const,
       version,
       integrity: INTEGRITY,
       ...(compatibility === undefined ? {} : { compatibility }),

--- a/packages/cli/src/__tests__/runtime-host-update-package.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-update-package.test.ts
@@ -34,6 +34,7 @@ describe('managed Runtime Host update package acquisition', () => {
   it('binds the official archive to its extracted release evidence', async () => {
     const calls: string[][] = [];
     const candidate = {
+      kind: 'npm_registry' as const,
       version: '2.0.0',
       integrity: INTEGRITY,
       compatibility: 7,
@@ -96,6 +97,7 @@ describe('managed Runtime Host update package acquisition', () => {
     await assert.rejects(
       withRuntimeHostRegistryUpdatePackage(
         {
+          kind: 'npm_registry',
           version: '2.0.0',
           integrity: `sha512-${Buffer.alloc(64).toString('base64')}`,
         },
@@ -118,7 +120,12 @@ describe('managed Runtime Host update package acquisition', () => {
 
     await assert.rejects(
       withRuntimeHostRegistryUpdatePackage(
-        { version: '2.0.0', integrity: INTEGRITY, compatibility: 7 },
+        {
+          kind: 'npm_registry',
+          version: '2.0.0',
+          integrity: INTEGRITY,
+          compatibility: 7,
+        },
         async () => assert.fail('invalid manifest must not expose a package'),
         async (args) => {
           if (args[0] === 'pack') {

--- a/packages/cli/src/__tests__/runtime-host-update-reconciliation.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-update-reconciliation.test.ts
@@ -225,7 +225,12 @@ describe('managed Runtime Host update reconciliation', () => {
           assert.deepEqual(options.expectedTarget, TARGET);
           return {
             selector: options.selector,
-            candidate: { version: '2.0.0', integrity: INTEGRITY, compatibility: 1 },
+            candidate: {
+              kind: 'npm_registry',
+              version: '2.0.0',
+              integrity: INTEGRITY,
+              compatibility: 1,
+            },
             outcome: { kind: 'unattended_update', compatibility: 1 },
             currentCliPath: '/managed/current/cli.js',
             service: SERVICE,
@@ -292,7 +297,12 @@ describe('managed Runtime Host update reconciliation', () => {
             await writeRuntimeHostManagedUpdatePolicy(deploymentRoot, null);
             return {
               selector: options.selector,
-              candidate: { version: '2.0.0', integrity: INTEGRITY, compatibility: 1 },
+              candidate: {
+                kind: 'npm_registry',
+                version: '2.0.0',
+                integrity: INTEGRITY,
+                compatibility: 1,
+              },
               outcome: { kind: 'unattended_update', compatibility: 1 },
               currentCliPath: '/managed/current/cli.js',
               service: SERVICE,
@@ -356,7 +366,7 @@ describe('managed Runtime Host update reconciliation', () => {
           createBackend: () => unusedBackend(),
           resolveSelection: async (options) => ({
             selector: options.selector,
-            candidate: { version: '2.0.0', integrity: INTEGRITY },
+            candidate: { kind: 'npm_registry', version: '2.0.0', integrity: INTEGRITY },
             outcome: { kind: 'manual_action', reason: 'target_compatibility_unknown' },
             currentCliPath: '/managed/current/cli.js',
             service: SERVICE,

--- a/packages/cli/src/runtime-host-update-discovery.ts
+++ b/packages/cli/src/runtime-host-update-discovery.ts
@@ -30,6 +30,7 @@ import {
   RUNTIME_HOST_SERVICE_ERROR_CODE_MAX_BYTES,
   RUNTIME_HOST_SERVICE_ERROR_MESSAGE_MAX_BYTES,
   type RuntimeHostServiceManagementFrame,
+  type RuntimeHostNpmDeploymentIdentity,
 } from '@maka/runtime-host/operator';
 import {
   manageRuntimeHostService,
@@ -51,9 +52,7 @@ const REGISTRY_TIMEOUT_MS = 30_000;
 const REGISTRY_OUTPUT_MAX_BYTES = 64 * 1024;
 const MANIFEST_MAX_BYTES = 64 * 1024;
 
-export interface RuntimeHostUpdateCandidate {
-  readonly version: string;
-  readonly integrity: string;
+export interface RuntimeHostUpdateCandidate extends RuntimeHostNpmDeploymentIdentity {
   readonly compatibility?: number;
 }
 
@@ -275,6 +274,7 @@ export async function resolveRuntimeHostRegistryUpdateCandidate(
   }
   const compatibility = positiveInteger(metadata[COMPATIBILITY_FIELD]);
   return {
+    kind: 'npm_registry',
     version,
     integrity,
     ...(compatibility === undefined ? {} : { compatibility }),

--- a/packages/cli/src/runtime-host-update-package.ts
+++ b/packages/cli/src/runtime-host-update-package.ts
@@ -23,7 +23,7 @@ import { createReadStream } from 'node:fs';
 import { lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { isProductReleaseVersion, isSha512PackageIntegrity } from '@maka/runtime-host/operator';
+import { isRuntimeHostNpmDeploymentIdentity } from '@maka/runtime-host/operator';
 import type { RuntimeHostUpdateCandidate } from './runtime-host-update-discovery.js';
 
 const PACKAGE_NAME = 'maka-agent';
@@ -53,8 +53,7 @@ export async function withRuntimeHostRegistryUpdatePackage<T>(
   runNpm: RunNpm = runNpmCommand,
 ): Promise<T> {
   if (
-    !isProductReleaseVersion(candidate.version) ||
-    !isSha512PackageIntegrity(candidate.integrity) ||
+    !isRuntimeHostNpmDeploymentIdentity(candidate) ||
     (candidate.compatibility !== undefined &&
       (!Number.isInteger(candidate.compatibility) || candidate.compatibility <= 0))
   ) {

--- a/packages/runtime-host/src/operator/index.ts
+++ b/packages/runtime-host/src/operator/index.ts
@@ -59,5 +59,8 @@ export {
 export {
   compareProductReleaseVersions,
   isProductReleaseVersion,
+  isRuntimeHostNpmDeploymentIdentity,
   isSha512PackageIntegrity,
+  type RuntimeHostDeploymentIdentity,
+  type RuntimeHostNpmDeploymentIdentity,
 } from './update-package-evidence.js';

--- a/packages/runtime-host/src/operator/update-package-evidence.ts
+++ b/packages/runtime-host/src/operator/update-package-evidence.ts
@@ -22,6 +22,28 @@ interface ProductReleaseVersion {
   readonly prerelease: readonly string[];
 }
 
+export interface RuntimeHostNpmDeploymentIdentity {
+  readonly kind: 'npm_registry';
+  readonly version: string;
+  readonly integrity: string;
+}
+
+/** Exact artifact evidence the Runtime Host can currently verify. */
+export type RuntimeHostDeploymentIdentity = RuntimeHostNpmDeploymentIdentity;
+
+export function isRuntimeHostNpmDeploymentIdentity(
+  value: unknown,
+): value is RuntimeHostNpmDeploymentIdentity {
+  return (
+    isRecord(value) &&
+    value.kind === 'npm_registry' &&
+    typeof value.version === 'string' &&
+    isProductReleaseVersion(value.version) &&
+    typeof value.integrity === 'string' &&
+    isSha512PackageIntegrity(value.integrity)
+  );
+}
+
 export function isProductReleaseVersion(value: string): boolean {
   return parseProductReleaseVersion(value) !== undefined;
 }
@@ -77,4 +99,8 @@ function parseProductReleaseVersion(value: string): ProductReleaseVersion | unde
     core: [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])],
     prerelease,
   };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary

- Define the exact Runtime Host deployment identity that Maka can currently verify: an npm registry version plus SHA-512 integrity.
- Make registry update candidates carry that shared identity from discovery through package acquisition.
- Revalidate the complete identity at the package boundary while keeping the existing service-management wire frame unchanged.

This is the first, behavior-preserving layer of the local deployment-owner work. It deliberately adds no owner record, transfer authority, Desktop evidence format, remote deployment authority, or lifecycle behavior.

Refs #3231
Design context: #3709

<details>
<summary>中文摘要</summary>

- 定义 Maka 当前能够验证的精确 Runtime Host 部署身份：npm registry 版本号与 SHA-512 integrity。
- 让 registry 更新候选从发现到包获取都携带同一份共享身份。
- 在包边界重新验证完整身份，同时保持现有 service-management wire frame 不变。

这是本地部署 owner 工作的第一层、行为不变的基础 PR。它不新增 owner 记录、转移权限、Desktop 证据格式、remote 部署权限或生命周期行为。

</details>

## Verification

- `npm --workspace @maka/runtime-host run build`
- `npm --workspace maka-agent run build`
- Focused Runtime Host update tests: 17 passed.
- Full CLI suite: 450 passed.
- Scoped Biome lint and `git diff --check` passed.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex helped design and implement the shared deployment-identity contract, propagation, validation, and tests under user direction. The affected commit includes a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
