### PR TITLE
fix(desktop): pin the GCM auth tag length when decrypting the QQ bot secret

### DIFF
--- a/apps/desktop/src/main/qq-bot-scan-login.ts
+++ b/apps/desktop/src/main/qq-bot-scan-login.ts
@@ -93,7 +93,7 @@ export function decryptQQBotSecret(encryptedSecret: string, decryptionKey: strin
   const iv = payload.subarray(0, 12);
   const authTag = payload.subarray(payload.length - 16);
   const ciphertext = payload.subarray(12, payload.length - 16);
-  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  const decipher = createDecipheriv('aes-256-gcm', key, iv, { authTagLength: 16 });
   decipher.setAuthTag(authTag);
   return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
 }


### PR DESCRIPTION
## Summary

Add `{ authTagLength: 16 }` to the `createDecipheriv('aes-256-gcm', …)` call in `decryptQQBotSecret` (`apps/desktop/src/main/qq-bot-scan-login.ts:96`), in response to the semgrep `gcm-no-tag-length` finding below.

This is behavior-identical on this path, not a tightening. `decryptQQBotSecret` already rejects any payload with `payload.length <= 28` five lines above this call, and the tag is then taken as `payload.subarray(payload.length - 16)`. A payload that survives that guard is always at least 29 bytes, so `authTag` is always exactly 16 bytes before it ever reaches `createDecipheriv`. `authTagLength: 16` therefore constrains nothing the framing hadn't already fixed — there is no input, attacker-supplied or otherwise, that this call accepted before and rejects now. The value of the change is that it states that existing invariant explicitly at the call site instead of leaving it implicit in the length guard above, and it silences the scanner.

## Vulnerability

| Field | Value |
|-------|-------|
| **ID** | javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length |
| **Severity** | MEDIUM |
| **Scanner** | semgrep |
| **Rule** | `javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length` |
| **File** | `apps/desktop/src/main/qq-bot-scan-login.ts:96` |

**Description**: A call to `createDecipheriv` with GCM that omits an expected authentication tag length can, in general, verify a shorter-than-expected tag, which can be abused to spoof ciphertexts or recover the implicit authentication key. On this specific call site that's moot — the tag length is fixed by our own parsing (see Summary), not by the remote server.

## Changes

- `apps/desktop/src/main/qq-bot-scan-login.ts` — added `authTagLength: 16` to the existing `createDecipheriv` call; no other lines changed.

## Verification

- `apps/desktop/src/main/__tests__/qq-bot-scan-login.test.ts` already exercises `decryptQQBotSecret` (a round-trip decrypt, and rejection of a payload at the 28/29-byte boundary) and is unmodified by this PR. It passes with or without this change, since the change doesn't alter which inputs are accepted or rejected.
- I was not able to complete a local `typecheck`/`lint`/`test` run in this session: partway through `npm ci`, the sandbox's disk-space watchdog reclaimed space by deleting this working tree entirely. That's unrelated to this diff — the branch was already pushed to the fork beforehand, so no work was lost — but I have not re-run those checks since, and this description does not claim they passed.
- CI (the required `test` check) has not run yet — this PR is from a fork and is awaiting the workflow-approval gate. It will need a green check before merge regardless.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OrbisAI Security (an automated, semgrep-triggered fix generator) authored the original one-line code change in commit `69a10e8d0`. Claude Code (Opus) was used afterward to analyze reviewer feedback on this PR ([review](https://github.com/apache/maka/pull/3861#pullrequestreview-5036984217)), verify the no-op/invariant claim in the Summary above against `decryptQQBotSecret`'s source, and rewrite this title and description accordingly. I (the author/reviewer of record) read `decryptQQBotSecret` myself, independently confirmed that the `payload.length <= 28` guard forces every surviving payload's tag to be exactly 16 bytes, and reviewed and accepted that reasoning before revising this description.

## Checklist

- [ ] Tests cover the change and fail without it — not applicable: per the Summary, the change is behavior-identical, so no test can fail without it.
- [ ] Lint, format, typecheck and the affected suites pass locally — not verified this session; see Verification above.

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
