### PR TITLE
test(runtime-host): fix flaky startup failure test via native fake timers

### DIFF
--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -1420,7 +1420,9 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
-  test('startup failure preserves its cause when shutdown reaches the active deadline', async () => {
+  test('startup failure preserves its cause when shutdown reaches the active deadline', {
+    timeout: 10_000,
+  }, async (t) => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
       const owner = await tryAcquireInteractiveRootOwner(capability);
@@ -1434,6 +1436,19 @@ describe('non-serving Runtime Host kernel', () => {
         releaseClose = resolve;
       });
       const lifecycle: string[] = [];
+
+      // Fake timers isolate the shutdownGraceMs deadline from real I/O jitter
+      // (registration writes, listener admission, storage-root binding) that
+      // #closeResources() performs before it ever calls composition.close().
+      // On a loaded runner that real work alone can exceed a real 100ms
+      // deadline, aborting shutdown via #assertShutdownCanContinue() before
+      // close() is entered at all — closeEntered then never resolves, and the
+      // test fails with "composition close did not begin" despite the kernel
+      // behaving correctly. Enabling mock timers only after `owner` is already
+      // acquired keeps the earlier real lock-acquisition path (which does poll
+      // via a real setTimeout in @maka/storage's file-update-lock) unaffected.
+      t.mock.timers.enable({ apis: ['setTimeout'] });
+
       const hostTask = RuntimeHostKernel.start({
         owner,
         idleGraceMs: 10_000,
@@ -1460,10 +1475,22 @@ describe('non-serving Runtime Host kernel', () => {
       );
 
       try {
-        // The storage/owner/drain chain before the close hook can exceed 1s
-        // on loaded CI runners (see #3840); tolerate that without weakening
-        // shutdownGraceMs, which still exercises the active-deadline path.
+        // #3844 widened these budgets to tolerate real wall-clock jitter on a
+        // loaded runner (see #3840). Fake timers remove that jitter, so these
+        // withTimeout wrappers no longer tolerate anything real - they are
+        // deliberate redundancy, kept only so a genuine regression (close()
+        // never entered, or startupFailure never settling after the tick)
+        // fails fast with a named error instead of the generic message from
+        // the outer 10_000ms test timeout.
         await withTimeout(closeEntered, 5_000, 'composition close did not begin');
+        // Deliberately fire the shutdown deadline now that close() is
+        // confirmed to be genuinely stuck on closeReleased - the exact
+        // scenario this test exists to exercise, reproduced deterministically
+        // instead of raced against wall-clock jitter.
+        t.mock.timers.tick(100);
+        // Let the promise chain settle after the synchronous timer callback
+        // (same pattern as gitoxide-helper-invocation-internal.test.ts).
+        await new Promise<void>((resolve) => setImmediate(resolve));
         const error = await withTimeout(
           startupFailure,
           5_000,


### PR DESCRIPTION
## Summary

Fixes #3840.

"startup failure preserves its cause when shutdown reaches the active deadline" (`host-kernel.test.ts`) raced a real 100ms `shutdownGraceMs` deadline against real I/O that `#closeResources()` must perform before it ever calls `composition.close()` - registration writes, listener admission close, storage-root identity re-validation. On a loaded runner that pre-close bookkeeping alone can exceed 100ms, so `#assertShutdownCanContinue()` aborts the shutdown sequence before `composition.close()` is ever invoked. `closeEntered` then never resolves, and the test fails with "composition close did not begin" - a false negative; the kernel is behaving exactly as designed (fail-stop on a missed shutdown deadline).

Fix: enable `node:test`'s built-in mock timers (`t.mock.timers`, already used in this package - see `gitoxide-helper-invocation-internal.test.ts`) right before starting the kernel, `await` the real, un-timed signal that `close()` was actually entered, then deterministically `tick(100)` the deadline forward. This reproduces the intended scenario - `close()` genuinely stuck when `shutdownGraceMs` elapses - without racing wall-clock jitter, and without touching kernel production code (`host-kernel.ts` is unmodified).

I considered two other approaches first and rejected both: stubbing the I/O layer (`writeHostRegistration`/listener setup aren't injectable without adding new seams to production code, and it wouldn't structurally remove the race, only shrink it) and deferring `context.requestDrain()` until "prep" finishes (the kernel has no way to know that from outside, and it would change what the test actually exercises - startup failure, not post-startup drain).

## Verification

- Reproduced the reported failure locally on the unmodified test (`Error: composition close did not begin`, ~1.1s) before making any change.
- After the fix: **50/50 consecutive runs passing**, average 1989ms/run, no run within 3x of the 10s safety-net timeout.
- Full `host-kernel.test.ts` suite: 60 passed / 5 skipped, one unrelated pre-existing failure (`answers an admitted bootstrap with draining after shutdown commits`, a Windows named-pipe EPIPE) confirmed via `git stash` to fail identically without this change - a local Windows-environment issue, not something this PR introduces.
- `npm run lint`, `npm run format:check`, `npm run build`, `npm run typecheck` all clean.

## Root cause

See Summary above - two timers were sharing one budget: incidental real setup I/O common to every shutdown, and the deliberately-stuck `close()` this test simulates. Under CI load the former could consume the whole 100ms before the latter was ever reached.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude (Anthropic, Claude Code) diagnosed the root cause by tracing the kernel's shutdown sequence, designed and implemented the fake-timer fix, and ran the verification above, under a human contributor's step-by-step review and approval at each stage (diagnosis, design, and implementation were each checkpointed before proceeding). `Generated-by` trailer added to the commit.

## Checklist

- [x] Tests cover the change and fail without it (verified via `git stash` against the unmodified test)
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes
- [x] No - test-only change; kernel production code is untouched