### PR TITLE
fix(desktop): clip sidebar overflow during expansion

### DIFF
--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -179,6 +179,8 @@
      e2e/sidebar-geometry.spec.ts locks. */
   height: 100%;
   width: var(--maka-sidenav-width);
+  /* Clip the expanded content while the sidebar width catches up. */
+  overflow: clip;
   transition: width var(--duration-large) var(--ease-out-strong);
 }
 


### PR DESCRIPTION
## Summary

Prevent the sidebar's expanded content from briefly creating a horizontal
scrollbar while the sidebar width transition catches up.

## Verification

- `npx biome check apps/desktop/src/renderer/styles/shell-layout.css`
- `npm --workspace @maka/desktop run typecheck`
### Before
https://github.com/user-attachments/assets/9b647022-7f2e-4be9-801c-fc2c732a1c1c
### After
https://github.com/user-attachments/assets/e8d26b3d-1f98-4786-8acf-984bcd04f645
## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

<!-- If the second option applies, name the tool(s) and briefly describe their
scope. If AI authored material contribution content, add Generated-by trailers
to the affected commits and ensure the final squash commit retains the trailer. -->

Tool(s) and scope:
Codex assisted with diagnosing the transient overflow and implementing the CSS fix.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
