### PR TITLE
fix(desktop): bound Runtime Host handler waits

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../ipc-reconnect-policy.js";
 import * as ipcReconnectPolicy from "../ipc-reconnect-policy.js";
 import {
+  RuntimeHostHandlerUnavailableError,
   RuntimeHostReconnectingIpcMain,
   RuntimeHostTargetChangedError,
 } from "../runtime-host-reconnecting-ipc-main.js";
@@ -336,6 +337,56 @@ test("holds an invocation across a Runtime Host candidate replacement", async ()
 
   router.close();
   assert.equal(ipc.size, 0);
+});
+
+test("bounds invocation while an active Runtime Host has no handler", async () => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc, {
+    handlerWaitTimeoutMs: 5,
+  });
+  const target = router.createTarget("target-a");
+  target.handle("sessions:send", async () => "sent");
+  router.activate("target-a");
+  target.removeHandler("sessions:send");
+
+  await assert.rejects(
+    () => ipc.invoke("sessions:send", scope("target-a")),
+    RuntimeHostHandlerUnavailableError,
+  );
+  target.handle("sessions:send", async () => "retried");
+  assert.equal(
+    await ipc.invoke("sessions:send", scope("target-a")),
+    "retried",
+  );
+  router.close();
+});
+
+test("bounds reconnectable reads when no replacement handler becomes available", async () => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc, {
+    handlerWaitTimeoutMs: 5,
+  });
+  const target = router.createTarget("target-a");
+  const failRead = deferred();
+  target.handleReconnectableRead?.("taskReadiness:getSnapshot", async () => {
+    await failRead.promise;
+    throw new RuntimeHostOperationError(
+      "session.catalog.query",
+      "host_draining",
+      "Runtime Host is draining",
+    );
+  });
+  router.activate("target-a");
+
+  const reading = ipc.invoke("taskReadiness:getSnapshot", scope("target-a"));
+  target.removeHandler("taskReadiness:getSnapshot");
+  failRead.resolve();
+
+  await assert.rejects(
+    () => reading,
+    RuntimeHostHandlerUnavailableError,
+  );
+  router.close();
 });
 
 test("does not return a late read from a replaced Runtime Host candidate", async () => {

--- a/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
@@ -34,9 +34,11 @@ type ReconcileIpcHandler = (
 type ReconciliationUnavailableIpcHandler = ReconcileIpcHandler;
 
 const DEFAULT_RECONCILIATION_WAIT_TIMEOUT_MS = 15_000;
+const DEFAULT_HANDLER_WAIT_TIMEOUT_MS = 5_000;
 
 export interface RuntimeHostReconnectingIpcMainOptions {
   readonly reconciliationWaitTimeoutMs?: number;
+  readonly handlerWaitTimeoutMs?: number;
 }
 
 class ReconciliationWaitExpiredError extends Error {
@@ -81,6 +83,13 @@ export class RuntimeHostTargetChangedError extends Error {
   }
 }
 
+export class RuntimeHostHandlerUnavailableError extends Error {
+  constructor() {
+    super("Runtime Host handler remained unavailable after the reconnection window");
+    this.name = "RuntimeHostHandlerUnavailableError";
+  }
+}
+
 /**
  * Keeps Electron IPC registration stable across reconnects while fencing each
  * target generation. Reconnectable reads may move to a replacement candidate,
@@ -91,6 +100,7 @@ export class RuntimeHostReconnectingIpcMain {
   readonly #slots = new Map<string, HandlerSlot>();
   readonly #activeEpochs = new Set<string>();
   readonly #reconciliationWaitTimeoutMs: number;
+  readonly #handlerWaitTimeoutMs: number;
   #closed = false;
 
   constructor(
@@ -104,6 +114,12 @@ export class RuntimeHostReconnectingIpcMain {
       throw new TypeError("Runtime Host reconciliation wait timeout must be positive");
     }
     this.#reconciliationWaitTimeoutMs = reconciliationWaitTimeoutMs;
+    const handlerWaitTimeoutMs =
+      options.handlerWaitTimeoutMs ?? DEFAULT_HANDLER_WAIT_TIMEOUT_MS;
+    if (!Number.isSafeInteger(handlerWaitTimeoutMs) || handlerWaitTimeoutMs <= 0) {
+      throw new TypeError("Runtime Host handler wait timeout must be positive");
+    }
+    this.#handlerWaitTimeoutMs = handlerWaitTimeoutMs;
   }
 
   createTarget(epoch: string): RuntimeHostTargetIpcMain {
@@ -233,14 +249,29 @@ export class RuntimeHostReconnectingIpcMain {
   ): Promise<unknown> {
     const epoch = this.#requireTargetEpoch(args[0]);
     let handler: BoundHandler =
-      slot.handlers.get(epoch) ?? await this.#waitForHandler(slot, epoch);
+      slot.handlers.get(epoch) ??
+      await this.#waitForHandler(
+        slot,
+        epoch,
+        undefined,
+        this.#handlerWaitTimeoutMs,
+        () => new RuntimeHostHandlerUnavailableError(),
+      );
     let reconciliationContext: unknown;
     let reconciling = false;
     let reconciliationDeadline: number | undefined;
     const waitForReplacement = async (
       previous: BoundHandler,
     ): Promise<BoundHandler | undefined> => {
-      if (!reconciling) return this.#waitForHandler(slot, epoch, previous);
+      if (!reconciling) {
+        return this.#waitForHandler(
+          slot,
+          epoch,
+          previous,
+          this.#handlerWaitTimeoutMs,
+          () => new RuntimeHostHandlerUnavailableError(),
+        );
+      }
       const remainingMs = Math.max(
         0,
         (reconciliationDeadline ?? Date.now()) - Date.now(),
@@ -314,6 +345,7 @@ export class RuntimeHostReconnectingIpcMain {
     epoch: string,
     previous?: BoundHandler,
     timeoutMs?: number,
+    timeoutError: () => Error = () => new ReconciliationWaitExpiredError(),
   ): Promise<BoundHandler> {
     try {
       this.#assertActive(epoch);
@@ -325,7 +357,7 @@ export class RuntimeHostReconnectingIpcMain {
       return Promise.resolve(current);
     }
     if (timeoutMs !== undefined && timeoutMs <= 0) {
-      return Promise.reject(new ReconciliationWaitExpiredError());
+      return Promise.reject(timeoutError());
     }
     return new Promise((resolve, reject) => {
       let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -344,7 +376,7 @@ export class RuntimeHostReconnectingIpcMain {
       if (timeoutMs !== undefined) {
         timeout = setTimeout(() => {
           if (!slot.waiters.delete(waiter)) return;
-          waiter.reject(new ReconciliationWaitExpiredError());
+          waiter.reject(timeoutError());
         }, timeoutMs);
       }
     });


### PR DESCRIPTION
## Problem

When a Runtime Host candidate exits, its channel handlers are removed while the target epoch remains active so a replacement candidate can reconnect. Calls arriving in that interval waited indefinitely for a handler.

The composer performs a reconnectable task-readiness read before sending. If the Host never returned, that promise never settled, so the composer kept its submission guard latched and both the Send button and Enter stopped working.

## Root cause

`RuntimeHostReconnectingIpcMain.#waitForHandler()` supported a timeout only for reconciled controls. Initial dispatches and ordinary reconnectable-read replacement waits called it without a deadline.

## Fix

- Add a configurable 5-second handler availability window.
- Apply it to initial dispatch and non-reconciliation replacement waits.
- Preserve same-epoch reconnect routing when a replacement arrives within the window.
- Reject with `RuntimeHostHandlerUnavailableError` after the deadline so callers release pending interaction state and retain retryable input.

## Tests

- Add coverage for an active target whose command handler was removed.
- Verify a later retry succeeds after a replacement handler registers.
- Add coverage for a reconnectable read whose replacement never arrives.
- `npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/runtime-host-reconnecting-ipc-main.test.js` (15/15, repeated 10 times)
- `npx biome check apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts`
- Full Desktop main suite: 1495/1499. The four failures are pre-existing `goal-dialog` DOM-environment failures (`getComputedStyle is not defined`) and do not touch this path.

## Repository baseline note

The full workspace dependency build on current `main` is independently blocked by three stale `RuntimeHostConnection.queryTurn/stopTurn/startTurn` calls in `execution-host-queue.test.ts` after #3784. This PR does not include that unrelated migration.

## UI evidence

No visual styling or layout changes. The behavior change is covered at the IPC ownership boundary where the indefinite promise originated.