### PR TITLE
fix(desktop): hide single Host settings selector

### DIFF
--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -891,7 +891,7 @@ export function SettingsSurface(props: {
                         <p className="settingsPageHeaderDescription">{headerCopy.description}</p>
                       )}
                     </div>
-                    {showsRuntimeHost && runtimeHostOptions.length > 0 ? (
+                    {showsRuntimeHost && runtimeHostOptions.length > 1 ? (
                       <div className="settingsRuntimeHostSelector">
                         <Selector
                           label={copy.runtimeHost}

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -2205,7 +2205,7 @@ export const ModelsConnectionsHostGenerationRevalidation: Story = {
       isDefault: true,
     });
 
-    await userEvent.click(canvas.getByRole('combobox', { name: 'Runtime Host' }));
+    await userEvent.click(await canvas.findByRole('combobox', { name: 'Runtime Host' }));
     await within(document.body).findByRole('option', { name: 'Remote' });
     await userEvent.keyboard('{Escape}');
     await expect(boundary).toHaveAttribute('inert');


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Hide the Runtime Host selector in Settings when only one Host is enabled. The selector remains visible when multiple enabled Hosts provide a real choice, including enabled Hosts that are temporarily unavailable.

## Verification

- Desktop preload, main, renderer, and Storybook typechecks passed
- Repository formatting and focused Biome lint passed
- `git diff --check` passed
- Verified before and after in the same real Electron window with an isolated Local-only profile through agent-browser

## Screenshots

| Before | After |
| --- | --- |
| ![](https://github.com/apache/maka/blob/3ee3f68753fc96dabbdd08208d80bd43f525c967/maka-settings-single-host-selector-before.png?raw=true) | ![](https://github.com/apache/maka/blob/3ee3f68753fc96dabbdd08208d80bd43f525c967/maka-settings-single-host-selector-after.png?raw=true) |

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the condition and performed type, formatting, lint, and real-window verification under maintainer direction

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## 摘要

当 Settings 中只有一个已启用 Host 时隐藏 Runtime Host selector。存在多个已启用 Host、因而确实可选择时仍显示 selector，包括暂时不可用但仍处于启用状态的 Host。

## 验证

- Desktop preload、main、renderer 与 Storybook typecheck 通过
- 仓库格式检查与聚焦的 Biome lint 通过
- `git diff --check` 通过
- 使用隔离的纯 Local profile，通过 agent-browser 在同一个真实 Electron 窗口完成 before/after 验证

## 截图

| 修改前 | 修改后 |
| --- | --- |
| ![](https://github.com/apache/maka/blob/3ee3f68753fc96dabbdd08208d80bd43f525c967/maka-settings-single-host-selector-before.png?raw=true) | ![](https://github.com/apache/maka/blob/3ee3f68753fc96dabbdd08208d80bd43f525c967/maka-settings-single-host-selector-after.png?raw=true) |

## AI 使用

- [ ] 没有生成式工具作出实质性贡献
- [x] 生成式工具作出了实质性贡献

工具与范围：OpenAI Codex 在维护者指导下实现条件修改，并完成类型、格式、lint 与真实窗口验证

## 检查清单

- [ ] 测试覆盖本次变更，并会在缺少本次变更时失败
- [x] lint、格式检查、类型检查和受影响检查均在本地通过

本 PR 是否会改变行为？

- [x] 是 — 已在上方摘要中说明
- [ ] 否

</details>