### PR TITLE
fix: repair post-merge storage and Runtime Host contracts

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-host-queue.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host-queue.test.ts
@@ -245,8 +245,11 @@ test('production UDS admission commits one transcript before the root handoff', 
     });
     assert.equal(started.disposition, 'turn_started');
     if (started.disposition !== 'turn_started') return;
-    const active = await client.queryTurn({ sessionId: fixture.sessionId, turnId: started.turnId });
-    await client.stopTurn({
+    const active = await client.request('turn.query', {
+      sessionId: fixture.sessionId,
+      turnId: started.turnId,
+    });
+    await client.request('turn.stop', {
       sessionId: fixture.sessionId,
       turnId: started.turnId,
       runId: active.runId,
@@ -268,7 +271,7 @@ test('a Host crash after queue admission recovers the durable successor once', a
     const firstHost = await fixture.startHost();
     const first = await connectClient(fixture.root);
     const started = requireStartedTurn(
-      await first.startTurn({
+      await first.request('turn.start', {
         sessionId: fixture.sessionId,
         turnId: randomUUID(),
         content: { text: FAKE_ASK_USER_QUESTION_PROMPT },

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -54,6 +54,73 @@ import {
 import { SQLITE_AGENT_GRAPH_CONTROL_TABLES } from '../sqlite-session-metadata-schema.js';
 
 describe('SqliteSessionMetadataStore', () => {
+  for (const version30Shape of ['admissions-only', 'coordination-only', 'complete'] as const) {
+    test(`converges the ${version30Shape} version-30 schema after the merge`, async () => {
+      const root = await mkdtemp(join(tmpdir(), `maka-session-v30-${version30Shape}-`));
+      const path = join(root, 'state.sqlite');
+      try {
+        const setup = createSqliteSessionMetadataStore(path);
+        setup.close();
+
+        const version30 = new DatabaseSync(path);
+        try {
+          if (version30Shape === 'admissions-only') {
+            version30.exec('DROP INDEX session_metadata_one_workhub_coordination_session');
+          } else if (version30Shape === 'coordination-only') {
+            version30.exec(`
+              DROP TABLE cancelled_message_admissions;
+              DROP TABLE message_admissions;
+            `);
+          }
+          version30
+            .prepare(
+              `UPDATE session_metadata_schema SET version = 30 WHERE scope = 'session_metadata'`,
+            )
+            .run();
+        } finally {
+          version30.close();
+        }
+
+        const converged = createSqliteSessionMetadataStore(path);
+        try {
+          assert.equal(converged.schemaVersion(), SQLITE_SESSION_METADATA_SCHEMA_VERSION);
+        } finally {
+          converged.close();
+        }
+
+        const schema = new DatabaseSync(path, { readOnly: true });
+        try {
+          const objects = schema
+            .prepare(
+              `
+              SELECT name
+              FROM sqlite_schema
+              WHERE name IN (
+                'message_admissions',
+                'message_admissions_by_session_order',
+                'cancelled_message_admissions',
+                'session_metadata_one_workhub_coordination_session'
+              )
+              ORDER BY name
+            `,
+            )
+            .all()
+            .map((row) => (row as { name: string }).name);
+          assert.deepEqual(objects, [
+            'cancelled_message_admissions',
+            'message_admissions',
+            'message_admissions_by_session_order',
+            'session_metadata_one_workhub_coordination_session',
+          ]);
+        } finally {
+          schema.close();
+        }
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+
   test('migrates v27 metadata to the current schema without backfilling external origin', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-metadata-v27-'));
     const path = join(root, 'state.sqlite');

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -19,7 +19,7 @@
 
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 30;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 31;
 export const SQLITE_SESSION_MESSAGE_CHUNK_BYTES = 64 * 1024;
 export const SQLITE_SESSION_MESSAGE_CHUNK_MARKER = '{"$maka":"session-message-chunks-v1"}';
 
@@ -1156,14 +1156,54 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   `,
   ],
   [
-    30,
+    31,
     `
-    CREATE UNIQUE INDEX session_metadata_one_workhub_coordination_session
+    CREATE TABLE IF NOT EXISTS message_admissions (
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      turn_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      content_json TEXT NOT NULL,
+      submitted_content_digest TEXT NOT NULL,
+      submitted_placement TEXT NOT NULL
+        CHECK (submitted_placement IN ('current_turn', 'next_turn')),
+      placement TEXT NOT NULL CHECK (placement IN ('current_turn', 'next_turn')),
+      disposition TEXT NOT NULL CHECK (disposition IN ('steering', 'followup')),
+      queue_order INTEGER NOT NULL CHECK (queue_order >= 0),
+      admitted_at INTEGER NOT NULL CHECK (admitted_at >= 0),
+      UNIQUE (session_id, message_id),
+      FOREIGN KEY(session_id) REFERENCES session_metadata(session_id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS message_admissions_by_session_order
+      ON message_admissions(session_id, queue_order, sequence);
+
+    CREATE TABLE IF NOT EXISTS cancelled_message_admissions (
+      session_id TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      submitted_content_digest TEXT NOT NULL,
+      submitted_placement TEXT NOT NULL
+        CHECK (submitted_placement IN ('current_turn', 'next_turn')),
+      PRIMARY KEY (session_id, message_id),
+      FOREIGN KEY(session_id) REFERENCES session_metadata(session_id) ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS session_metadata_one_workhub_coordination_session
       ON session_metadata(json_extract(payload_json, '$.role'))
       WHERE json_extract(payload_json, '$.role') = 'workhub_coordination';
   `,
   ],
 ]);
+
+if (MIGRATIONS.size !== SQLITE_SESSION_METADATA_SCHEMA_VERSION) {
+  throw new Error('SQLite session metadata migrations contain a duplicate or missing version');
+}
+for (let version = 1; version <= SQLITE_SESSION_METADATA_SCHEMA_VERSION; version += 1) {
+  if (!MIGRATIONS.has(version)) {
+    throw new Error(`Missing SQLite session metadata migration ${version}`);
+  }
+}
 
 export function configureSqliteSessionMetadataDatabase(db: DatabaseSync): void {
   db.exec('PRAGMA busy_timeout = 5000');

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -429,9 +429,15 @@ export class SqliteSessionMetadataStore {
       return;
     }
     const { DatabaseSync } = loadSqliteModule();
-    this.db = new DatabaseSync(path);
-    configureSqliteSessionMetadataDatabase(this.db);
-    migrateSqliteSessionMetadataDatabase(this.db);
+    const database = new DatabaseSync(path);
+    try {
+      configureSqliteSessionMetadataDatabase(database);
+      migrateSqliteSessionMetadataDatabase(database);
+    } catch (error) {
+      database.close();
+      throw error;
+    }
+    this.db = database;
     this.now = options.now ?? Date.now;
   }
 


### PR DESCRIPTION
## Summary

Repair two independent post-merge regressions that currently form a required-CI bootstrap loop on `main`:

1. #3721 and #3764 both assigned session metadata migration version 30. JavaScript `Map` construction silently retained only the later migration, so current-main databases record version 30 without creating `message_admissions`.
2. #3784 removed operation-specific `RuntimeHostConnection` aliases but left three queue-test calls on `queryTurn`, `stopTurn`, and `startTurn`, so current main does not build.

The fixes remain separate commits in this PR.

## Migration compatibility

Schema version advances to 31. Migration 30 retains the admission-table authority introduced by #3721. Migration 31 uses guarded creation to converge every version-30 shape that may already exist:

- admission tables only (#3721 head);
- WorkHub coordination index only (#3764 head and current main);
- both objects present.

Fresh/older databases run 30 then 31 and reach the same schema. Module initialization now verifies that migration keys cover every version exactly once by rejecting duplicate-or-missing `Map` entries.

The session metadata constructor also closes a newly opened `DatabaseSync` when schema configuration or migration rejects, so a newer-schema refusal does not leak its handle on Windows.

## Runtime Host test migration

The three stale calls are migrated to the existing typed operations without changing inputs or assertions:

- `turn.query`
- `turn.stop`
- `turn.start`

## Verification

- Session metadata store: 56 passed, 0 failed, including all three version-30 starting shapes and the five message-admission tests previously failing on main.
- Core, Storage, MCP, Runtime, and Runtime Host builds: passed.
- Runtime Host queue suite starts and exercises the repaired storage authority; 9/12 passed locally. Three tests hit the existing fixed 10-second Host-readiness deadline on this Windows machine, with no process error or protocol failure. The directly changed production UDS test passed in the first complete run; hosted CI is authoritative for timing.
- lint, format, and `git diff --check`: passed.

Fixes #3788. Fixes #3790.

## AI use

Codex diagnosed the semantic merge collision, implemented the compatibility migration and stale-call updates, and ran the listed checks.
## Checklist

- [x] Tests cover the change and fail without it
- [x] Core/Storage/MCP/Runtime/Runtime Host builds pass locally
- [x] Session metadata migration and message-admission suites pass locally
- [x] Lint, format, and `git diff --check` pass
- [x] Exact-head required `test` passed before the trailer-only history rewrite; a fresh check was triggered for the new head

Does this PR entail a change in behavior?

- [x] Yes - existing version-30 databases converge to schema 31 without losing either merged authority; stale test callers use the supported typed request API.
- [ ] No