### PR TITLE
test(runtime-host): migrate queue tests to typed requests

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-host-queue.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host-queue.test.ts
@@ -245,8 +245,11 @@ test('production UDS admission commits one transcript before the root handoff', 
     });
     assert.equal(started.disposition, 'turn_started');
     if (started.disposition !== 'turn_started') return;
-    const active = await client.queryTurn({ sessionId: fixture.sessionId, turnId: started.turnId });
-    await client.stopTurn({
+    const active = await client.request('turn.query', {
+      sessionId: fixture.sessionId,
+      turnId: started.turnId,
+    });
+    await client.request('turn.stop', {
       sessionId: fixture.sessionId,
       turnId: started.turnId,
       runId: active.runId,
@@ -268,7 +271,7 @@ test('a Host crash after queue admission recovers the durable successor once', a
     const firstHost = await fixture.startHost();
     const first = await connectClient(fixture.root);
     const started = requireStartedTurn(
-      await first.startTurn({
+      await first.request('turn.start', {
         sessionId: fixture.sessionId,
         turnId: randomUUID(),
         content: { text: FAKE_ASK_USER_QUESTION_PROMPT },


### PR DESCRIPTION
## Summary

Migrate the three stale `RuntimeHostConnection` alias calls left in `execution-host-queue.test.ts` after #3784 made typed `request<K>()` the sole operation API.

- `queryTurn` -> `request('turn.query', ...)`
- `stopTurn` -> `request('turn.stop', ...)`
- `startTurn` -> `request('turn.start', ...)`

Inputs and assertions are unchanged. This restores the Runtime Host TypeScript build on current main and allows native CI lanes to reach their actual tests.

## Verification

- Core, Storage, MCP, Runtime, and Runtime Host builds passed locally.
- lint, format, and `git diff --check` passed.
- The complete queue suite currently cannot start on current main because #3788 leaves `message_admissions` absent. That failure reproduces without this patch and is independent of the typed request migration.

Fixes #3790.

## AI use

Codex located and migrated the three stale test calls and ran the listed checks.