### PR TITLE
test(windows): stabilize root marker race evidence

### DIFF
--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -67,6 +67,21 @@ jobs:
             exit 1
           }
 
+      - name: Verify root initialization replacement race
+        shell: pwsh
+        run: |
+          node.exe --test --test-reporter=tap --test-concurrency=1 `
+            --test-name-pattern="rejects replacement before opening the temporary marker" `
+            packages/storage/dist/__tests__/root-authority.test.js `
+            2>&1 | Tee-Object -FilePath "$env:RUNNER_TEMP/root-initialization-race.tap"
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -ne 0) { exit $exitCode }
+          $output = Get-Content "$env:RUNNER_TEMP/root-initialization-race.tap"
+          if ($output -notcontains '# tests 1' -or $output -notcontains '# pass 1' -or $output -notcontains '# skipped 0') {
+            Write-Error 'Root initialization race gate did not run exactly one passing Windows test'
+            exit 1
+          }
+
       - name: Verify Runtime Host Local IPC trust boundary
         shell: pwsh
         run: |

--- a/packages/storage/src/__tests__/fixtures/root-initialization-race.ts
+++ b/packages/storage/src/__tests__/fixtures/root-initialization-race.ts
@@ -18,7 +18,7 @@
  */
 
 import fs from 'node:fs';
-import { join } from 'node:path';
+import { basename } from 'node:path';
 
 const [rootArgument, markerFile] = process.argv.slice(2);
 if (!rootArgument || !markerFile || !process.send) {
@@ -26,16 +26,18 @@ if (!rootArgument || !markerFile || !process.send) {
 }
 
 const root = fs.realpathSync(rootArgument);
-const markerTempPrefix = join(root, `${markerFile}.`);
+const markerTempPrefix = `${markerFile}.`;
 const originalOpen = fs.promises.open;
 let intercepted = false;
 
 fs.promises.open = (async (path, flags, mode) => {
+  // This child initializes one root. Match its unique marker basename so the
+  // cut does not depend on Windows long/short, namespaced, or case spelling.
   if (
     !intercepted &&
     typeof path === 'string' &&
-    path.startsWith(markerTempPrefix) &&
-    path.endsWith('.tmp')
+    basename(path).startsWith(markerTempPrefix) &&
+    basename(path).endsWith('.tmp')
   ) {
     intercepted = true;
     await send({ type: 'marker_open_pending' });

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -464,6 +464,20 @@ test('Windows recovery executes the exact managed dependency ADS regressions', (
   assert.match(recovery, /# skipped 0/u);
 });
 
+test('Windows recovery executes the root initialization replacement race', () => {
+  const recovery = readWorkflow('windows-recovery.yml');
+
+  assert.match(recovery, /name: Verify root initialization replacement race/u);
+  assert.match(
+    recovery,
+    /--test-name-pattern="rejects replacement before opening the temporary marker"/u,
+  );
+  assert.match(recovery, /packages\/storage\/dist\/__tests__\/root-authority\.test\.js/u);
+  assert.match(recovery, /# tests 1/u);
+  assert.match(recovery, /# pass 1/u);
+  assert.match(recovery, /# skipped 0/u);
+});
+
 test('workflows never persist the job credential into the checkout', () => {
   for (const name of readdirSync(WORKFLOW_DIR)) {
     for (const step of checkoutSteps(name)) {


### PR DESCRIPTION
## Summary

Close the remaining deterministic Windows root-initialization race failure found while validating #2624.

- matches the child fixture's unique temporary marker basename instead of requiring the opened path to share the exact `realpath` string spelling;
- keeps the interception before the dynamic authority import, so production marker I/O remains bound and immutable;
- adds the exact race to required `windows_recovery` with a strict `1 test / 1 pass / 0 skip` assertion;
- pins the workflow step, test pattern, file, and counts in the repository-control test.

## Why

The first post-#3789 full Windows baseline on byte-identical `main@32a1db0eb` reproduced one deterministic failure in both the focused Storage gate and the complete Storage suite:

- [fork full baseline run](https://github.com/liugddx/maka-agent/actions/runs/32936082313)
- focused Storage: 87 passed / 1 failed / 12 skipped;
- complete Storage: 939 passed / 1 failed / 38 skipped;
- failure: `initialization race fixture reported resolved while waiting for marker_open_pending`.

The child fixture compared the opened temporary path against a `realpath`-derived parent prefix. Windows can expose equivalent parents with different long/short, namespaced, case, or canonical spellings. This child performs exactly one root initialization, so the marker filename uniquely identifies the intended open cut without relying on parent spelling.

All other baseline groups passed: install/build, CLI and Electron smoke, Runtime PTY 3/3, PowerShell UTF-8 2/2, the remaining Storage path/lock gates, and residual-process audit.

## Verification

Local Windows, Node 24:

- focused root replacement race: 20 consecutive passes;
- marker suite: 7 passed, 0 failed;
- strict workflow-equivalent root gate: 1 test / 1 pass / 0 skip;
- CI planner and Windows harness: passed, including the new workflow contract;
- Core/Storage builds, lint, format, and `git diff --check`: passed.

Hosted exact-head [`windows_recovery`](https://github.com/apache/maka/actions/runs/32937846931/job/98082532654) passed and directly executed the new root race step. Hosted [`test`](https://github.com/apache/maka/actions/runs/32937846791/job/98082532434) also passed.

Three consecutive fork full-baseline runs on this exact head are clean: [run 1](https://github.com/liugddx/maka-agent/actions/runs/32938517938), [run 2](https://github.com/liugddx/maka-agent/actions/runs/32938905136), and [run 3](https://github.com/liugddx/maka-agent/actions/runs/32939345069). Each reports focused Storage 88/0/12, full Storage 940/0/38, empty residual-process evidence, and successful PTY/UTF-8/smoke steps.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool and scope: Codex inspected the full Windows baseline artifact, isolated the path-spelling-sensitive fixture cut, implemented the fixture and workflow contract changes, and ran the listed local gates.

Refs #2624. Refs #2142.

## Checklist

- [x] Tests cover the exact failure and fail if the gate disappears
- [x] Lint, format, affected builds, and focused Windows tests pass locally
- [x] Hosted `test` and `windows_recovery` pass on exact head `6dae318b9`

Does this PR entail a change in behavior?

- [ ] Yes
- [x] No - this changes a race fixture and its required Windows evidence only.
