### PR TITLE
fix(cli): abbreviate home-relative cwd on Windows statusline

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -18,6 +18,8 @@
  */
 
 import assert from 'node:assert/strict';
+import { homedir } from 'node:os';
+import { join, sep } from 'node:path';
 import { describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import type { PipeShellOutput, PtyShellOutput } from '@maka/core/shell-run';
@@ -38,6 +40,7 @@ import {
   hydrateToolsWithStoredMessages,
   makaPiToolPresentationStatus,
   replaceTranscriptWithStoredMessages,
+  shortenCwd,
   submitCompactToTranscript,
   toggleAllThinkingExpansion,
   toggleAllToolExpansion,
@@ -242,6 +245,46 @@ describe('Maka Pi TUI transcript', () => {
       ),
       /ctx 20k\/500k 4%/,
     );
+  });
+
+  test('abbreviates a home-relative cwd on every platform (#3825)', () => {
+    // Windows reports the profile with backslashes, so the abbreviation has to
+    // be decided on separator-normalized paths rather than on a `home + '/'`
+    // prefix, which matched nothing there. Home and cwd are injected as plain
+    // strings so every expectation holds on any runner.
+    const cases: [cwd: string, home: string, expected: string][] = [
+      ['/Users/alice/workspace/project', '/Users/alice', '~/workspace/project'],
+      ['/Users/alice', '/Users/alice', '~'],
+      ['C:\\Users\\alice\\Videos\\clip', 'C:\\Users\\alice', '~\\Videos\\clip'],
+      ['C:\\Users\\alice', 'C:\\Users\\alice', '~'],
+      ['C:\\Users\\alice\\', 'C:\\Users\\alice', '~'],
+      // Windows accepts either separator inside one path.
+      ['C:/Users/alice/Videos', 'C:\\Users\\alice', '~/Videos'],
+      ['C:\\Users\\alice\\Videos', 'C:/Users/alice', '~\\Videos'],
+      // Outside home, or only sharing a name prefix with it: unchanged.
+      ['/opt/maka', '/Users/alice', '/opt/maka'],
+      ['/Users/alicebob/x', '/Users/alice', '/Users/alicebob/x'],
+      ['D:\\Projects\\maka', 'C:\\Users\\alice', 'D:\\Projects\\maka'],
+      ['C:\\Users\\alicebob\\x', 'C:\\Users\\alice', 'C:\\Users\\alicebob\\x'],
+      // A `..` segment can walk back out of home, so the full path is kept.
+      ['/Users/alice/../bob', '/Users/alice', '/Users/alice/../bob'],
+      ['C:\\Users\\alice\\..\\bob', 'C:\\Users\\alice', 'C:\\Users\\alice\\..\\bob'],
+      // No usable home: nothing to abbreviate against.
+      ['/Users/alice/project', '', '/Users/alice/project'],
+    ];
+    for (const [cwd, home, expected] of cases) {
+      assert.equal(shortenCwd(cwd, home), expected, `${cwd} under ${home}`);
+    }
+  });
+
+  test('status line renders the cwd through the home abbreviation (#3825)', () => {
+    // The statusline resolves home itself, so drive the wiring through the
+    // real one and build the expectation with the platform's own separator.
+    const line = stripAnsi(
+      renderMakaPiStatusLine({ ...meta(), cwd: join(homedir(), 'workspace', 'project') }, 200),
+    );
+    assert.match(line, new RegExp(`~\\${sep}workspace\\${sep}project$`));
+    assert.equal(line.includes(homedir()), false);
   });
 
   test('keeps assistant text after a tool call visible after the tool block', () => {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -248,32 +248,55 @@ describe('Maka Pi TUI transcript', () => {
   });
 
   test('abbreviates a home-relative cwd on every platform (#3825)', () => {
-    // Windows reports the profile with backslashes, so the abbreviation has to
-    // be decided on separator-normalized paths rather than on a `home + '/'`
-    // prefix, which matched nothing there. Home and cwd are injected as plain
-    // strings so every expectation holds on any runner.
-    const cases: [cwd: string, home: string, expected: string][] = [
-      ['/Users/alice/workspace/project', '/Users/alice', '~/workspace/project'],
-      ['/Users/alice', '/Users/alice', '~'],
-      ['C:\\Users\\alice\\Videos\\clip', 'C:\\Users\\alice', '~\\Videos\\clip'],
-      ['C:\\Users\\alice', 'C:\\Users\\alice', '~'],
-      ['C:\\Users\\alice\\', 'C:\\Users\\alice', '~'],
+    // Home, cwd and platform are all injected, so each row asserts the same
+    // thing on a POSIX and a Windows runner. The `linux` rows carrying a drive
+    // letter or a UNC root are the point of the win32 sniffing: a Windows path
+    // must abbreviate correctly even when the process is not on Windows.
+    const cases: [cwd: string, home: string, platform: NodeJS.Platform, expected: string][] = [
+      ['/Users/alice/workspace/project', '/Users/alice', 'linux', '~/workspace/project'],
+      ['/Users/alice', '/Users/alice', 'linux', '~'],
+      ['C:\\Users\\alice\\Videos\\clip', 'C:\\Users\\alice', 'linux', '~\\Videos\\clip'],
+      ['C:\\Users\\alice', 'C:\\Users\\alice', 'linux', '~'],
+      ['C:\\Users\\alice\\', 'C:\\Users\\alice', 'linux', '~'],
+      ['\\\\server\\home\\alice\\Videos', '\\\\server\\home\\alice', 'linux', '~\\Videos'],
+      ['C:\\Users', 'C:\\', 'linux', '~\\Users'],
       // Windows accepts either separator inside one path.
-      ['C:/Users/alice/Videos', 'C:\\Users\\alice', '~/Videos'],
-      ['C:\\Users\\alice\\Videos', 'C:/Users/alice', '~\\Videos'],
+      ['C:/Users/alice/Videos', 'C:\\Users\\alice', 'linux', '~/Videos'],
+      ['C:\\Users\\alice\\Videos', 'C:/Users/alice', 'linux', '~\\Videos'],
+      // Windows names are case-insensitive, so a differently-cased profile
+      // path still abbreviates, and the tail keeps the casing it came with.
+      ['c:\\users\\ALICE\\work', 'C:\\Users\\Alice', 'linux', '~\\work'],
+      ['C:\\USERS\\Alice\\Videos', 'c:\\users\\alice', 'linux', '~\\Videos'],
+      ['C:\\Users\\ALICE', 'C:\\Users\\alice', 'linux', '~'],
+      // POSIX names are not: same-spelling-different-case is a different path.
+      ['/Users/ALICE/work', '/Users/alice', 'linux', '/Users/ALICE/work'],
+      // ...unless the process itself is on Windows, where the whole filesystem
+      // is case-insensitive regardless of how the path is spelled.
+      ['/Users/ALICE/work', '/Users/alice', 'win32', '~/work'],
+      // `\` is a legal POSIX filename character, not a separator: `alice\evil`
+      // is a sibling of `alice`, and `a\b` is one directory name.
+      ['/Users/alice\\evil', '/Users/alice', 'linux', '/Users/alice\\evil'],
+      ['/Users/alice/a\\b', '/Users/alice', 'linux', '~/a\\b'],
       // Outside home, or only sharing a name prefix with it: unchanged.
-      ['/opt/maka', '/Users/alice', '/opt/maka'],
-      ['/Users/alicebob/x', '/Users/alice', '/Users/alicebob/x'],
-      ['D:\\Projects\\maka', 'C:\\Users\\alice', 'D:\\Projects\\maka'],
-      ['C:\\Users\\alicebob\\x', 'C:\\Users\\alice', 'C:\\Users\\alicebob\\x'],
+      ['/opt/maka', '/Users/alice', 'linux', '/opt/maka'],
+      ['/Users/alicebob/x', '/Users/alice', 'linux', '/Users/alicebob/x'],
+      ['D:\\Projects\\maka', 'C:\\Users\\alice', 'linux', 'D:\\Projects\\maka'],
+      ['C:\\Users\\alicebob\\x', 'C:\\Users\\alice', 'linux', 'C:\\Users\\alicebob\\x'],
       // A `..` segment can walk back out of home, so the full path is kept.
-      ['/Users/alice/../bob', '/Users/alice', '/Users/alice/../bob'],
-      ['C:\\Users\\alice\\..\\bob', 'C:\\Users\\alice', 'C:\\Users\\alice\\..\\bob'],
-      // No usable home: nothing to abbreviate against.
-      ['/Users/alice/project', '', '/Users/alice/project'],
+      ['/Users/alice/../bob', '/Users/alice', 'linux', '/Users/alice/../bob'],
+      ['C:\\Users\\alice\\..\\bob', 'C:\\Users\\alice', 'linux', 'C:\\Users\\alice\\..\\bob'],
+      // An empty or bare-root home would otherwise swallow every absolute path.
+      ['/Users/alice/project', '', 'linux', '/Users/alice/project'],
+      ['/usr/bin', '/', 'linux', '/usr/bin'],
+      ['/usr/bin', '//', 'linux', '/usr/bin'],
+      ['C:\\Users\\alice', '\\', 'win32', 'C:\\Users\\alice'],
     ];
-    for (const [cwd, home, expected] of cases) {
-      assert.equal(shortenCwd(cwd, home), expected, `${cwd} under ${home}`);
+    for (const [cwd, home, platform, expected] of cases) {
+      assert.equal(
+        shortenCwd(cwd, home, platform),
+        expected,
+        `${cwd} under ${home} on ${platform}`,
+      );
     }
   });
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1517,32 +1517,60 @@ function firstLinePreview(text: string): string {
  * `/Users/alice/workspace/project` → `~/workspace/project`,
  * `C:\Users\alice\Videos\clip` → `~\Videos\clip`.
  *
- * Containment is decided on separator-normalized copies. Windows reports the
- * profile as `C:\Users\<name>` and accepts either separator inside one path, so
- * a literal `home + '/'` prefix test matched nothing there and the statusline
- * showed every profile subdirectory in full (#3825). `path.relative` is not
- * used for the same reason in reverse: it follows the host platform, so a
- * Windows path would be misread on a POSIX runner. The tail is sliced out of
- * the original `cwd` rather than the normalized copy, keeping whichever
- * separators the platform actually produced.
+ * Windows and POSIX get different containment rules, because `\` and letter
+ * case mean different things on each. A win32 path — the host platform, a `C:`
+ * drive root, or a `\\` UNC root — treats `\` and `/` as interchangeable
+ * separators and compares without regard to case, so `c:\users\ALICE\work`
+ * abbreviates under `C:\Users\Alice` the way the shell and Explorer read it.
+ * A POSIX path compares case-sensitively and treats `\` as the ordinary
+ * filename character it is, so a sibling entry literally named `alice\evil`
+ * is not mistaken for something inside `/home/alice`.
  *
- * Falls back to the original path when it is not under home. A `..` segment
- * falls back too — it can walk back out, and only the unabbreviated path is
- * guaranteed to still name the same directory. Comparison stays
- * case-sensitive, like the other path helpers in the tree.
+ * The original `home + '/'` prefix test was false for every subdirectory of a
+ * Windows profile, so the statusline showed the full absolute path there
+ * (#3825). `path.relative` is not the fix: it follows the host platform, so a
+ * Windows path would be misread on a POSIX runner and the tests would only
+ * mean anything on Windows. The tail is sliced out of the original `cwd`, so
+ * it keeps the separators and the casing the platform actually produced.
+ *
+ * Falls back to the original path when it is not under home, when home is
+ * empty or a bare root (every absolute path would otherwise collapse to `~`),
+ * or when a `..` segment walks back out — only the unabbreviated path is
+ * guaranteed to still name the same directory.
  */
-export function shortenCwd(cwd: string, homeDir?: string): string {
+export function shortenCwd(
+  cwd: string,
+  homeDir?: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
   const home = homeDir ?? homedir();
+  const windows = platform === 'win32' || hasWin32Root(home) || hasWin32Root(cwd);
   // A trailing separator on home would push the slice offset past the prefix.
-  const normalizedHome = home.replace(/[\\/]+$/, '').replaceAll('\\', '/');
-  if (!normalizedHome) return cwd;
-  const normalizedCwd = cwd.replaceAll('\\', '/');
-  if (normalizedCwd === normalizedHome) return '~';
-  if (!normalizedCwd.startsWith(`${normalizedHome}/`)) return cwd;
-  const tail = normalizedCwd.slice(normalizedHome.length + 1);
-  if (!tail) return '~';
+  const trimmedHome = home.replace(windows ? /[\\/]+$/ : /\/+$/, '');
+  if (!trimmedHome) return cwd;
+  const normalizedHome = windows ? trimmedHome.replaceAll('\\', '/') : trimmedHome;
+  const normalizedCwd = windows ? cwd.replaceAll('\\', '/') : cwd;
+  // Equal-length slices, folded only for the comparison: case folding can
+  // change a string's length, which would shift the offset the tail is cut at.
+  const prefix = normalizedCwd.slice(0, normalizedHome.length);
+  const contained = windows
+    ? prefix.toLowerCase() === normalizedHome.toLowerCase()
+    : prefix === normalizedHome;
+  if (!contained) return cwd;
+  const tail = normalizedCwd.slice(normalizedHome.length);
+  if (tail === '' || tail === '/') return '~';
+  if (!tail.startsWith('/')) return cwd;
   if (tail.split('/').includes('..')) return cwd;
   return `~${cwd.slice(normalizedHome.length)}`;
+}
+
+/**
+ * A path rooted the win32 way: a `C:` drive or a `\\` UNC share. Only those
+ * two shapes count. A lone `\` anywhere else is a legal POSIX filename
+ * character, so sniffing on it would make POSIX paths change meaning.
+ */
+function hasWin32Root(path: string): boolean {
+  return /^[a-zA-Z]:([\\/]|$)/.test(path) || path.startsWith('\\\\');
 }
 
 function formatCost(costUsd: number): string {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1513,15 +1513,36 @@ function firstLinePreview(text: string): string {
 }
 
 /**
- * Shorten an absolute path to a `~`-relative form for the statusline.
- * `/Users/alice/workspace/project` → `~/workspace/project`.
- * Falls back to the original path if it is not under the home directory.
+ * Shorten an absolute path to a `~`-relative form for the statusline:
+ * `/Users/alice/workspace/project` → `~/workspace/project`,
+ * `C:\Users\alice\Videos\clip` → `~\Videos\clip`.
+ *
+ * Containment is decided on separator-normalized copies. Windows reports the
+ * profile as `C:\Users\<name>` and accepts either separator inside one path, so
+ * a literal `home + '/'` prefix test matched nothing there and the statusline
+ * showed every profile subdirectory in full (#3825). `path.relative` is not
+ * used for the same reason in reverse: it follows the host platform, so a
+ * Windows path would be misread on a POSIX runner. The tail is sliced out of
+ * the original `cwd` rather than the normalized copy, keeping whichever
+ * separators the platform actually produced.
+ *
+ * Falls back to the original path when it is not under home. A `..` segment
+ * falls back too — it can walk back out, and only the unabbreviated path is
+ * guaranteed to still name the same directory. Comparison stays
+ * case-sensitive, like the other path helpers in the tree.
  */
-function shortenCwd(cwd: string, homeDir?: string): string {
+export function shortenCwd(cwd: string, homeDir?: string): string {
   const home = homeDir ?? homedir();
-  if (home && cwd.startsWith(home + '/')) return `~${cwd.slice(home.length)}`;
-  if (home && cwd === home) return '~';
-  return cwd;
+  // A trailing separator on home would push the slice offset past the prefix.
+  const normalizedHome = home.replace(/[\\/]+$/, '').replaceAll('\\', '/');
+  if (!normalizedHome) return cwd;
+  const normalizedCwd = cwd.replaceAll('\\', '/');
+  if (normalizedCwd === normalizedHome) return '~';
+  if (!normalizedCwd.startsWith(`${normalizedHome}/`)) return cwd;
+  const tail = normalizedCwd.slice(normalizedHome.length + 1);
+  if (!tail) return '~';
+  if (tail.split('/').includes('..')) return cwd;
+  return `~${cwd.slice(normalizedHome.length)}`;
 }
 
 function formatCost(costUsd: number): string {


### PR DESCRIPTION
Fixes #3825. shortenCwd used home + slash, which never matches Windows subdirectories. Separator-normalized containment; tests in packages/cli/src/__tests__/pi-transcript.test.ts.