### PR TITLE
feat(desktop): open workspace Markdown references

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -501,6 +501,7 @@ export const test = base.extend<{
   promptRailMotionWindow: Page;
   requestHeaderRowWindow: Page;
   newTaskTargetWindow: Page;
+  workspaceMarkdownWindow: Page;
 }>({
   // Seeded: a pre-staged connection clears onboarding so the composer is ready.
   window: async ({}, use) => {
@@ -638,6 +639,15 @@ export const test = base.extend<{
       readinessSelector: '.settingsSurface',
       e2eFixtureScenario: 'settings-models',
       locale: 'zh',
+      showWindow: true,
+    }, use);
+  },
+  workspaceMarkdownWindow: async ({}, use) => {
+    await withE2eWindow({
+      seed: false,
+      readinessSelector: '[data-workspace-file="docs/guide with spaces.md"]',
+      e2eFixtureScenario: 'chat-workspace-markdown',
+      locale: 'en',
       showWindow: true,
     }, use);
   },

--- a/apps/desktop/e2e/workspace-markdown.spec.ts
+++ b/apps/desktop/e2e/workspace-markdown.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect, test } from './fixtures';
+
+test('opens explicit, bare, and sent workspace Markdown references in the side preview', async ({
+  workspaceMarkdownWindow: page,
+}) => {
+  const transcript = page.locator('[data-chat-scroll-container="true"]');
+  await expect(transcript).toBeVisible();
+  await expect(page.locator('[data-workspace-file="tools/setup.command"]')).toHaveCount(0);
+
+  const explicitLink = transcript.locator(
+    '[data-workspace-file="docs/guide with spaces.md"]',
+  );
+  await explicitLink.click();
+  const explicitPreview = page.locator(
+    '.maka-workspace-file-preview[data-workspace-file="docs/guide with spaces.md"]',
+  );
+  await expect(explicitPreview).toBeVisible();
+  await expect(explicitPreview.getByText('Workspace guide')).toBeVisible();
+  await expect(transcript.locator('[data-turn-id="turn-workspace-markdown"]')).toBeAttached();
+
+  await explicitPreview.getByRole('button', { name: 'Back' }).click();
+  const bareLink = transcript.locator('[data-workspace-file="docs/notes.md"]');
+  await bareLink.click();
+  const barePreview = page.locator(
+    '.maka-workspace-file-preview[data-workspace-file="docs/notes.md"]',
+  );
+  await expect(barePreview.getByText('Workspace notes')).toBeVisible();
+
+  await barePreview.getByRole('button', { name: 'Back' }).click();
+  const sentFileReference = transcript.locator('[data-workspace-file="docs/chip.md"]');
+  await sentFileReference.click();
+  const sentFilePreview = page.locator(
+    '.maka-workspace-file-preview[data-workspace-file="docs/chip.md"]',
+  );
+  await expect(sentFilePreview.getByText('Workspace chip')).toBeVisible();
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-workspace-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-workspace-ipc-main.test.ts
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, realpath, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { DesktopRuntimeHostClient } from '../runtime-host-client.js';
+import {
+  readBoundedWorkspaceText,
+  registerRuntimeHostWorkspaceIpc,
+} from '../runtime-host-workspace-ipc-main.js';
+import type { IpcHandler, ReconnectableReadIpcMain } from '../ipc-reconnect-policy.js';
+
+type WorkspaceHandler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
+
+test('workspace IPC reads Markdown within the limit and opens only Markdown files', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-workspace-ipc-'));
+  try {
+    await mkdir(join(workspaceRoot, 'docs'), { recursive: true });
+    await mkdir(join(workspaceRoot, 'tools'), { recursive: true });
+    await writeFile(join(workspaceRoot, 'docs', 'guide.md'), '# Guide\n', 'utf8');
+    await writeFile(join(workspaceRoot, 'tools', 'setup.command'), 'echo unsafe\n', 'utf8');
+
+    const opened: string[] = [];
+    const revealed: string[] = [];
+    const handlers = new Map<string, WorkspaceHandler>();
+    registerRuntimeHostWorkspaceIpc({
+      ipcMain: ipcHarness(handlers),
+      client: workspaceClient(workspaceRoot),
+      openPath: async (path) => {
+        opened.push(path);
+        return '';
+      },
+      showItemInFolder: (path) => revealed.push(path),
+    });
+
+    assert.deepEqual(
+      await invoke(handlers, 'workspace:readText', 'session-1', 'docs/guide.md'),
+      { ok: true, relativePath: 'docs/guide.md', text: '# Guide\n' },
+    );
+    assert.deepEqual(
+      await invoke(handlers, 'workspace:openFile', 'session-1', 'docs/guide.md'),
+      { ok: true, opened: 'docs/guide.md' },
+    );
+    assert.deepEqual(
+      await invoke(handlers, 'workspace:revealFile', 'session-1', 'docs/guide.md'),
+      { ok: true, opened: 'docs/guide.md' },
+    );
+    assert.deepEqual(
+      await invoke(handlers, 'workspace:openFile', 'session-1', 'tools/setup.command'),
+      { ok: false, reason: 'not-a-file' },
+    );
+    assert.deepEqual(
+      await invoke(handlers, 'workspace:revealFile', 'session-1', 'tools/setup.command'),
+      { ok: false, reason: 'not-a-file' },
+    );
+    const guidePath = await realpath(join(workspaceRoot, 'docs', 'guide.md'));
+    assert.deepEqual(opened, [guidePath]);
+    assert.deepEqual(revealed, [guidePath]);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('workspace IPC bounds Markdown reads at 256 KiB', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-workspace-ipc-limit-'));
+  try {
+    const exactText = 'a'.repeat(256 * 1024);
+    await writeFile(join(workspaceRoot, 'exact.md'), exactText, 'utf8');
+    await writeFile(join(workspaceRoot, 'too-large.md'), `${exactText}b`, 'utf8');
+
+    const handlers = new Map<string, WorkspaceHandler>();
+    registerRuntimeHostWorkspaceIpc({
+      ipcMain: ipcHarness(handlers),
+      client: workspaceClient(workspaceRoot),
+    });
+
+    assert.deepEqual(
+      await invoke(handlers, 'workspace:readText', 'session-1', 'exact.md'),
+      { ok: true, relativePath: 'exact.md', text: exactText },
+    );
+    assert.deepEqual(
+      await invoke(handlers, 'workspace:readText', 'session-1', 'too-large.md'),
+      { ok: false, reason: 'too-large', sizeBytes: 256 * 1024 + 1 },
+    );
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('workspace text read rejects replacement after authorization and reads only the opened inode', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-workspace-ipc-race-'));
+  const outsideRoot = await mkdtemp(join(tmpdir(), 'maka-workspace-ipc-race-out-'));
+  try {
+    await mkdir(join(workspaceRoot, 'docs'), { recursive: true });
+    const guidePath = join(workspaceRoot, 'docs', 'guide.md');
+    await writeFile(guidePath, '# Safe\n', 'utf8');
+    const secretPath = join(outsideRoot, 'secret.md');
+    await writeFile(secretPath, 'secret', 'utf8');
+
+    const result = await readBoundedWorkspaceText(
+      { workspaceRoot, relativePath: 'docs/guide.md' },
+      async (authorizedPath) => {
+        await rename(authorizedPath, `${authorizedPath}.old`);
+        await symlink(secretPath, authorizedPath);
+      },
+    );
+
+    assert.deepEqual(result, { ok: false, reason: 'not-allowed' });
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(outsideRoot, { recursive: true, force: true });
+  }
+});
+
+function ipcHarness(handlers: Map<string, WorkspaceHandler>): ReconnectableReadIpcMain {
+  const register = (channel: string, listener: IpcHandler) => {
+    handlers.set(channel, listener as WorkspaceHandler);
+  };
+  return {
+    handle: register,
+    handleReconnectableRead: register,
+  };
+}
+
+function workspaceClient(workspaceRoot: string): Pick<DesktopRuntimeHostClient, 'getSession'> {
+  return {
+    async getSession() {
+      return {
+        workspace: { hostCwd: workspaceRoot },
+      } as Awaited<ReturnType<DesktopRuntimeHostClient['getSession']>>;
+    },
+  };
+}
+
+async function invoke(
+  handlers: Map<string, WorkspaceHandler>,
+  channel: string,
+  ...args: unknown[]
+): Promise<unknown> {
+  const handler = handlers.get(channel);
+  assert.ok(handler, `missing ${channel} handler`);
+  return handler({}, ...args);
+}

--- a/apps/desktop/src/main/__tests__/workbar-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/workbar-controller.test.ts
@@ -236,6 +236,32 @@ describe('useWorkbarController', () => {
     );
   });
 
+  it('opens only Markdown workspace references in the Files tool', async () => {
+    const { root } = installReactRenderer();
+    await act(async () =>
+      renderController(root, createFakeWorkbarServices(), input(session('a'))),
+    );
+
+    await act(async () =>
+      controller().commands.openWorkspaceFile('a', 'docs/guide.md'),
+    );
+    assert.deepEqual(controller().host.workspaceFilePreview, {
+      sessionId: 'a',
+      relativePath: 'docs/guide.md',
+    });
+    assert.equal(
+      controller().host.panelsState.right.tabs.some((tab) => tab.kind === 'files'),
+      true,
+    );
+
+    await act(async () => controller().host.onCloseWorkspaceFilePreview());
+    assert.equal(controller().host.workspaceFilePreview, null);
+    await act(async () =>
+      controller().commands.openWorkspaceFile('a', 'docs/guide.md.txt'),
+    );
+    assert.equal(controller().host.workspaceFilePreview, null);
+  });
+
   it('stops a Terminal whose start resolves after the owner Session changes', async () => {
     const { root } = installReactRenderer();
     const start = deferred<ShellRunUpdate>();

--- a/apps/desktop/src/main/__tests__/workbar-services-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/workbar-services-adapter.test.ts
@@ -77,6 +77,7 @@ function createBridgeRecorder(): {
       inspector: domain('inspector'),
       attachments: domain('attachments'),
       transcripts: domain('transcripts'),
+      workspace: domain('workspace'),
     } as unknown as MakaBridge,
   };
 }
@@ -144,6 +145,10 @@ describe('createDesktopWorkbarServices', () => {
     services.artifacts.subscribeChanges(eventHandler)();
     await services.artifacts.openPath('s', 'a');
     await services.artifacts.saveAs('s', 'a');
+
+    await services.workspace.readText('s', 'docs/guide.md');
+    await services.workspace.openFile('s', 'docs/guide.md');
+    await services.workspace.revealFile('s', 'docs/guide.md');
 
     await services.inspector.trace('s', 'cursor-1');
     await services.inspector.summary('s');
@@ -214,6 +219,9 @@ describe('createDesktopWorkbarServices', () => {
         'artifacts.subscribeChanges',
         'app.openArtifactPath',
         'app.saveArtifactAs',
+        'workspace.readText',
+        'workspace.openFile',
+        'workspace.revealFile',
         'inspector.trace',
         'inspector.summary',
         'inspector.context',

--- a/apps/desktop/src/main/__tests__/workspace-file-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/workspace-file-guard.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { resolveWorkspaceFile } from '../workspace-file-guard.js';
+
+test('resolves a workspace-relative Markdown file and rejects escapes', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-workspace-file-'));
+  const outsideRoot = await mkdtemp(join(tmpdir(), 'maka-workspace-file-out-'));
+  try {
+    await mkdir(join(workspaceRoot, 'docs'), { recursive: true });
+    await mkdir(join(workspaceRoot, 'docs..'), { recursive: true });
+    await writeFile(join(workspaceRoot, 'docs', 'guide.md'), '# Guide\n', 'utf8');
+    await writeFile(join(workspaceRoot, 'docs..', 'guide.md'), '# Dotted guide\n', 'utf8');
+    await writeFile(join(outsideRoot, 'secret.md'), 'secret', 'utf8');
+    await writeFile(join(workspaceRoot, '.env'), 'TOKEN=secret', 'utf8');
+    await symlink(join(outsideRoot, 'secret.md'), join(workspaceRoot, 'docs', 'escape.md'));
+    await symlink(join(workspaceRoot, '.env'), join(workspaceRoot, 'docs', 'public.md'));
+
+    const resolved = await resolveWorkspaceFile({
+      workspaceRoot,
+      relativePath: 'docs/guide.md',
+    });
+    assert.equal(resolved.ok, true);
+    if (resolved.ok) {
+      assert.equal(resolved.path, await realpath(join(workspaceRoot, 'docs', 'guide.md')));
+    }
+
+    const dottedDirectory = await resolveWorkspaceFile({
+      workspaceRoot,
+      relativePath: 'docs../guide.md',
+    });
+    assert.equal(dottedDirectory.ok, true);
+
+    assert.deepEqual(
+      await resolveWorkspaceFile({ workspaceRoot, relativePath: '../secret.md' }),
+      { ok: false, reason: 'invalid' },
+    );
+    assert.deepEqual(
+      await resolveWorkspaceFile({ workspaceRoot, relativePath: 'docs/escape.md' }),
+      { ok: false, reason: 'not-allowed' },
+    );
+    assert.deepEqual(
+      await resolveWorkspaceFile({ workspaceRoot, relativePath: 'docs/missing.md' }),
+      { ok: false, reason: 'missing' },
+    );
+    assert.deepEqual(
+      await resolveWorkspaceFile({ workspaceRoot, relativePath: 'docs/public.md' }),
+      { ok: false, reason: 'not-a-file' },
+    );
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(outsideRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { E2eFixtureScenario, E2eFixtureState } from '@maka/core/e2e-fixture';
 import { MODEL_CALL_ATTEMPT_EVENT_TYPE } from '@maka/core/model-call-attempt';
@@ -46,6 +46,7 @@ import {
   promptRailSession,
   turnMessages,
   turnSession,
+  workspaceMarkdownMessages,
 } from './e2e-fixture/scenarios-chat.js';
 import { seedMcpFixture, seedSkillsMarketFixture } from './e2e-fixture/scenarios-modules.js';
 import { longSidebarSessions } from './e2e-fixture/scenarios-sessions.js';
@@ -63,6 +64,7 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   'turn-narrative-browser',
   'chat-prompt-rail',
   'chat-partial-history',
+  'chat-workspace-markdown',
   'settings-data',
   'settings-bots-onboarding',
   'settings-general',
@@ -180,6 +182,8 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
       return { ...state, activeSessionId: PROMPT_RAIL_SESSION_ID, workbarCollapsed: true };
     case 'chat-partial-history':
       return { ...state, activeSessionId: PARTIAL_HISTORY_SESSION_ID, workbarCollapsed: true };
+    case 'chat-workspace-markdown':
+      return { ...state, activeSessionId: TURN_SESSION_ID, workbarCollapsed: true };
     case 'settings-data':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'data' };
     case 'settings-bots-onboarding':
@@ -226,7 +230,21 @@ export async function seedE2eFixture(input: {
   const storageRoot = await resolveStorageRoot({ path: input.workspaceRoot, kind: 'interactive' });
   await writeSettings(input.workspaceRoot, scenario);
   await writeConnections(input.workspaceRoot, now, scenario);
-  await writeSession(input.workspaceRoot, turnSession(now), turnMessages(now));
+  await writeSession(
+    input.workspaceRoot,
+    turnSession(now),
+    scenario === 'chat-workspace-markdown'
+      ? workspaceMarkdownMessages(now)
+      : turnMessages(now),
+  );
+
+  if (scenario === 'chat-workspace-markdown') {
+    const docsRoot = join(input.workspaceRoot, 'docs');
+    await mkdir(docsRoot, { recursive: true });
+    await writeFile(join(docsRoot, 'guide with spaces.md'), '# Workspace guide\n\nOpened from an explicit Markdown link.\n', 'utf8');
+    await writeFile(join(docsRoot, 'notes.md'), '# Workspace notes\n\nOpened from a bare path.\n', 'utf8');
+    await writeFile(join(docsRoot, 'chip.md'), '# Workspace chip\n\nOpened from a sent file reference.\n', 'utf8');
+  }
 
   if (scenario === 'chat-prompt-rail') {
     await writeSession(input.workspaceRoot, promptRailSession(now), promptRailMessages(now));

--- a/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
@@ -110,6 +110,42 @@ export function turnMessages(now: number): StoredMessage[] {
   ];
 }
 
+export function workspaceMarkdownMessages(now: number): StoredMessage[] {
+  const turnId = 'turn-workspace-markdown';
+  const userText = 'Review @docs/chip.md before the other documents.';
+  return [
+    {
+      type: 'user',
+      id: 'msg-workspace-markdown-user',
+      turnId,
+      ts: now - 2_000,
+      text: userText,
+      inlineReferences: [
+        {
+          kind: 'workspace_file',
+          value: '@docs/chip.md',
+          label: 'chip.md',
+          start: userText.indexOf('@docs/chip.md'),
+        },
+      ],
+    },
+    {
+      type: 'assistant',
+      id: 'msg-workspace-markdown-assistant',
+      turnId,
+      ts: now - 1_000,
+      text: [
+        'Open [the workspace guide](docs/guide%20with%20spaces.md).',
+        '',
+        'Then read the bare path docs/notes.md.',
+        '',
+        'Keep this executable inert: [setup](tools/setup.command).',
+      ].join('\n'),
+      modelId: 'glm-5.1',
+    },
+  ];
+}
+
 export function promptRailSession(now: number): SessionHeader {
   return header({
     id: PROMPT_RAIL_SESSION_ID,

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -1335,6 +1335,8 @@ function registerHostClientIpc(
     ipcMain: scopedIpc,
     client,
     allowLocalWorkspace: !usesHostWorkspace,
+    openPath: (path) => shell.openPath(path),
+    showItemInFolder: (path) => shell.showItemInFolder(path),
   });
   const resolveProjectRootForContext = (sessionId: unknown): Promise<string> =>
     resolveProjectContextRoot(sessionId, {

--- a/apps/desktop/src/main/runtime-host-workspace-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-workspace-ipc-main.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { stat } from 'node:fs/promises';
+import { open, realpath, stat } from 'node:fs/promises';
 import type { GitReviewSource } from '@maka/core/git-review';
 import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
 import { readGitReview } from './git-review-main.js';
@@ -25,6 +25,13 @@ import {
   handleReconnectableRead,
   type ReconnectableReadIpcMain,
 } from './ipc-reconnect-policy.js';
+import {
+  isAllowedWorkspaceMarkdownPath,
+  isPathInsideWorkspace,
+  resolveWorkspaceFile,
+} from './workspace-file-guard.js';
+
+const WORKSPACE_TEXT_LIMIT_BYTES = 256 * 1024;
 
 type WorkspaceClient = Pick<DesktopRuntimeHostClient, 'getSession'>;
 
@@ -33,6 +40,8 @@ export function registerRuntimeHostWorkspaceIpc(
     readonly ipcMain: ReconnectableReadIpcMain;
     readonly client: WorkspaceClient;
     readonly allowLocalWorkspace?: boolean;
+    readonly openPath?: (path: string) => Promise<string>;
+    readonly showItemInFolder?: (path: string) => void;
   },
 ): void {
   handleReconnectableRead(input.ipcMain, 'git-review:read', async (_event, raw: unknown) => {
@@ -44,6 +53,122 @@ export function registerRuntimeHostWorkspaceIpc(
     if (!cwd) return { ok: false as const, reason: 'workspace_unavailable' as const };
     return readGitReview(cwd, request.source, undefined, request.baseBranch);
   });
+  handleReconnectableRead(
+    input.ipcMain,
+    'workspace:readText',
+    async (_event, sessionId: unknown, relativePath: unknown) => {
+      if (input.allowLocalWorkspace === false) {
+        return { ok: false as const, reason: 'not-allowed' as const };
+      }
+      if (typeof sessionId !== 'string' || sessionId.length === 0) {
+        return { ok: false as const, reason: 'invalid' as const };
+      }
+      if (typeof relativePath !== 'string') {
+        return { ok: false as const, reason: 'invalid' as const };
+      }
+      const cwd = await sessionWorkspace(input.client, sessionId);
+      if (!cwd) return { ok: false as const, reason: 'missing' as const };
+      return readBoundedWorkspaceText({ workspaceRoot: cwd, relativePath });
+    },
+  );
+
+  input.ipcMain.handle('workspace:openFile', async (_event, sessionId: unknown, relativePath: unknown) => {
+    const resolved = await resolveSessionWorkspaceFile(input, sessionId, relativePath);
+    if (!resolved.ok) return resolved;
+    const error = await input.openPath?.(resolved.path);
+    if (error) return { ok: false as const, reason: 'open-failed' as const };
+    return { ok: true as const, opened: resolved.relativePath };
+  });
+
+  input.ipcMain.handle('workspace:revealFile', async (_event, sessionId: unknown, relativePath: unknown) => {
+    const resolved = await resolveSessionWorkspaceFile(input, sessionId, relativePath);
+    if (!resolved.ok) return resolved;
+    input.showItemInFolder?.(resolved.path);
+    return { ok: true as const, opened: resolved.relativePath };
+  });
+}
+
+async function resolveSessionWorkspaceFile(
+  input: {
+    readonly client: WorkspaceClient;
+    readonly allowLocalWorkspace?: boolean;
+  },
+  sessionId: unknown,
+  relativePath: unknown,
+): Promise<
+  | { ok: true; path: string; root: string; relativePath: string }
+  | { ok: false; reason: 'invalid' | 'missing' | 'not-a-file' | 'not-allowed' }
+> {
+  if (input.allowLocalWorkspace === false) return { ok: false, reason: 'not-allowed' };
+  if (typeof sessionId !== 'string' || sessionId.length === 0) {
+    return { ok: false, reason: 'invalid' };
+  }
+  if (typeof relativePath !== 'string') return { ok: false, reason: 'invalid' };
+  const cwd = await sessionWorkspace(input.client, sessionId);
+  if (!cwd) return { ok: false, reason: 'missing' };
+  return resolveWorkspaceFile({ workspaceRoot: cwd, relativePath });
+}
+
+export async function readBoundedWorkspaceText(
+  input: { readonly workspaceRoot: string; readonly relativePath: string },
+  beforeOpen: (path: string) => void | Promise<void> = () => undefined,
+): Promise<
+  | { ok: true; relativePath: string; text: string }
+  | { ok: false; reason: 'invalid' | 'missing' | 'not-a-file' | 'not-allowed' }
+  | { ok: false; reason: 'too-large'; sizeBytes: number }
+> {
+  const resolved = await resolveWorkspaceFile(input);
+  if (!resolved.ok) return resolved;
+  await beforeOpen(resolved.path);
+
+  const handle = await open(resolved.path, 'r').catch(() => null);
+  if (!handle) return { ok: false, reason: 'missing' };
+  try {
+    const fileStat = await handle.stat({ bigint: true });
+    if (!fileStat.isFile()) return { ok: false, reason: 'not-a-file' };
+
+    const currentTarget = await realpath(resolved.path).catch(() => null);
+    if (!currentTarget) return { ok: false, reason: 'missing' };
+    if (!isPathInsideWorkspace(resolved.root, currentTarget)) {
+      return { ok: false, reason: 'not-allowed' };
+    }
+    if (!isAllowedWorkspaceMarkdownPath(currentTarget)) {
+      return { ok: false, reason: 'not-a-file' };
+    }
+    const currentStat = await stat(currentTarget, { bigint: true }).catch(() => null);
+    if (
+      !currentStat
+      || currentStat.dev !== fileStat.dev
+      || currentStat.ino !== fileStat.ino
+    ) {
+      return { ok: false, reason: 'not-allowed' };
+    }
+    if (fileStat.size > BigInt(WORKSPACE_TEXT_LIMIT_BYTES)) {
+      return { ok: false, reason: 'too-large', sizeBytes: Number(fileStat.size) };
+    }
+
+    const bytes = Buffer.allocUnsafe(WORKSPACE_TEXT_LIMIT_BYTES + 1);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const result = await handle.read(bytes, offset, bytes.byteLength - offset, null);
+      if (result.bytesRead === 0) break;
+      offset += result.bytesRead;
+    }
+    if (offset > WORKSPACE_TEXT_LIMIT_BYTES) {
+      return {
+        ok: false,
+        reason: 'too-large',
+        sizeBytes: Math.max(Number(fileStat.size), offset),
+      };
+    }
+    return {
+      ok: true,
+      relativePath: resolved.relativePath,
+      text: bytes.subarray(0, offset).toString('utf8'),
+    };
+  } finally {
+    await handle.close();
+  }
 }
 
 async function sessionWorkspace(client: WorkspaceClient, sessionId: string): Promise<string | null> {

--- a/apps/desktop/src/main/workspace-file-guard.ts
+++ b/apps/desktop/src/main/workspace-file-guard.ts
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { realpath, stat } from 'node:fs/promises';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+
+const RELATIVE_PATH_MAX_LENGTH = 4096;
+
+export type WorkspaceFileFailureReason = 'invalid' | 'missing' | 'not-a-file' | 'not-allowed';
+
+export async function resolveWorkspaceFile(input: {
+  readonly workspaceRoot: string;
+  readonly relativePath: string;
+}): Promise<
+  | { ok: true; path: string; root: string; relativePath: string }
+  | { ok: false; reason: WorkspaceFileFailureReason }
+> {
+  const relativePath = parseWorkspaceRelativePath(input.relativePath);
+  if (!relativePath) return { ok: false, reason: 'invalid' };
+  if (!/\.(?:md|markdown|mdx)$/i.test(relativePath)) {
+    return { ok: false, reason: 'not-a-file' };
+  }
+
+  let root: string;
+  let target: string;
+  try {
+    [root, target] = await Promise.all([
+      realpath(input.workspaceRoot),
+      realpath(resolve(input.workspaceRoot, relativePath)),
+    ]);
+  } catch {
+    return { ok: false, reason: 'missing' };
+  }
+  if (!isInsideOrSamePath(root, target) || target === root) {
+    return { ok: false, reason: 'not-allowed' };
+  }
+  if (!isMarkdownPath(target)) return { ok: false, reason: 'not-a-file' };
+
+  const targetStat = await stat(target).catch(() => null);
+  if (!targetStat) return { ok: false, reason: 'missing' };
+  if (!targetStat.isFile()) return { ok: false, reason: 'not-a-file' };
+  return { ok: true, path: target, root, relativePath };
+}
+
+export function isAllowedWorkspaceMarkdownPath(path: string): boolean {
+  return isMarkdownPath(path);
+}
+
+function parseWorkspaceRelativePath(value: string): string | null {
+  if (value.length === 0 || value.length > RELATIVE_PATH_MAX_LENGTH) return null;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+  if (/[\u0000-\u001f\u007f]/.test(decoded)) return null;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(decoded)) return null;
+  if (decoded.startsWith('/') || decoded.startsWith('~') || decoded.startsWith('\\')) return null;
+  if (decoded.includes('\\') || decoded.includes('?') || decoded.includes('#')) return null;
+  const segments = decoded.replace(/^\.\//, '').split('/');
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    return null;
+  }
+  return segments.join('/');
+}
+
+function isInsideOrSamePath(root: string, target: string): boolean {
+  if (target === root) return true;
+  const rel = relative(root, target);
+  return rel !== '' && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+export function isPathInsideWorkspace(root: string, target: string): boolean {
+  return isInsideOrSamePath(root, target) && target !== root;
+}
+
+function isMarkdownPath(path: string): boolean {
+  return /\.(?:md|markdown|mdx)$/i.test(path);
+}

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -1664,6 +1664,31 @@ export interface MakaBridge {
       | { ok: true; files: Array<{ relativePath: string }> }
       | { ok: false; reason: 'no_project' | 'search_failed' }
     >;
+    readText(
+      sessionId: string,
+      relativePath: string,
+    ): Promise<
+      | { ok: true; relativePath: string; text: string }
+      | {
+          ok: false;
+          reason: 'invalid' | 'missing' | 'not-a-file' | 'not-allowed' | 'too-large';
+          sizeBytes?: number;
+        }
+    >;
+    openFile(
+      sessionId: string,
+      relativePath: string,
+    ): Promise<
+      | { ok: true; opened: string }
+      | { ok: false; reason: 'invalid' | 'missing' | 'not-a-file' | 'not-allowed' | 'open-failed' }
+    >;
+    revealFile(
+      sessionId: string,
+      relativePath: string,
+    ): Promise<
+      | { ok: true; opened: string }
+      | { ok: false; reason: 'invalid' | 'missing' | 'not-a-file' | 'not-allowed' }
+    >;
   };
   e2eFixture: {
     getState(): Promise<E2eFixtureState | null>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3299,6 +3299,15 @@ const makaBridge = {
           })
         : invokeActiveRuntimeHost('workspace:searchFiles', { query, ...options });
     },
+    readText(sessionId: string, relativePath: string) {
+      return invokeSessionRuntimeHost('workspace:readText', sessionId, relativePath);
+    },
+    openFile(sessionId: string, relativePath: string) {
+      return invokeSessionRuntimeHost('workspace:openFile', sessionId, relativePath);
+    },
+    revealFile(sessionId: string, relativePath: string) {
+      return invokeSessionRuntimeHost('workspace:revealFile', sessionId, relativePath);
+    },
   },
   e2eFixture: {
     async getState(): Promise<E2eFixtureState | null> {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2530,25 +2530,22 @@ function AppShellContent({
    *     auto-submit the prompt; the user still presses Enter. That
    *     keeps an injected `maka://compose?text=ransfer my keys...`
    *     from sending without a human in the loop.
+   *   - `kind: 'workspace_file'` → ask the Workbar controller to open
+   *     the validated Markdown target for the active Session.
    *
-   * No other cases exist today by design — the parser only emits
-   * these two discriminants. If a new variant is added in `MakaUriDest`,
+   * No other cases exist today by design. If a new variant is added in `MakaUriDest`,
    * TypeScript's exhaustiveness check below trips and a new branch
    * must be wired here with corresponding fixture and journey coverage.
    */
   function dispatchMakaUri(dest: MakaUriDest) {
     switch (dest.kind) {
       case 'settings':
-        openSettingsSection(dest.section);
-        return;
+        return openSettingsSection(dest.section);
       case 'compose':
         composerRef.current?.setText(dest.text);
-        composerRef.current?.focus();
-        return;
-      default: {
-        const _exhaustive: never = dest;
-        return _exhaustive;
-      }
+        return composerRef.current?.focus();
+      default:
+        return workbar.commands.openWorkspaceFile(activeId, dest.relativePath);
     }
   }
 

--- a/apps/desktop/src/renderer/features/workbar/controller/use-workbar-controller.ts
+++ b/apps/desktop/src/renderer/features/workbar/controller/use-workbar-controller.ts
@@ -28,7 +28,7 @@ import {
 } from 'react';
 import type { QuoteRef } from '@maka/core/events';
 import type { SessionSummary } from '@maka/core/session';
-import { Composer, useUiLocale } from '@maka/ui';
+import { Composer, isMarkdownWorkspaceFile, useUiLocale } from '@maka/ui';
 import type { ChatModelChoice } from '@maka/ui';
 import { safeLocalStorageGet, safeLocalStorageSet } from '../../../browser-storage.js';
 import { getDesktopConversationCopy } from '../../../locales/conversation-copy.js';
@@ -74,6 +74,7 @@ export interface WorkbarControllerCommands {
     options?: OpenToolOptions,
   ): void;
   openSideChatWithQuote(quote: QuoteRef): void;
+  openWorkspaceFile(sessionId: string | undefined, relativePath: string): void;
   toggleRight(): void;
 }
 
@@ -169,6 +170,10 @@ export function useWorkbarController(
     ReadonlySet<string>
   >(() => new Set());
   const [, setLiveBrowserSessionIds] = useState<readonly string[]>([]);
+  const [workspaceFilePreview, setWorkspaceFilePreview] = useState<{
+    sessionId: string;
+    relativePath: string;
+  } | null>(null);
 
   const activeSessionId = input.activeSession?.id;
   const activeSessionIdRef = useRef<string | undefined>(undefined);
@@ -370,6 +375,17 @@ export function useWorkbarController(
       terminal,
       terminalCopy.startFailed,
     ],
+  );
+
+  const openWorkspaceFile = useCallback<
+    WorkbarControllerCommands['openWorkspaceFile']
+  >(
+    (sessionId, relativePath) => {
+      if (!sessionId || !isMarkdownWorkspaceFile(relativePath)) return;
+      setWorkspaceFilePreview({ sessionId, relativePath });
+      openTool('files', 'right');
+    },
+    [openTool],
   );
 
   const openSideChatWithQuote = useCallback(
@@ -641,8 +657,8 @@ export function useWorkbarController(
   );
 
   const commands = useMemo<WorkbarControllerCommands>(
-    () => ({ openTool, openSideChatWithQuote, toggleRight }),
-    [openSideChatWithQuote, openTool, toggleRight],
+    () => ({ openTool, openSideChatWithQuote, openWorkspaceFile, toggleRight }),
+    [openSideChatWithQuote, openTool, openWorkspaceFile, toggleRight],
   );
 
   const activeSideChatTabIds = useMemo(
@@ -680,6 +696,8 @@ export function useWorkbarController(
       rightWidth: layout.workbarWidth,
       bottomHeight: layout.bottomPanelHeight,
       panelsState: hostPanelsState,
+      workspaceFilePreview,
+      onCloseWorkspaceFilePreview: () => setWorkspaceFilePreview(null),
       onActivateTab: layout.activateWorkbarTab,
       onCloseTab: closeTab,
       onCloseTabs: closeTabs,

--- a/apps/desktop/src/renderer/features/workbar/ports.ts
+++ b/apps/desktop/src/renderer/features/workbar/ports.ts
@@ -152,6 +152,34 @@ export interface WorkbarArtifactsService {
   saveAs(sessionId: string, artifactId: string): Promise<ArtifactSaveResult>;
 }
 
+export interface WorkbarWorkspaceFileService {
+  readText(
+    sessionId: string,
+    relativePath: string,
+  ): Promise<
+    | { ok: true; relativePath: string; text: string }
+    | {
+        ok: false;
+        reason: 'invalid' | 'missing' | 'not-a-file' | 'not-allowed' | 'too-large';
+        sizeBytes?: number;
+      }
+  >;
+  openFile(
+    sessionId: string,
+    relativePath: string,
+  ): Promise<
+    | { ok: true; opened: string }
+    | { ok: false; reason: 'invalid' | 'missing' | 'not-a-file' | 'not-allowed' | 'open-failed' }
+  >;
+  revealFile(
+    sessionId: string,
+    relativePath: string,
+  ): Promise<
+    | { ok: true; opened: string }
+    | { ok: false; reason: 'invalid' | 'missing' | 'not-a-file' | 'not-allowed' }
+  >;
+}
+
 export interface WorkbarSessionTracePage {
   readonly trace: SessionTrace;
   readonly nextCursor: string | null;
@@ -275,6 +303,7 @@ export interface WorkbarServices {
   readonly tasks: WorkbarTasksService;
   readonly browser: WorkbarBrowserService;
   readonly artifacts: WorkbarArtifactsService;
+  readonly workspace: WorkbarWorkspaceFileService;
   readonly inspector: WorkbarInspectorService;
   readonly attachments: WorkbarAttachmentsService;
   readonly sideChat: SideChatSessionPort;

--- a/apps/desktop/src/renderer/features/workbar/testing.ts
+++ b/apps/desktop/src/renderer/features/workbar/testing.ts
@@ -99,6 +99,11 @@ export function createFakeWorkbarServices(
       openPath: async () => ({ ok: false, reason: 'missing' }),
       saveAs: async () => ({ ok: false, reason: 'canceled' }),
     },
+    workspace: {
+      readText: async () => ({ ok: false, reason: 'missing' }),
+      openFile: async () => ({ ok: false, reason: 'missing' }),
+      revealFile: async () => ({ ok: false, reason: 'missing' }),
+    },
     inspector: {
       trace: async () => {
         throw new Error('Fake inspector.trace is not configured');

--- a/apps/desktop/src/renderer/features/workbar/ui/workbar-host.tsx
+++ b/apps/desktop/src/renderer/features/workbar/ui/workbar-host.tsx
@@ -88,6 +88,11 @@ export interface WorkbarHostModel {
   rightWidth: number;
   bottomHeight: number;
   panelsState: SessionWorkbarPanelsState;
+  workspaceFilePreview: {
+    sessionId: string;
+    relativePath: string;
+  } | null;
+  onCloseWorkspaceFilePreview(): void;
   onActivateTab: (placement: SessionWorkbarPlacement, tabId: string) => void;
   onCloseTab: (placement: SessionWorkbarPlacement, tab: SessionWorkbarTab) => void;
   onCloseTabs: (
@@ -186,6 +191,8 @@ export function WorkbarHost({ model: props }: { model: WorkbarHostModel }) {
               hidden={props.hidden}
               onDismissPanel={props.onDismissPanel}
               panelsState={props.panelsState}
+              workspaceFilePreview={props.workspaceFilePreview}
+              onCloseWorkspaceFilePreview={props.onCloseWorkspaceFilePreview}
               rightCollapsed={props.rightCollapsed}
               bottomOpen={props.bottomOpen}
               onActivateTab={props.onActivateTab}

--- a/apps/desktop/src/renderer/features/workbar/ui/workbar-surface.tsx
+++ b/apps/desktop/src/renderer/features/workbar/ui/workbar-surface.tsx
@@ -45,8 +45,10 @@ import {
   TaskLedgerPanel,
   deriveTaskLedgerPanelModel,
   IconButton,
+  MarkdownBody,
   Composer,
   useUiLocale,
+  useToast,
   type ChatModelChoice,
 } from '@maka/ui';
 import {
@@ -96,6 +98,7 @@ import type {
   QuoteCompanionPanelState,
 } from '../tools/side-chat/quote-companion-panel-state';
 import type { CompanionForkVisibilityEvent } from '../tools/side-chat/quote-companion-visibility';
+import { useWorkbarServices } from '../services-context.js';
 
 const ArtifactPane = lazy(() =>
   import('../tools/artifacts/artifact-pane').then((module) => ({ default: module.ArtifactPane })),
@@ -672,6 +675,109 @@ function WorkbarLauncher(props: {
   );
 }
 
+function WorkspaceMarkdownPreview(props: {
+  sessionId: string;
+  relativePath: string;
+  copy: {
+    back: string;
+    openLocally: string;
+    reveal: string;
+    previewFailed: string;
+    actionFailed: string;
+    failures: Record<string, string>;
+  };
+  onClose(): void;
+}) {
+  const { copy } = props;
+  const toast = useToast();
+  const { workspace } = useWorkbarServices();
+  const [state, setState] = useState<
+    | { kind: 'loading' }
+    | { kind: 'ready'; text: string }
+    | { kind: 'error'; reason: string }
+  >({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: 'loading' });
+    void workspace
+      .readText(props.sessionId, props.relativePath)
+      .then((result) => {
+        if (cancelled) return;
+        setState(
+          result.ok
+            ? { kind: 'ready', text: result.text }
+            : { kind: 'error', reason: result.reason },
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setState({ kind: 'error', reason: 'default' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [props.relativePath, props.sessionId, workspace]);
+
+  async function runAction(action: 'open' | 'reveal') {
+    try {
+      const result =
+        action === 'open'
+          ? await workspace.openFile(props.sessionId, props.relativePath)
+          : await workspace.revealFile(props.sessionId, props.relativePath);
+      if (!result.ok) {
+        toast.error(
+          copy.actionFailed,
+          copy.failures[result.reason] ?? copy.failures.default,
+        );
+      }
+    } catch {
+      toast.error(copy.actionFailed, copy.failures.default);
+    }
+  }
+
+  return (
+    <div
+      className="maka-workspace-file-preview"
+      data-workspace-file={props.relativePath}
+      aria-busy={state.kind === 'loading'}
+    >
+      <div className="maka-workspace-file-preview-header">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          label={copy.back}
+          onClick={props.onClose}
+        />
+        <strong>{props.relativePath}</strong>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          label={copy.openLocally}
+          onClick={() => void runAction('open')}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          label={copy.reveal}
+          onClick={() => void runAction('reveal')}
+        />
+      </div>
+      {state.kind === 'error' ? (
+        <div className="maka-workspace-file-preview-error" role="alert">
+          <strong>{copy.previewFailed}</strong>
+          <span>{copy.failures[state.reason] ?? copy.failures.default}</span>
+        </div>
+      ) : null}
+      {state.kind === 'ready' ? (
+        <MarkdownBody text={state.text} density="default" />
+      ) : null}
+    </div>
+  );
+}
+
 export function WorkbarSurface(props: {
   sessionId: string;
   projectId?: string | null;
@@ -679,6 +785,11 @@ export function WorkbarSurface(props: {
   hidden: boolean;
   onDismissPanel: (placement: SessionWorkbarPlacement) => void;
   panelsState: SessionWorkbarPanelsState;
+  workspaceFilePreview?: {
+    sessionId: string;
+    relativePath: string;
+  } | null;
+  onCloseWorkspaceFilePreview?(): void;
   rightCollapsed: boolean;
   bottomOpen: boolean;
   onActivateTab: (placement: SessionWorkbarPlacement, tabId: string) => void;
@@ -718,7 +829,12 @@ export function WorkbarSurface(props: {
   sourceSession?: SessionSummary;
   modelChoices?: readonly ChatModelChoice[];
 }) {
-  const copy = getDesktopConversationCopy(useUiLocale()).workbar;
+  const conversationCopy = getDesktopConversationCopy(useUiLocale());
+  const copy = conversationCopy.workbar;
+  const workspacePreviewTarget =
+    props.workspaceFilePreview?.sessionId === props.sessionId
+      ? props.workspaceFilePreview
+      : null;
   const sessionTasks = useSessionTasks(props.sessionId);
   const taskCount = deriveTaskLedgerPanelModel(sessionTasks.tasks).activeCount;
   const [artifactCount, setArtifactCount] = useState(0);
@@ -847,11 +963,20 @@ export function WorkbarSurface(props: {
         } else if (tab.kind === 'files') {
           content = (
             <Suspense fallback={<WorkbarPanelLoading label={copy.files} />}>
-              <ArtifactPane
-                sessionId={props.sessionId}
-                onCountChange={setArtifactCount}
-                onDismiss={() => props.onDismissPanel(placement)}
-              />
+              {workspacePreviewTarget ? (
+                <WorkspaceMarkdownPreview
+                  sessionId={workspacePreviewTarget.sessionId}
+                  relativePath={workspacePreviewTarget.relativePath}
+                  copy={conversationCopy.workspaceFile}
+                  onClose={() => props.onCloseWorkspaceFilePreview?.()}
+                />
+              ) : (
+                <ArtifactPane
+                  sessionId={props.sessionId}
+                  onCountChange={setArtifactCount}
+                  onDismiss={() => props.onDismissPanel(placement)}
+                />
+              )}
             </Suspense>
           );
         } else if (tab.kind === 'inspector') {

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -147,6 +147,14 @@ export interface DesktopConversationCopy {
     delete: string;
     archived: string;
   };
+  workspaceFile: {
+    back: string;
+    openLocally: string;
+    reveal: string;
+    previewFailed: string;
+    actionFailed: string;
+    failures: Record<string, string>;
+  };
   reviewPanel: {
     ariaLabel: string;
     empty: string;
@@ -510,6 +518,22 @@ const COPY = {
       delete: '删除',
       archived: '已归档',
     },
+    workspaceFile: {
+      back: '返回生成文件',
+      openLocally: '用系统应用打开',
+      reveal: '在访达中显示',
+      previewFailed: '无法预览这个文件',
+      actionFailed: '无法打开这个文件',
+      failures: {
+        invalid: '这个链接不是当前工作区里的文件。',
+        missing: '文件不存在或已被移走。',
+        'not-a-file': '只能预览工作区里的 Markdown 文件。',
+        'not-allowed': '这个路径超出了当前任务的工作区。',
+        'too-large': '文件太大，无法在 Maka 里预览。',
+        'open-failed': '系统没能打开这个文件。',
+        default: '请稍后重试。',
+      },
+    },
     reviewPanel: {
       ariaLabel: 'Git 变更',
       empty: '当前 Git 工作区没有变化',
@@ -738,6 +762,22 @@ const COPY = {
       unarchive: 'Restore',
       delete: 'Delete',
       archived: 'Archived',
+    },
+    workspaceFile: {
+      back: 'Back to generated files',
+      openLocally: 'Open locally',
+      reveal: 'Show in folder',
+      previewFailed: 'This file could not be previewed',
+      actionFailed: 'This file could not be opened',
+      failures: {
+        invalid: 'This link is not a file in the current workspace.',
+        missing: 'The file is missing or has been moved.',
+        'not-a-file': 'Only workspace Markdown files can be previewed here.',
+        'not-allowed': 'This path is outside the current task workspace.',
+        'too-large': 'The file is too large to preview in Maka.',
+        'open-failed': 'The system could not open this file.',
+        default: 'Try again later.',
+      },
     },
     reviewPanel: {
       ariaLabel: 'Git changes',

--- a/apps/desktop/src/renderer/platform/desktop/create-workbar-services.ts
+++ b/apps/desktop/src/renderer/platform/desktop/create-workbar-services.ts
@@ -33,6 +33,7 @@ export type DesktopWorkbarBridge = Pick<
   | 'shellRuns'
   | 'tasks'
   | 'transcripts'
+  | 'workspace'
 >;
 
 export interface DesktopWorkbarServiceDependencies {
@@ -93,6 +94,14 @@ export function createDesktopWorkbarServices(
         bridge.app.openArtifactPath(sessionId, artifactId),
       saveAs: (sessionId, artifactId) =>
         bridge.app.saveArtifactAs(sessionId, artifactId),
+    },
+    workspace: {
+      readText: (sessionId, relativePath) =>
+        bridge.workspace.readText(sessionId, relativePath),
+      openFile: (sessionId, relativePath) =>
+        bridge.workspace.openFile(sessionId, relativePath),
+      revealFile: (sessionId, relativePath) =>
+        bridge.workspace.revealFile(sessionId, relativePath),
     },
     inspector: {
       trace: (sessionId, cursor) => bridge.inspector.trace(sessionId, cursor),

--- a/apps/desktop/src/renderer/styles/workbar/artifacts.css
+++ b/apps/desktop/src/renderer/styles/workbar/artifacts.css
@@ -394,6 +394,43 @@
   color: var(--info-text);
 }
 
+.maka-workspace-file-preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 0;
+  height: 100%;
+  overflow: auto;
+  padding: var(--space-3);
+}
+
+.maka-workspace-file-preview-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.maka-workspace-file-preview-header strong {
+  flex: 1 1 auto;
+  min-width: 0;
+  font: var(--maka-text-heading-5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maka-workspace-file-preview-error {
+  display: grid;
+  gap: var(--space-1-5);
+  padding: var(--space-2-5) var(--space-3);
+  border: var(--border-width-hairline) solid oklch(from var(--destructive) l c h / 0.22);
+  border-radius: var(--radius-surface);
+  background: oklch(from var(--destructive) l c h / 0.08);
+  color: var(--destructive-text);
+  font: var(--maka-text-body);
+}
+
 /* Narrow windows place the single workbar below the conversation. */
 @media (max-width: 990px) {
   .maka-detail-with-artifacts {

--- a/packages/core/src/e2e-fixture.ts
+++ b/packages/core/src/e2e-fixture.ts
@@ -28,6 +28,7 @@ export type E2eFixtureScenario =
   | 'turn-narrative-browser'
   | 'chat-prompt-rail'
   | 'chat-partial-history'
+  | 'chat-workspace-markdown'
   | 'settings-data'
   | 'settings-bots-onboarding'
   | 'settings-general'

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,7 @@
     "./assistant-stream": "./dist/assistant-stream.js",
     "./icons": "./dist/icons.js",
     "./maka-uri": "./dist/maka-uri.js",
+    "./workspace-file-href": "./dist/workspace-file-href.js",
     "./styles.css": "./src/styles.css"
   },
   "scripts": {

--- a/packages/ui/src/__tests__/inline-reference.test.ts
+++ b/packages/ui/src/__tests__/inline-reference.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { InlineReferenceText } from '../inline-reference.js';
+import { MakaUriContext } from '../markdown.js';
+
+test('makes a sent Markdown workspace-file reference interactive', () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      MakaUriContext.Provider,
+      { value: () => {} },
+      createElement(InlineReferenceText, {
+        text: 'Read @docs/guide.md next',
+        references: [
+          {
+            kind: 'workspace_file',
+            value: '@docs/guide.md',
+            label: 'guide.md',
+            start: 5,
+          },
+        ],
+      }),
+    ),
+  );
+
+  assert.match(markup, /role="button"/);
+  assert.match(markup, /tabindex="0"/);
+  assert.match(markup, /data-maka-uri-kind="workspace_file"/);
+  assert.match(markup, /data-workspace-file="docs\/guide.md"/);
+});
+
+test('keeps executable workspace-file references inert', () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      MakaUriContext.Provider,
+      { value: () => {} },
+      createElement(InlineReferenceText, {
+        text: '@tools/setup.command',
+        references: [
+          {
+            kind: 'workspace_file',
+            value: '@tools/setup.command',
+            label: 'setup.command',
+            start: 0,
+          },
+        ],
+      }),
+    ),
+  );
+
+  assert.doesNotMatch(markup, /role="button"/);
+  assert.doesNotMatch(markup, /data-workspace-file=/);
+});

--- a/packages/ui/src/__tests__/markdown-body.test.ts
+++ b/packages/ui/src/__tests__/markdown-body.test.ts
@@ -332,6 +332,49 @@ it('preserves allowlisted Maka navigation links through sanitization', () => {
   assert.doesNotMatch(markup, /Blocked URL/);
 });
 
+it('turns workspace-relative Markdown files into internal links', () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      LocaleProvider,
+      {
+        locale: 'en',
+        children: createElement(
+          MakaUriContext.Provider,
+          { value: () => {} },
+          createElement(MarkdownBody, {
+            text: '[Guide](docs/guide.md)',
+          }),
+        ),
+      },
+    ),
+  );
+
+  assert.match(markup, /data-maka-uri-kind="workspace_file"/);
+  assert.match(markup, /data-workspace-file="docs\/guide.md"/);
+  assert.doesNotMatch(markup, /data-reason="unsafe-scheme"/);
+});
+
+it('turns bare Markdown paths into internal links without activating executable paths', () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      LocaleProvider,
+      {
+        locale: 'en',
+        children: createElement(
+          MakaUriContext.Provider,
+          { value: () => {} },
+          createElement(MarkdownBody, {
+            text: 'Read docs/guide.md. Do not open tools/setup.command.',
+          }),
+        ),
+      },
+    ),
+  );
+
+  assert.match(markup, /data-workspace-file="docs\/guide.md"/);
+  assert.doesNotMatch(markup, /data-workspace-file="tools\/setup.command"/);
+});
+
 it('keeps non-allowlisted external schemes inert', () => {
   for (const href of [
     'file:///Users/example/.ssh/id_rsa',

--- a/packages/ui/src/__tests__/workspace-file-href.test.ts
+++ b/packages/ui/src/__tests__/workspace-file-href.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  isMarkdownWorkspaceFile,
+  linkifyBareWorkspaceMarkdownReferences,
+  parseWorkspaceFileHref,
+} from '../workspace-file-href.js';
+
+test('accepts workspace-relative file hrefs including encoded spaces', () => {
+  assert.deepEqual(parseWorkspaceFileHref('docs/guide.md'), {
+    kind: 'workspace_file',
+    relativePath: 'docs/guide.md',
+  });
+  assert.deepEqual(parseWorkspaceFileHref('./notes/hello%20world.md'), {
+    kind: 'workspace_file',
+    relativePath: 'notes/hello world.md',
+  });
+  assert.equal(isMarkdownWorkspaceFile('docs/guide.md'), true);
+  assert.equal(isMarkdownWorkspaceFile('src/main.ts'), false);
+});
+
+test('rejects schemes, traversal, and absolute paths', () => {
+  for (const href of [
+    'file:///etc/passwd',
+    'https://example.test/readme.md',
+    '../secret.md',
+    'docs/../../secret.md',
+    '/etc/passwd.md',
+    '~/secret.md',
+    'docs/guide.md?raw=1',
+    'docs/guide.md#section',
+    'src/main.ts',
+    'tools/setup.exe',
+    'tools/install.command',
+    'just-a-word',
+    '',
+  ]) {
+    assert.equal(parseWorkspaceFileHref(href), null, href);
+  }
+});
+
+test('linkifies bare Markdown paths outside existing Markdown syntax and code', () => {
+  const source = [
+    'Read README.md, docs/guide.md and 文档/说明.markdown.',
+    '[Existing](docs/existing.md) and ![image](docs/image.md)',
+    '[docs/shortcut.md] and [docs/collapsed.md][]',
+    '`inline/code.md` and <https://example.test/remote.md>',
+    '[guide]: docs/reference.md',
+    '```text',
+    'fenced/code.md',
+    '```',
+    'Ignore tools/setup.command and docs/note.md#heading.',
+  ].join('\n');
+
+  assert.equal(
+    linkifyBareWorkspaceMarkdownReferences(source),
+    [
+      'Read [README.md](README.md), [docs/guide.md](docs/guide.md) and [文档/说明.markdown](文档/说明.markdown).',
+      '[Existing](docs/existing.md) and ![image](docs/image.md)',
+      '[docs/shortcut.md] and [docs/collapsed.md][]',
+      '`inline/code.md` and <https://example.test/remote.md>',
+      '[guide]: docs/reference.md',
+      '```text',
+      'fenced/code.md',
+      '```',
+      'Ignore tools/setup.command and docs/note.md#heading.',
+    ].join('\n'),
+  );
+});
+
+test('preserves code blocks, external autolinks, and longer non-Markdown suffixes', () => {
+  const source = [
+    '    indented/code.md',
+    '\ttabbed/code.md',
+    '> - ```text',
+    '>   nested/fenced.md',
+    '>   ```',
+    'docs/guide.md.txt',
+    'www.example.com/docs/guide.md',
+    'After docs/after.md.',
+  ].join('\r\n');
+
+  assert.equal(
+    linkifyBareWorkspaceMarkdownReferences(source),
+    [
+      '    indented/code.md',
+      '\ttabbed/code.md',
+      '> - ```text',
+      '>   nested/fenced.md',
+      '>   ```',
+      'docs/guide.md.txt',
+      'www.example.com/docs/guide.md',
+      'After [docs/after.md](docs/after.md).',
+    ].join('\r\n'),
+  );
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -47,6 +47,7 @@ export * from './locale-helpers.js';
 export * from './locale-context.js';
 export { MakaUriContext } from './markdown.js';
 export * from './maka-uri.js';
+export * from './workspace-file-href.js';
 export * from './materialize.js';
 export * from './live-turn-projection.js';
 export * from './transcript-projection.js';

--- a/packages/ui/src/inline-reference.tsx
+++ b/packages/ui/src/inline-reference.tsx
@@ -19,8 +19,10 @@
 
 import type { InlineReference } from '@maka/core/events';
 import { ChatTokenizedText, type ChatComposerToken } from '@astryxdesign/core';
-import type { ReactNode } from 'react';
+import { useContext, type ReactNode } from 'react';
 import { ICON_SIZE, Sparkles } from './icons.js';
+import { MakaUriContext } from './markdown.js';
+import { parseWorkspaceFileHref } from './workspace-file-href.js';
 
 type InlineReferenceVisual = Pick<InlineReference, 'kind' | 'value' | 'label'>;
 
@@ -107,15 +109,54 @@ export function InlineReferenceText(props: {
     }
     if (reference.start > cursor) parts.push(props.text.slice(cursor, reference.start));
     parts.push(
-      <ChatTokenizedText
-        key={`${reference.start}:${reference.value}`}
-        tokens={[inlineReferenceToken(reference)]}
-      >
-        {reference.value}
-      </ChatTokenizedText>,
+      reference.kind === 'workspace_file' ? (
+        <WorkspaceFileInlineReference
+          key={`${reference.start}:${reference.value}`}
+          reference={reference}
+        />
+      ) : (
+        <ChatTokenizedText
+          key={`${reference.start}:${reference.value}`}
+          tokens={[inlineReferenceToken(reference)]}
+        >
+          {reference.value}
+        </ChatTokenizedText>
+      ),
     );
     cursor = reference.start + reference.value.length;
   }
   if (cursor < props.text.length) parts.push(props.text.slice(cursor));
   return <span>{parts}</span>;
+}
+
+/** Keep ordinary messages outside the navigation context subscription. */
+function WorkspaceFileInlineReference(props: { reference: InlineReference }) {
+  const dispatch = useContext(MakaUriContext);
+  const workspaceFile = props.reference.value.startsWith('@')
+    ? parseWorkspaceFileHref(props.reference.value.slice(1))
+    : null;
+  const tokenizedText = (
+    <ChatTokenizedText tokens={[inlineReferenceToken(props.reference)]}>
+      {props.reference.value}
+    </ChatTokenizedText>
+  );
+  if (!workspaceFile || !dispatch) return tokenizedText;
+  const openWorkspaceFile = () => dispatch(workspaceFile);
+  return (
+    <ChatTokenizedText
+      tokens={[inlineReferenceToken(props.reference)]}
+      role="button"
+      tabIndex={0}
+      data-maka-uri-kind={workspaceFile.kind}
+      data-workspace-file={workspaceFile.relativePath}
+      onClick={openWorkspaceFile}
+      onKeyDown={(event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        openWorkspaceFile();
+      }}
+    >
+      {props.reference.value}
+    </ChatTokenizedText>
+  );
 }

--- a/packages/ui/src/maka-uri.ts
+++ b/packages/ui/src/maka-uri.ts
@@ -18,6 +18,7 @@
  */
 
 import { SETTINGS_SECTIONS, type SettingsSection } from '@maka/core/settings';
+import type { WorkspaceFileDest } from './workspace-file-href.js';
 
 const ALLOWED_SETTINGS_SECTIONS = new Set<SettingsSection>(SETTINGS_SECTIONS);
 const RAW_HREF_MAX_LENGTH = 4096;
@@ -26,7 +27,8 @@ const COMPOSE_TEXT_MAX_LENGTH = 4096;
 /** Closed internal navigation surface; it never executes actions. */
 export type MakaUriDest =
   | { kind: 'settings'; section: SettingsSection }
-  | { kind: 'compose'; text: string };
+  | { kind: 'compose'; text: string }
+  | WorkspaceFileDest;
 
 /**
  * Parse an exact lowercase internal URI. Unsupported namespaces and malformed

--- a/packages/ui/src/markdown-body.tsx
+++ b/packages/ui/src/markdown-body.tsx
@@ -42,6 +42,10 @@ import {
   isSafeExternalScheme,
   parseMakaUri,
 } from './maka-uri.js';
+import {
+  linkifyBareWorkspaceMarkdownReferences,
+  parseWorkspaceFileHref,
+} from './workspace-file-href.js';
 import { MakaUriContext } from './markdown.js';
 import { useUiLocale } from './locale-context.js';
 import { getSharedUiCopy } from './shared-ui-copy.js';
@@ -141,7 +145,15 @@ export function MarkdownBody(props: {
     (source: string) => prepareMarkdownMath(source, mathCache.current),
     [],
   );
-  const budgetedText = props.streaming ? props.text : applyMermaidRenderBudget(props.text);
+  const safeText = neutralizeUnsafeMarkdownImages(
+    linkifyBareWorkspaceMarkdownReferences(props.text),
+  );
+  const settledText = props.settledText === undefined
+    ? undefined
+    : neutralizeUnsafeMarkdownImages(
+        linkifyBareWorkspaceMarkdownReferences(props.settledText),
+      );
+  const budgetedText = props.streaming ? safeText : applyMermaidRenderBudget(safeText);
   const density = props.density ?? 'default';
   const components = props.streaming
     ? density === 'compact'
@@ -184,7 +196,7 @@ export function MarkdownBody(props: {
         components={components}
         inlinePlugins={MARKDOWN_MATH_PLUGINS}
         isStreaming={props.streaming}
-        settledText={props.settledText}
+        settledText={settledText}
         transformSource={transformMathSource}
       >
         {budgetedText}
@@ -278,6 +290,82 @@ function MarkdownImage(props: { src: string; alt: string }) {
   return <img src={props.src} alt={props.alt} style={{ display: 'inline-block' }} />;
 }
 
+/**
+ * Astryx delegates inline images to `components.image`, but its standalone
+ * image branch renders a native image directly. Neutralizing unsafe direct
+ * image syntax before parsing keeps both branches behind Maka's URL policy.
+ */
+function neutralizeUnsafeMarkdownImages(source: string): string {
+  let fence: string | null = null;
+  return source
+    .split('\n')
+    .map((line) => {
+      if (fence) {
+        if (line.startsWith(fence)) fence = null;
+        return line;
+      }
+
+      const fenceMatch = line.match(/^(`{3,}|~{3,})(\w*)/);
+      if (fenceMatch?.[1]) {
+        fence = fenceMatch[1];
+        return line;
+      }
+
+      return neutralizeUnsafeImagesInLine(line);
+    })
+    .join('\n');
+}
+
+function neutralizeUnsafeImagesInLine(line: string): string {
+  let output = '';
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    if (line[cursor] === '`') {
+      let tickCount = 1;
+      while (line[cursor + tickCount] === '`') tickCount += 1;
+      const delimiter = '`'.repeat(tickCount);
+      const close = line.indexOf(delimiter, cursor + tickCount);
+      if (close !== -1) {
+        const end = close + tickCount;
+        output += line.slice(cursor, end);
+        cursor = end;
+        continue;
+      }
+    }
+
+    if (line[cursor] === '!' && line[cursor + 1] === '[') {
+      const altClose = line.indexOf(']', cursor + 2);
+      if (altClose !== -1 && line[altClose + 1] === '(') {
+        const srcStart = altClose + 2;
+        const srcClose = findMarkdownClosingParen(line, srcStart);
+        if (srcClose !== -1) {
+          const src = line.slice(srcStart, srcClose);
+          output += (parseAttachmentResourceRef(src) || isSafeMarkdownImageUrl(src))
+            ? line.slice(cursor, srcClose + 1)
+            : `!\\[${line.slice(cursor + 2, srcClose + 1)}`;
+          cursor = srcClose + 1;
+          continue;
+        }
+      }
+    }
+
+    output += line[cursor];
+    cursor += 1;
+  }
+
+  return output;
+}
+
+function findMarkdownClosingParen(text: string, start: number): number {
+  let depth = 1;
+  for (let index = start; index < text.length; index += 1) {
+    if (text[index] === '(') depth += 1;
+    if (text[index] === ')' && --depth === 0) return index;
+  }
+  return -1;
+}
+
 function isSafeMarkdownImageUrl(url: string): boolean {
   try {
     const protocol = new URL(url).protocol;
@@ -318,6 +406,21 @@ function MarkdownLink(props: { href: string; children: ReactNode }) {
       >
         {children}
       </span>
+    );
+  }
+
+  const workspaceFile = parseWorkspaceFileHref(href);
+  if (workspaceFile && dispatch) {
+    return (
+      <AstryxLink
+        type="inherit"
+        hasUnderline
+        data-maka-uri-kind={workspaceFile.kind}
+        data-workspace-file={workspaceFile.relativePath}
+        onClick={() => dispatch(workspaceFile)}
+      >
+        {children}
+      </AstryxLink>
     );
   }
 

--- a/packages/ui/src/markdown.tsx
+++ b/packages/ui/src/markdown.tsx
@@ -104,4 +104,6 @@ export function Markdown(props: {
  * lazy body reads it via `useContext(MakaUriContext)` imported back
  * from here.
  */
-export const MakaUriContext = createContext<((dest: import('./maka-uri.js').MakaUriDest) => void) | undefined>(undefined);
+export const MakaUriContext = createContext<
+  ((dest: import('./maka-uri.js').MakaUriDest) => void) | undefined
+>(undefined);

--- a/packages/ui/src/workspace-file-href.ts
+++ b/packages/ui/src/workspace-file-href.ts
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const HREF_MAX_LENGTH = 4096;
+const BARE_MARKDOWN_PATH = /(?:\.\/)?(?:[\p{L}\p{N}_@.+-]+\/)*[\p{L}\p{N}_@+-]+(?:\.[\p{L}\p{N}_@+-]+)*\.(?:markdown|mdx|md)/iyu;
+
+export type WorkspaceFileDest = {
+  readonly kind: 'workspace_file';
+  readonly relativePath: string;
+};
+
+/**
+ * Parse a workspace-relative file href from Markdown. Absolute paths, schemes,
+ * traversal, and query/hash fragments stay inert so transcript text cannot
+ * point outside the session workspace.
+ */
+export function parseWorkspaceFileHref(href: string): WorkspaceFileDest | null {
+  if (typeof href !== 'string') return null;
+  if (href.length === 0 || href.length > HREF_MAX_LENGTH) return null;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(href);
+  } catch {
+    return null;
+  }
+  if (/[\u0000-\u001f\u007f]/.test(decoded)) return null;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(decoded)) return null;
+  if (decoded.startsWith('/') || decoded.startsWith('~') || decoded.startsWith('\\')) return null;
+  if (decoded.includes('\\') || decoded.includes('?') || decoded.includes('#')) return null;
+  const trimmed = decoded.replace(/^\.\//, '');
+  const segments = trimmed.split('/');
+  if (segments.length === 0 || segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    return null;
+  }
+  const relativePath = segments.join('/');
+  if (!isMarkdownWorkspaceFile(relativePath)) return null;
+  return { kind: 'workspace_file', relativePath };
+}
+
+export function isMarkdownWorkspaceFile(relativePath: string): boolean {
+  return /\.(?:md|markdown|mdx)$/i.test(relativePath);
+}
+
+/**
+ * Make unambiguous bare Markdown paths clickable without rewriting code,
+ * existing links, autolinks, or reference definitions. Paths containing
+ * spaces remain supported through ordinary Markdown link destinations.
+ */
+export function linkifyBareWorkspaceMarkdownReferences(source: string): string {
+  let fence: { character: string; length: number } | null = null;
+  return source
+    .split('\n')
+    .map((line) => {
+      const blockLine = markdownBlockContent(line.endsWith('\r') ? line.slice(0, -1) : line);
+      if (fence) {
+        const closing = new RegExp(
+          `^ {0,3}${escapeRegExp(fence.character)}{${fence.length},}[ \\t]*$`,
+        );
+        if (closing.test(blockLine)) fence = null;
+        return line;
+      }
+
+      const opening = /^ {0,3}(`{3,}|~{3,})/.exec(blockLine);
+      if (opening?.[1]) {
+        fence = { character: opening[1][0]!, length: opening[1].length };
+        return line;
+      }
+      if (/^(?: {4}|\t)/.test(blockLine)) return line;
+      if (/^ {0,3}\[[^\]]+\]:/.test(blockLine)) return line;
+      return linkifyBareWorkspacePathsInLine(line);
+    })
+    .join('\n');
+}
+
+function linkifyBareWorkspacePathsInLine(line: string): string {
+  let output = '';
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    if (line[cursor] === '`') {
+      let delimiterLength = 1;
+      while (line[cursor + delimiterLength] === '`') delimiterLength += 1;
+      const delimiter = '`'.repeat(delimiterLength);
+      const close = line.indexOf(delimiter, cursor + delimiterLength);
+      if (close !== -1) {
+        const end = close + delimiterLength;
+        output += line.slice(cursor, end);
+        cursor = end;
+        continue;
+      }
+    }
+
+    const labelStart = line[cursor] === '['
+      ? cursor
+      : line[cursor] === '!' && line[cursor + 1] === '['
+        ? cursor + 1
+        : -1;
+    if (labelStart !== -1) {
+      const labelClose = line.indexOf(']', labelStart + 1);
+      if (labelClose !== -1) {
+        const destinationStart = labelClose + 1;
+        if (line[destinationStart] === '(') {
+          const destinationClose = findClosingParen(line, destinationStart + 1);
+          if (destinationClose !== -1) {
+            output += line.slice(cursor, destinationClose + 1);
+            cursor = destinationClose + 1;
+            continue;
+          }
+        } else if (line[destinationStart] === '[') {
+          const referenceClose = line.indexOf(']', destinationStart + 1);
+          if (referenceClose !== -1) {
+            output += line.slice(cursor, referenceClose + 1);
+            cursor = referenceClose + 1;
+            continue;
+          }
+        }
+        output += line.slice(cursor, labelClose + 1);
+        cursor = labelClose + 1;
+        continue;
+      }
+    }
+
+    if (line[cursor] === '<') {
+      const close = line.indexOf('>', cursor + 1);
+      if (close !== -1) {
+        output += line.slice(cursor, close + 1);
+        cursor = close + 1;
+        continue;
+      }
+    }
+
+    if (isBarePathStartBoundary(line, cursor)) {
+      BARE_MARKDOWN_PATH.lastIndex = cursor;
+      const match = BARE_MARKDOWN_PATH.exec(line);
+      const candidate = match?.[0];
+      if (
+        candidate
+        && !looksLikeExternalAutolink(candidate)
+        && isBarePathEndBoundary(line, cursor + candidate.length)
+        && parseWorkspaceFileHref(candidate)
+      ) {
+        output += `[${candidate}](${candidate})`;
+        cursor += candidate.length;
+        continue;
+      }
+    }
+
+    output += line[cursor];
+    cursor += 1;
+  }
+  return output;
+}
+
+function isBarePathStartBoundary(line: string, index: number): boolean {
+  if (index === 0) return true;
+  return /[\s([\]{}'"*_~>|]/u.test(line[index - 1]!);
+}
+
+function isBarePathEndBoundary(line: string, index: number): boolean {
+  if (index === line.length) return true;
+  const next = line[index]!;
+  if (next === '.') {
+    const afterPeriod = line[index + 1];
+    return afterPeriod === undefined || /[\s,;:!()[\]{}'"*_~<>|]/u.test(afterPeriod);
+  }
+  return /[\s,;:!()[\]{}'"*_~<>|]/u.test(next);
+}
+
+function looksLikeExternalAutolink(candidate: string): boolean {
+  return /^(?:www\.|[^/]+@)/iu.test(candidate);
+}
+
+function markdownBlockContent(line: string): string {
+  let content = line;
+  while (true) {
+    const container = /^(?: {0,3}>[ \t]?| {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+)/.exec(content);
+    if (!container) return content;
+    content = content.slice(container[0].length);
+  }
+}
+
+function findClosingParen(text: string, start: number): number {
+  let depth = 1;
+  for (let index = start; index < text.length; index += 1) {
+    if (text[index] === '(') depth += 1;
+    if (text[index] === ')' && --depth === 0) return index;
+  }
+  return -1;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary

- Make workspace-relative Markdown references clickable in assistant output and sent workspace-file chips, including encoded spaces and non-ASCII paths.
- Preview .md, .markdown, and .mdx files in the existing Files workbar while keeping the transcript mounted, with Open locally and Show in folder actions.
- Resolve paths in the main process against the session workspace realpath, reject traversal, schemes, symlink escapes, and non-Markdown files, and cap previews at 256 KiB.

Fixes #2664

## Verification

- npm run typecheck
- npm run format:check
- npx biome lint --changed --since=origin/main
- npm run check:asf-headers
- npm --workspace @maka/ui test (236 passed)
- node --test apps/desktop/dist/main/__tests__/runtime-host-workspace-ipc-main.test.js apps/desktop/dist/main/__tests__/workspace-file-guard.test.js (3 passed)
- npm --workspace @maka/desktop run e2e -- e2e/workspace-markdown.spec.ts (1 passed)

The full local Desktop run reached 1504 passing tests. Eight existing MCP OAuth deadline tests were cancelled under local Node 22.22.1; the affected workspace tests and exact-head Electron E2E pass, and the OAuth source and test files are unchanged from main.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No