### PR TITLE
fix(desktop): prevent collapsed workbar flash

### DIFF
--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -51,6 +51,69 @@ async function createSession(page: Page, prompt: string) {
   return { composer, sessionId: sessionId!, sidebar };
 }
 
+test('a collapsed workbar never flashes during the first send', async ({
+  window: page,
+}) => {
+  await page.evaluate(() => {
+    const watch = { visibleRightWorkbar: false };
+    const inspect = () => {
+      const panel = document.querySelector<HTMLElement>(
+        '.maka-session-workbar[data-placement="right"]',
+      );
+      if (
+        panel &&
+        getComputedStyle(panel).display !== 'none' &&
+        panel.getBoundingClientRect().width > 0
+      ) {
+        watch.visibleRightWorkbar = true;
+      }
+    };
+    const observer = new MutationObserver(inspect);
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+    });
+    (
+      window as typeof window & {
+        __makaFirstSendWorkbarWatch?: typeof watch;
+        __makaFirstSendWorkbarWatchStop?: () => void;
+      }
+    ).__makaFirstSendWorkbarWatch = watch;
+    (
+      window as typeof window & {
+        __makaFirstSendWorkbarWatchStop?: () => void;
+      }
+    ).__makaFirstSendWorkbarWatchStop = () => {
+      inspect();
+      observer.disconnect();
+    };
+  });
+
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('create a session without opening the workbar');
+  await page.getByRole('button', { name: '发送' }).click();
+  const expandWorkbar = page.getByRole('button', { name: '展开任务工作栏' });
+  await expect(expandWorkbar).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const watch = await page.evaluate(() => {
+    const target = window as typeof window & {
+      __makaFirstSendWorkbarWatch?: { visibleRightWorkbar: boolean };
+      __makaFirstSendWorkbarWatchStop?: () => void;
+    };
+    target.__makaFirstSendWorkbarWatchStop?.();
+    return target.__makaFirstSendWorkbarWatch;
+  });
+  expect(watch?.visibleRightWorkbar, 'the collapsed right workbar stayed hidden').toBe(false);
+
+  await expandWorkbar.evaluate((button) => button.click());
+  await expect(
+    page.locator('.maka-session-workbar[data-placement="right"]'),
+  ).toBeVisible();
+});
+
 async function waitForCompanionForkId(page: Page, sourceSessionId: string) {
   let forkId: string | undefined;
   await expect

--- a/apps/desktop/src/renderer/features/workbar/ui/workbar-host.tsx
+++ b/apps/desktop/src/renderer/features/workbar/ui/workbar-host.tsx
@@ -46,24 +46,35 @@ const WorkbarSurface = lazy(() =>
   })),
 );
 
-function SessionWorkbarFallback() {
+function SessionWorkbarFallback(props: {
+  hidden: boolean;
+  rightCollapsed: boolean;
+  bottomOpen: boolean;
+}) {
   const copy = getShellCopy(useUiLocale()).app;
+  if (props.hidden || (props.rightCollapsed && !props.bottomOpen)) return null;
+  const placements: SessionWorkbarPlacement[] = [];
+  if (!props.rightCollapsed) placements.push('right');
+  if (props.bottomOpen) placements.push('bottom');
   return (
     <div className="maka-workbar-workspace-contents">
-      <Card
-        variant="transparent"
-        padding={0}
-        height="100%"
-        className="maka-session-workbar maka-session-workbar-frame"
-        data-placement="right"
-        role="status"
-        aria-busy="true"
-        aria-label={copy.loadingWorkbarLabel}
-      >
-        <div className="maka-lazy-fallback" data-surface="panel">
-          <Spinner size="sm" shade="subtle" label={copy.loadingWorkbar} />
-        </div>
-      </Card>
+      {placements.map((placement) => (
+        <Card
+          key={placement}
+          variant="transparent"
+          padding={0}
+          height="100%"
+          className="maka-session-workbar maka-session-workbar-frame"
+          data-placement={placement}
+          role="status"
+          aria-busy="true"
+          aria-label={copy.loadingWorkbarLabel}
+        >
+          <div className="maka-lazy-fallback" data-surface="panel">
+            <Spinner size="sm" shade="subtle" label={copy.loadingWorkbar} />
+          </div>
+        </Card>
+      ))}
     </div>
   );
 }
@@ -163,7 +174,15 @@ export function WorkbarHost({ model: props }: { model: WorkbarHostModel }) {
       )}
       {props.activeId && (
         <div className="maka-workbar-layout-vars" style={style}>
-          <Suspense fallback={<SessionWorkbarFallback />}>
+          <Suspense
+            fallback={
+              <SessionWorkbarFallback
+                hidden={props.hidden}
+                rightCollapsed={props.rightCollapsed}
+                bottomOpen={props.bottomOpen}
+              />
+            }
+          >
             <WorkbarSurface
               key={props.activeId}
               sessionId={props.activeId}


### PR DESCRIPTION
## Summary

- Keep the lazy Workbar fallback aligned with the resolved surface visibility state.
- Do not render a right-side loading panel when the Workbar is collapsed during the first send.
- Preserve loading feedback for genuinely open right and bottom panels.
- Add Electron regression coverage that records transient panel visibility across DOM mutations.

## Verification

- Red test on `origin/main`: the new Electron test observed `visibleRightWorkbar === true` during the first send.
- `npm --workspace @maka/ui run build`
- `npx tsc -p apps/desktop/tsconfig.renderer.json --noEmit --pretty false`
- `npx biome lint apps/desktop/src/renderer/features/workbar/ui/workbar-host.tsx apps/desktop/e2e/session-workbar.spec.ts`
- `npm --workspace @maka/desktop run build:renderer`
- `node --test apps/desktop/dist/main/__tests__/workbar-boundary.test.js apps/desktop/dist/main/__tests__/workbar-model.test.js` (14/14 passed)
- The targeted Electron regression passed three consecutive runs.
- Before/after screenshots are attached in the visual evidence comment below.

## Root cause

Creating the first session mounts `WorkbarHost` while the lazy `WorkbarSurface` is still resolving. The old Suspense fallback always rendered a visible 480 px right panel, even when `rightCollapsed` was true. Once the real surface loaded, its collapsed state hid that panel, producing the brief flash. The fallback now derives its rendered placements from the same `hidden`, `rightCollapsed`, and `bottomOpen` state as the resolved surface.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex investigated the render path, implemented the fix and regression test, and ran the verification described above.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
