### PR TITLE
fix(runtime): rewrite parentOperationId when copying conversations

### DIFF
--- a/packages/runtime/src/__tests__/conversation-copy.test.ts
+++ b/packages/runtime/src/__tests__/conversation-copy.test.ts
@@ -1196,6 +1196,157 @@ test('conversation copy rewrites a complete tool recovery bundle atomically', as
   }
 });
 
+test('conversation copy rewrites the parent operation id of a nested Code Mode call', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-conversation-copy-parent-op-'));
+  const runStore = createSqliteAgentRunStore(root);
+  const runtimeEventStore = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
+  try {
+    await runStore.ready?.();
+    await runStore.createRun(
+      agentRunHeader({
+        runId: 'run-source',
+        invocationId: 'invocation-source',
+        turnId: 'turn-1',
+        cwd: root,
+      }),
+    );
+    const sourceEvents: RuntimeEvent[] = [
+      runtimeEvent({
+        id: 'event-user',
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: 'run some code' },
+      }),
+      runtimeEvent({
+        id: 'event-call',
+        ts: 2,
+        role: 'model',
+        author: 'agent',
+        content: {
+          kind: 'function_call',
+          id: 'provider-call-1',
+          name: 'CodeMode',
+          args: { code: 'await tools.Write({ path: "notes.txt", content: "hi" })' },
+        },
+      }),
+      runtimeEvent({
+        id: 'event-dispatch',
+        ts: 3,
+        actions: {
+          toolDispatch: {
+            protocol: 't1_after_preflight_v1',
+            operationId: 'operation-1',
+            providerToolCallId: 'provider-call-1',
+            toolName: 'CodeMode',
+            canonicalArgsHash: canonicalToolArgsHash('CodeMode', {
+              code: 'await tools.Write({ path: "notes.txt", content: "hi" })',
+            }),
+            recoveryMode: 'replay_safe',
+          },
+        },
+        refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+      }),
+      // Nested tool call produced from inside the Code Mode cell. Its enclosing
+      // operation is `operation-1`; ai-sdk-backend writes that source-owned id
+      // into refs.parentOperationId. The provider-owned parentToolCallId is not
+      // runtime-owned and must be preserved unchanged.
+      runtimeEvent({
+        id: 'event-nested-call',
+        ts: 4,
+        role: 'model',
+        author: 'agent',
+        origin: 'code_mode',
+        modelVisibility: 'hidden',
+        content: {
+          kind: 'function_call',
+          id: 'provider-call-1:nested:nested-1',
+          name: 'Write',
+          args: { path: 'notes.txt', content: 'hi' },
+        },
+        refs: {
+          parentOperationId: 'operation-1',
+          parentToolCallId: 'provider-call-1',
+        },
+      }),
+      runtimeEvent({
+        id: 'event-outcome',
+        ts: 5,
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'provider-call-1',
+          name: 'CodeMode',
+          result: { kind: 'text', text: 'ok' },
+          isError: false,
+        },
+        refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+      }),
+      runtimeEvent({
+        id: 'event-terminal',
+        ts: 6,
+        status: 'completed',
+      }),
+    ];
+    await runtimeEventStore.importConversationCopyRuntimeEvents('session-source', [
+      { runId: 'run-source', events: sourceEvents },
+    ]);
+    await runStore.appendEvent('session-source', 'run-source', {
+      type: 'run_completed',
+      id: 'completed-source',
+      runId: 'run-source',
+      sessionId: 'session-source',
+      turnId: 'turn-1',
+      ts: 6,
+    });
+    const source = await new RuntimeReadModel({
+      runStore,
+      runtimeEventStore,
+    }).getSessionView('session-source');
+    await cloneConversationRuntimeLedger({
+      plan: await prepareTestCopyPlan(source, source.messages, runStore, runtimeEventStore),
+      copiedMessages: source.messages,
+      referenceMap: {
+        mode: 'exact',
+        linkedChildren: { mode: 'reject' },
+        sourceSessionId: 'session-source',
+        targetSessionId: 'session-target',
+        artifactIds: new Map(),
+        relativePaths: new Map(),
+      },
+      runStore,
+      runtimeEventStore,
+      newId: () => crypto.randomUUID(),
+    });
+    const [targetRun] = await runStore.listSessionRuns('session-target');
+    assert.ok(targetRun);
+    assert.ok(targetRun.invocationId);
+    const targetOperationId = buildToolOperationId({
+      invocationId: targetRun.invocationId,
+      providerToolCallId: 'provider-call-1',
+    });
+    assert.notEqual(targetOperationId, 'operation-1');
+    const targetEvents = await runtimeEventStore.readRuntimeEvents(
+      'session-target',
+      targetRun.runId,
+    );
+    const nested = targetEvents.find((event) => event.refs?.parentOperationId !== undefined);
+    assert.ok(nested, 'nested Code Mode call survived the copy');
+    // The parent operation id is rewritten to the target namespace, not stranded
+    // at the source identity.
+    assert.equal(nested.refs?.parentOperationId, targetOperationId);
+    // The provider-owned parentToolCallId is not runtime-owned and is preserved.
+    assert.equal(nested.refs?.parentToolCallId, 'provider-call-1');
+    const dispatch = targetEvents.find((event) => event.actions?.toolDispatch)?.actions
+      ?.toolDispatch;
+    assert.equal(dispatch?.operationId, targetOperationId);
+  } finally {
+    runtimeEventStore.close();
+    runStore.close?.();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('conversation copy validates operational events before persisting target ledgers', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-conversation-copy-preflight-'));
   try {

--- a/packages/runtime/src/conversation-copy.ts
+++ b/packages/runtime/src/conversation-copy.ts
@@ -1087,7 +1087,12 @@ function rewriteRuntimeEventReferences(
         : event.content;
   const refs = event.refs
     ? (() => {
-        const { operationId: _operationId, traceEventId: _traceEventId, ...preserved } = event.refs;
+        const {
+          operationId: _operationId,
+          parentOperationId: _parentOperationId,
+          traceEventId: _traceEventId,
+          ...preserved
+        } = event.refs;
         const traceEventId = event.refs.traceEventId
           ? references.agentRunEventIds.get(event.refs.traceEventId)
           : undefined;
@@ -1098,6 +1103,15 @@ function rewriteRuntimeEventReferences(
             ? {
                 operationId: rewriteOwnedId(
                   event.refs.operationId,
+                  references.operationIds,
+                  'tool operation',
+                ),
+              }
+            : {}),
+          ...(event.refs.parentOperationId
+            ? {
+                parentOperationId: rewriteOwnedId(
+                  event.refs.parentOperationId,
                   references.operationIds,
                   'tool operation',
                 ),


### PR DESCRIPTION
## Summary

`rewriteRuntimeEventReferences` in `conversation-copy.ts` rewrote `refs.operationId` but let `refs.parentOperationId` fall into `...preserved`, so it was carried into the copied session unchanged:

```ts
const { operationId: _operationId, traceEventId: _traceEventId, ...preserved } = event.refs;
```

This is always wrong after a copy, not sometimes. `toolOperationIdMap` rebuilds every operation id as `buildToolOperationId({ invocationId: <target>, providerToolCallId })` under a freshly minted target invocation, and the write site (`ai-sdk-backend.ts`) sets `parentOperationId: context.operationId` — the same namespace. So a copied nested Code Mode call keeps pointing at the *source* session's operation while its parent has been renamed in the target. `runtime-event-read-model.ts` projects the field into `StoredMessage`, so parent/child pairing breaks, and `tool-ledger-scanner.ts` only shape-checks — the corruption is silent (like #3775).

The fix routes `parentOperationId` through the same `rewriteOwnedId(..., references.operationIds, 'tool operation')` as `operationId`, in the same destructure. The provider-owned `parentToolCallId` is deliberately left in `...preserved` (it is not runtime-owned).

Fixes #3800

## Verification

- Added `conversation copy rewrites the parent operation id of a nested Code Mode call`, which copies a Code Mode session and asserts the nested call's `parentOperationId` is rewritten to the target operation id while `parentToolCallId` is preserved.
- Confirmed the test **fails without the fix** (temporarily reverted the source change → 1 fail; restored → pass).
- `packages/runtime` typecheck (`tsc`) passes.
- `biome check` on both changed files passes.
- Full `conversation-copy.test.js` suite passes (20/20).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — diagnosed the gap, implemented the one-line-scope fix in `rewriteRuntimeEventReferences`, and wrote the regression test. Human-reviewed.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No