### PR TITLE
fix(cli): accept Windows home paths in /move

### DIFF
--- a/packages/cli/src/__tests__/session-driver-policy.test.ts
+++ b/packages/cli/src/__tests__/session-driver-policy.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { test } from 'node:test';
+import { expandMoveCwdHome } from '../session-driver-policy.js';
+
+test('expands home-relative move paths with platform separators', () => {
+  const homeDir = resolve('home');
+
+  assert.equal(expandMoveCwdHome('~', homeDir, 'win32'), homeDir);
+  assert.equal(expandMoveCwdHome('~/Documents', homeDir, 'win32'), resolve(homeDir, 'Documents'));
+  assert.equal(expandMoveCwdHome('~\\Documents', homeDir, 'win32'), resolve(homeDir, 'Documents'));
+  assert.equal(expandMoveCwdHome('~\\Documents', homeDir, 'linux'), '~\\Documents');
+});

--- a/packages/cli/src/session-driver-policy.ts
+++ b/packages/cli/src/session-driver-policy.ts
@@ -35,12 +35,7 @@ export async function resolveMoveCwd(rawCwd: string, currentCwd: string): Promis
       (input.startsWith("'") && input.endsWith("'")))
       ? input.slice(1, -1)
       : input;
-  const expanded =
-    unquoted === '~'
-      ? homedir()
-      : unquoted.startsWith('~/')
-        ? resolve(homedir(), unquoted.slice(2))
-        : unquoted;
+  const expanded = expandMoveCwdHome(unquoted, homedir(), process.platform);
   const candidate = resolve(currentCwd, expanded);
   let canonical: string;
   try {
@@ -56,6 +51,18 @@ export async function resolveMoveCwd(rawCwd: string, currentCwd: string): Promis
     throw new Error(`Working directory is not a directory: ${canonical}`);
   }
   return canonical;
+}
+
+export function expandMoveCwdHome(
+  path: string,
+  homeDir: string,
+  platform: NodeJS.Platform,
+): string {
+  if (path === '~') return homeDir;
+  if (path.startsWith('~/') || (platform === 'win32' && path.startsWith('~\\'))) {
+    return resolve(homeDir, path.slice(2));
+  }
+  return path;
 }
 
 export async function inspectGitCwdChanges(cwd: string): Promise<boolean | undefined> {


### PR DESCRIPTION
Fixes #3906

## Summary

Windows users cannot move a Session with a native home-relative path such as `~\Documents`; the CLI reports a nonexistent literal `~` directory beneath the current working directory.

`resolveMoveCwd()` recognizes `~` and `~/`, but lets the Windows `~\` form fall through to ordinary relative-path resolution. The fix centralizes home expansion and accepts either separator on Windows while preserving the existing POSIX interpretation of backslashes.

The change is limited to typed `/move` and relocation paths; absolute paths, ordinary relative paths, and POSIX home expansion are unchanged.

## Verification

The same `resolveMoveCwd('~\\Documents', 'D:\\workspace')` call was bundled from the parent and current commits with `node:path.win32`, a Windows home, and filesystem stubs:

```text
Before
D:\workspace\~\Documents

After
C:\Users\alice\Documents
```

The focused regression test, `npx biome check` on both changed files, and `npm --workspace maka-agent run typecheck` pass. The full compiled CLI suite passes 478/479 tests; its unrelated macOS `/var` versus `/private/var` failure is tracked separately.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the defect, implemented the fix and regression test, and ran verification. The human contributor remains responsible for the contribution.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
