### PR TITLE
fix(desktop): ignore slash path separators

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -135,6 +135,48 @@ test('offers commands only for the first token and keeps explicit Skill queries 
   await expect(inlineMenu.getByRole('group', { name: '命令' })).toHaveCount(0);
 });
 
+test('does not open the slash menu for path separators', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  const menu = page.getByRole('listbox', { name: '命令和技能' });
+
+  for (const prefix of ['帮我整理到/Users', 'path/to/file']) {
+    await composer.fill(prefix);
+    await composer.evaluate((editable) => {
+      // Chromium can put the next typed character in a new text node. Recreate
+      // that observed input shape without letting Playwright normalize the DOM.
+      const node = editable.appendChild(document.createTextNode('/'));
+      const range = document.createRange();
+      range.setStart(node, 1);
+      range.collapse(true);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      editable.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        data: '/',
+        inputType: 'insertText',
+      }));
+    });
+
+    await expect(menu).toHaveCount(0);
+    await expect.poll(() => composer.textContent()).toBe(`${prefix}/`);
+    await expect
+      .poll(() =>
+        composer.evaluate((editable) => {
+          const selection = window.getSelection();
+          if (!selection?.focusNode || !editable.contains(selection.focusNode)) return -1;
+          const range = document.createRange();
+          range.selectNodeContents(editable);
+          range.setEnd(selection.focusNode, selection.focusOffset);
+          return range.toString().length;
+        }),
+      )
+      .toBe(`${prefix}/`.length);
+  }
+});
+
 test('dispatches /side instead of steering it into a running turn', async ({
   invocableSkillsWindow: page,
 }) => {

--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -177,6 +177,37 @@ test('does not open the slash menu for path separators', async ({
   }
 });
 
+test('opens the slash menu after a DOM block break', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  const menu = page.getByRole('listbox', { name: '命令和技能' });
+
+  await composer.fill('first line');
+  await composer.evaluate((editable) => {
+    const block = document.createElement('div');
+    const slash = block.appendChild(document.createTextNode('/'));
+    editable.appendChild(block);
+
+    const range = document.createRange();
+    range.setStart(slash, 1);
+    range.collapse(true);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    editable.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      data: '/',
+      inputType: 'insertText',
+    }));
+  });
+
+  await expect.poll(() => composer.evaluate((editable) => editable.innerText)).toBe(
+    'first line\n/',
+  );
+  await expect(menu).toBeVisible();
+});
+
 test('dispatches /side instead of steering it into a running turn', async ({
   invocableSkillsWindow: page,
 }) => {

--- a/patches/@astryxdesign+core+0.5.0.patch
+++ b/patches/@astryxdesign+core+0.5.0.patch
@@ -934,31 +934,69 @@ index 55b441e..7aa4174 100644
 +  );
  }
 diff --git a/node_modules/@astryxdesign/core/dist/Chat/useTriggerMenu.js b/node_modules/@astryxdesign/core/dist/Chat/useTriggerMenu.js
-index e1d2ebd6c..f2f4f3f86 100644
+index e1d2ebd6c..d4bb8cb03 100644
 --- a/node_modules/@astryxdesign/core/dist/Chat/useTriggerMenu.js
 +++ b/node_modules/@astryxdesign/core/dist/Chat/useTriggerMenu.js
-@@ -64 +64,9 @@ function getTextBeforeCursor(editable) {
+@@ -49,0 +50,39 @@ const styles = {
++const blockDisplays = new Set(['block', 'flex', 'flow-root', 'grid', 'list-item', 'table']);
++function createsLineBoundary(node) {
++  return node instanceof HTMLBRElement || node instanceof HTMLElement && blockDisplays.has(window.getComputedStyle(node).display);
++}
++function getTrailingContextCharacter(node) {
++  if (node.nodeType === Node.TEXT_NODE) {
++    return (node.textContent ?? '').slice(-1);
++  }
++  if (createsLineBoundary(node)) {
++    return '\n';
++  }
++  for (let child = node.lastChild; child; child = child.previousSibling) {
++    const character = getTrailingContextCharacter(child);
++    if (character) {
++      return character;
++    }
++  }
++  return '';
++}
++function getCharacterBeforeNode(editable, node) {
++  let current = node;
++  while (current && current !== editable) {
++    for (let sibling = current.previousSibling; sibling; sibling = sibling.previousSibling) {
++      const character = getTrailingContextCharacter(sibling);
++      if (character) {
++        return character;
++      }
++    }
++    const parent = current.parentNode;
++    if (!parent || parent === editable) {
++      return '';
++    }
++    if (createsLineBoundary(parent)) {
++      return '\n';
++    }
++    current = parent;
++  }
++  return '';
++}
+@@ -64 +103,6 @@ function getTextBeforeCursor(editable) {
 -    return (node.textContent ?? '').slice(0, range.startOffset);
 +    const nodeText = (node.textContent ?? '').slice(0, range.startOffset);
-+    const beforeNode = range.cloneRange();
-+    beforeNode.selectNodeContents(editable);
-+    beforeNode.setEnd(node, 0);
-+    const prefix = beforeNode.toString().slice(-1);
++    const prefix = getCharacterBeforeNode(editable, node);
 +    return {
 +      text: prefix + nodeText,
 +      nodeStart: prefix.length
 +    };
-@@ -309,2 +317,2 @@ export function useTriggerMenu(options) {
+@@ -309,2 +353,2 @@ export function useTriggerMenu(options) {
 -    const textBefore = getTextBeforeCursor(editable);
 -    if (textBefore === null) {
 +    const cursorContext = getTextBeforeCursor(editable);
 +    if (cursorContext === null) {
-@@ -316,2 +324,2 @@ export function useTriggerMenu(options) {
+@@ -316,2 +360,2 @@ export function useTriggerMenu(options) {
 -    const found = findActiveTrigger(textBefore, triggers);
 -    if (!found) {
 +    const found = findActiveTrigger(cursorContext.text, triggers);
 +    if (!found || found.triggerStart < cursorContext.nodeStart) {
-@@ -324,5 +332,5 @@ export function useTriggerMenu(options) {
+@@ -322,9 +366,9 @@ export function useTriggerMenu(options) {
+     }
      const {
        trigger,
 -      query,
@@ -966,34 +1004,81 @@ index e1d2ebd6c..f2f4f3f86 100644
 +      query
      } = found;
 +    const triggerStart = found.triggerStart - cursorContext.nodeStart;
+     if (!state.isActive || state.activeTrigger !== trigger) {
+       triggerStartRef.current = triggerStart;
+       setState(prev => ({
 diff --git a/node_modules/@astryxdesign/core/src/Chat/useTriggerMenu.tsx b/node_modules/@astryxdesign/core/src/Chat/useTriggerMenu.tsx
-index 6eefd4a59..8bec39086 100644
+index 6eefd4a59..17071f1b2 100644
 --- a/node_modules/@astryxdesign/core/src/Chat/useTriggerMenu.tsx
 +++ b/node_modules/@astryxdesign/core/src/Chat/useTriggerMenu.tsx
-@@ -170 +170,3 @@ const styles = stylex.create({
+@@ -170 +170,50 @@ const styles = stylex.create({
 -function getTextBeforeCursor(editable: HTMLDivElement): string | null {
++const blockDisplays = new Set(['block', 'flex', 'flow-root', 'grid', 'list-item', 'table']);
++
++function createsLineBoundary(node: Node): boolean {
++  return (
++    node instanceof HTMLBRElement ||
++    (node instanceof HTMLElement && blockDisplays.has(window.getComputedStyle(node).display))
++  );
++}
++
++function getTrailingContextCharacter(node: Node): string {
++  if (node.nodeType === Node.TEXT_NODE) {
++    return (node.textContent ?? '').slice(-1);
++  }
++  if (createsLineBoundary(node)) {
++    return '\n';
++  }
++  for (let child = node.lastChild; child; child = child.previousSibling) {
++    const character = getTrailingContextCharacter(child);
++    if (character) {
++      return character;
++    }
++  }
++  return '';
++}
++
++function getCharacterBeforeNode(editable: HTMLDivElement, node: Node): string {
++  let current: Node | null = node;
++  while (current && current !== editable) {
++    for (let sibling = current.previousSibling; sibling; sibling = sibling.previousSibling) {
++      const character = getTrailingContextCharacter(sibling);
++      if (character) {
++        return character;
++      }
++    }
++
++    const parent = current.parentNode;
++    if (!parent || parent === editable) {
++      return '';
++    }
++    if (createsLineBoundary(parent)) {
++      return '\n';
++    }
++    current = parent;
++  }
++  return '';
++}
++
 +function getTextBeforeCursor(
 +  editable: HTMLDivElement,
 +): {text: string; nodeStart: number} | null {
-@@ -186 +188,6 @@ function getTextBeforeCursor(editable: HTMLDivElement): string | null {
+@@ -186 +235,3 @@ function getTextBeforeCursor(editable: HTMLDivElement): string | null {
 -    return (node.textContent ?? '').slice(0, range.startOffset);
 +    const nodeText = (node.textContent ?? '').slice(0, range.startOffset);
-+    const beforeNode = range.cloneRange();
-+    beforeNode.selectNodeContents(editable);
-+    beforeNode.setEnd(node, 0);
-+    const prefix = beforeNode.toString().slice(-1);
++    const prefix = getCharacterBeforeNode(editable, node);
 +    return {text: prefix + nodeText, nodeStart: prefix.length};
-@@ -489,2 +496,2 @@ export function useTriggerMenu(
+@@ -489,2 +540,2 @@ export function useTriggerMenu(
 -    const textBefore = getTextBeforeCursor(editable);
 -    if (textBefore === null) {
 +    const cursorContext = getTextBeforeCursor(editable);
 +    if (cursorContext === null) {
-@@ -497,2 +504,2 @@ export function useTriggerMenu(
+@@ -497,2 +548,2 @@ export function useTriggerMenu(
 -    const found = findActiveTrigger(textBefore, triggers);
 -    if (!found) {
 +    const found = findActiveTrigger(cursorContext.text, triggers);
 +    if (!found || found.triggerStart < cursorContext.nodeStart) {
-@@ -505 +512,2 @@ export function useTriggerMenu(
+@@ -505 +556,2 @@ export function useTriggerMenu(
 -    const {trigger, query, triggerStart} = found;
 +    const {trigger, query} = found;
 +    const triggerStart = found.triggerStart - cursorContext.nodeStart;

--- a/patches/@astryxdesign+core+0.5.0.patch
+++ b/patches/@astryxdesign+core+0.5.0.patch
@@ -933,3 +933,67 @@ index 55b441e..7aa4174 100644
 +    snapToGraphemeBoundary(targetText, renderedPresentation.displayedLen),
 +  );
  }
+diff --git a/node_modules/@astryxdesign/core/dist/Chat/useTriggerMenu.js b/node_modules/@astryxdesign/core/dist/Chat/useTriggerMenu.js
+index e1d2ebd6c..f2f4f3f86 100644
+--- a/node_modules/@astryxdesign/core/dist/Chat/useTriggerMenu.js
++++ b/node_modules/@astryxdesign/core/dist/Chat/useTriggerMenu.js
+@@ -64 +64,9 @@ function getTextBeforeCursor(editable) {
+-    return (node.textContent ?? '').slice(0, range.startOffset);
++    const nodeText = (node.textContent ?? '').slice(0, range.startOffset);
++    const beforeNode = range.cloneRange();
++    beforeNode.selectNodeContents(editable);
++    beforeNode.setEnd(node, 0);
++    const prefix = beforeNode.toString().slice(-1);
++    return {
++      text: prefix + nodeText,
++      nodeStart: prefix.length
++    };
+@@ -309,2 +317,2 @@ export function useTriggerMenu(options) {
+-    const textBefore = getTextBeforeCursor(editable);
+-    if (textBefore === null) {
++    const cursorContext = getTextBeforeCursor(editable);
++    if (cursorContext === null) {
+@@ -316,2 +324,2 @@ export function useTriggerMenu(options) {
+-    const found = findActiveTrigger(textBefore, triggers);
+-    if (!found) {
++    const found = findActiveTrigger(cursorContext.text, triggers);
++    if (!found || found.triggerStart < cursorContext.nodeStart) {
+@@ -324,5 +332,5 @@ export function useTriggerMenu(options) {
+     const {
+       trigger,
+-      query,
+-      triggerStart
++      query
+     } = found;
++    const triggerStart = found.triggerStart - cursorContext.nodeStart;
+diff --git a/node_modules/@astryxdesign/core/src/Chat/useTriggerMenu.tsx b/node_modules/@astryxdesign/core/src/Chat/useTriggerMenu.tsx
+index 6eefd4a59..8bec39086 100644
+--- a/node_modules/@astryxdesign/core/src/Chat/useTriggerMenu.tsx
++++ b/node_modules/@astryxdesign/core/src/Chat/useTriggerMenu.tsx
+@@ -170 +170,3 @@ const styles = stylex.create({
+-function getTextBeforeCursor(editable: HTMLDivElement): string | null {
++function getTextBeforeCursor(
++  editable: HTMLDivElement,
++): {text: string; nodeStart: number} | null {
+@@ -186 +188,6 @@ function getTextBeforeCursor(editable: HTMLDivElement): string | null {
+-    return (node.textContent ?? '').slice(0, range.startOffset);
++    const nodeText = (node.textContent ?? '').slice(0, range.startOffset);
++    const beforeNode = range.cloneRange();
++    beforeNode.selectNodeContents(editable);
++    beforeNode.setEnd(node, 0);
++    const prefix = beforeNode.toString().slice(-1);
++    return {text: prefix + nodeText, nodeStart: prefix.length};
+@@ -489,2 +496,2 @@ export function useTriggerMenu(
+-    const textBefore = getTextBeforeCursor(editable);
+-    if (textBefore === null) {
++    const cursorContext = getTextBeforeCursor(editable);
++    if (cursorContext === null) {
+@@ -497,2 +504,2 @@ export function useTriggerMenu(
+-    const found = findActiveTrigger(textBefore, triggers);
+-    if (!found) {
++    const found = findActiveTrigger(cursorContext.text, triggers);
++    if (!found || found.triggerStart < cursorContext.nodeStart) {
+@@ -505 +512,2 @@ export function useTriggerMenu(
+-    const {trigger, query, triggerStart} = found;
++    const {trigger, query} = found;
++    const triggerStart = found.triggerStart - cursorContext.nodeStart;


### PR DESCRIPTION
Chromium can place a newly typed `/` in a separate contentEditable text node. Astryx previously treated that DOM node boundary as a token boundary, so a path separator attached to preceding text could open the command/Skill picker.

Read the preceding editor character when evaluating a trigger at a text-node edge, then translate the accepted trigger offset back to the current node. This preserves leading and whitespace-delimited slash discovery while keeping path separators as ordinary draft text.

Fixes #3849

## Before / After

### Before

The trailing `/` is attached to the filesystem path, but the command/Skill picker opens.

https://github.com/user-attachments/assets/f6081b0f-e2d7-45d7-ace1-e28f74a6faab

### After

The same trailing `/` remains ordinary draft text; no picker opens and the caret stays at the end.

https://github.com/user-attachments/assets/e77d23cc-4261-4301-8cee-749544006948

### Recording method

Both clips were generated from Maka's deterministic Desktop E2E environment using the `invocableSkillsWindow` fixture with the fake backend and seeded test data. The Before clip temporarily built the renderer with the unpatched Astryx trigger-menu implementation; the After clip rebuilt the same flow with this PR's patch. The renderer was captured frame by frame and encoded as H.264 MP4, so no desktop content outside the Maka window was recorded.

The `Claude Sonnet 4.5` label visible in the composer is informational fixture UI state only. The recording made no Anthropic request and invoked no real model; both clips use the same fake backend and differ only in the slash-trigger implementation.

## Verification

- `npm ci`
- `npm --workspace @maka/desktop run build:with-deps`
- `env -u ELECTRON_RUN_AS_NODE npm --workspace @maka/desktop exec -- playwright test --config e2e/playwright.config.ts e2e/slash-command-menu.spec.ts --grep "does not open the slash menu for path separators" --repeat-each=3 --workers=1` — 3 passed
- `env -u ELECTRON_RUN_AS_NODE npm --workspace @maka/desktop exec -- playwright test --config e2e/playwright.config.ts e2e/slash-command-menu.spec.ts --workers=1` — 6 passed
- `npm --workspace @maka/ui run typecheck`
- `npm --workspace @maka/desktop run typecheck`
- `npx --no-install biome check apps/desktop/e2e/slash-command-menu.spec.ts`
- `git diff --check`

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka analyzed the issue, implemented the dependency patch and regression test, and ran the listed verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — path separators inside continuous text no longer open the slash picker; leading and whitespace-delimited slash discovery is preserved
- [ ] No


