### PR TITLE
fix(desktop): shorten Windows Memory paths

### DIFF
--- a/apps/desktop/src/main/__tests__/memory-settings-labels.test.ts
+++ b/apps/desktop/src/main/__tests__/memory-settings-labels.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { displayMemoryPath } from '../../renderer/settings/memory-settings-labels.js';
+
+test('shortens Memory paths with their native separator', () => {
+  assert.equal(
+    displayMemoryPath('/Users/alice/.maka/memory/MEMORY.md'),
+    '…/.maka/memory/MEMORY.md',
+  );
+  assert.equal(
+    displayMemoryPath('C:\\Users\\alice\\.maka\\memory\\MEMORY.md'),
+    '…\\.maka\\memory\\MEMORY.md',
+  );
+  assert.equal(
+    displayMemoryPath('\\\\server\\share\\.maka\\memory\\MEMORY.md'),
+    '…\\.maka\\memory\\MEMORY.md',
+  );
+});
+
+test('leaves short Memory paths unchanged', () => {
+  assert.equal(displayMemoryPath('/data/MEMORY.md'), '/data/MEMORY.md');
+  assert.equal(displayMemoryPath('C:\\data\\MEMORY.md'), 'C:\\data\\MEMORY.md');
+});

--- a/apps/desktop/src/renderer/settings/memory-settings-labels.ts
+++ b/apps/desktop/src/renderer/settings/memory-settings-labels.ts
@@ -55,16 +55,11 @@ export function formatLocalMemorySaveSummary(state: LocalMemoryState, copy: Memo
   return copy.saveSummary(state.activeEntryCount, state.archivedEntryCount);
 }
 
-/** Display-only path shortening: the full absolute MEMORY.md path used
- * to render as a full-width mono line that shoved the sibling status
- * words into a cramped stack (and leaked the raw absolute path into
- * the renderer, against the UI quality plan). Show the meaningful
- * trailing segments; the full path stays available via title= and the
- * copy-path action. */
 export function displayMemoryPath(path: string): string {
-  const parts = path.split('/').filter(Boolean);
+  const separator = /^[A-Za-z]:\\/.test(path) || path.startsWith('\\\\') ? '\\' : '/';
+  const parts = path.split(/[/\\]+/).filter(Boolean);
   if (parts.length <= 3) return path;
-  return `…/${parts.slice(-3).join('/')}`;
+  return `…${separator}${parts.slice(-3).join(separator)}`;
 }
 
 export function localMemoryBackupKindLabel(kind: NonNullable<LocalMemoryState['latestBackup']>['kind'], copy: MemorySettingsCopy): string {


### PR DESCRIPTION
Fixes #3889

## Summary

Windows users see the complete local `MEMORY.md` path in Settings while the equivalent POSIX path is shortened, allowing the label to crowd the adjacent saved/dirty status.

Desktop constructs this value with platform-native `node:path.join`, but `displayMemoryPath` split only on `/`. The formatter now recognizes both path separators and preserves the native separator in the compact tail. Opening and copying Memory files continue to use the untouched absolute path.

## UI evidence

Before — the complete Windows path is rendered:

![Settings Memory before: complete Windows MEMORY.md path](https://github.com/user-attachments/assets/14542387-e2e0-427a-8255-e3ecd27b37e5)

After — the Windows path is shortened and the saved status remains clear:

![Settings Memory after: shortened Windows MEMORY.md path](https://github.com/user-attachments/assets/c9933307-d2c7-404a-8c22-1b81b9b3aac9)

## Verification

```text
Before
projected_path=C:\Users\alice\.maka\memory\MEMORY.md
display=C:\Users\alice\.maka\memory\MEMORY.md

After
projected_path=C:\Users\alice\.maka\memory\MEMORY.md
display=…\.maka\memory\MEMORY.md
```

```text
tests 1522
pass 1522
fail 0

Desktop typecheck: passed
Biome: Checked 2 files. No fixes applied.
git diff --check: passed
```

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex traced the production path, implemented the formatter change, and added regression tests. The human contributor reviewed and directed the submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
