### PR TITLE
fix(runtime): pass option-like Grep patterns after a -- separator

### DIFF
--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -243,6 +243,43 @@ describe('filesystem worker operations', () => {
     });
   });
 
+  test('passes option-like Grep patterns after a `--` separator', async () => {
+    const root = await temporaryDirectory('maka-worker-grep-option-like-');
+    const target = join(root, 'file.ts');
+    await writeFile(target, 'const style = "-webkit-box";', 'utf8');
+    let grepArgs: readonly string[] | undefined;
+
+    const response = await executeFilesystemWorkerRequest(
+      await requestFor(
+        {
+          kind: 'grep',
+          cwd: root,
+          path: target,
+          pattern: '-webkit-box',
+          maxCountPerFile: 50,
+          limit: 200,
+          timeoutMs: 1_000,
+        },
+        { enforcementPath: target, access: 'read', scope: 'exact', targetType: 'file' },
+      ),
+      {
+        grepExecutable: '/usr/bin/rg',
+        runGrep: async (input) => {
+          grepArgs = input.args;
+          return { exitCode: 0, stdout: '1:const style = "-webkit-box";\n', stderrTail: '' };
+        },
+      },
+    );
+
+    assert.deepEqual(grepArgs?.slice(-3), ['--', '-webkit-box', target]);
+    assert.deepEqual(response, {
+      version: FILESYSTEM_WORKER_PROTOCOL_VERSION,
+      requestId: 'request-1',
+      ok: true,
+      result: { kind: 'grep', matches: ['1:const style = "-webkit-box";'] },
+    });
+  });
+
   test('returns no Grep matches for exit code 1 and surfaces bounded stderr for failures', async () => {
     const root = await temporaryDirectory('maka-worker-grep-result-');
     const target = join(root, 'file.ts');

--- a/packages/runtime/src/filesystem-worker/operations.ts
+++ b/packages/runtime/src/filesystem-worker/operations.ts
@@ -413,7 +413,7 @@ export async function executeFilesystemOperation(
         throw operationError('grep_unavailable', 'Grep is unavailable in this runtime.');
       const args = ['-n', '--no-heading', `--max-count=${operation.maxCountPerFile}`];
       if (operation.glob) args.push('--glob', operation.glob);
-      args.push(operation.pattern, path);
+      args.push('--', operation.pattern, path);
       const result = await (dependencies.runGrep ?? runRipgrep)({
         executable: dependencies.grepExecutable,
         args,


### PR DESCRIPTION
## Summary

The sandboxed filesystem worker appended the Grep pattern as a bare positional, so ripgrep parsed a pattern starting with `-` as flags. `-webkit-box` made rg exit 1, which `operations.ts` maps to `{ kind: 'grep', matches: [] }` — the model was told the string is absent from a file that contains it, with no error and no diagnostic.

The host-local sibling already handles this at `workspace-executor.ts:455`; this change mirrors it in the worker.

Fixes #3733

## Verification

Confirmed the underlying behaviour against ripgrep directly:

```
rg -n --no-heading --max-count=50 '-webkit-box' file.ts      -> exit 1, no output
rg -n --no-heading --max-count=50 -- '-webkit-box' file.ts   -> exit 0, 1:const style = "-webkit-box";
```

Ran locally against `packages/runtime`:

- `npm --workspace @maka/core run build`, `@maka/storage`, `@maka/runtime` — all clean
- `node --test dist/__tests__/filesystem-worker.test.js` — the new test passes; pass count goes 19 -> 20 with no new failures
- `biome lint` and `biome format` on both changed files — clean

Not run: the full workspace suite and the desktop app. This sandbox could not complete a root `npm install` (the registry mirror blocks `@xterm/xterm`, and the Electron postinstall cannot reach its download host), so only the `core` / `storage` / `runtime` workspaces were built and exercised.

One pre-existing failure in that file — `reports no diff — not a new-file diff — when an existing file cannot be read` — fails on unmodified `main` in this environment too, because the test runs as root and `chmod 000` does not deny root. Unrelated to this change.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude (Anthropic) — drafted the one-line fix and the regression test, and ran the local verification above. Reviewed and submitted by me. `Generated-by: Claude` trailers are on both commits.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
