### PR TITLE
fix(runtime): fall back Responses relay discovery to /v1

### DIFF
--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -1111,6 +1111,199 @@ describe('models.dev provider conformance', () => {
     assert.equal(probedPath, '/v1/responses');
   });
 
+  test('a root-mounted Responses relay keeps discovery and probes at the configured root', async () => {
+    const requests: Array<{ method: string; url: string }> = [];
+    const server = await startJsonServer((request, response) => {
+      requests.push({ method: request.method ?? '', url: request.url ?? '' });
+      if (request.method === 'GET' && request.url === '/models') {
+        respondJson(response, 200, { data: [{ id: 'relay-reasoner' }] });
+        return;
+      }
+      if (request.method === 'POST' && request.url === '/responses') {
+        respondJson(response, 200, {});
+        return;
+      }
+      respondJson(response, 404, { error: { message: 'not found' } });
+    });
+    const connection: LlmConnection = {
+      slug: 'responses-relay',
+      name: 'Responses Relay',
+      providerType: 'openai-responses-compatible',
+      baseUrl: server.url,
+      defaultModel: 'relay-reasoner',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    assert.deepEqual(
+      (await fetchProviderModels(connection, 'relay-key')).map(({ id }) => id),
+      ['relay-reasoner'],
+    );
+    assert.equal((await testConnection(connection, 'relay-key')).ok, true);
+    assert.deepEqual(requests, [
+      { method: 'GET', url: '/models' },
+      { method: 'POST', url: '/responses' },
+    ]);
+  });
+
+  test('a Responses relay falls back to /v1/models when its root model route is absent', async () => {
+    const requests: Array<{ method: string; url: string }> = [];
+    const server = await startJsonServer((request, response) => {
+      requests.push({ method: request.method ?? '', url: request.url ?? '' });
+      if (request.method === 'GET' && request.url === '/models') {
+        respondJson(response, 404, { error: { message: 'not found' } });
+        return;
+      }
+      if (request.method === 'GET' && request.url === '/v1/models') {
+        respondJson(response, 200, { data: [{ id: 'relay-reasoner' }] });
+        return;
+      }
+      if (request.method === 'POST' && request.url === '/responses') {
+        respondJson(response, 200, {});
+        return;
+      }
+      respondJson(response, 404, { error: { message: 'not found' } });
+    });
+    const connection: LlmConnection = {
+      slug: 'responses-relay',
+      name: 'Responses Relay',
+      providerType: 'openai-responses-compatible',
+      baseUrl: server.url,
+      defaultModel: 'relay-reasoner',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    assert.deepEqual(
+      (await fetchProviderModels(connection, 'relay-key')).map(({ id }) => id),
+      ['relay-reasoner'],
+    );
+    assert.equal((await testConnection(connection, 'relay-key')).ok, true);
+    assert.deepEqual(requests, [
+      { method: 'GET', url: '/models' },
+      { method: 'GET', url: '/v1/models' },
+      { method: 'POST', url: '/responses' },
+    ]);
+  });
+
+  test('a plain OpenAI-compatible relay never retries discovery at /v1/models', async () => {
+    // The 404 fallback is scoped to the Responses relay by provider type; both
+    // OpenAI-shaped adapters share this discovery branch.
+    const requestedPaths: string[] = [];
+    const server = await startJsonServer((request, response) => {
+      requestedPaths.push(request.url ?? '');
+      respondJson(response, 404, { error: { message: 'not found' } });
+    });
+    const connection: LlmConnection = {
+      slug: 'chat-relay',
+      name: 'Chat Relay',
+      providerType: 'openai-compatible',
+      baseUrl: server.url,
+      defaultModel: 'relay-model',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    await assert.rejects(fetchProviderModels(connection, 'relay-key'));
+    assert.deepEqual(requestedPaths, ['/models']);
+  });
+
+  test('a path-mounted Responses relay never appends /v1 to its own prefix', async () => {
+    const requestedPaths: string[] = [];
+    const server = await startJsonServer((request, response) => {
+      requestedPaths.push(request.url ?? '');
+      respondJson(response, 404, { error: { message: 'not found' } });
+    });
+    const connection: LlmConnection = {
+      slug: 'responses-relay',
+      name: 'Responses Relay',
+      providerType: 'openai-responses-compatible',
+      baseUrl: `${server.url}/gateway`,
+      defaultModel: 'relay-reasoner',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    await assert.rejects(fetchProviderModels(connection, 'relay-key'));
+    assert.deepEqual(requestedPaths, ['/gateway/models']);
+  });
+
+  test('an endpoint-form Responses relay discovers through its own API base', async () => {
+    const requestedPaths: string[] = [];
+    const server = await startJsonServer((request, response) => {
+      requestedPaths.push(request.url ?? '');
+      if (request.url === '/v1/models') {
+        respondJson(response, 200, { data: [{ id: 'relay-reasoner' }] });
+        return;
+      }
+      respondJson(response, 404, { error: { message: 'not found' } });
+    });
+    const connection: LlmConnection = {
+      slug: 'responses-relay',
+      name: 'Responses Relay',
+      providerType: 'openai-responses-compatible',
+      baseUrl: `${server.url}/v1/responses`,
+      defaultModel: 'relay-reasoner',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    assert.deepEqual(
+      (await fetchProviderModels(connection, 'relay-key')).map(({ id }) => id),
+      ['relay-reasoner'],
+    );
+    assert.deepEqual(requestedPaths, ['/v1/models']);
+  });
+
+  test('a Responses relay does not mask root authorization failures with a /v1 fallback', async () => {
+    const requestedPaths: string[] = [];
+    const server = await startJsonServer((request, response) => {
+      requestedPaths.push(request.url ?? '');
+      respondJson(response, 401, { error: { message: 'unauthorized' } });
+    });
+    const connection: LlmConnection = {
+      slug: 'responses-relay',
+      name: 'Responses Relay',
+      providerType: 'openai-responses-compatible',
+      baseUrl: server.url,
+      defaultModel: 'relay-reasoner',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    await assert.rejects(fetchProviderModels(connection, 'bad-key'));
+    assert.deepEqual(requestedPaths, ['/models']);
+  });
+
+  test('a DeepSeek root base keeps serving Responses at the root it publishes', async () => {
+    let probedPath: string | undefined;
+    const server = await startJsonServer((request, response) => {
+      probedPath = request.url;
+      respondJson(response, 200, {});
+    });
+    const connection: LlmConnection = {
+      slug: 'deepseek',
+      name: 'DeepSeek',
+      providerType: 'deepseek',
+      baseUrl: server.url,
+      defaultModel: 'deepseek-v4-pro',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    // The compatibility fallback is scoped to custom relay discovery; a
+    // built-in root probe must remain unversioned.
+    assert.equal((await testConnection(connection, 'deepseek-token')).ok, true);
+    assert.equal(probedPath, '/responses');
+  });
+
   for (const [label, providerType] of [
     ['a plain OpenAI-compatible relay', 'openai-compatible'],
     ['local Ollama', 'ollama'],

--- a/packages/runtime/src/__tests__/responses-wire-contract.test.ts
+++ b/packages/runtime/src/__tests__/responses-wire-contract.test.ts
@@ -301,6 +301,40 @@ describe('responses wire contract', () => {
     assert.deepEqual(urls, ['https://relay.example/v1/responses']);
   });
 
+  test('keeps a Responses relay host root on its configured API base', async () => {
+    assert.equal(
+      resolveModelRuntime(
+        { providerType: 'openai-responses-compatible', baseUrl: 'http://relay.example:3000' },
+        'relay-model',
+      ).baseUrl,
+      'http://relay.example:3000',
+    );
+
+    const urls: string[] = [];
+    const fetch = (async (url: string | URL | Request) => {
+      urls.push(String(url));
+      return Response.json({
+        id: 'r',
+        object: 'response',
+        status: 'completed',
+        output: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    }) as typeof globalThis.fetch;
+    const model = getAIModel({
+      connection: { ...conn('openai-responses-compatible'), baseUrl: 'http://relay.example:3000' },
+      apiKey: '[redacted]',
+      modelId: 'relay-model',
+      fetch,
+    });
+
+    await model.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'ping' }] }],
+    });
+
+    assert.deepEqual(urls, ['http://relay.example:3000/responses']);
+  });
+
   test('resolves only supported Responses adapter and replay pairings', () => {
     const deepseek = resolveModelRuntime({ providerType: 'deepseek' }, 'deepseek-v4-flash');
     assert.deepEqual(deepseek.reasoningReplay, {

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -33,7 +33,7 @@ import {
   CONNECTION_MODEL_ID_MAX_LENGTH,
   normalizeConnectionModelDiscoveryResult,
 } from '@maka/core/runtime-policy';
-import { anthropicV1Url, googleApiUrl } from './provider-urls.js';
+import { anthropicV1Url, googleApiUrl, openAiResponsesBaseUrl } from './provider-urls.js';
 import { openAiCodexHeaders } from './subscription-auth.js';
 import {
   GITHUB_COPILOT_API_VERSION,
@@ -182,7 +182,14 @@ async function fetchProviderModelsStrict(
   apiKey: string,
   fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ModelInfo[]> {
-  const baseUrl = effectiveBaseUrl(connection);
+  // Endpoint-form overrides are valid for Responses send and probe. Reduce
+  // them to the API base before deriving `/models`; bare roots stay
+  // authoritative and get only the route-not-found fallback below (#3320).
+  const configuredBaseUrl = effectiveBaseUrl(connection);
+  const baseUrl =
+    connection.providerType === 'openai-responses-compatible'
+      ? openAiResponsesBaseUrl(configuredBaseUrl)
+      : configuredBaseUrl;
   const definition = PROVIDER_REGISTRY[connection.providerType];
   // Unknown providerType → no discovery path. Throw a clear error (caught and
   // generalized by the caller) rather than crashing on `.modelDiscovery`.
@@ -245,21 +252,33 @@ async function fetchProviderModelsStrict(
     }
     case 'openai':
     case 'openai-compatible': {
-      const r = await fetchForConnectionEffect(
+      const requestInit = {
+        headers: {
+          'content-type': 'application/json',
+          ...(apiKey &&
+          (discovery.auth === 'oauth-bearer' ||
+            (discovery.auth !== 'none' && providerAuthSupportsApiKey(connection.providerType)))
+            ? { authorization: `Bearer ${apiKey}` }
+            : {}),
+        },
+        timeoutMs: MODEL_FETCH_TIMEOUT_MS,
+      };
+      let r = await fetchForConnectionEffect(
         fetchFn,
         modelListUrl(baseUrl, discovery.path, discovery.query),
-        {
-          headers: {
-            'content-type': 'application/json',
-            ...(apiKey &&
-            (discovery.auth === 'oauth-bearer' ||
-              (discovery.auth !== 'none' && providerAuthSupportsApiKey(connection.providerType)))
-              ? { authorization: `Bearer ${apiKey}` }
-              : {}),
-          },
-          timeoutMs: MODEL_FETCH_TIMEOUT_MS,
-        },
+        requestInit,
       );
+      if (!r.ok && r.status === 404 && connection.providerType === 'openai-responses-compatible') {
+        const fallbackBaseUrl = responsesRelayV1FallbackBaseUrl(baseUrl);
+        if (fallbackBaseUrl) {
+          await r.cancel();
+          r = await fetchForConnectionEffect(
+            fetchFn,
+            modelListUrl(fallbackBaseUrl, discovery.path, discovery.query),
+            requestInit,
+          );
+        }
+      }
       if (!r.ok) {
         await r.cancel();
         if (connection.providerType === 'xai-oauth') {
@@ -667,6 +686,23 @@ function modelListUrl(
     : `${stripTrailing(baseUrl)}/models`;
   const search = query ? new URLSearchParams(query).toString() : '';
   return search ? `${url}?${search}` : url;
+}
+
+/**
+ * A pathless Responses relay keeps its configured root as the primary
+ * contract. If that exact `/models` route is absent, discovery can safely
+ * retry the conventional versioned list once; send and probe are not replayed.
+ */
+function responsesRelayV1FallbackBaseUrl(baseUrl: string): string | undefined {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    return undefined;
+  }
+  if (stripTrailing(url.pathname) !== '') return undefined;
+  url.pathname = '/v1';
+  return url.toString();
 }
 
 async function fetchFireworksModels(


### PR DESCRIPTION
## Summary

A custom OpenAI Responses relay configured with its host root can pass the connection probe at `<root>/responses` while publishing its model catalog at `/v1/models`. Discovery previously stopped after `<root>/models` returned 404, so the connection looked verified but its catalog never refreshed.

This revision preserves the configured API base as the primary contract and adds a narrow discovery fallback:

1. Send and probe keep using the configured Responses endpoint.
2. Discovery first requests `<configured-base>/models`.
3. Only when a **pathless root** returns **404**, discovery retries the same-origin `/v1/models` route once.
4. Authorization, network, and invalid-response failures remain authoritative; no POST request is replayed.
5. Endpoint-form overrides such as `…/v1/responses` are reduced to their API base before deriving `…/v1/models`.

| configured | send / probe | discovery |
| --- | --- | --- |
| `http://relay.example:3000` | `/responses` | `/models`, then `/v1/models` only after 404 |
| `https://relay.example/v1` | `/v1/responses` | `/v1/models` |
| `https://relay.example/v1/responses` | `/v1/responses` | `/v1/models` |
| `https://relay.example/relay/v1` | `/relay/v1/responses` | `/relay/v1/models` |

Fixes #3320

## Compatibility and review response

This supersedes the earlier root → `/v1` normalization and addresses [the P2 compatibility review](https://github.com/apache/maka/pull/3797#discussion_r3889273012): persisted root-mounted relays continue to use `/responses` and `/models` exactly as before. The fallback is provider-scoped to `openai-responses-compatible`, same-origin, GET-only, 404-only, and attempted once. Built-in providers such as DeepSeek retain their unversioned root behavior.

Regression coverage locks:

- a root-mounted relay succeeds without any `/v1` request;
- a relay whose root `/models` route is absent falls back once to `/v1/models` while probe/send stay at `/responses`;
- a plain `openai-compatible` relay surfaces its root 404 without retrying `/v1/models`;
- a path-mounted relay (`…/gateway`) surfaces its 404 without appending `/v1` to its own prefix;
- an endpoint-form base (`…/v1/responses`) discovers through `/v1/models` and nothing else;
- a 401 is not hidden behind the fallback;
- built-in-provider send behavior remains unchanged.

The three negative discovery cases matter more after the rebase: `#4411` dispatches discovery on `runtimeAdapter.kind` and merged `openai` with `openai-compatible` into a single branch, so the exact `providerType` check and the pathless-root check are now the only things holding the fallback's scope. Each of those cases fails if its guard is removed.

## Verification

Rebased onto `b1369c808` (`main`). The two conflicts were in `packages/runtime/src/model-fetcher.ts` (`PROVIDER_DEFAULTS` → `PROVIDER_REGISTRY`, and `switch (definition.protocol)` → `switch (definition.runtimeAdapter.kind)` with `openai` / `openai-compatible` merged) and in `provider-conformance.test.ts` (both sides appended tests; both are kept).

Passed:

- `npm --workspace @maka/core run build`, `npm --workspace @maka/storage run build`, `npm --workspace @maka/mcp run build`, `npm --workspace @maka/runtime run build`
- `node --test dist/__tests__/provider-conformance.test.js dist/__tests__/provider-contract-matrix.test.js dist/__tests__/responses-wire-contract.test.js` in `packages/runtime` — 178 passed, 0 failed
- `npx biome check` on the three touched files — clean
- `npm run check:asf-headers` — clean

`npm --workspace @maka/runtime run test:dist` on this head: 3,249 tests, 3,232 passed, 13 skipped, 4 failed. The same 4 fail on unmodified `b1369c808` (3,241 tests, 3,224 passed, 13 skipped, 4 failed): `openai-responses-plaintext-reasoning`, one Alibaba Responses reasoning-replay expectation, `task-ledger-tools.test.js`, and `tool-catalog-derive.test.js`, which still cannot import the unexported `@maka/core/tool-catalog` subpath. None touch this PR's paths.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Opus 5 performed the original investigation and implementation, then rebased onto the latest `main`, resolved the two conflicts, and added the three negative discovery regressions. OpenAI Codex (GPT-5.6) traced the compatibility path, replaced the root-rewriting behavior with the 404-only discovery fallback, added the compatibility/error-boundary regressions, and reviewed the conflict resolution. The author owns the submission.

## Checklist

- [x] Tests cover the change and fail on the missing fallback
- [x] The affected package build, targeted suites, lint, and format checks pass

Does this PR entail a change in behavior?

- [x] Yes — described under Summary and Compatibility above
- [ ] No
