### PR TITLE
fix(windows): make recovery evidence authoritative

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -69,6 +69,10 @@ github:
         # reports and no committer can override it.
         contexts:
           - test
+          # Windows recovery is a separate native crash/owner-death boundary.
+          # The workflow runs on every PR and main push so this context can be
+          # required without leaving unrelated pull requests pending forever.
+          - windows_recovery
 
   rulesets:
     - name: Immutable release tags

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -18,10 +18,15 @@
 name: Windows recovery
 
 on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
   group: windows-recovery-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -52,6 +52,21 @@ jobs:
       - name: Build test artifacts
         run: npm.cmd run build:test
 
+      - name: Verify managed dependency alternate streams
+        shell: pwsh
+        run: |
+          node.exe --test --test-reporter=tap --test-concurrency=1 `
+            --test-name-pattern="NTFS alternate stream" `
+            packages/storage/dist/__tests__/managed-dependency-environment.test.js `
+            2>&1 | Tee-Object -FilePath "$env:RUNNER_TEMP/managed-dependency-ads.tap"
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -ne 0) { exit $exitCode }
+          $output = Get-Content "$env:RUNNER_TEMP/managed-dependency-ads.tap"
+          if ($output -notcontains '# tests 3' -or $output -notcontains '# pass 3' -or $output -notcontains '# skipped 0') {
+            Write-Error 'Managed dependency ADS gate did not run exactly three passing Windows tests'
+            exit 1
+          }
+
       - name: Verify Runtime Host Local IPC trust boundary
         shell: pwsh
         run: |

--- a/packages/storage/src/__tests__/fixtures/root-initialization-race.ts
+++ b/packages/storage/src/__tests__/fixtures/root-initialization-race.ts
@@ -44,6 +44,8 @@ fs.promises.open = (async (path, flags, mode) => {
   return originalOpen(path, flags, mode);
 }) as typeof fs.promises.open;
 
+// Import after the interposition: marker-file captures the intrinsic at module
+// evaluation, while production code must ignore later global mutations.
 const { resolveStorageRoot, StorageRootAuthorityError } = await import('../../root-authority.js');
 
 const parentDisconnected = new Promise<void>((resolvePromise) =>

--- a/packages/storage/src/__tests__/fixtures/root-initialization-race.ts
+++ b/packages/storage/src/__tests__/fixtures/root-initialization-race.ts
@@ -18,7 +18,6 @@
  */
 
 import fs from 'node:fs';
-import { syncBuiltinESMExports } from 'node:module';
 import { join } from 'node:path';
 
 const [rootArgument, markerFile] = process.argv.slice(2);
@@ -44,7 +43,6 @@ fs.promises.open = (async (path, flags, mode) => {
   }
   return originalOpen(path, flags, mode);
 }) as typeof fs.promises.open;
-syncBuiltinESMExports();
 
 const { resolveStorageRoot, StorageRootAuthorityError } = await import('../../root-authority.js');
 

--- a/packages/storage/src/__tests__/managed-dependency-environment.test.ts
+++ b/packages/storage/src/__tests__/managed-dependency-environment.test.ts
@@ -372,6 +372,76 @@ test('rejects an NTFS alternate stream created inside a dependency artifact', {
   await authority.close();
 });
 
+test('rejects an NTFS alternate stream attached to the published dependency root', {
+  skip: process.platform !== 'win32',
+}, async (t) => {
+  const storageRoot = await mkdtemp(join(tmpdir(), 'maka-dependency-root-ads-'));
+  t.after(() => rm(storageRoot, { recursive: true, force: true }));
+  const producer = {
+    capability: FIXTURE_PRODUCER_CAPABILITY,
+    packageManagerName: 'npm' as const,
+    packageManagerVersion: '11.12.1',
+    nodeRuntime: fixtureNodeRuntime(),
+    async provision(input: { outputRoot: string }) {
+      await writeFile(join(input.outputRoot, 'index.js'), 'trusted\n', 'utf8');
+    },
+  };
+  const source = dependencySourceForName('root-ads');
+  const identity = computeManagedDependencyEnvironmentIdentity(source);
+  const authority = await createManagedDependencyEnvironmentAuthority({ storageRoot, producer });
+  const lease = await authority.acquire(identity, source);
+  await writeFile(`${lease.dependencyRoot}:unhashed`, 'malicious\n', 'utf8');
+  await lease.release();
+  await authority.close();
+
+  const reopened = await createManagedDependencyEnvironmentAuthority({ storageRoot, producer });
+  await assert.rejects(
+    reopened.acquire(identity, source),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message === 'Managed dependency environment contains an alternate data stream',
+  );
+  await reopened.close();
+});
+
+test('rejects an NTFS alternate stream attached to a published nested directory', {
+  skip: process.platform !== 'win32',
+}, async (t) => {
+  const storageRoot = await mkdtemp(join(tmpdir(), 'maka-dependency-directory-ads-'));
+  t.after(() => rm(storageRoot, { recursive: true, force: true }));
+  const producer = {
+    capability: FIXTURE_PRODUCER_CAPABILITY,
+    packageManagerName: 'npm' as const,
+    packageManagerVersion: '11.12.1',
+    nodeRuntime: fixtureNodeRuntime(),
+    async provision(input: { outputRoot: string }) {
+      const packageRoot = join(input.outputRoot, 'fixture-package');
+      await mkdir(packageRoot);
+      await writeFile(join(packageRoot, 'index.js'), 'trusted\n', 'utf8');
+    },
+  };
+  const source = dependencySourceForName('nested-directory-ads');
+  const identity = computeManagedDependencyEnvironmentIdentity(source);
+  const authority = await createManagedDependencyEnvironmentAuthority({ storageRoot, producer });
+  const lease = await authority.acquire(identity, source);
+  await writeFile(
+    `${join(lease.dependencyRoot, 'fixture-package')}:unhashed`,
+    'malicious\n',
+    'utf8',
+  );
+  await lease.release();
+  await authority.close();
+
+  const reopened = await createManagedDependencyEnvironmentAuthority({ storageRoot, producer });
+  await assert.rejects(
+    reopened.acquire(identity, source),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message === 'Managed dependency environment contains an alternate data stream',
+  );
+  await reopened.close();
+});
+
 test('accepts a POSIX package bin symlink whose target remains inside the dependency root', {
   skip: process.platform === 'win32',
 }, async (t) => {

--- a/packages/storage/src/__tests__/managed-dependency-environment.test.ts
+++ b/packages/storage/src/__tests__/managed-dependency-environment.test.ts
@@ -363,7 +363,12 @@ test('rejects an NTFS alternate stream created inside a dependency artifact', {
     storageRoot,
     producer,
   });
-  await assert.rejects(authority.acquire(identity, source), /alternate data stream/u);
+  await assert.rejects(
+    authority.acquire(identity, source),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message === 'Managed dependency environment contains an alternate data stream',
+  );
   await authority.close();
 });
 

--- a/packages/storage/src/__tests__/managed-dependency-environment.test.ts
+++ b/packages/storage/src/__tests__/managed-dependency-environment.test.ts
@@ -407,7 +407,7 @@ test('rejects an NTFS alternate stream attached to the published dependency root
 test('rejects an NTFS alternate stream attached to a published nested directory', {
   skip: process.platform !== 'win32',
 }, async (t) => {
-  const storageRoot = await mkdtemp(join(tmpdir(), 'maka-dependency-directory-ads-'));
+  const storageRoot = await mkdtemp(join(tmpdir(), 'maka-dependency-目录-ads-'));
   t.after(() => rm(storageRoot, { recursive: true, force: true }));
   const producer = {
     capability: FIXTURE_PRODUCER_CAPABILITY,
@@ -415,7 +415,7 @@ test('rejects an NTFS alternate stream attached to a published nested directory'
     packageManagerVersion: '11.12.1',
     nodeRuntime: fixtureNodeRuntime(),
     async provision(input: { outputRoot: string }) {
-      const packageRoot = join(input.outputRoot, 'fixture-package');
+      const packageRoot = join(input.outputRoot, 'fixture-包');
       await mkdir(packageRoot);
       await writeFile(join(packageRoot, 'index.js'), 'trusted\n', 'utf8');
     },
@@ -424,11 +424,7 @@ test('rejects an NTFS alternate stream attached to a published nested directory'
   const identity = computeManagedDependencyEnvironmentIdentity(source);
   const authority = await createManagedDependencyEnvironmentAuthority({ storageRoot, producer });
   const lease = await authority.acquire(identity, source);
-  await writeFile(
-    `${join(lease.dependencyRoot, 'fixture-package')}:unhashed`,
-    'malicious\n',
-    'utf8',
-  );
+  await writeFile(`${join(lease.dependencyRoot, 'fixture-包')}:unhashed`, 'malicious\n', 'utf8');
   await lease.release();
   await authority.close();
 

--- a/packages/storage/src/__tests__/marker-file.test.ts
+++ b/packages/storage/src/__tests__/marker-file.test.ts
@@ -30,8 +30,8 @@ import {
   type MarkerFileHandle,
 } from '../marker-file.js';
 
-test('uses the live process open implementation for initialization race fixtures', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'maka-marker-file-live-open-'));
+test('keeps the open primitive captured at module initialization', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-marker-file-captured-open-'));
   const markerFile = '.marker.json';
   const originalOpen = fs.promises.open;
   let intercepted = false;
@@ -50,7 +50,7 @@ test('uses the live process open implementation for initialization race fixtures
       publication: 'create',
       invalidFile: () => new Error('invalid marker'),
     });
-    assert.equal(intercepted, true);
+    assert.equal(intercepted, false);
   } finally {
     fs.promises.open = originalOpen;
     await rm(root, { recursive: true, force: true });

--- a/packages/storage/src/__tests__/marker-file.test.ts
+++ b/packages/storage/src/__tests__/marker-file.test.ts
@@ -18,6 +18,7 @@
  */
 
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import { mkdtemp, open, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -28,6 +29,33 @@ import {
   type MarkerFileDependencies,
   type MarkerFileHandle,
 } from '../marker-file.js';
+
+test('uses the live process open implementation for initialization race fixtures', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-marker-file-live-open-'));
+  const markerFile = '.marker.json';
+  const originalOpen = fs.promises.open;
+  let intercepted = false;
+  fs.promises.open = (async (path, flags, mode) => {
+    if (typeof path === 'string' && path.startsWith(join(root, `${markerFile}.`))) {
+      intercepted = true;
+    }
+    return originalOpen(path, flags, mode);
+  }) as typeof fs.promises.open;
+  try {
+    await publishMarkerFile({
+      root,
+      markerFile,
+      contents: '{"schemaVersion":1}\n',
+      maxBytes: 1_024,
+      publication: 'create',
+      invalidFile: () => new Error('invalid marker'),
+    });
+    assert.equal(intercepted, true);
+  } finally {
+    fs.promises.open = originalOpen;
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 for (const publication of ['create', 'replace'] as const) {
   for (const failurePhase of ['write', 'sync', 'close'] as const) {

--- a/packages/storage/src/managed-dependency-environment.ts
+++ b/packages/storage/src/managed-dependency-environment.ts
@@ -147,7 +147,16 @@ public static class MakaWindowsStreamQuery
     }
 }
 '@
-$raw = [Console]::In.ReadToEnd()
+$reader = [IO.StreamReader]::new(
+  [Console]::OpenStandardInput(),
+  [Text.UTF8Encoding]::new($false, $true),
+  $true
+)
+try {
+  $raw = $reader.ReadToEnd()
+} finally {
+  $reader.Dispose()
+}
 $paths = if ([string]::IsNullOrWhiteSpace($raw)) { @() } else { @($raw | ConvertFrom-Json) }
 $alternate = [System.Collections.Generic.List[string]]::new()
 foreach ($path in $paths) {

--- a/packages/storage/src/managed-dependency-environment.ts
+++ b/packages/storage/src/managed-dependency-environment.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { execFile } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -36,7 +36,16 @@ import {
   stat,
   utimes,
 } from 'node:fs/promises';
-import { dirname, isAbsolute, join, normalize, posix, relative, resolve } from 'node:path';
+import {
+  dirname,
+  isAbsolute,
+  join,
+  normalize,
+  posix,
+  relative,
+  resolve,
+  toNamespacedPath,
+} from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import { tryLock, unlock } from 'fs-native-extensions';
 
@@ -57,6 +66,24 @@ const MANAGED_DEPENDENCY_PRODUCER_POLICY_V1 = Object.freeze({
   lifecycleScripts: 'disabled' as const,
 });
 const activeAuthorityOwners = new Map<string, object>();
+const WINDOWS_STREAM_QUERY_TIMEOUT_MS = 30_000;
+const WINDOWS_STREAM_QUERY_MAX_OUTPUT_BYTES = 1024 * 1024;
+const WINDOWS_STREAM_QUERY_SCRIPT = String.raw`
+$ErrorActionPreference = 'Stop'
+$OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+$raw = [Console]::In.ReadToEnd()
+$paths = if ([string]::IsNullOrWhiteSpace($raw)) { @() } else { @($raw | ConvertFrom-Json) }
+$alternate = [System.Collections.Generic.List[string]]::new()
+foreach ($path in $paths) {
+  foreach ($stream in @(Get-Item -LiteralPath $path -Stream * -ErrorAction Stop)) {
+    if ($stream.Stream -notin @(':$DATA', '::$DATA')) {
+      $alternate.Add([string]$path)
+      break
+    }
+  }
+}
+[Console]::Out.Write((ConvertTo-Json -InputObject @($alternate.ToArray()) -Compress))
+`;
 const RECEIPT_KEYS = [
   'protocolVersion',
   'environmentId',
@@ -983,20 +1010,22 @@ async function hashDirectory(
 /**
  * Reject NTFS alternate data streams under a dependency tree.
  *
- * Previously this shellled out to a recursive PowerShell `Get-ChildItem -Recurse`
+ * Previously this shelled out to a recursive PowerShell `Get-ChildItem -Recurse`
  * + `Get-Item -Stream *` walk. On GitHub-hosted Windows runners that path
  * routinely hung until the 30s `execFile` timeout, which misreported every
  * timeout as "contains an alternate data stream" and burned ~5 minutes across
  * managed-dependency crash recovery tests. Walk the tree in Node (no reparse
- * follow) and query streams per file with `fsutil`, which is bounded and
- * does not recurse through junctions.
+ * follow), then send the bounded file list through stdin to one non-recursive
+ * Windows PowerShell stream query. `fsutil file queryStreams` is not a supported
+ * command on the Windows builds used by developers or hosted runners.
  */
 async function assertNoWindowsAlternateStreams(root: string): Promise<void> {
   const systemRoot = process.env.SystemRoot ?? process.env.WINDIR;
   if (!systemRoot) {
     throw new Error('Cannot verify Windows alternate streams without SystemRoot');
   }
-  const fsutil = join(systemRoot, 'System32', 'fsutil.exe');
+  const powershell = join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+  const files: string[] = [];
   const stack = [root];
   while (stack.length > 0) {
     const directory = stack.pop()!;
@@ -1014,63 +1043,93 @@ async function assertNoWindowsAlternateStreams(root: string): Promise<void> {
         continue;
       }
       if (!entry.isFile()) continue;
-      await assertWindowsFileHasOnlyDefaultStream(fsutil, absolutePath);
+      // Windows PowerShell 5.1 cannot open long provider paths unless the
+      // caller supplies the Win32 namespaced spelling.
+      files.push(toNamespacedPath(absolutePath));
     }
+  }
+  const alternate = await queryWindowsAlternateStreams(powershell, files);
+  if (alternate.length > 0) {
+    throw new Error('Managed dependency environment contains an alternate data stream');
   }
 }
 
-async function assertWindowsFileHasOnlyDefaultStream(
-  fsutil: string,
-  filePath: string,
-): Promise<void> {
-  const stdout = await new Promise<string>((resolvePromise, rejectPromise) => {
-    execFile(
-      fsutil,
-      ['file', 'queryStreams', filePath],
-      {
-        windowsHide: true,
-        timeout: 15_000,
-        maxBuffer: 1024 * 1024,
-      },
-      (error, out) => {
-        if (error) {
-          const execError = error as Error & { killed?: boolean; code?: string | number | null };
-          const timedOut =
-            execError.killed === true ||
-            execError.code === 'ETIMEDOUT' ||
-            /ETIMEDOUT|timeout/i.test(execError.message);
-          rejectPromise(
-            new Error(
-              timedOut
-                ? `Timed out querying alternate data streams for ${filePath}`
-                : `Unable to query alternate data streams for ${filePath}`,
-              { cause: error },
-            ),
-          );
-          return;
-        }
-        resolvePromise(typeof out === 'string' ? out : String(out ?? ''));
-      },
+function queryWindowsAlternateStreams(
+  powershell: string,
+  filePaths: readonly string[],
+): Promise<readonly string[]> {
+  if (filePaths.length === 0) return Promise.resolve([]);
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(
+      powershell,
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', WINDOWS_STREAM_QUERY_SCRIPT],
+      { windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'] },
     );
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let overflow = false;
+    let settled = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, WINDOWS_STREAM_QUERY_TIMEOUT_MS);
+    const append = (current: string, chunk: Buffer): string => {
+      const next = current + chunk.toString('utf8');
+      if (Buffer.byteLength(next, 'utf8') <= WINDOWS_STREAM_QUERY_MAX_OUTPUT_BYTES) return next;
+      overflow = true;
+      child.kill();
+      return current;
+    };
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout = append(stdout, chunk);
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr = append(stderr, chunk);
+    });
+    child.stdin.on('error', () => {});
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      rejectPromise(
+        new Error('Unable to start the Windows alternate-stream query', { cause: error }),
+      );
+    });
+    child.once('close', (code) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      if (timedOut) {
+        rejectPromise(new Error('Timed out querying Windows alternate data streams'));
+        return;
+      }
+      if (overflow) {
+        rejectPromise(new Error('Windows alternate-stream query output exceeded its limit'));
+        return;
+      }
+      if (code !== 0) {
+        rejectPromise(
+          new Error(
+            `Unable to query Windows alternate data streams: ${stderr.trim() || `exit ${code}`}`,
+          ),
+        );
+        return;
+      }
+      try {
+        const value: unknown = JSON.parse(stdout || '[]');
+        if (!Array.isArray(value) || !value.every((path) => typeof path === 'string')) {
+          throw new Error('query returned an invalid result');
+        }
+        resolvePromise(value);
+      } catch (error) {
+        rejectPromise(
+          new Error('Windows alternate-stream query returned invalid JSON', { cause: error }),
+        );
+      }
+    });
+    child.stdin.end(JSON.stringify(filePaths));
   });
-  for (const rawLine of stdout.split(/\r?\n/u)) {
-    const line = rawLine.trim();
-    if (!line) continue;
-    // Verbose form: "Name         : :$DATA" or "Name : :unhashed:$DATA"
-    const nameMatch = /^Name\s*:\s*(.+)$/iu.exec(line);
-    if (nameMatch) {
-      if (isDefaultWindowsDataStreamName(nameMatch[1]!.trim())) continue;
-      throw new Error('Managed dependency environment contains an alternate data stream');
-    }
-    // Compact form used by some fsutil builds: ":$DATA" / "Zone.Identifier:$DATA"
-    if (/:\$DATA\b/iu.test(line) && !isDefaultWindowsDataStreamName(line.split(/\s+/u)[0]!)) {
-      throw new Error('Managed dependency environment contains an alternate data stream');
-    }
-  }
-}
-
-function isDefaultWindowsDataStreamName(name: string): boolean {
-  return name === ':$DATA' || name === '::$DATA';
 }
 
 function isPathWithin(candidate: string, root: string): boolean {

--- a/packages/storage/src/managed-dependency-environment.ts
+++ b/packages/storage/src/managed-dependency-environment.ts
@@ -71,15 +71,88 @@ const WINDOWS_STREAM_QUERY_MAX_OUTPUT_BYTES = 1024 * 1024;
 const WINDOWS_STREAM_QUERY_SCRIPT = String.raw`
 $ErrorActionPreference = 'Stop'
 $OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+public static class MakaWindowsStreamQuery
+{
+    private const int ErrorHandleEof = 38;
+    private static readonly IntPtr InvalidHandleValue = new IntPtr(-1);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct FindStreamData
+    {
+        public long StreamSize;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 296)]
+        public string StreamName;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr FindFirstStreamW(
+        string fileName,
+        int infoLevel,
+        out FindStreamData findStreamData,
+        int flags);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool FindNextStreamW(
+        IntPtr findStream,
+        out FindStreamData findStreamData);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool FindClose(IntPtr findHandle);
+
+    public static bool HasAlternateDataStream(string path)
+    {
+        FindStreamData data;
+        IntPtr handle = FindFirstStreamW(path, 0, out data, 0);
+        if (handle == InvalidHandleValue)
+        {
+            int error = Marshal.GetLastWin32Error();
+            if (error == ErrorHandleEof)
+            {
+                return false;
+            }
+            throw new Win32Exception(error);
+        }
+
+        try
+        {
+            do
+            {
+                if (!String.Equals(data.StreamName, "::$DATA", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            while (FindNextStreamW(handle, out data));
+
+            int error = Marshal.GetLastWin32Error();
+            if (error != ErrorHandleEof)
+            {
+                throw new Win32Exception(error);
+            }
+            return false;
+        }
+        finally
+        {
+            if (!FindClose(handle))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+    }
+}
+'@
 $raw = [Console]::In.ReadToEnd()
 $paths = if ([string]::IsNullOrWhiteSpace($raw)) { @() } else { @($raw | ConvertFrom-Json) }
 $alternate = [System.Collections.Generic.List[string]]::new()
 foreach ($path in $paths) {
-  foreach ($stream in @(Get-Item -LiteralPath $path -Stream * -ErrorAction Stop)) {
-    if ($stream.Stream -notin @(':$DATA', '::$DATA')) {
-      $alternate.Add([string]$path)
-      break
-    }
+  if ([MakaWindowsStreamQuery]::HasAlternateDataStream([string]$path)) {
+    $alternate.Add([string]$path)
   }
 }
 [Console]::Out.Write((ConvertTo-Json -InputObject @($alternate.ToArray()) -Compress))
@@ -1015,7 +1088,7 @@ async function hashDirectory(
  * routinely hung until the 30s `execFile` timeout, which misreported every
  * timeout as "contains an alternate data stream" and burned ~5 minutes across
  * managed-dependency crash recovery tests. Walk the tree in Node (no reparse
- * follow), then send the bounded file list through stdin to one non-recursive
+ * follow), then send the bounded object list through stdin to one non-recursive
  * Windows PowerShell stream query. `fsutil file queryStreams` is not a supported
  * command on the Windows builds used by developers or hosted runners.
  */
@@ -1025,7 +1098,7 @@ async function assertNoWindowsAlternateStreams(root: string): Promise<void> {
     throw new Error('Cannot verify Windows alternate streams without SystemRoot');
   }
   const powershell = join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
-  const files: string[] = [];
+  const paths = [toNamespacedPath(root)];
   const stack = [root];
   while (stack.length > 0) {
     const directory = stack.pop()!;
@@ -1039,16 +1112,17 @@ async function assertNoWindowsAlternateStreams(root: string): Promise<void> {
         throw new Error('Managed dependency environment contains a Windows reparse point');
       }
       if (entry.isDirectory()) {
+        paths.push(toNamespacedPath(absolutePath));
         stack.push(absolutePath);
         continue;
       }
       if (!entry.isFile()) continue;
       // Windows PowerShell 5.1 cannot open long provider paths unless the
       // caller supplies the Win32 namespaced spelling.
-      files.push(toNamespacedPath(absolutePath));
+      paths.push(toNamespacedPath(absolutePath));
     }
   }
-  const alternate = await queryWindowsAlternateStreams(powershell, files);
+  const alternate = await queryWindowsAlternateStreams(powershell, paths);
   if (alternate.length > 0) {
     throw new Error('Managed dependency environment contains an alternate data stream');
   }
@@ -1056,9 +1130,9 @@ async function assertNoWindowsAlternateStreams(root: string): Promise<void> {
 
 function queryWindowsAlternateStreams(
   powershell: string,
-  filePaths: readonly string[],
+  paths: readonly string[],
 ): Promise<readonly string[]> {
-  if (filePaths.length === 0) return Promise.resolve([]);
+  if (paths.length === 0) return Promise.resolve([]);
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(
       powershell,
@@ -1128,7 +1202,7 @@ function queryWindowsAlternateStreams(
         );
       }
     });
-    child.stdin.end(JSON.stringify(filePaths));
+    child.stdin.end(JSON.stringify(paths));
   });
 }
 

--- a/packages/storage/src/marker-file.ts
+++ b/packages/storage/src/marker-file.ts
@@ -18,8 +18,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { constants as fsConstants, type BigIntStats } from 'node:fs';
-import { link, lstat, open, rename, unlink } from 'node:fs/promises';
+import fs, { constants as fsConstants, type BigIntStats } from 'node:fs';
+import { link, lstat, rename, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 
 export interface MarkerFileHandle {
@@ -36,7 +36,9 @@ export interface MarkerFileDependencies {
 }
 
 const defaultDependencies: MarkerFileDependencies = {
-  open: async (path, flags, mode) => open(path, flags, mode),
+  // Read the live process implementation so process-level race fixtures can
+  // interpose before importing this module on every supported Node platform.
+  open: async (path, flags, mode) => fs.promises.open(path, flags, mode),
   randomUUID,
 };
 

--- a/packages/storage/src/marker-file.ts
+++ b/packages/storage/src/marker-file.ts
@@ -35,10 +35,12 @@ export interface MarkerFileDependencies {
   randomUUID(): string;
 }
 
+const openMarkerFile = fs.promises.open.bind(fs.promises);
 const defaultDependencies: MarkerFileDependencies = {
-  // Read the live process implementation so process-level race fixtures can
-  // interpose before importing this module on every supported Node platform.
-  open: async (path, flags, mode) => fs.promises.open(path, flags, mode),
+  // Capture once so later-loaded code cannot replace the marker authority's
+  // filesystem primitive. Race fixtures interpose before dynamically importing
+  // this module and are captured at the same boundary.
+  open: openMarkerFile,
   randomUUID,
 };
 

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -346,8 +346,19 @@ test('pull request triggers stay on an explicit allowlist', () => {
     'gitoxide-helper-admission.yml',
     'release-windows-check.yml',
     'runtime-host-owner-platform.yml',
+    'windows-recovery.yml',
     'windows-sandbox-w0.yml',
   ]);
+});
+
+test('Windows recovery publishes one stable PR and main check for ruleset enforcement', () => {
+  const workflow = readWorkflow('windows-recovery.yml');
+
+  assert.match(workflow, /\n {2}pull_request:\n {4}branches: \[main\]/u);
+  assert.match(workflow, /\n {2}push:\n {4}branches: \[main\]/u);
+  assert.match(workflow, /\n {2}workflow_dispatch:/u);
+  assert.match(workflow, /\n {4}name: windows_recovery/u);
+  assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/u);
 });
 
 test('the sandbox lane pairs its path filter with a nightly run', () => {

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -449,6 +449,20 @@ test('specialized platform workflows stay reachable without pull requests', () =
   assert.match(baseline, /\n  schedule:/u);
 });
 
+test('Windows recovery executes the exact managed dependency ADS regressions', () => {
+  const recovery = readWorkflow('windows-recovery.yml');
+
+  assert.match(recovery, /name: Verify managed dependency alternate streams/u);
+  assert.match(recovery, /--test-name-pattern="NTFS alternate stream"/u);
+  assert.match(
+    recovery,
+    /packages\/storage\/dist\/__tests__\/managed-dependency-environment\.test\.js/u,
+  );
+  assert.match(recovery, /# tests 3/u);
+  assert.match(recovery, /# pass 3/u);
+  assert.match(recovery, /# skipped 0/u);
+});
+
 test('workflows never persist the job credential into the checkout', () => {
   for (const name of readdirSync(WORKFLOW_DIR)) {
     for (const step of checkoutSteps(name)) {

--- a/scripts/product-release.test.mjs
+++ b/scripts/product-release.test.mjs
@@ -724,6 +724,10 @@ test('one product workflow gates one draft release on every required artifact', 
 
 test('repository control plane admits only reviewed immutable release tags', async () => {
   const config = parseYaml(await readFile(new URL('../.asf.yaml', import.meta.url), 'utf8'));
+  assert.deepEqual(config.github.protected_branches.main.required_status_checks.contexts, [
+    'test',
+    'windows_recovery',
+  ]);
   const environments = config.github.environments;
   for (const [name, tagPattern] of [
     ['release', 'v*-incubating-rc*'],


### PR DESCRIPTION
## Summary

This PR advances #2624 and the Windows support plan in #2142 by making the native recovery check eligible for branch protection and removing two deterministic failure groups from the Windows baseline.

- restores `windows_recovery` on every pull request and `main` push;
- declares `windows_recovery` beside `test` in the ASF-managed required status checks and locks the workflow/config relationship with a CI contract;
- captures the marker `fs.promises.open` intrinsic at module initialization, while the Node 24 Windows initialization-race fixture patches it before dynamically importing the authority;
- replaces the unsupported `fsutil file queryStreams` call with one bounded Windows stream query fed by Node's no-reparse tree walk;
- checks the dependency root, nested directories, and regular files through `FindFirstStreamW` / `FindNextStreamW`, including Win32 namespaced paths for long-path compatibility;
- keeps every query/start/timeout/output/parse/API failure fail-closed.

Runtime PTY cleanup is intentionally excluded because another contributor has already claimed that slice on #2624. The remaining Git fixture cleanup and symlink-permission inventory are also not folded into this PR.

## Why the ADS change is needed

`fsutil file queryStreams` is not a supported subcommand on the current developer Windows build or the GitHub hosted runner. Normal dependency trees therefore failed before their receipt could be verified. The previous ADS test matched the words "alternate data stream" in the query-failure diagnostic, so it passed without proving a named stream had been observed.

The replacement keeps traversal in Node, rejects reparse points before the external query, and sends a JSON array over stdin to one bounded Windows PowerShell 5.1 process. The process hosts the documented Win32 stream enumeration APIs because the PowerShell 5.1 provider does not enumerate directory streams. Only `ERROR_HANDLE_EOF` is accepted as no streams; other API and process failures reject the environment. Regressions now prove exact named-stream rejection for a regular file, the published dependency root, and a nested directory.

## Verification

Local Windows, Node 24.19 for platform-sensitive tests:

- managed dependency environment: 17 passed, 0 failed, 2 POSIX-only skips;
- focused file/root/nested-directory ADS cases under Windows code page 936 with a Chinese root and entry: 3 passed, 0 failed, 0 skipped;
- managed dependency crash recovery: 5 passed, 0 failed;
- marker file: 7 passed, 0 failed;
- focused root-authority concurrency selection: 4 passed, 0 failed;
- CI planner and Windows harness: 76 passed, 0 failed, 1 privilege skip;
- repository control-plane YAML contract: 1 passed, 0 failed;
- `npm run windows:inventory`: current, 64 declarations;
- lint, format, Core/Storage builds, and `git diff --check`: passed.

Hosted exact-head evidence:

- [`windows_recovery`](https://github.com/apache/maka/actions/runs/32930874533/job/98062727064): passed, including the strict UTF-8/non-ASCII managed-dependency ADS gate (3 tests / 3 pass / 0 skip), followed by every recovery step;
- [`test`](https://github.com/apache/maka/actions/runs/32930874507/job/98062726773): all steps through Runtime Host passed, then the independent prompt-rail virtualization timing issue #3862 failed Desktop e2e (65 passed, 1 failed, 1 skipped). The separate fix #3863 is exact-head green, including the full Desktop e2e suite.

The post-merge #3788/#3790 blockers were repaired by merged #3796. The overlapping schema-constructor handle fix is inherited from `main` and no longer appears in this PR diff. The marker P2 is closed by commit `917e3d110`; the fixture binding clarification is in `648585896`; the strict ADS gate is in `4645cec9c`; the UTF-8 pipe fix is in `b98f3b329`.

## Administration boundary

`.asf.yaml` is the repository's declarative branch-protection authority. After merge, ASF infrastructure must apply the updated `main` protection so `windows_recovery` is actually required. The workflow now reports that stable context on every PR and main push, so enabling it cannot leave unrelated PRs permanently pending.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool and scope: Codex traced recent Windows baseline artifacts, reproduced the system API and handle failures on Windows/Node 24, implemented the storage and workflow changes, and ran the listed local gates.

Refs #2624. Refs #2142.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, affected builds, Windows inventory, and focused Windows suites pass locally
- [x] Exact-head hosted `windows_recovery` passes on head `b98f3b329` with strict UTF-8/non-ASCII ADS evidence
- [ ] Exact-head hosted `test` passes; currently blocked only by independent #3862, fixed in green #3863

Does this PR entail a change in behavior?

- [x] Yes - `windows_recovery` returns to PR/main and becomes a required context; Windows storage validation now uses supported Win32 ADS enumeration for files and directories plus a portable marker-race interception boundary.
- [ ] No
