### PR TITLE
fix(desktop): stop renderer before quit cleanup

### DIFF
--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -1558,6 +1558,7 @@ function wireLifecycle(): void {
 }
 
 async function prepareRuntimeHostDesktopQuit(): Promise<void> {
+  mainWindowController.browserWindow()?.destroy();
   const retirement = await runtimeHostManager?.retireOwnedLocalHost(
     "interrupt_active_work",
   );


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Destroy the main Renderer before retiring the owned local Runtime Host. This prevents Renderer IPC from racing handler teardown during a normal Desktop quit and removes misleading `No handler registered` errors from the shutdown log.

## Verification

- Launched `npm run dev` with an isolated profile and quit through the macOS application quit event; shutdown logged only the clean local Host exit
- `npx tsc -p apps/desktop/tsconfig.main.json --noEmit`
- App quit coordinator tests: 6 passed
- `npm run lint`
- `npm run format:check`
- Full repository typecheck remains blocked on the current `origin/main` error in `runtime-host-session-catalog.ts` (`DesktopSessionSummary.id`)

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex investigated the shutdown race, implemented the one-line lifecycle ordering fix, and ran verification

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, main-process typecheck, and the affected suite pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 摘要

在退出自有的本地 Runtime Host 前先销毁主 Renderer，避免正常退出时 Renderer IPC 与 handler 清理发生竞态，并消除退出日志中误导性的 `No handler registered` 错误

## 验证

- 使用隔离 profile 启动 `npm run dev`，通过 macOS 应用退出事件退出；日志只保留本地 Host 正常退出记录
- `npx tsc -p apps/desktop/tsconfig.main.json --noEmit`
- App quit coordinator 测试：6 项通过
- `npm run lint`
- `npm run format:check`
- 仓库整体 typecheck 仍被当前 `origin/main` 中 `runtime-host-session-catalog.ts` 的 `DesktopSessionSummary.id` 错误阻断

## AI 使用

- [ ] 没有生成式工具作出实质性贡献
- [x] 生成式工具作出了实质性贡献

工具及范围：Codex 调查退出竞态、实现一行生命周期顺序修复并完成验证

## 检查清单

- [ ] 测试覆盖该变更，且在没有该变更时会失败
- [x] lint、format、Main 进程 typecheck 及相关测试均在本地通过

此 PR 是否改变行为？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
