### PR TITLE
fix(ui): settle live turn after persisted completion

### DIFF
--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -839,6 +839,59 @@ describe('reconcileTerminalLiveTurn', () => {
     ]), textTurn);
   });
 
+  it('terminalizes live text when persisted history proves a missed terminal event', () => {
+    const live: LiveTurnProjection = {
+      turnId: 'turn-1',
+      phase: 'streamed',
+      providerRetry: {
+        type: 'provider_retry',
+        id: 'retry-1',
+        turnId: 'turn-1',
+        ts: 2,
+        phase: 'started',
+        attempt: 2,
+        maxAttempts: 3,
+        reason: 'network',
+      },
+      steps: [{
+        stepId: 'assistant-1',
+        thinking: { text: 'reasoning', truncated: false, complete: false },
+        text: { text: 'answer', truncated: false, complete: false },
+        tools: [],
+      }],
+    };
+
+    assert.deepEqual(reconcileTerminalLiveTurn(live, [
+      {
+        type: 'assistant',
+        id: 'assistant-1',
+        turnId: 'turn-1',
+        ts: 3,
+        text: 'answer',
+        thinking: { text: 'reasoning' },
+        modelId: 'm',
+      },
+      {
+        type: 'turn_state',
+        id: 'state-1',
+        turnId: 'turn-1',
+        ts: 4,
+        status: 'completed',
+        partialOutputRetained: false,
+      },
+    ]), {
+      turnId: 'turn-1',
+      phase: 'streamed',
+      terminal: true,
+      steps: [{
+        stepId: 'assistant-1',
+        thinking: { text: 'reasoning', truncated: false, complete: true },
+        text: { text: 'answer', truncated: false, complete: true },
+        tools: [],
+      }],
+    });
+  });
+
   it('settles a persisted thinking-only step whose text slot is empty', () => {
     const thinkingOnly: LiveTurnProjection = {
       turnId: 'turn-1',

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -607,15 +607,24 @@ export function reconcileTerminalLiveTurn(
   const transcriptReachedTerminal = turnMessages.some(
     (message) => message.type === 'turn_state' && message.status !== 'running',
   );
+  let projection = current;
+  if (transcriptReachedTerminal && current.terminal !== true) {
+    const { providerRetry: _providerRetry, ...withoutRetry } = confirmed(current);
+    projection = {
+      ...withoutRetry,
+      terminal: true,
+      steps: terminalizeLiveSteps(current.steps),
+    };
+  }
   if (
-    current.terminal === true
-    && liveSteeringMessages(current).length > 0
+    projection.terminal === true
+    && liveSteeringMessages(projection).length > 0
     && !transcriptReachedTerminal
-  ) return current;
+  ) return projection;
   const assistantIds = new Set(turnMessages.flatMap((message) => message.type === 'assistant' ? [message.id] : []));
   const toolCallIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_call' ? [message.id] : []));
   const toolResultIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_result' ? [message.toolUseId] : []));
-  let steps = current.steps.filter((step) => {
+  let steps = projection.steps.filter((step) => {
     if (step.text?.text.length) return true;
     if (step.thinking && !assistantIds.has(step.stepId)) return true;
     const toolsCovered = step.tools.every((tool) => {
@@ -633,9 +642,9 @@ export function reconcileTerminalLiveTurn(
   // Once persisted turn_state records the terminal handoff, the transcript is
   // authoritative for accepted steering; retaining the live copy would leave
   // a duplicate or a nacked ghost instruction on screen.
-  const steeringSettled = current.terminal === true
+  const steeringSettled = projection.terminal === true
     && transcriptReachedTerminal
-    && liveSteeringMessages(current).length > 0;
+    && liveSteeringMessages(projection).length > 0;
   if (steeringSettled) {
     steps = steps.map((step) => {
       if (!step.leadingSteering) return step;
@@ -643,9 +652,9 @@ export function reconcileTerminalLiveTurn(
       return withoutSteering;
     });
   }
-  if (steps.length === current.steps.length && !steeringSettled) return current;
-  if (steps.length === 0 && current.terminal) return undefined;
-  if (!steeringSettled) return { ...current, steps };
-  const { pendingSteering: _pendingSteering, ...withoutSteering } = current;
+  if (steps.length === projection.steps.length && !steeringSettled) return projection;
+  if (steps.length === 0 && projection.terminal) return undefined;
+  if (!steeringSettled) return { ...projection, steps };
+  const { pendingSteering: _pendingSteering, ...withoutSteering } = projection;
   return { ...withoutSteering, steps };
 }


### PR DESCRIPTION
## Summary

- treat a persisted non-running `turn_state` as authoritative terminal evidence when the renderer missed the live terminal event
- terminalize retained thinking/text/tool projections and clear stale provider retry state so the composer, timer, and stop control leave their running state
- add a regression test for a completed durable transcript paired with a stale non-terminal live projection
- finish the three queue-test call sites left behind by the typed Runtime Host request migration so the current main revision compiles

## Root cause

The Runtime Host had completed the run and persisted both the assistant response and terminal `turn_state`, but `reconcileTerminalLiveTurn()` only used the persisted terminal marker to settle steering messages. A live projection containing text was retained unchanged, so a missed terminal event could leave the renderer permanently active even though the answer was already visible.

## Verification

- `npm --workspace @maka/ui test` — 228/228 passed
- `npx biome check packages/ui/src/live-turn-projection.ts packages/ui/src/__tests__/live-turn-projection.test.ts packages/runtime-host/src/__tests__/execution-host-queue.test.ts` — passed
- `npm --workspace @maka/ui run typecheck` — passed
- `npm --workspace @maka/runtime-host run typecheck` — passed
- `npm --workspace @maka/desktop run typecheck` — passed
- `git diff --check origin/main...HEAD` — passed
- Electron smoke test — a completed answer no longer retained the processing indicator or Stop control, and the composer returned to its idle state

The full Runtime Host suite was attempted, but current-main integration fixtures fail during Host startup with `no such table: message_admissions` and then do not exit cleanly. The Runtime Host build and typecheck pass; the failure occurs before the changed queue assertions execute.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the runtime/renderer state mismatch, implemented the reconciliation fallback, added regression coverage, and performed local verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
