### PR TITLE
fix(ui): preserve composer paste undo history

### DIFF
--- a/apps/desktop/e2e/composer-undo.spec.ts
+++ b/apps/desktop/e2e/composer-undo.spec.ts
@@ -34,6 +34,20 @@ async function expectComposerText(
     .toBe(expected);
 }
 
+async function pastePlainText(composer: Locator, pasted: string): Promise<void> {
+  await composer.evaluate((element, text) => {
+    const transfer = new DataTransfer();
+    transfer.setData('text/plain', text);
+    element.dispatchEvent(
+      new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: transfer,
+      }),
+    );
+  }, pasted);
+}
+
 test('plain-text paste is undone separately from prior typing', async ({ window: page }) => {
   const composer = page.locator(COMPOSER_INPUT);
 
@@ -41,13 +55,7 @@ test('plain-text paste is undone separately from prior typing', async ({ window:
   await page.keyboard.type(TYPED);
   await expectComposerText(composer, TYPED);
 
-  await composer.evaluate((element, pasted) => {
-    const transfer = new DataTransfer();
-    transfer.setData('text/plain', pasted);
-    element.dispatchEvent(
-      new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: transfer }),
-    );
-  }, PASTED);
+  await pastePlainText(composer, PASTED);
   await expectComposerText(composer, `${TYPED}${PASTED_AS_PLAIN_TEXT}`);
 
   await page.keyboard.press(UNDO_SHORTCUT);
@@ -58,4 +66,78 @@ test('plain-text paste is undone separately from prior typing', async ({ window:
 
   await page.keyboard.press(UNDO_SHORTCUT);
   await expectComposerText(composer, '');
+});
+
+test('pasted absolute path sends on the first Enter without opening the slash menu', async ({
+  window: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  const pasted = '/Users/me/notes.txt';
+
+  await expect(page.locator('button.maka-workspace-picker')).toBeEnabled();
+  await composer.click();
+  await pastePlainText(composer, pasted);
+
+  await expect(composer).toHaveAttribute('aria-expanded', 'false');
+  await composer.press('Enter');
+  await expect(page.getByText(`Fake backend received: ${pasted}`)).toBeVisible();
+});
+
+test('pasted mention-looking text does not open the file menu', async ({ window: page }) => {
+  const composer = page.locator(COMPOSER_INPUT);
+
+  await expect(page.locator('button.maka-workspace-picker')).toBeEnabled();
+  await composer.click();
+  await pastePlainText(composer, 'review @name');
+
+  await expect(composer).toHaveAttribute('aria-expanded', 'false');
+  await expect(page.getByRole('listbox')).toHaveCount(0);
+});
+
+test('plain-text paste closes an existing trigger menu before the first Enter', async ({
+  window: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  const pasted = 'Users/me/notes.txt';
+
+  await expect(page.locator('button.maka-workspace-picker')).toBeEnabled();
+  await composer.click();
+  await composer.pressSequentially('/');
+  await expect(composer).toHaveAttribute('aria-expanded', 'true');
+
+  await pastePlainText(composer, pasted);
+
+  await expect(composer).toHaveAttribute('aria-expanded', 'false');
+  await composer.press('Enter');
+  await expect(page.getByText(`Fake backend received: /${pasted}`)).toBeVisible();
+});
+
+test('plain-text paste synchronizes the controlled draft once', async ({ window: page }) => {
+  const composer = page.locator(COMPOSER_INPUT);
+
+  await expect(page.locator('button.maka-workspace-picker')).toBeEnabled();
+  await page.evaluate(() => {
+    const storageKey = 'maka-new-task-reload-intent-v1';
+    sessionStorage.setItem(storageKey, JSON.stringify({ draft: '' }));
+    const originalSetItem = Storage.prototype.setItem;
+    let writes = 0;
+    Storage.prototype.setItem = function setItem(key: string, value: string): void {
+      if (key === storageKey) writes += 1;
+      originalSetItem.call(this, key, value);
+    };
+    Object.defineProperty(globalThis, '__makaComposerDraftWrites', {
+      configurable: true,
+      get: () => writes,
+    });
+  });
+
+  await composer.click();
+  await pastePlainText(composer, 'one controlled change');
+
+  const writes = await page.evaluate(
+    () =>
+      (globalThis as typeof globalThis & { __makaComposerDraftWrites?: number })
+        .__makaComposerDraftWrites ?? 0,
+  );
+  expect(writes).toBe(1);
 });

--- a/apps/desktop/e2e/composer-undo.spec.ts
+++ b/apps/desktop/e2e/composer-undo.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { Locator } from '@playwright/test';
+import { expect, test, COMPOSER_INPUT } from './fixtures';
+
+const TYPED = 'x';
+const PASTED = '中文 <tag>& "quoted"\r\nhttps://example.test/path?x=1&y=2\n第二行 <>&';
+const PASTED_AS_PLAIN_TEXT = PASTED.replace(/\r\n/g, '\n');
+const UNDO_SHORTCUT = process.platform === 'darwin' ? 'Meta+z' : 'Control+z';
+
+async function expectComposerText(
+  composer: Locator,
+  expected: string,
+): Promise<void> {
+  await expect
+    .poll(() => composer.evaluate((element) => element.innerText.replace(/\r\n/g, '\n')))
+    .toBe(expected);
+}
+
+test('plain-text paste is undone separately from prior typing', async ({ window: page }) => {
+  const composer = page.locator(COMPOSER_INPUT);
+
+  await composer.click();
+  await page.keyboard.type(TYPED);
+  await expectComposerText(composer, TYPED);
+
+  await composer.evaluate((element, pasted) => {
+    const transfer = new DataTransfer();
+    transfer.setData('text/plain', pasted);
+    element.dispatchEvent(
+      new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: transfer }),
+    );
+  }, PASTED);
+  await expectComposerText(composer, `${TYPED}${PASTED_AS_PLAIN_TEXT}`);
+
+  await page.keyboard.press(UNDO_SHORTCUT);
+  await expectComposerText(composer, TYPED);
+
+  await page.keyboard.press(UNDO_SHORTCUT);
+  await expectComposerText(composer, '');
+
+  await page.keyboard.press(UNDO_SHORTCUT);
+  await expectComposerText(composer, '');
+});

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -1711,6 +1711,20 @@ export const Composer = forwardRef<
                 hasHistory={false}
                 triggers={triggers}
                 pasteAsToken={pasteAsToken}
+                onPaste={(_event, pasted) => {
+                  // Astryx has already offered token-adjacent, file, and
+                  // reference-sized-token pastes before it reaches this seam.
+                  // `insertHTML` creates a browser undo transaction distinct
+                  // from the keyboard input immediately before the paste.
+                  if (props.disabled || isReferenceSizedPaste(pasted)) return false;
+                  const plainTextContainer = document.createElement('div');
+                  plainTextContainer.textContent = pasted;
+                  return document.execCommand(
+                    'insertHTML',
+                    false,
+                    plainTextContainer.innerHTML.replace(/\r\n?|\n/g, '<br>'),
+                  );
+                }}
                 onFiles={onInputFiles}
                 onKeyDown={onInputKeyDown}
                 onCompositionStart={() => { compositionActiveRef.current = true; }}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -478,6 +478,7 @@ export const Composer = forwardRef<
   const composerMountedRef = useMountedRef();
   const sendPendingRef = useRef(false);
   const compositionActiveRef = useRef(false);
+  const plainTextPasteInputActiveRef = useRef(false);
   const importActionOwnerRef = useRef<ChatInputActionOwner<ComposerImportActionId> | null>(null);
   if (!importActionOwnerRef.current) {
     importActionOwnerRef.current = createChatInputActionOwner((action) => {
@@ -1681,6 +1682,9 @@ export const Composer = forwardRef<
           input={(
             <div
               className="maka-composer-input"
+              onInputCapture={(event) => {
+                if (plainTextPasteInputActiveRef.current) event.stopPropagation();
+              }}
               // PR-FE-BUG-HUNT-10: a paste that lands mid-CJK-composition must
               // not be consumed — `ChatComposerInput` always preventDefault()s
               // the paste, which would interrupt the IME mid-character. The
@@ -1711,19 +1715,35 @@ export const Composer = forwardRef<
                 hasHistory={false}
                 triggers={triggers}
                 pasteAsToken={pasteAsToken}
-                onPaste={(_event, pasted) => {
+                onPaste={(event, pasted) => {
                   // Astryx has already offered token-adjacent, file, and
                   // reference-sized-token pastes before it reaches this seam.
-                  // `insertHTML` creates a browser undo transaction distinct
-                  // from the keyboard input immediately before the paste.
-                  if (props.disabled || isReferenceSizedPaste(pasted)) return false;
                   const plainTextContainer = document.createElement('div');
                   plainTextContainer.textContent = pasted;
-                  return document.execCommand(
-                    'insertHTML',
-                    false,
-                    plainTextContainer.innerHTML.replace(/\r\n?|\n/g, '<br>'),
-                  );
+                  const menuWasOpen = event.currentTarget.getAttribute('aria-expanded') === 'true';
+                  plainTextPasteInputActiveRef.current = true;
+                  try {
+                    // Deprecated, but still the composer's only insertion
+                    // primitive that creates a browser undo transaction.
+                    // Migrate when Astryx exposes a transactional plain-text
+                    // insertion authority.
+                    return document.execCommand(
+                      'insertHTML',
+                      false,
+                      plainTextContainer.innerHTML.replace(/\r\n?|\n/g, '<br>'),
+                    );
+                  } finally {
+                    plainTextPasteInputActiveRef.current = false;
+                    if (menuWasOpen) {
+                      event.currentTarget.dispatchEvent(
+                        new KeyboardEvent('keydown', {
+                          key: 'Escape',
+                          bubbles: true,
+                          cancelable: true,
+                        }),
+                      );
+                    }
+                  }
                 }}
                 onFiles={onInputFiles}
                 onKeyDown={onInputKeyDown}


### PR DESCRIPTION
## Summary

- route ordinary inline plain-text paste through the existing `ChatComposerInput.onPaste` seam
- insert escaped HTML as one browser transaction so paste is undone separately from immediately preceding keyboard input
- suppress only the nested `input` event produced by that transaction, preventing pasted `@`/`/` text from opening trigger menus and preventing duplicate draft synchronization
- close a trigger menu that was already open before the paste so the first Enter sends instead of being consumed by the menu
- preserve the existing file, reference-sized token, token-adjacent, attachment, disabled-composer, and IME paste paths
- remove the duplicate disabled/reference-sized guard from the outer handler; Astryx remains the single routing authority for those cases

Fixes #3786

## Review follow-up

The review at `pullrequestreview-5037111788` has been checked item by item:

- **P2 — pasted trigger-looking text opens a menu and consumes Enter:** fixed by stopping the nested `input` event during the browser paste transaction. Regression coverage includes an absolute path, mention-looking text, and a menu that was already open before paste.
- **P3 — duplicate paste guard:** fixed by removing the outer `props.disabled || isReferenceSizedPaste(pasted)` guard and relying on Astryx's existing routing.
- **Duplicate change/draft persistence:** fixed by allowing Astryx's paste result to synchronize the controlled value once while suppressing the redundant nested input path. An Electron regression test asserts one persistence write.
- **Broader `insertTextAtCursor` limitation:** documented here rather than expanded into this implementation. Other Astryx callers, including slash-command text insertion, still use its Range-based insertion behavior and are outside this PR's ordinary inline plain-text paste scope.
- **IME behavior:** IME composition bypasses this handler through the existing capture-phase guard, so this change does not interrupt an active composition.
- **`execCommand` deprecation:** `execCommand('insertHTML')` is deprecated, but it is currently the only composer insertion primitive that creates the required browser undo transaction. The intended migration point is a future Astryx transactional plain-text insertion API.

## Before / after evidence

Both recordings run the same real Electron flow with the same minimal input: type `x` → paste ordinary multiline text → press undo three times. Each step displays the current composer text.

### Before — `upstream/main@7235069ad`

The first undo removes `x` while leaving the pasted text. The second and third undo still leave the pasted text, reproducing #3786.

[issue-3786-before-corrected.webm](https://github.com/user-attachments/assets/60a68d0a-ed83-49e3-84cb-b297ae3be1be)

### After

The first undo removes only the pasted text and leaves `x`; the second removes `x`; the third remains empty without reinsertion or duplication.

[issue-3786-after-corrected.webm](https://github.com/user-attachments/assets/bcf92641-02f6-4306-bd08-7a6b8600084f)

## Verification

Passed locally on the final head:

- `npm --workspace @maka/desktop run e2e -- composer-undo.spec.ts` (5/5)
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run check:asf-headers`
- `npx knip --workspace packages/ui`
- `npx knip --workspace apps/desktop`
- `npm run build`
- `git diff --check`
- isolated rerun of runtime-host's transiently failing test: 1/1 passed

The full local `npm test` command completed the affected Desktop suite successfully, but the repository-wide command still exited non-zero on unrelated/environment-sensitive tests in unchanged workspaces:

- `@maka/runtime`: expects `/usr/local` at executable-root index 1 although this Node installation deduplicates it to index 0.
- `@maka/mcp`: macOS resolves the temporary working directory as `/private/var/...` while the assertion expects `/var/...`.
- `maka-agent` CLI: the same `/private/var/...` versus `/var/...` canonical-path difference appears in the global-installation fixture.
- `@maka/runtime-host`: the parallel workspace run transiently lost a shared cache registration directory; the exact failed test passed immediately when rerun in isolation.

### Current CI status

CI for head `3270202c2` passed, including the affected standard workspace tests, Desktop E2E, Browser WebContentsView semantic smoke, alignment audit, and Storybook smoke:

- [CI run 33043954336](https://github.com/apache/maka/actions/runs/33043954336)

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex analyzed the review, implemented the focused composer changes, added Electron regression coverage, ran verification, performed an independent code review, and updated this PR description. The commit includes the required `Generated-by` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck, build, and the affected suite pass locally
- [x] No documentation files are included in the change

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
