### PR TITLE
fix(desktop): hide collapsed sidebar icon rail

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -55,6 +55,23 @@ export const PARENT_REMOVAL_CHILD_NAME = '应归档的子任务';
 export const NEW_TASK_PROJECT_NAME = 'new-task-project';
 
 /**
+ * Restore the navigation column through the titlebar action when a test needs
+ * controls that only exist in the expanded sidebar. The fixture starts with
+ * the sidebar collapsed, and the action follows the configured UI locale.
+ */
+export async function ensureSidebarExpanded(page: Page): Promise<void> {
+  const expandSidebar = page.getByRole('button', {
+    name: /^(?:展开侧边栏|Expand sidebar)$/,
+  });
+  if (!(await expandSidebar.isVisible())) return;
+
+  await expandSidebar.click();
+  await expect(
+    page.getByRole('button', { name: /^(?:收起侧边栏|Collapse sidebar)$/ }),
+  ).toBeVisible();
+}
+
+/**
  * Wait for Runtime's authoritative Skill projection, not merely for the
  * composer DOM to mount. The renderer requests this projection after its first
  * render, so a visible editor can still have an empty `/` source during cold

--- a/apps/desktop/e2e/new-task-reload.spec.ts
+++ b/apps/desktop/e2e/new-task-reload.spec.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { COMPOSER_INPUT, expect, test } from './fixtures';
+import { COMPOSER_INPUT, ensureSidebarExpanded, expect, test } from './fixtures';
 
 test('an explicit new task survives a renderer reload without reopening history', async ({
   window: page,
@@ -27,6 +27,7 @@ test('an explicit new task survives a renderer reload without reopening history'
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: create history/)).toBeVisible();
 
+  await ensureSidebarExpanded(page);
   await page.getByRole('button', { name: '新任务', exact: true }).click();
   await expect(page.locator('.maka-turn')).toHaveCount(0);
   await composer.fill('draft survives renderer replacement');

--- a/apps/desktop/e2e/settings-row-focus-ring.spec.ts
+++ b/apps/desktop/e2e/settings-row-focus-ring.spec.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { expect, test } from './fixtures';
+import { ensureSidebarExpanded, expect, test } from './fixtures';
 import type { Locator, Page } from '@playwright/test';
 
 /**
@@ -48,6 +48,7 @@ import type { Locator, Page } from '@playwright/test';
  */
 
 async function openSettingsPage(page: Page, section: string) {
+  await ensureSidebarExpanded(page);
   await page.getByRole('button', { name: '设置' }).click();
   await page.getByRole('button', { name: section, exact: true }).click();
 }

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { test, expect, COMPOSER_INPUT } from './fixtures';
+import { COMPOSER_INPUT, ensureSidebarExpanded, expect, test } from './fixtures';
 
 interface SettingsChunkLatchWindow extends Window {
   makaE2eLatch?: {
@@ -52,6 +52,7 @@ test('Settings loading surface owns unmodified Escape', async ({ window: page })
   expect(latchInstalled, 'the preload E2E latch is installed').toBe(true);
 
   try {
+    await ensureSidebarExpanded(page);
     await page.getByRole('button', { name: '设置' }).click();
 
     const loadingSurface = page.locator('.maka-lazy-fallback');
@@ -130,6 +131,7 @@ test('settings hides expanded workbar chrome and restores it on close', async ({
   const taskTab = workbarToolbar.getByRole('tab', { name: '待办' });
   await expect(taskTab).toBeVisible();
 
+  await ensureSidebarExpanded(page);
   await page.getByRole('button', { name: '设置' }).click();
   await expect(page.getByRole('main', { name: '设置内容' })).toBeVisible();
   await expect(workbar).not.toBeVisible();
@@ -141,6 +143,7 @@ test('settings hides expanded workbar chrome and restores it on close', async ({
 
 test('wide settings gutters scroll the whole main pane', async ({ window: page }) => {
   await page.setViewportSize({ width: 1600, height: 520 });
+  await ensureSidebarExpanded(page);
   await page.getByRole('button', { name: '设置' }).click();
   await page.getByRole('button', { name: '通用', exact: true }).click();
   await expect(page.getByRole('textbox', { name: '助手语气偏好' })).toBeEnabled();
@@ -184,6 +187,7 @@ test('appearance choice content stays vertically centered in stretched grid rows
   await page.reload();
   await page.waitForSelector(COMPOSER_INPUT);
   await page.setViewportSize({ width: 1650, height: 992 });
+  await ensureSidebarExpanded(page);
   await page.getByRole('button', { name: 'Settings' }).click();
   await page.getByRole('button', { name: 'Appearance', exact: true }).click();
   await expect(page.getByRole('heading', { name: 'App icon' })).toBeVisible();
@@ -200,6 +204,7 @@ test('appearance choice content stays vertically centered in stretched grid rows
 test('reopening settings keeps the last-ready General page stable while refreshing', async ({
   window: page,
 }) => {
+  await ensureSidebarExpanded(page);
   await page.getByRole('button', { name: '设置' }).click();
   const settings = page.locator('.settingsSurface');
   await page.getByRole('button', { name: '通用', exact: true }).click();

--- a/apps/desktop/e2e/sidebar-titlebar-actions.spec.ts
+++ b/apps/desktop/e2e/sidebar-titlebar-actions.spec.ts
@@ -39,3 +39,21 @@ test('expanded sidebar chrome follows Astryx toolbar geometry', async ({ window 
   expect(trailingInset).toBeLessThanOrEqual(16);
   await expect(actions).toHaveCSS('column-gap', '4px');
 });
+
+test('collapsed sidebar removes its icon rail but keeps the titlebar restore action', async ({
+  window,
+}) => {
+  const sidebar = window.getByRole('navigation', { name: '任务列表' });
+  const collapseSidebar = window.getByRole('button', { name: '收起侧边栏' });
+
+  if (await collapseSidebar.isVisible()) await collapseSidebar.click();
+
+  await expect(sidebar).toBeHidden();
+  await expect(window.locator('.maka-sidenav-motion')).toHaveCSS('width', '0px');
+  const expandSidebar = window.getByRole('button', { name: '展开侧边栏' });
+  await expect(expandSidebar).toBeVisible();
+
+  await expandSidebar.click();
+  await expect(sidebar).toBeVisible();
+  await expect(window.getByRole('button', { name: '收起侧边栏' })).toBeVisible();
+});

--- a/apps/desktop/e2e/streaming-remount.spec.ts
+++ b/apps/desktop/e2e/streaming-remount.spec.ts
@@ -23,7 +23,7 @@ import {
   FAKE_WAIT_FOR_STEERING_LARGE_RESPONSE_PROMPT,
 } from '@maka/runtime/test-only/fake-backend';
 import type { Locator } from '@playwright/test';
-import { expect, COMPOSER_INPUT, test } from './fixtures';
+import { COMPOSER_INPUT, ensureSidebarExpanded, expect, test } from './fixtures';
 
 function sessionRow(sidebar: Locator, sessionId: string): Locator {
   return sidebar.locator(`[data-session-id=${JSON.stringify(sessionId)}]`);
@@ -51,14 +51,13 @@ test('remounting a live surface leaves accumulated output settled', async ({
   await expect(liveBubble).toContainText(accumulatedOutput);
 
   const sidebar = page.getByRole('navigation', { name: '任务列表' });
+  await ensureSidebarExpanded(page);
   await sidebar.getByRole('button', { name: '扩展' }).click();
   await expect(page.locator('[data-module="skills"]')).toBeVisible();
   await expect(liveBubble).toHaveCount(0);
-  // Back the way the product actually offers: the rail is collapsed here, so
-  // the task rows are not rendered and there is no 任务 row to press (#2984).
-  // Widening it is the titlebar's job, and the task left behind is still
-  // `activeId`, so it comes back marked and one click away.
-  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  // Return through the task row the product exposes. Module navigation can
+  // preserve either sidebar state, so restore it only when it is collapsed.
+  await ensureSidebarExpanded(page);
   const currentTaskRow = sidebar.locator(
     '[data-maka-contract="session-row"] [aria-current="page"]',
   );

--- a/apps/desktop/e2e/workhub-reconstruction.spec.ts
+++ b/apps/desktop/e2e/workhub-reconstruction.spec.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { expect, test, COMPOSER_INPUT } from './fixtures';
+import { COMPOSER_INPUT, ensureSidebarExpanded, expect, test } from './fixtures';
 
 test('WorkHub rebuilds Session conversation after navigating away and back', async ({
   window: page,
@@ -56,6 +56,7 @@ test('WorkHub rebuilds Session conversation after navigating away and back', asy
     .click();
   await expect(page.getByRole('main', { name: 'WorkHub' })).toBeHidden();
 
+  await ensureSidebarExpanded(page);
   await page.getByRole('button', { name: 'WorkHub', exact: true }).click();
   await expect(page.getByRole('main', { name: 'WorkHub' })).toBeVisible();
   await expect(

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -184,17 +184,31 @@
   transition: width var(--duration-large) var(--ease-out-strong);
 }
 
-/* Same source as Astryx's own `rootCollapsed` width, so the rail cannot drift
-   from the value SideNav lands on when the ease finishes. Keyed off the shell's
-   own collapsed flag — the wrapper carried a second copy of it until this rule
-   read the one `.appFrame` already publishes and the hairlines already use.
+/* Collapsed means absent, not a second 48px icon-only navigation mode. Keeping
+   Astryx's collapsed rail visible left the native macOS traffic-light group
+   straddling the rail and content surfaces, while the remaining icon buttons
+   were too narrow to carry their meaning without tooltips. The titlebar keeps
+   the explicit expand action, so the navigation column can close all the way.
+
+   Keyed off the shell's own collapsed flag — the wrapper carried a second copy
+   of it until this rule read the one `.appFrame` already publishes and the
+   hairlines already use.
 
    It overrides the VARIABLE, not the wrapper's width, because the wrapper is no
    longer the only reader: the titlebar starts its session breadcrumb at this
    column's right edge. Setting the width here instead would leave the titlebar
    reading the expanded value while the column sat collapsed. */
 .appFrame[data-sidebar-state='collapsed'] {
-  --maka-sidenav-width: var(--spacing-12);
+  --maka-sidenav-width: 0px;
+}
+
+/* `visibility`, rather than opacity, removes the hidden rail's buttons from
+   focus navigation and accessibility hit testing. SideNav stays mounted so its
+   imperative collapse handle can restore both the boolean and the resizable
+   width when the titlebar's expand button is pressed. */
+.appFrame[data-sidebar-state='collapsed'] .maka-sidenav-motion {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .maka-shell-astryx .maka-sidenav-motion:has([data-resizing]) {
@@ -281,9 +295,9 @@
      start.
 
      `minmax(..., auto)` rather than a fixed width for the collapsed state,
-     where the two icons are wider than the 48px rail: the column grows to the
-     icons and the gap then holds the breadcrumb off them, which is the same
-     clearance by a different measure.
+     where the navigation column is absent but the two titlebar actions remain:
+     the track grows to those actions and the gap then holds the breadcrumb off
+     them, which is the same clearance by a different measure.
 
      Every child names its own column. Two of the three are conditional — the
      breadcrumb only in a session, the workspace actions only in views that have

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -502,9 +502,9 @@ export const UpdateFailed: Story = {
   render: () => <ComposedShell updateReminder={{ state: 'error', latestVersion: '0.1.7' }} />,
 };
 
-// Real path: an update is waiting while the rail is collapsed to 48px. The row
-// cannot hold two controls side by side there, so it stacks — off the frame's
-// own `data-sidebar-state`, which is why ShellFrame above has to carry it.
+// Real path: an update is waiting while the sidebar is fully hidden. The
+// titlebar's restore action remains visible; expanding the sidebar reveals the
+// pending update in its footer again.
 export const UpdateDownloadedCollapsed: Story = {
   render: () => (
     <ComposedShell sidebarCollapsed updateReminder={{ state: 'downloaded', latestVersion: '0.1.7' }} />


### PR DESCRIPTION
## Summary

Fixes the macOS traffic-light buttons so they no longer span the sidebar and main content area.

<img width="158" height="45" alt="Collapsed macOS titlebar" src="https://github.com/user-attachments/assets/0860a185-8bb1-4955-a0f6-e86dea51e74e" />

When collapsed, the sidebar now:

- Closes completely instead of leaving a 48px icon rail.
- Removes hidden sidebar controls from pointer and keyboard interaction.
- Keeps the titlebar restore action visible so the sidebar can be reopened.

## Verification

Added Playwright coverage confirming that:

- The collapsed sidebar has a width of `0px`.
- Sidebar navigation is hidden while collapsed.
- The titlebar restore action remains visible.
- The sidebar can be expanded again.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Investigated the collapsed-sidebar layout, implemented the CSS and Storybook updates, added targeted Playwright coverage.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No