### PR TITLE
fix(test): fix CLI and MCP tests fail on macOS

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-cli-installation.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-cli-installation.test.ts
@@ -18,7 +18,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -138,7 +138,7 @@ test('rejects non-UTF-8 package metadata instead of normalizing an owner observa
 });
 
 async function installationFixture(t: test.TestContext, version: string) {
-  const base = await mkdtemp(join(tmpdir(), 'maka-cli-global-installation-'));
+  const base = await realpath(await mkdtemp(join(tmpdir(), 'maka-cli-global-installation-')));
   t.after(() => rm(base, { recursive: true, force: true }));
   const homeDir = join(base, 'home');
   const globalRoot = join(base, 'lib', 'node_modules');

--- a/packages/mcp/src/__tests__/stdio-negotiation.test.ts
+++ b/packages/mcp/src/__tests__/stdio-negotiation.test.ts
@@ -18,7 +18,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -206,7 +206,7 @@ async function fixtureConfig(
   protocol?: McpProtocolPreference,
   extraEnv: Record<string, string> = {},
 ): Promise<{ config: McpConfigFile; log: string; root: string }> {
-  const root = await mkdtemp(join(tmpdir(), 'maka-mcp-stdio-negotiation-'));
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'maka-mcp-stdio-negotiation-')));
   roots.push(root);
   const log = join(root, 'events.jsonl');
   const fixturePath = kind === 'legacy' ? legacyFixturePath : dualEraFixturePath;


### PR DESCRIPTION

## Summary

<!-- The problem this solves and the outcome it produces. If the approach
is not the obvious one, say why. -->

CLI and MCP tests fail on macOS due to /var vs /private/var path mismatch

Fixes #3870

<!-- Delete the line above if this PR closes no issue. Use "Refs #N" instead
when an issue is context only. -->

## Verification

<!-- The checks you actually ran and their results. Name relevant checks
you did not run. For user-visible changes, attach the lightest evidence
that demonstrates the behavior (screenshot, recording, or command output). -->

<!--
Add a section only when it changes how this PR should be reviewed,
released, or operated, and name it after the real risk: e.g.
Breaking change, Migration, Rollout, Root cause, Security, Review focus.
If work intentionally remains, open as a draft and track it with a
task list under its own section.
-->

All the tests pass after this change. 


## AI use

Select exactly one:

- [x] No generative tool made a substantive contribution
- [ ] Generative tooling made a substantive contribution

<!-- If the second option applies, name the tool(s) and briefly describe their
scope. If AI authored material contribution content, add Generated-by trailers
to the affected commits and ensure the final squash commit retains the trailer. -->

Tool(s) and scope:

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
