### PR TITLE
test(runtime-host): tolerate loaded CI runners in the shutdown-deadline test (#3840)

### DIFF
--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -1460,10 +1460,13 @@ describe('non-serving Runtime Host kernel', () => {
       );
 
       try {
-        await withTimeout(closeEntered, 1_000, 'composition close did not begin');
+        // The storage/owner/drain chain before the close hook can exceed 1s
+        // on loaded CI runners (see #3840); tolerate that without weakening
+        // shutdownGraceMs, which still exercises the active-deadline path.
+        await withTimeout(closeEntered, 5_000, 'composition close did not begin');
         const error = await withTimeout(
           startupFailure,
-          1_000,
+          5_000,
           'Runtime Host startup ignored its shutdown deadline',
         );
         assert.ok(error instanceof AggregateError);


### PR DESCRIPTION
## Problem

`startup failure preserves its cause when shutdown reaches the active deadline` intermittently fails on CI with `composition close did not begin`. The test arms a real Runtime Host kernel and waits 1s for the composition `close` hook; on loaded CI runners the storage-root resolution → owner acquisition → drain → recover-rejection chain can exceed 1s (observed 1053ms/1080ms), so the timeout fires before the kernel is actually wrong.

## Change

Raise both `withTimeout` budgets in the test to 5s, matching the loaded-CI-tolerant waits already used elsewhere in this file (e.g. `silently-handshaked ephemeral candidate never drained`, `uncooperative Runtime Host did not exit`). `shutdownGraceMs: 100` is unchanged, so the active-deadline semantics under test are identical.

## Verification

- Target test passes 3/3 on this machine (the whole test now runs ~1.0–1.7s, which the old 1s budget would have been dangerously close to).
- Mutation check from the issue's acceptance criteria: with `markCloseEntered()` removed from the `close` hook, the test fails with `composition close did not begin` after the 5s budget — a genuine skip is still detected.
- `tsc` build of `@maka/runtime-host` passes; biome format reports no changes needed.

Note: 3 unrelated tests in this file fail on my Windows machine (`does not take over a generation-mismatched Host`, `Node and Electron Candidates arbitrate`, `answers an admitted bootstrap with draining after shutdown commits`) — reproduced identically with this change stashed, so they are pre-existing local/environment issues (one shows an `EPERM` rename against the real `%LOCALAPPDATA%\Maka\runtime-hosts` profile).

<details>
<summary>简体中文</summary>

## 问题

`startup failure preserves its cause when shutdown reaches the active deadline` 在 CI 上间歇性失败，报错 `composition close did not begin`。该测试会启动真实的 Runtime Host kernel，并等待 composition 的 `close` 钩子，墙钟预算只有 1s；在负载较高的 CI runner 上，存储根解析 → owner 获取 → drain → recover 拒绝传播这条链路可能超过 1s（观察到 1053ms / 1080ms），于是超时先于真实错误触发。

## 改动

将该测试中的两处 `withTimeout` 预算从 1s 提高到 5s，与本文件其他已适配高负载 CI 的等待保持一致（如 `silently-handshaked ephemeral candidate never drained`、`uncooperative Runtime Host did not exit`）。`shutdownGraceMs: 100` 保持不变，被测试的 active-deadline 语义完全一致。

## 验证

- 目标测试在本机 3/3 通过（完整测试现在耗时约 1.0–1.7s，旧 1s 预算本就在临界线上）。
- 按 issue 验收标准做变异检查：删除 `close` 钩子中的 `markCloseEntered()` 后，测试仍在 5s 预算处报 `composition close did not begin` —— 预算放宽没有削弱对真实跳过的检测。
- `@maka/runtime-host` 的 `tsc` 构建通过；biome format 无改动。

备注：本文件另有 3 个与本次改动无关的测试在我这台 Windows 机器上失败（`does not take over a generation-mismatched Host`、`Node and Electron Candidates arbitrate`、`answers an admitted bootstrap with draining after shutdown commits`）——在 stash 掉本次改动后复现结果完全相同，属于预先存在的本地/环境问题（其中一个是对真实 `%LOCALAPPDATA%\Maka\runtime-hosts` 配置文件执行 `rename` 时报 `EPERM`）。

</details>
