### PR TITLE
docs(cli): Ctrl+T help says latest thinking block but the binding toggles all in view

### DIFF
--- a/packages/cli/src/tui-primary-guidance.ts
+++ b/packages/cli/src/tui-primary-guidance.ts
@@ -76,7 +76,7 @@ const TUI_PRIMARY_GUIDANCE = {
       keybindingsHeading: '快捷键',
       keybindings: [
         '  Ctrl+O — 展开或折叠所有工具输出',
-        '  Ctrl+T — 展开或折叠最近的思考块',
+        '  Ctrl+T — 展开或折叠视图中的所有思考块',
         '  使用终端或触控板滚动对话记录',
         '  Enter（任务运行中）— 将消息注入当前任务',
         '  Alt+Enter（任务运行中）— 将消息排入下一轮',
@@ -124,7 +124,7 @@ const TUI_PRIMARY_GUIDANCE = {
       keybindingsHeading: 'Keybindings',
       keybindings: [
         '  Ctrl+O — expand or collapse all tool output',
-        '  Ctrl+T — expand or collapse the latest thinking block',
+        '  Ctrl+T — expand or collapse all thinking in view',
         '  Scroll the transcript with your terminal or trackpad',
         '  Enter (during a turn) — steer: inject a message into the running turn',
         '  Alt+Enter (during a turn) — queue a message for the next turn',


### PR DESCRIPTION
Closes #3826

## Summary

`/help` claimed Ctrl+T expands or collapses only *the latest* thinking block, but the binding calls `toggleAllThinkingExpansion`, which flips every thinking entry in the live viewport and retargets future entries — exactly the same `#1134`-style viewport contract as Ctrl+O's "all tool output" binding. With two thinking blocks in view, both toggle while `/help` promised only the latest.

This rewords both locales to match the handler, consistent with the adjacent Ctrl+O phrasing:

- EN: "expand or collapse **all thinking in view**"
- zh-CN: 展开或折叠**视图中的所有思考块**

Rewording rather than scoping the handler to the latest entry: the function name, its `#1134` contract comment (`pi-transcript.ts:471`), and its parallel with `toggleAllToolExpansion` all say viewport-wide was the intent.

## Verification

- `npm run build`, `npm run lint`, `npm run format:check`, `npm run typecheck` (from root) — pass
- `packages/cli` suite: 459/459 pass
- Repo-wide grep: no remaining copies of the old wording in either locale

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: opencode verified the mismatch against the handler, drafted the reworded copy in both locales, and ran verification. Human contributor of record reviewed and owns the change.

## Checklist

- [x] Tests cover the change and fail without it — not applicable: user-facing `/help` copy only; no behavior change
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] No