### PR TITLE
fix(runtime): honor isRetryable flag in provider retry classifier

### DIFF
--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -205,6 +205,37 @@ describe('Provider error classification', () => {
     );
   });
 
+  test('retries transport failures wrapped as "Cannot connect to API" when isRetryable is set', () => {
+    // The AI SDK wraps TLS/transport failures as APICallError with isRetryable:
+    // true and a message like "Cannot connect to API: <cause>". Maka's classifier
+    // must honor the isRetryable flag even when the wrapped message contains no
+    // recognized network keywords (#3756).
+    const tlsFailure = Object.assign(
+      new Error(
+        'Cannot connect to API: 80E1BDF601000000:error:0A000119:SSL routines:tls_get_more_records:decryption failed or bad record mac:../deps/openssl/openssl/ssl/record/methods/tls_common.c:869:',
+      ),
+      {
+        name: 'AI_APICallError',
+        isRetryable: true,
+      },
+    );
+
+    assert.equal(classifyError(tlsFailure), 'AI_APICallError');
+    assert.deepEqual(providerRetryMetadata(tlsFailure), { retryable: true });
+    assert.equal(providerFailureDiagnostic(tlsFailure).retryable, true);
+  });
+
+  test('honors isRetryable on a cause error when the top-level error has no structured evidence', () => {
+    const cause = Object.assign(new Error('ECONNRESET'), { isRetryable: true });
+    const wrapped = Object.assign(new Error('Cannot connect to API: ECONNRESET'), {
+      name: 'AI_APICallError',
+      cause,
+    });
+
+    assert.equal(classifyError(wrapped), 'AI_APICallError');
+    assert.deepEqual(providerRetryMetadata(wrapped), { retryable: true });
+  });
+
   test('retries incremental Responses transport failures with stable classification', () => {
     const websocketFailure = Object.assign(new Error('closed before completion'), {
       name: 'OpenAiResponsesTransportError',

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -220,7 +220,13 @@ function parseRetryAfterMs(headers: Record<string, string>): number | null | und
  */
 export function providerRetryMetadata(error: unknown): ProviderRetryMetadata {
   const facts = normalizeProviderError(error);
-  if (!facts) return { retryable: false };
+  if (!facts) {
+    // Even when normalizeProviderError cannot extract structured evidence,
+    // the AI SDK may have set isRetryable on the error or on a cause in the
+    // chain — honor that as a last-resort retry signal.
+    if (isRetryableInChain(error)) return { retryable: true };
+    return { retryable: false };
+  }
   const { evidence } = facts;
 
   if (RUNTIME_RETRYABLE_ERROR_CODES.has(evidence.code)) return { retryable: true };
@@ -246,12 +252,40 @@ export function providerRetryMetadata(error: unknown): ProviderRetryMetadata {
     status === 408 ||
     status === 409 ||
     (status >= 500 && status <= 599);
-  if (!retryable) return { retryable: false };
+  if (!retryable) {
+    // The classifier did not surface a retryable class, but the AI SDK may
+    // have marked the error or a wrapped cause as retryable — honor that.
+    if (isRetryableInChain(error)) return { retryable: true };
+    return { retryable: false };
+  }
   if (retryAfterMs === null) return { retryable: false };
   return {
     retryable: true,
     ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
   };
+}
+
+/**
+ * Walks the `cause` chain of an error looking for the AI SDK's `isRetryable`
+ * flag. The AI SDK sets `APICallError.isRetryable = true` for transport
+ * failures (TLS errors, connection resets, etc.) that it wraps as
+ * `Cannot connect to API: ${cause.message}`. Without this, Maka's classifier
+ * sees only the wrapped message and classifies it as non-retryable.
+ */
+function isRetryableInChain(error: unknown): boolean {
+  let current = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 8 && current !== undefined && !seen.has(current); depth += 1) {
+    seen.add(current);
+    if (typeof current === 'object' && current !== null) {
+      const record = current as Record<string, unknown>;
+      if (record.isRetryable === true) return true;
+      current = record.cause;
+    } else {
+      break;
+    }
+  }
+  return false;
 }
 
 /** Collects `code`/`type` strings from a payload and from its `error` wrapper. */


### PR DESCRIPTION
## Summary

Fixes #3756

The AI SDK wraps TLS/transport failures as \APICallError\ with \isRetryable: true\ and a message like \Cannot connect to API: <cause>\. Maka's \providerRetryMetadata\ did not check this flag or walk the \cause\ chain, so these failures were classified as non-retryable and the turn exited immediately.

### Changes

- **\provider-error-classification.ts\**: Added \isRetryableInChain()\ helper that walks up to 8 levels of the error's \cause\ chain looking for \isRetryable: true\. Called as a fallback when the classifier doesn't surface a retryable class, or when \
ormalizeProviderError\ returns undefined.
- **\provider-error-classification.test.ts\**: Added two regression tests:
  1. TLS failure with the exact message from the issue report (\decryption failed or bad record mac\) — verifies it's now retryable.
  2. Wrapped cause error with \isRetryable: true\ when the top-level error has no structured evidence — verifies the cause flag is honored.

## Verification

- \
pm --workspace @maka/runtime run build\: passes
- \
pm --workspace @maka/runtime test\: 17/17 pass (including 2 new regression tests)
- \
pm --workspace @maka/core test\: 656/656 pass
- \
pm run lint\: passes
- \
pm run format:check\: passes

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: opencode/big-pickle — diagnosed root cause, implemented fix and regression tests

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — transport failures marked retryable by the AI SDK are now retried instead of terminating the turn