### PR TITLE
test(desktop): await Plan turn settlement

### DIFF
--- a/apps/desktop/e2e/composer-plus-menu-stability.spec.ts
+++ b/apps/desktop/e2e/composer-plus-menu-stability.spec.ts
@@ -69,6 +69,21 @@ async function rejectBridgeLatch(
   );
 }
 
+// The fake echo can paint before Runtime Host publishes terminal turn ownership.
+// Use the catalog's known-empty live set as the barrier before latching its next read.
+async function waitForSessionTurnToSettle(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await expect
+    .poll(async () =>
+      page.evaluate(async () => {
+        const sessions = await window.maka.sessions.list();
+        return sessions[0]?.runningTurnIds ?? null;
+      }),
+    )
+    .toEqual([]);
+}
+
 /**
  * Toggling Plan from the ＋ menu must not move the menu.
  *
@@ -266,6 +281,7 @@ test('two rapid Plan toggles land on the last requested state', async ({
   await composer.fill('alpha-marker');
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: alpha-marker/)).toBeVisible();
+  await waitForSessionTurnToSettle(page);
 
   await page.getByRole('button', { name: '添加上下文' }).click();
   const menu = page.getByRole('menu', { name: '添加上下文' });
@@ -300,6 +316,7 @@ test('a failed catalog refresh keeps the committed Plan state visible', async ({
   await composer.fill('alpha-marker');
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: alpha-marker/)).toBeVisible();
+  await waitForSessionTurnToSettle(page);
 
   await page.getByRole('button', { name: '添加上下文' }).click();
   const menu = page.getByRole('menu', { name: '添加上下文' });
@@ -322,6 +339,7 @@ test('latest Plan intent still reaches the Host after a catalog refresh fails', 
   await composer.fill('alpha-marker');
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: alpha-marker/)).toBeVisible();
+  await waitForSessionTurnToSettle(page);
 
   await page.getByRole('button', { name: '添加上下文' }).click();
   const planRow = page.getByRole('menu', { name: '添加上下文' })
@@ -352,6 +370,7 @@ test('deleting the session while a toggle is pending settles clean', async ({
   await composer.fill('alpha-marker');
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: alpha-marker/)).toBeVisible();
+  await waitForSessionTurnToSettle(page);
 
   await page.getByRole('button', { name: '添加上下文' }).click();
   const menu = page.getByRole('menu', { name: '添加上下文' });


### PR DESCRIPTION
## Summary

Stabilize the Plan/catalog-refresh Desktop e2e scenarios by waiting for Runtime Host's authoritative terminal turn ownership before latching the next session-catalog read.

- adds one shared barrier that requires `runningTurnIds` to be known-empty;
- applies it to the four Plan scenarios that first create a session through the fake backend;
- preserves the existing pending refresh, rejected refresh, queued latest-intent, and deletion-race assertions.

## Why

The fake backend response can become visible before Runtime Host publishes terminal turn ownership. The tests previously treated that text as a completion barrier, then observed the Plan row enabled briefly before a late running projection disabled it between the assertion and click.

This reproduced on two unrelated #3789 heads:

- [run 32867280955](https://github.com/apache/maka/actions/runs/32867280955/job/97865535723) timed out on the second Plan click in the latest-intent scenario;
- [run 32870919058](https://github.com/apache/maka/actions/runs/32870919058/job/97877439151) timed out on the first Plan click in the committed-state scenario.

The new barrier uses the same known-empty `runningTurnIds` authority already used by the Desktop streaming e2e suite. It runs before `sessions.list` is latched, so the latch still owns only the Plan commit's catalog refresh.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- `git diff --check`
- Playwright discovery compiles and selects the focused scenario correctly.
- Hosted [`test`](https://github.com/apache/maka/actions/runs/32918399089/job/98026819746) passed in 9m11s, including the complete Desktop e2e suite.

Local Windows Electron did not create its first test window, so the focused runtime assertion requires the hosted Linux/xvfb CI lane. The failure occurred before the test body and is not counted as passing evidence.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool and scope: Codex analyzed the two hosted traces, added the test-only settlement barrier, and ran the listed local gates.

Fixes #3814.

## Checklist

- [x] Tests cover the timing boundary that failed in hosted CI
- [x] Lint, format, build, typecheck, knip, and diff checks pass locally
- [x] Hosted `test` passes on exact head `e62c5756e`

Does this PR entail a change in behavior?

- [ ] Yes
- [x] No - this changes only Desktop e2e synchronization.
