### PR TITLE
test(desktop): settle prompt-rail scroll jumps

### DIFF
--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -91,6 +91,8 @@ async function scrollTranscriptTo(page: Page, position: 'top' | 'bottom'): Promi
     if (!scroller) throw new Error('the chat scroll container is missing');
     scroller.scrollTop = where === 'top' ? 0 : scroller.scrollHeight;
   }, position);
+  await notifyTranscriptScrolled(page);
+  await waitForPaintedFrames(page);
 }
 
 async function waitForPaintedFrames(page: Page, count = 2): Promise<void> {


### PR DESCRIPTION
## Summary

Make prompt-rail test scrolling deterministic for the turn virtualizer.

- explicitly dispatches the transcript scroll notification after assigning `scrollTop`;
- waits two painted frames before the caller asserts the mounted turn window;
- keeps the exact tail-mount, eviction, focus-return, and selection-collapse assertions unchanged.

## Why

`scrollTranscriptTo` previously only assigned `scrollTop`. A programmatic assignment did not provide a deterministic observation/paint boundary for the virtualizer, so the eviction scenario could wait ten seconds for `turn-prompt-rail-120` while the mounted window remained stale.

This reproduced on an unrelated #3789 head in [run 32930874507](https://github.com/apache/maka/actions/runs/32930874507/job/98062726773). That PR has no Desktop/UI diff.

The spec already used `notifyTranscriptScrolled` and `waitForPaintedFrames` later in the same eviction journey. This change moves that existing boundary into the shared scroll helper so every top/bottom setup has deterministic semantics.

## Verification

- `npm run lint`
- `npm run format:check`
- `npx knip --workspace apps/desktop`
- `git diff --check`

The local Windows full build currently reproduces unrelated current-main Runtime Host type failures, while the exact `main` push CI is green. The authoritative Desktop e2e evidence for this test-only change is therefore the hosted Linux/xvfb `test` check on this PR.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool and scope: Codex analyzed the hosted trace, reused the spec's existing scroll notification and paint helpers, and ran the listed local gates.

Fixes #3862.

## Checklist

- [x] Existing assertions cover the failed boundary without being weakened
- [x] Lint, format, Desktop knip, and diff checks pass locally
- [x] Hosted [`test`](https://github.com/apache/maka/actions/runs/32932185830/job/98066399370) passes on exact head `52e9a6024`, including the full Desktop e2e suite

Does this PR entail a change in behavior?

- [ ] Yes
- [x] No - this changes only Desktop e2e synchronization.
