### PR TITLE
ci(windows): scope the recovery lane to its own inputs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -67,12 +67,12 @@ github:
         # Storybook. Renaming it there, or adding a paths filter that stops
         # ci.yml from running, freezes every pull request: the check never
         # reports and no committer can override it.
+        # A required context must report on every pull request, so a lane
+        # behind a paths filter cannot be listed here: the filter would keep
+        # the workflow from starting and the check would stay pending forever.
+        # windows_recovery is filtered and therefore deliberately absent.
         contexts:
           - test
-          # Windows recovery is a separate native crash/owner-death boundary.
-          # The workflow runs on every PR and main push so this context can be
-          # required without leaving unrelated pull requests pending forever.
-          - windows_recovery
 
   rulesets:
     - name: Immutable release tags

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -67,6 +67,10 @@ github:
         # Storybook. Renaming it there, or adding a paths filter that stops
         # ci.yml from running, freezes every pull request: the check never
         # reports and no committer can override it.
+        # A required context must report on every pull request, so a lane
+        # behind a paths filter cannot be listed here: the filter would keep
+        # the workflow from starting and the check would stay pending forever.
+        # windows_recovery is filtered and therefore deliberately absent.
         contexts:
           - test
 

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -69,10 +69,6 @@ github:
         # reports and no committer can override it.
         contexts:
           - test
-          # Windows recovery is a separate native crash/owner-death boundary.
-          # The workflow runs on every PR and main push so this context can be
-          # required without leaving unrelated pull requests pending forever.
-          - windows_recovery
 
   rulesets:
     - name: Immutable release tags

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -67,12 +67,12 @@ github:
         # Storybook. Renaming it there, or adding a paths filter that stops
         # ci.yml from running, freezes every pull request: the check never
         # reports and no committer can override it.
-        # A required context must report on every pull request, so a lane
-        # behind a paths filter cannot be listed here: the filter would keep
-        # the workflow from starting and the check would stay pending forever.
-        # windows_recovery is filtered and therefore deliberately absent.
         contexts:
           - test
+          # Windows recovery is a separate native crash/owner-death boundary.
+          # The workflow runs on every PR and main push so this context can be
+          # required without leaving unrelated pull requests pending forever.
+          - windows_recovery
 
   rulesets:
     - name: Immutable release tags

--- a/.github/workflows/windows-baseline.yml
+++ b/.github/workflows/windows-baseline.yml
@@ -149,7 +149,7 @@ jobs:
 
       # Full packages/storage test:dist is ~10 minutes on windows-latest and
       # mostly duplicates the Linux unit lane. Baseline keeps process/path/
-      # lock-sensitive gates here. Release-blocking crash evidence belongs to
+      # lock-sensitive gates here. Crash and owner-death evidence belongs to
       # windows-recovery.yml, so this diagnostic lane does not duplicate it.
       # Bump concurrency carefully — several suites spawn child processes and
       # fight for disk under high fan-out.

--- a/.github/workflows/windows-baseline.yml
+++ b/.github/workflows/windows-baseline.yml
@@ -149,7 +149,7 @@ jobs:
 
       # Full packages/storage test:dist is ~10 minutes on windows-latest and
       # mostly duplicates the Linux unit lane. Baseline keeps process/path/
-      # lock-sensitive gates here. Crash and owner-death evidence belongs to
+      # lock-sensitive gates here. Release-blocking crash evidence belongs to
       # windows-recovery.yml, so this diagnostic lane does not duplicate it.
       # Bump concurrency carefully — several suites spawn child processes and
       # fight for disk under high fan-out.

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -17,16 +17,73 @@
 
 name: Windows recovery
 
+# The paths below are a pre-filter, not this lane's real input. The real input
+# is the import closure of the crash and owner-death recovery authorities in
+# storage, runtime and Runtime Host, which reaches well past any list worth
+# hand-maintaining. So they name those workspaces and every workspace they hold
+# a TypeScript project reference to, plus the manifests, patches and scripts
+# the unconditional install and clean steps consume. That keeps a change there
+# reported before merge, and the nightly run covers the transitive edits the
+# list cannot match.
+#
+# A pull request whose diff exceeds 3,000 files can skip the filter outright,
+# because GitHub does not promise the matched files are in the first 3,000 it
+# returns. A repository-wide sweep is exactly the change that touches every
+# recovery authority at once, which is one more reason the main push below
+# carries no filter at all.
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'patches/**'
+      - 'scripts/apply-dependency-patches.mjs'
+      - 'scripts/install-electron-with-retry.mjs'
+      - 'scripts/clean-build.mjs'
+      - 'scripts/clean-paths.mjs'
+      - 'scripts/windows-runtime-host-local-ipc-trust.ps1'
+      - 'tsconfig.base.json'
+      - 'tsconfig.lib.json'
+      - 'packages/core/package.json'
+      - 'packages/core/tsconfig.json'
+      - 'packages/core/src/**'
+      - 'packages/storage/package.json'
+      - 'packages/storage/tsconfig.json'
+      - 'packages/storage/src/**'
+      - 'packages/runtime/package.json'
+      - 'packages/runtime/tsconfig.json'
+      - 'packages/runtime/src/**'
+      - 'packages/runtime/scripts/**'
+      - 'packages/runtime-host/package.json'
+      - 'packages/runtime-host/tsconfig.json'
+      - 'packages/runtime-host/src/**'
+      - '.github/workflows/windows-recovery.yml'
+  # Unfiltered on purpose: required_status_checks is `strict: false`, so a pull
+  # request goes green against a stale base and only the merged result proves
+  # two independently green halves still agree. It is also the backstop for the
+  # 3,000-file case above. The nightly alone would find either a day later,
+  # against a batch of commits instead of one.
   push:
     branches: [main]
+  schedule:
+    # Offset from windows-sandbox-w0 so the Windows lanes do not overlap.
+    - cron: '17 8 * * *'
   workflow_dispatch:
 
+# Pull request pushes supersede each other, keyed on the pull request number
+# because github.head_ref is a bare branch name two forks can share: a second
+# contributor pushing to their own `main` would otherwise cancel the first
+# contributor's run, and a cancelled check is not a failed one.
+# Scheduled, manual and main-push runs fall back to the run id, since
+# github.ref is refs/heads/main for all three and one shared group would let a
+# dispatch queue behind the nightly and then be discarded while still pending.
+# That deliberately stops main pushes from superseding each other: this lane is
+# the only place a merged Windows regression is observed, so every merge needs
+# its own evidence rather than only the newest one surviving.
 concurrency:
-  group: windows-recovery-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: windows-recovery-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -39,42 +96,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
-      - id: plan
-        name: Select the recovery surface
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
-        run: |
-          # The same planner the core lane selects with, so this lane and
-          # `test` agree on what a diff touches instead of keeping a second
-          # relevance authority in YAML. A dispatch, a first push and any
-          # unavailable history all fail safe to running every gate.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "${BASE_SHA}^{commit}"; then
-            node scripts/ci-test-plan.mjs --full >> "$GITHUB_OUTPUT"
-          else
-            node scripts/ci-test-plan.mjs --base "$BASE_SHA" --head "$HEAD_SHA" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: steps.plan.outputs.windows_recovery == 'true'
         with:
           node-version: "24"
           cache: npm
 
       - name: Install dependencies
-        if: steps.plan.outputs.windows_recovery == 'true'
         run: npm.cmd ci
 
       - name: Build test artifacts
-        if: steps.plan.outputs.windows_recovery == 'true'
         run: npm.cmd run build:test
 
       - name: Verify managed dependency alternate streams
-        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test --test-reporter=tap --test-concurrency=1 `
@@ -90,14 +125,12 @@ jobs:
           }
 
       - name: Verify Runtime Host Local IPC trust boundary
-        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test packages/runtime-host/dist/__tests__/control-endpoint.test.js
           ./scripts/windows-runtime-host-local-ipc-trust.ps1
 
       - name: Verify SQLite crash recovery
-        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test --test-concurrency=1 `
@@ -105,7 +138,6 @@ jobs:
             packages/storage/dist/__tests__/sqlite-long-term-memory-crash.test.js
 
       - name: Verify Runtime continuation recovery
-        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test --test-concurrency=1 `
@@ -113,7 +145,6 @@ jobs:
             packages/runtime/dist/__tests__/runtime-continuation-crash.test.js
 
       - name: Verify Runtime Host owner-death recovery
-        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test --test-reporter=tap --test-concurrency=1 `
@@ -130,7 +161,6 @@ jobs:
           }
 
       - name: Verify managed workspace crash recovery
-        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           $env:MAKA_STORAGE_STRESS = '1'

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -20,18 +20,33 @@ name: Windows recovery
 # The paths below are a pre-filter, not this lane's real input. The real input
 # is the import closure of the crash and owner-death recovery authorities in
 # storage, runtime and Runtime Host, which reaches well past any list worth
-# hand-maintaining. So they name the directories owning those authorities, plus
-# the manifests, patches and project files the unconditional install and build
-# steps consume directly. That keeps a change there reported before merge, and
-# the nightly run is what covers transitive edits once they land.
+# hand-maintaining. So they name those workspaces and every workspace they hold
+# a TypeScript project reference to, plus the manifests, patches and scripts
+# the unconditional install and clean steps consume. That keeps a change there
+# reported before merge, and the nightly run covers the transitive edits the
+# list cannot match.
+#
+# A pull request whose diff exceeds 3,000 files can skip the filter outright,
+# because GitHub does not promise the matched files are in the first 3,000 it
+# returns. A repository-wide sweep is exactly the change that touches every
+# recovery authority at once, which is one more reason the main push below
+# carries no filter at all.
 on:
   pull_request:
+    branches: [main]
     paths:
       - 'package.json'
       - 'package-lock.json'
       - 'patches/**'
+      - 'scripts/apply-dependency-patches.mjs'
+      - 'scripts/install-electron-with-retry.mjs'
+      - 'scripts/clean-build.mjs'
+      - 'scripts/clean-paths.mjs'
+      - 'scripts/windows-runtime-host-local-ipc-trust.ps1'
       - 'tsconfig.base.json'
       - 'tsconfig.lib.json'
+      - 'packages/core/tsconfig.json'
+      - 'packages/core/src/**'
       - 'packages/storage/tsconfig.json'
       - 'packages/storage/src/**'
       - 'packages/runtime/tsconfig.json'
@@ -39,14 +54,12 @@ on:
       - 'packages/runtime/scripts/**'
       - 'packages/runtime-host/tsconfig.json'
       - 'packages/runtime-host/src/**'
-      - 'scripts/clean-build.mjs'
-      - 'scripts/clean-paths.mjs'
-      - 'scripts/windows-runtime-host-local-ipc-trust.ps1'
       - '.github/workflows/windows-recovery.yml'
   # Unfiltered on purpose: required_status_checks is `strict: false`, so a pull
   # request goes green against a stale base and only the merged result proves
-  # two independently green halves still agree. The nightly alone would find
-  # that a day later, against a batch of commits instead of one.
+  # two independently green halves still agree. It is also the backstop for the
+  # 3,000-file case above. The nightly alone would find either a day later,
+  # against a batch of commits instead of one.
   push:
     branches: [main]
   schedule:
@@ -54,12 +67,15 @@ on:
     - cron: '17 8 * * *'
   workflow_dispatch:
 
-# Pull request pushes supersede each other. Scheduled, manual and main-push
-# runs each get a unique group, because github.ref is refs/heads/main for all
-# three: a shared group made a dispatch queue behind the nightly and let the
-# next dispatch discard it while still pending.
+# Pull request pushes supersede each other, keyed on the pull request number
+# because github.head_ref is a bare branch name two forks can share: a second
+# contributor pushing to their own `main` would otherwise cancel the first
+# contributor's run, and a cancelled check is not a failed one.
+# Scheduled, manual and main-push runs fall back to the run id, since
+# github.ref is refs/heads/main for all three and one shared group would let a
+# dispatch queue behind the nightly and then be discarded while still pending.
 concurrency:
-  group: windows-recovery-${{ github.head_ref || github.run_id }}
+  group: windows-recovery-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -17,11 +17,23 @@
 
 name: Windows recovery
 
+# The paths below are a pre-filter, not this lane's real input. The real input
+# is the import closure of the crash and owner-death recovery authorities in
+# storage, runtime, and Runtime Host, which reaches well past any list worth
+# hand-maintaining. So they name the directories that own those authorities,
+# which keeps a change there blocking before merge, and the nightly run is what
+# covers transitive edits once they land.
 on:
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+    paths:
+      - 'packages/storage/src/**'
+      - 'packages/runtime/src/**'
+      - 'packages/runtime-host/src/**'
+      - 'scripts/windows-runtime-host-local-ipc-trust.ps1'
+      - '.github/workflows/windows-recovery.yml'
+  schedule:
+    # Offset from windows-sandbox-w0 so the Windows lanes do not overlap.
+    - cron: '17 8 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -19,26 +19,48 @@ name: Windows recovery
 
 # The paths below are a pre-filter, not this lane's real input. The real input
 # is the import closure of the crash and owner-death recovery authorities in
-# storage, runtime, and Runtime Host, which reaches well past any list worth
-# hand-maintaining. So they name the directories that own those authorities,
-# which keeps a change there blocking before merge, and the nightly run is what
-# covers transitive edits once they land.
+# storage, runtime and Runtime Host, which reaches well past any list worth
+# hand-maintaining. So they name the directories owning those authorities, plus
+# the manifests, patches and project files the unconditional install and build
+# steps consume directly. That keeps a change there reported before merge, and
+# the nightly run is what covers transitive edits once they land.
 on:
   pull_request:
     paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'patches/**'
+      - 'tsconfig.base.json'
+      - 'tsconfig.lib.json'
+      - 'packages/storage/tsconfig.json'
       - 'packages/storage/src/**'
+      - 'packages/runtime/tsconfig.json'
       - 'packages/runtime/src/**'
+      - 'packages/runtime/scripts/**'
+      - 'packages/runtime-host/tsconfig.json'
       - 'packages/runtime-host/src/**'
+      - 'scripts/clean-build.mjs'
+      - 'scripts/clean-paths.mjs'
       - 'scripts/windows-runtime-host-local-ipc-trust.ps1'
       - '.github/workflows/windows-recovery.yml'
+  # Unfiltered on purpose: required_status_checks is `strict: false`, so a pull
+  # request goes green against a stale base and only the merged result proves
+  # two independently green halves still agree. The nightly alone would find
+  # that a day later, against a batch of commits instead of one.
+  push:
+    branches: [main]
   schedule:
     # Offset from windows-sandbox-w0 so the Windows lanes do not overlap.
     - cron: '17 8 * * *'
   workflow_dispatch:
 
+# Pull request pushes supersede each other. Scheduled, manual and main-push
+# runs each get a unique group, because github.ref is refs/heads/main for all
+# three: a shared group made a dispatch queue behind the nightly and let the
+# next dispatch discard it while still pending.
 concurrency:
-  group: windows-recovery-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: windows-recovery-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -40,6 +40,7 @@ on:
       - 'patches/**'
       - 'scripts/apply-dependency-patches.mjs'
       - 'scripts/install-electron-with-retry.mjs'
+      - 'scripts/run-electron-installer.cjs'
       - 'scripts/clean-build.mjs'
       - 'scripts/clean-paths.mjs'
       - 'scripts/windows-runtime-host-local-ipc-trust.ps1'

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -26,9 +26,8 @@ name: Windows recovery
 # reported before merge, and the nightly run covers the transitive edits the
 # list cannot match.
 #
-# A pull request whose diff exceeds 3,000 files can skip the filter outright,
-# because GitHub does not promise the matched files are in the first 3,000 it
-# returns. A repository-wide sweep is exactly the change that touches every
+# GitHub evaluates a path filter against the first 300 files of the diff only,
+# so a pull request wider than that can skip the filter outright. A repository-wide sweep is exactly the change that touches every
 # recovery authority at once, which is one more reason the main push below
 # carries no filter at all.
 on:
@@ -63,7 +62,7 @@ on:
   # Unfiltered on purpose: required_status_checks is `strict: false`, so a pull
   # request goes green against a stale base and only the merged result proves
   # two independently green halves still agree. It is also the backstop for the
-  # 3,000-file case above. The nightly alone would find either a day later,
+  # 300-file case above. The nightly alone would find either a day later,
   # against a batch of commits instead of one.
   push:
     branches: [main]

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -17,66 +17,16 @@
 
 name: Windows recovery
 
-# The paths below are a pre-filter, not this lane's real input. The real input
-# is the import closure of the crash and owner-death recovery authorities in
-# storage, runtime and Runtime Host, which reaches well past any list worth
-# hand-maintaining. So they name those workspaces and every workspace they hold
-# a TypeScript project reference to, plus the manifests, patches and scripts
-# the unconditional install and clean steps consume. That keeps a change there
-# reported before merge, and the nightly run covers the transitive edits the
-# list cannot match.
-#
-# A pull request whose diff exceeds 3,000 files can skip the filter outright,
-# because GitHub does not promise the matched files are in the first 3,000 it
-# returns. A repository-wide sweep is exactly the change that touches every
-# recovery authority at once, which is one more reason the main push below
-# carries no filter at all.
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'package.json'
-      - 'package-lock.json'
-      - 'patches/**'
-      - 'scripts/apply-dependency-patches.mjs'
-      - 'scripts/install-electron-with-retry.mjs'
-      - 'scripts/clean-build.mjs'
-      - 'scripts/clean-paths.mjs'
-      - 'scripts/windows-runtime-host-local-ipc-trust.ps1'
-      - 'tsconfig.base.json'
-      - 'tsconfig.lib.json'
-      - 'packages/core/tsconfig.json'
-      - 'packages/core/src/**'
-      - 'packages/storage/tsconfig.json'
-      - 'packages/storage/src/**'
-      - 'packages/runtime/tsconfig.json'
-      - 'packages/runtime/src/**'
-      - 'packages/runtime/scripts/**'
-      - 'packages/runtime-host/tsconfig.json'
-      - 'packages/runtime-host/src/**'
-      - '.github/workflows/windows-recovery.yml'
-  # Unfiltered on purpose: required_status_checks is `strict: false`, so a pull
-  # request goes green against a stale base and only the merged result proves
-  # two independently green halves still agree. It is also the backstop for the
-  # 3,000-file case above. The nightly alone would find either a day later,
-  # against a batch of commits instead of one.
   push:
     branches: [main]
-  schedule:
-    # Offset from windows-sandbox-w0 so the Windows lanes do not overlap.
-    - cron: '17 8 * * *'
   workflow_dispatch:
 
-# Pull request pushes supersede each other, keyed on the pull request number
-# because github.head_ref is a bare branch name two forks can share: a second
-# contributor pushing to their own `main` would otherwise cancel the first
-# contributor's run, and a cancelled check is not a failed one.
-# Scheduled, manual and main-push runs fall back to the run id, since
-# github.ref is refs/heads/main for all three and one shared group would let a
-# dispatch queue behind the nightly and then be discarded while still pending.
 concurrency:
-  group: windows-recovery-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  group: windows-recovery-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -89,20 +39,42 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - id: plan
+        name: Select the recovery surface
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
+        run: |
+          # The same planner the core lane selects with, so this lane and
+          # `test` agree on what a diff touches instead of keeping a second
+          # relevance authority in YAML. A dispatch, a first push and any
+          # unavailable history all fail safe to running every gate.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "${BASE_SHA}^{commit}"; then
+            node scripts/ci-test-plan.mjs --full >> "$GITHUB_OUTPUT"
+          else
+            node scripts/ci-test-plan.mjs --base "$BASE_SHA" --head "$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.plan.outputs.windows_recovery == 'true'
         with:
           node-version: "24"
           cache: npm
 
       - name: Install dependencies
+        if: steps.plan.outputs.windows_recovery == 'true'
         run: npm.cmd ci
 
       - name: Build test artifacts
+        if: steps.plan.outputs.windows_recovery == 'true'
         run: npm.cmd run build:test
 
       - name: Verify managed dependency alternate streams
+        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test --test-reporter=tap --test-concurrency=1 `
@@ -118,12 +90,14 @@ jobs:
           }
 
       - name: Verify Runtime Host Local IPC trust boundary
+        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test packages/runtime-host/dist/__tests__/control-endpoint.test.js
           ./scripts/windows-runtime-host-local-ipc-trust.ps1
 
       - name: Verify SQLite crash recovery
+        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test --test-concurrency=1 `
@@ -131,6 +105,7 @@ jobs:
             packages/storage/dist/__tests__/sqlite-long-term-memory-crash.test.js
 
       - name: Verify Runtime continuation recovery
+        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test --test-concurrency=1 `
@@ -138,6 +113,7 @@ jobs:
             packages/runtime/dist/__tests__/runtime-continuation-crash.test.js
 
       - name: Verify Runtime Host owner-death recovery
+        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           node.exe --test --test-reporter=tap --test-concurrency=1 `
@@ -154,6 +130,7 @@ jobs:
           }
 
       - name: Verify managed workspace crash recovery
+        if: steps.plan.outputs.windows_recovery == 'true'
         shell: pwsh
         run: |
           $env:MAKA_STORAGE_STRESS = '1'

--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -145,30 +145,6 @@ function isReleaseContractPath(path) {
   );
 }
 
-// The Windows recovery lane executes the crash and owner-death gates that live
-// in these workspaces. Selection is the reverse dependency closure below, so a
-// packages/core change reaches them without being named here.
-const WINDOWS_RECOVERY_WORKSPACES = [
-  'packages/storage',
-  'packages/runtime',
-  'packages/runtime-host',
-];
-
-// Inputs that lane consumes from outside the workspace graph: its own
-// definition, the trust probe it shells out to, and the base project files its
-// build step compiles every workspace against.
-const WINDOWS_RECOVERY_FILES = new Set([
-  '.github/workflows/windows-recovery.yml',
-  'scripts/windows-runtime-host-local-ipc-trust.ps1',
-  'tsconfig.base.json',
-  'tsconfig.lib.json',
-]);
-
-function selectsWindowsRecovery(files, workspaces) {
-  if (files.some((path) => WINDOWS_RECOVERY_FILES.has(path))) return true;
-  return WINDOWS_RECOVERY_WORKSPACES.some((workspace) => workspaces.includes(workspace));
-}
-
 const DEDICATED_WORKSPACE_LANES = new Set(['packages/runtime-host']);
 
 // Scripts the Electron e2e job runs. Editing one of these changes what that
@@ -374,7 +350,6 @@ export function planTests(changedFiles, options = {}) {
       // every unrelated merge into a 10K-chunk pressure run.
       storageStress: false,
       storybook: true,
-      windowsRecovery: true,
       workspaces,
       ...workspaceLanes(workspaces, graph),
     };
@@ -445,7 +420,6 @@ export function planTests(changedFiles, options = {}) {
     // PR — product ship gates are typecheck, unit, and Electron e2e. See
     // isStorybookPath.
     storybook: files.some((path) => isStorybookPath(path)),
-    windowsRecovery: selectsWindowsRecovery(files, workspaces),
     workspaces,
     ...workspaceLanes(workspaces, graph),
   };
@@ -463,7 +437,6 @@ export function formatGitHubOutputs(plan) {
     `release_contract=${plan.releaseContract}`,
     `storage_stress=${plan.storageStress}`,
     `storybook=${plan.storybook}`,
-    `windows_recovery=${plan.windowsRecovery}`,
     `standard_workspaces=${plan.standardWorkspaces.join(',')}`,
   ].join('\n');
 }

--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -145,6 +145,30 @@ function isReleaseContractPath(path) {
   );
 }
 
+// The Windows recovery lane executes the crash and owner-death gates that live
+// in these workspaces. Selection is the reverse dependency closure below, so a
+// packages/core change reaches them without being named here.
+const WINDOWS_RECOVERY_WORKSPACES = [
+  'packages/storage',
+  'packages/runtime',
+  'packages/runtime-host',
+];
+
+// Inputs that lane consumes from outside the workspace graph: its own
+// definition, the trust probe it shells out to, and the base project files its
+// build step compiles every workspace against.
+const WINDOWS_RECOVERY_FILES = new Set([
+  '.github/workflows/windows-recovery.yml',
+  'scripts/windows-runtime-host-local-ipc-trust.ps1',
+  'tsconfig.base.json',
+  'tsconfig.lib.json',
+]);
+
+function selectsWindowsRecovery(files, workspaces) {
+  if (files.some((path) => WINDOWS_RECOVERY_FILES.has(path))) return true;
+  return WINDOWS_RECOVERY_WORKSPACES.some((workspace) => workspaces.includes(workspace));
+}
+
 const DEDICATED_WORKSPACE_LANES = new Set(['packages/runtime-host']);
 
 // Scripts the Electron e2e job runs. Editing one of these changes what that
@@ -350,6 +374,7 @@ export function planTests(changedFiles, options = {}) {
       // every unrelated merge into a 10K-chunk pressure run.
       storageStress: false,
       storybook: true,
+      windowsRecovery: true,
       workspaces,
       ...workspaceLanes(workspaces, graph),
     };
@@ -420,6 +445,7 @@ export function planTests(changedFiles, options = {}) {
     // PR — product ship gates are typecheck, unit, and Electron e2e. See
     // isStorybookPath.
     storybook: files.some((path) => isStorybookPath(path)),
+    windowsRecovery: selectsWindowsRecovery(files, workspaces),
     workspaces,
     ...workspaceLanes(workspaces, graph),
   };
@@ -437,6 +463,7 @@ export function formatGitHubOutputs(plan) {
     `release_contract=${plan.releaseContract}`,
     `storage_stress=${plan.storageStress}`,
     `storybook=${plan.storybook}`,
+    `windows_recovery=${plan.windowsRecovery}`,
     `standard_workspaces=${plan.standardWorkspaces.join(',')}`,
   ].join('\n');
 }

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -360,60 +360,71 @@ test('the recovery lane pairs its path filter with a nightly run and a main push
   // transitive edit it cannot match, and dropping the filter would put every
   // Windows recovery run back on every pull request. The main push carries no
   // filter because `strict: false` lets a stale-base pull request go green,
-  // and only the merged result proves two green halves still agree.
-  assert.match(workflow, /\n {2}pull_request:\n {4}paths:/u);
-  assert.match(workflow, /\n {2}push:\n {4}branches: \[main\]/u);
-  assert.match(workflow, /\n {2}schedule:/u);
+  // and because a diff over 3,000 files can skip a paths filter outright.
+  assert.match(workflow, /\n {2}pull_request:\n {4}branches: \[main\]\n {4}paths:/u);
+  assert.match(workflow, /\n {2}push:\n {4}branches: \[main\]\n {2}schedule:/u);
   assert.match(workflow, /\n {2}workflow_dispatch:/u);
   assert.match(workflow, /\n {4}name: windows_recovery/u);
 });
 
-test('the recovery lane keeps scheduled and manual runs out of one shared group', () => {
+test('the recovery lane keeps every run kind out of one shared concurrency group', () => {
   const workflow = readWorkflow('windows-recovery.yml');
 
-  // github.ref is refs/heads/main for the nightly, a dispatch and a main push
-  // alike, so a ref-keyed group made a dispatch queue behind the nightly for
-  // up to the job timeout and let the next dispatch discard it while pending.
+  // github.head_ref is a bare branch name, so two forks pushing their own
+  // `main` would share a group and cancel each other; github.ref is
+  // refs/heads/main for the nightly, a dispatch and a main push alike, so a
+  // ref-keyed group made a dispatch queue behind the nightly and let the next
+  // dispatch discard it while pending.
   assert.match(
     workflow,
-    /group: windows-recovery-\$\{\{ github\.head_ref \|\| github\.run_id \}\}/u,
+    /group: windows-recovery-\$\{\{ github\.event\.pull_request\.number \|\| github\.run_id \}\}/u,
   );
   assert.match(workflow, /\n {2}cancel-in-progress: true/u);
 });
 
-test('the recovery lane filter covers every workspace its steps execute', () => {
+test('the recovery lane filters pull requests by the workspaces its steps build', () => {
   const workflow = readWorkflow('windows-recovery.yml');
-  // Derived from the dist paths the steps actually run, so adding a workspace
-  // to this lane fails here until its sources and project file are filtered.
+  const filtered = new Set(pullRequestPathFilter('windows-recovery.yml'));
+
+  // Derived from the dist paths the steps actually run, then widened along the
+  // TypeScript project references those workspaces compile against. A new
+  // workspace on this lane, or a new reference under one of them, fails here
+  // until the filter admits its sources and project file.
   const executed = [
     ...new Set([...workflow.matchAll(/packages\/([^/]+)\/dist\//gu)].map((match) => match[1])),
   ].sort();
-
   assert.deepEqual(executed, ['runtime', 'runtime-host', 'storage']);
-  for (const workspace of executed) {
-    assert.ok(workflow.includes(`      - 'packages/${workspace}/src/**'`), workspace);
-    assert.ok(workflow.includes(`      - 'packages/${workspace}/tsconfig.json'`), workspace);
+
+  const closure = projectReferenceClosure(executed);
+  assert.ok(closure.includes('core'), 'project reference closure must reach core');
+  for (const workspace of closure) {
+    assert.ok(filtered.has(`packages/${workspace}/src/**`), `${workspace}: sources`);
+    assert.ok(filtered.has(`packages/${workspace}/tsconfig.json`), `${workspace}: project file`);
   }
 });
 
-test('the recovery lane filter names what its install and build steps consume', () => {
-  const workflow = readWorkflow('windows-recovery.yml');
+test('the recovery lane filters pull requests by what its install and clean steps consume', () => {
+  const filtered = new Set(pullRequestPathFilter('windows-recovery.yml'));
 
-  // `npm.cmd ci` and `npm.cmd run build:test` run unconditionally, so their
-  // inputs are first-class inputs of this lane rather than transitive edits
-  // the nightly can be left to cover. A grouped dependabot bump touches only
-  // the manifests, and the crash gates below sit on a native file lock that
-  // the Linux `test` lane cannot observe at all.
+  // `npm.cmd ci` and `npm.cmd run build:test` run unconditionally, so these are
+  // first-class inputs of the lane rather than transitive edits the nightly can
+  // be left to cover. A grouped dependabot bump touches only the manifests, and
+  // the crash gates sit on a native file lock the Linux `test` lane never sees.
   for (const path of [
     'package.json',
     'package-lock.json',
     'patches/**',
+    'scripts/apply-dependency-patches.mjs',
+    'scripts/install-electron-with-retry.mjs',
+    'scripts/clean-build.mjs',
+    'scripts/clean-paths.mjs',
+    'scripts/windows-runtime-host-local-ipc-trust.ps1',
     'tsconfig.base.json',
     'tsconfig.lib.json',
-    'scripts/windows-runtime-host-local-ipc-trust.ps1',
+    'packages/runtime/scripts/**',
     '.github/workflows/windows-recovery.yml',
   ]) {
-    assert.ok(workflow.includes(`      - '${path}'`), path);
+    assert.ok(filtered.has(path), path);
   }
 });
 
@@ -548,6 +559,50 @@ test('core CI runs the live Eval proxy lifecycle when Eval is selected', () => {
 });
 
 const WORKFLOW_DIR = new URL('../.github/workflows/', import.meta.url);
+
+/**
+ * Reads the `paths` list belonging to a workflow's `pull_request` trigger.
+ * Anchoring to the trigger, instead of matching entry text anywhere in the
+ * file, is what makes the filter assertions fail when entries move under
+ * `paths-ignore`, under another trigger, or out of `on:` altogether.
+ */
+function pullRequestPathFilter(name) {
+  const lines = readWorkflow(name).split('\n');
+  const start = lines.indexOf('  pull_request:');
+  assert.ok(start >= 0, `${name}: no pull_request trigger`);
+
+  const paths = [];
+  let inPaths = false;
+  for (const line of lines.slice(start + 1)) {
+    if (/^ {0,2}\S/u.test(line)) break;
+    if (/^ {4}\S/u.test(line)) {
+      inPaths = line === '    paths:';
+      continue;
+    }
+    const entry = inPaths ? /^ {6}- '(.+)'$/u.exec(line) : null;
+    if (entry) paths.push(entry[1]);
+  }
+  return paths;
+}
+
+/** Workspace names reachable from `workspaces` through tsconfig references. */
+function projectReferenceClosure(workspaces) {
+  const selected = new Set(workspaces);
+  const pending = [...workspaces];
+  while (pending.length > 0) {
+    const workspace = pending.shift();
+    const config = JSON.parse(
+      readFileSync(new URL(`../packages/${workspace}/tsconfig.json`, import.meta.url), 'utf8'),
+    );
+    for (const reference of config.references ?? []) {
+      const name = reference.path.replace(/^\.\.\//u, '');
+      if (selected.has(name)) continue;
+      selected.add(name);
+      pending.push(name);
+    }
+  }
+  return [...selected].sort();
+}
 
 function readWorkflow(name) {
   return readFileSync(new URL(name, WORKFLOW_DIR), 'utf8');

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -236,12 +236,70 @@ test('full-suite authority files select every surface', () => {
 test('GitHub output matches the selections consumed by CI', () => {
   const output = formatGitHubOutputs(planTests([], { graph, forceFull: true }));
   const outputKeys = new Set(output.split('\n').map((line) => line.split('=', 1)[0]));
-  const workflow = readWorkflow('ci.yml');
+  // Both planning lanes, so an output that no workflow reads fails here rather
+  // than accumulating as a selection nobody acts on.
   const consumedKeys = new Set(
-    [...workflow.matchAll(/steps\.plan\.outputs\.([a-z0-9_]+)/gu)].map((match) => match[1]),
+    ['ci.yml', 'windows-recovery.yml']
+      .flatMap((name) => [...readWorkflow(name).matchAll(/steps\.plan\.outputs\.([a-z0-9_]+)/gu)])
+      .map((match) => match[1]),
   );
 
   assert.deepEqual(outputKeys, consumedKeys);
+});
+
+test('the Windows recovery lane is selected through the workspaces it executes', () => {
+  // packages/core is not named in the selection: the reverse dependency closure
+  // reaches storage, runtime and Runtime Host on its own, which is why this
+  // lane does not need a second hand-maintained path list.
+  for (const [path, expected] of [
+    ['packages/core/src/session.ts', true],
+    ['packages/storage/src/root-authority.ts', true],
+    ['packages/runtime-host/src/server/control-endpoint.ts', true],
+    ['scripts/windows-runtime-host-local-ipc-trust.ps1', true],
+    ['.github/workflows/windows-recovery.yml', true],
+    ['package-lock.json', true],
+    ['apps/desktop/src/main/index.ts', false],
+    ['packages/ui/src/button.tsx', false],
+    ['docs/windows-support.md', false],
+  ]) {
+    assert.equal(planTests([path], { graph }).windowsRecovery, expected, path);
+  }
+});
+
+test('every Windows recovery gate runs behind the planner selection', () => {
+  const workflow = readWorkflow('windows-recovery.yml');
+
+  // The lane stays a required context, so it has to report on every pull
+  // request and cannot carry a paths filter. The relevance check therefore
+  // lives inside the job, and every step that installs, builds or verifies has
+  // to sit behind it or an unrelated diff pays the lane's full cost.
+  assert.match(workflow, /\n {6}- id: plan\n {8}name: Select the recovery surface/u);
+  assert.match(workflow, /node scripts\/ci-test-plan\.mjs --full/u);
+  // Read from the `on:` block rather than the whole file, and reject the filter
+  // wherever it sits inside a trigger: a required context behind one would stop
+  // reporting and leave every unrelated pull request pending forever.
+  assert.doesNotMatch(triggerBlock('windows-recovery.yml'), /\bpaths(-ignore)?:/u);
+
+  const steps = workflow.split(/\n {6}- (?=id:|name:|uses:)/u).slice(1);
+  assert.ok(steps.length >= 9, `unexpected step count: ${steps.length}`);
+  for (const step of steps) {
+    const heading = step.split('\n', 1)[0];
+    if (heading.startsWith('id: plan') || step.includes('actions/checkout@')) continue;
+    assert.ok(
+      step.includes("if: steps.plan.outputs.windows_recovery == 'true'"),
+      `step runs unconditionally: ${heading}`,
+    );
+  }
+});
+
+test('the recovery planner needs history to compare against', () => {
+  // Without full history `git cat-file -e` on the base fails and the lane falls
+  // back to running every gate, which is safe but silently permanent.
+  const workflow = readWorkflow('windows-recovery.yml');
+  const checkout = checkoutSteps('windows-recovery.yml')[0];
+
+  assert.match(checkout, /fetch-depth: 0/u);
+  assert.match(workflow, /git cat-file -e "\$\{BASE_SHA\}\^\{commit\}"/u);
 });
 
 test('core CI validates pull requests and the resulting main branch state', () => {
@@ -352,80 +410,14 @@ test('pull request triggers stay on an explicit allowlist', () => {
   ]);
 });
 
-test('the recovery lane pairs its path filter with a nightly run and a main push', () => {
+test('Windows recovery publishes one stable PR and main check for ruleset enforcement', () => {
   const workflow = readWorkflow('windows-recovery.yml');
 
-  // Same contract as the sandbox lane: the filter is a pre-filter, not the
-  // lane's import closure, so dropping the schedule would silently lose every
-  // transitive edit it cannot match, and dropping the filter would put every
-  // Windows recovery run back on every pull request. The main push carries no
-  // filter because `strict: false` lets a stale-base pull request go green,
-  // and because a diff over 3,000 files can skip a paths filter outright.
-  assert.match(workflow, /\n {2}pull_request:\n {4}branches: \[main\]\n {4}paths:/u);
-  assert.match(workflow, /\n {2}push:\n {4}branches: \[main\]\n {2}schedule:/u);
+  assert.match(workflow, /\n {2}pull_request:\n {4}branches: \[main\]/u);
+  assert.match(workflow, /\n {2}push:\n {4}branches: \[main\]/u);
   assert.match(workflow, /\n {2}workflow_dispatch:/u);
   assert.match(workflow, /\n {4}name: windows_recovery/u);
-});
-
-test('the recovery lane keeps every run kind out of one shared concurrency group', () => {
-  const workflow = readWorkflow('windows-recovery.yml');
-
-  // github.head_ref is a bare branch name, so two forks pushing their own
-  // `main` would share a group and cancel each other; github.ref is
-  // refs/heads/main for the nightly, a dispatch and a main push alike, so a
-  // ref-keyed group made a dispatch queue behind the nightly and let the next
-  // dispatch discard it while pending.
-  assert.match(
-    workflow,
-    /group: windows-recovery-\$\{\{ github\.event\.pull_request\.number \|\| github\.run_id \}\}/u,
-  );
-  assert.match(workflow, /\n {2}cancel-in-progress: true/u);
-});
-
-test('the recovery lane filters pull requests by the workspaces its steps build', () => {
-  const workflow = readWorkflow('windows-recovery.yml');
-  const filtered = new Set(pullRequestPathFilter('windows-recovery.yml'));
-
-  // Derived from the dist paths the steps actually run, then widened along the
-  // TypeScript project references those workspaces compile against. A new
-  // workspace on this lane, or a new reference under one of them, fails here
-  // until the filter admits its sources and project file.
-  const executed = [
-    ...new Set([...workflow.matchAll(/packages\/([^/]+)\/dist\//gu)].map((match) => match[1])),
-  ].sort();
-  assert.deepEqual(executed, ['runtime', 'runtime-host', 'storage']);
-
-  const closure = projectReferenceClosure(executed);
-  assert.ok(closure.includes('core'), 'project reference closure must reach core');
-  for (const workspace of closure) {
-    assert.ok(filtered.has(`packages/${workspace}/src/**`), `${workspace}: sources`);
-    assert.ok(filtered.has(`packages/${workspace}/tsconfig.json`), `${workspace}: project file`);
-  }
-});
-
-test('the recovery lane filters pull requests by what its install and clean steps consume', () => {
-  const filtered = new Set(pullRequestPathFilter('windows-recovery.yml'));
-
-  // `npm.cmd ci` and `npm.cmd run build:test` run unconditionally, so these are
-  // first-class inputs of the lane rather than transitive edits the nightly can
-  // be left to cover. A grouped dependabot bump touches only the manifests, and
-  // the crash gates sit on a native file lock the Linux `test` lane never sees.
-  for (const path of [
-    'package.json',
-    'package-lock.json',
-    'patches/**',
-    'scripts/apply-dependency-patches.mjs',
-    'scripts/install-electron-with-retry.mjs',
-    'scripts/clean-build.mjs',
-    'scripts/clean-paths.mjs',
-    'scripts/windows-runtime-host-local-ipc-trust.ps1',
-    'tsconfig.base.json',
-    'tsconfig.lib.json',
-    'packages/runtime/scripts/**',
-    '.github/workflows/windows-recovery.yml',
-  ]) {
-    assert.ok(filtered.has(path), path);
-  }
+  assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/u);
 });
 
 test('the sandbox lane pairs its path filter with a nightly run', () => {
@@ -560,50 +552,6 @@ test('core CI runs the live Eval proxy lifecycle when Eval is selected', () => {
 
 const WORKFLOW_DIR = new URL('../.github/workflows/', import.meta.url);
 
-/**
- * Reads the `paths` list belonging to a workflow's `pull_request` trigger.
- * Anchoring to the trigger, instead of matching entry text anywhere in the
- * file, is what makes the filter assertions fail when entries move under
- * `paths-ignore`, under another trigger, or out of `on:` altogether.
- */
-function pullRequestPathFilter(name) {
-  const lines = readWorkflow(name).split('\n');
-  const start = lines.indexOf('  pull_request:');
-  assert.ok(start >= 0, `${name}: no pull_request trigger`);
-
-  const paths = [];
-  let inPaths = false;
-  for (const line of lines.slice(start + 1)) {
-    if (/^ {0,2}\S/u.test(line)) break;
-    if (/^ {4}\S/u.test(line)) {
-      inPaths = line === '    paths:';
-      continue;
-    }
-    const entry = inPaths ? /^ {6}- '(.+)'$/u.exec(line) : null;
-    if (entry) paths.push(entry[1]);
-  }
-  return paths;
-}
-
-/** Workspace names reachable from `workspaces` through tsconfig references. */
-function projectReferenceClosure(workspaces) {
-  const selected = new Set(workspaces);
-  const pending = [...workspaces];
-  while (pending.length > 0) {
-    const workspace = pending.shift();
-    const config = JSON.parse(
-      readFileSync(new URL(`../packages/${workspace}/tsconfig.json`, import.meta.url), 'utf8'),
-    );
-    for (const reference of config.references ?? []) {
-      const name = reference.path.replace(/^\.\.\//u, '');
-      if (selected.has(name)) continue;
-      selected.add(name);
-      pending.push(name);
-    }
-  }
-  return [...selected].sort();
-}
-
 function readWorkflow(name) {
   return readFileSync(new URL(name, WORKFLOW_DIR), 'utf8');
 }
@@ -612,11 +560,14 @@ function readWorkflow(name) {
  * Reads the `on:` block only, so a workflow cannot escape a trigger contract by
  * writing `on: [pull_request]`, and prose elsewhere in the file cannot fake one.
  */
-function hasPullRequestTrigger(name) {
+function triggerBlock(name) {
   const withoutComments = readWorkflow(name).replaceAll(/^[ \t]*#.*$/gmu, '');
-  const triggers = withoutComments.match(/^on:(.*(?:\n(?![^\s#]).*)*)/mu)?.[1] ?? '';
 
-  return /\bpull_request(_target)?\b/u.test(triggers);
+  return withoutComments.match(/^on:(.*(?:\n(?![^\s#]).*)*)/mu)?.[1] ?? '';
+}
+
+function hasPullRequestTrigger(name) {
+  return /\bpull_request(_target)?\b/u.test(triggerBlock(name));
 }
 
 /**

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -352,14 +352,32 @@ test('pull request triggers stay on an explicit allowlist', () => {
   ]);
 });
 
-test('Windows recovery publishes one stable PR and main check for ruleset enforcement', () => {
+test('the recovery lane pairs its path filter with a nightly run', () => {
   const workflow = readWorkflow('windows-recovery.yml');
 
-  assert.match(workflow, /\n {2}pull_request:\n {4}branches: \[main\]/u);
-  assert.match(workflow, /\n {2}push:\n {4}branches: \[main\]/u);
+  // Same contract as the sandbox lane: the filter is a pre-filter, not the
+  // lane's import closure, so dropping the schedule would silently lose every
+  // transitive edit it cannot match, and dropping the filter would put every
+  // Windows recovery run back on every pull request.
+  assert.match(workflow, /\n {2}pull_request:\n {4}paths:/u);
+  assert.match(workflow, /\n {2}schedule:/u);
   assert.match(workflow, /\n {2}workflow_dispatch:/u);
   assert.match(workflow, /\n {4}name: windows_recovery/u);
   assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/u);
+});
+
+test('the recovery lane filter names the authorities its steps execute', () => {
+  const workflow = readWorkflow('windows-recovery.yml');
+
+  for (const path of [
+    'packages/storage/src/**',
+    'packages/runtime/src/**',
+    'packages/runtime-host/src/**',
+    'scripts/windows-runtime-host-local-ipc-trust.ps1',
+    '.github/workflows/windows-recovery.yml',
+  ]) {
+    assert.ok(workflow.includes(`      - '${path}'`), path);
+  }
 });
 
 test('the sandbox lane pairs its path filter with a nightly run', () => {

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { formatGitHubOutputs, planTests } from './ci-test-plan.mjs';
+import { formatGitHubOutputs, loadWorkspaceGraph, planTests } from './ci-test-plan.mjs';
 
 const dirs = [
   'packages/core',
@@ -236,70 +236,12 @@ test('full-suite authority files select every surface', () => {
 test('GitHub output matches the selections consumed by CI', () => {
   const output = formatGitHubOutputs(planTests([], { graph, forceFull: true }));
   const outputKeys = new Set(output.split('\n').map((line) => line.split('=', 1)[0]));
-  // Both planning lanes, so an output that no workflow reads fails here rather
-  // than accumulating as a selection nobody acts on.
+  const workflow = readWorkflow('ci.yml');
   const consumedKeys = new Set(
-    ['ci.yml', 'windows-recovery.yml']
-      .flatMap((name) => [...readWorkflow(name).matchAll(/steps\.plan\.outputs\.([a-z0-9_]+)/gu)])
-      .map((match) => match[1]),
+    [...workflow.matchAll(/steps\.plan\.outputs\.([a-z0-9_]+)/gu)].map((match) => match[1]),
   );
 
   assert.deepEqual(outputKeys, consumedKeys);
-});
-
-test('the Windows recovery lane is selected through the workspaces it executes', () => {
-  // packages/core is not named in the selection: the reverse dependency closure
-  // reaches storage, runtime and Runtime Host on its own, which is why this
-  // lane does not need a second hand-maintained path list.
-  for (const [path, expected] of [
-    ['packages/core/src/session.ts', true],
-    ['packages/storage/src/root-authority.ts', true],
-    ['packages/runtime-host/src/server/control-endpoint.ts', true],
-    ['scripts/windows-runtime-host-local-ipc-trust.ps1', true],
-    ['.github/workflows/windows-recovery.yml', true],
-    ['package-lock.json', true],
-    ['apps/desktop/src/main/index.ts', false],
-    ['packages/ui/src/button.tsx', false],
-    ['docs/windows-support.md', false],
-  ]) {
-    assert.equal(planTests([path], { graph }).windowsRecovery, expected, path);
-  }
-});
-
-test('every Windows recovery gate runs behind the planner selection', () => {
-  const workflow = readWorkflow('windows-recovery.yml');
-
-  // The lane stays a required context, so it has to report on every pull
-  // request and cannot carry a paths filter. The relevance check therefore
-  // lives inside the job, and every step that installs, builds or verifies has
-  // to sit behind it or an unrelated diff pays the lane's full cost.
-  assert.match(workflow, /\n {6}- id: plan\n {8}name: Select the recovery surface/u);
-  assert.match(workflow, /node scripts\/ci-test-plan\.mjs --full/u);
-  // Read from the `on:` block rather than the whole file, and reject the filter
-  // wherever it sits inside a trigger: a required context behind one would stop
-  // reporting and leave every unrelated pull request pending forever.
-  assert.doesNotMatch(triggerBlock('windows-recovery.yml'), /\bpaths(-ignore)?:/u);
-
-  const steps = workflow.split(/\n {6}- (?=id:|name:|uses:)/u).slice(1);
-  assert.ok(steps.length >= 9, `unexpected step count: ${steps.length}`);
-  for (const step of steps) {
-    const heading = step.split('\n', 1)[0];
-    if (heading.startsWith('id: plan') || step.includes('actions/checkout@')) continue;
-    assert.ok(
-      step.includes("if: steps.plan.outputs.windows_recovery == 'true'"),
-      `step runs unconditionally: ${heading}`,
-    );
-  }
-});
-
-test('the recovery planner needs history to compare against', () => {
-  // Without full history `git cat-file -e` on the base fails and the lane falls
-  // back to running every gate, which is safe but silently permanent.
-  const workflow = readWorkflow('windows-recovery.yml');
-  const checkout = checkoutSteps('windows-recovery.yml')[0];
-
-  assert.match(checkout, /fetch-depth: 0/u);
-  assert.match(workflow, /git cat-file -e "\$\{BASE_SHA\}\^\{commit\}"/u);
 });
 
 test('core CI validates pull requests and the resulting main branch state', () => {
@@ -410,14 +352,93 @@ test('pull request triggers stay on an explicit allowlist', () => {
   ]);
 });
 
-test('Windows recovery publishes one stable PR and main check for ruleset enforcement', () => {
+test('the recovery lane pairs its path filter with a nightly run and a main push', () => {
+  // Read from the `on:` block with comments stripped, so documenting a trigger
+  // cannot break its contract.
+  const triggers = triggerBlock('windows-recovery.yml');
+
+  // Same contract as the sandbox lane: the filter is a pre-filter, not the
+  // lane's import closure, so dropping the schedule would silently lose every
+  // transitive edit it cannot match, and dropping the filter would put every
+  // Windows recovery run back on every pull request. The main push carries no
+  // filter because `strict: false` lets a stale-base pull request go green,
+  // and because a diff over 3,000 files can skip a paths filter outright.
+  // Stripped comment lines survive as blank ones, so the gap between the
+  // trigger and its list is any mix of blank and four-space lines.
+  assert.match(triggers, /\n {2}pull_request:\n(?:(?: {4}[^\n]*)?\n)* {4}paths:/u);
+  assert.match(triggers, /\n {2}push:\n {4}branches: \[main\]\n/u);
+  assert.doesNotMatch(
+    triggers.match(/\n {2}push:\n(?:(?: {4}[^\n]*)?\n)*/u)?.[0] ?? '',
+    /\bpaths(-ignore)?:/u,
+  );
+  assert.match(triggers, /\n {2}schedule:\n/u);
+  assert.match(triggers, /\n {2}workflow_dispatch:/u);
+  assert.match(readWorkflow('windows-recovery.yml'), /\n {4}name: windows_recovery/u);
+});
+
+test('the recovery lane keeps every run kind out of one shared concurrency group', () => {
   const workflow = readWorkflow('windows-recovery.yml');
 
-  assert.match(workflow, /\n {2}pull_request:\n {4}branches: \[main\]/u);
-  assert.match(workflow, /\n {2}push:\n {4}branches: \[main\]/u);
-  assert.match(workflow, /\n {2}workflow_dispatch:/u);
-  assert.match(workflow, /\n {4}name: windows_recovery/u);
-  assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/u);
+  // github.head_ref is a bare branch name, so two forks pushing their own
+  // `main` would share a group and cancel each other; github.ref is
+  // refs/heads/main for the nightly, a dispatch and a main push alike, so a
+  // ref-keyed group made a dispatch queue behind the nightly and let the next
+  // dispatch discard it while pending.
+  assert.match(
+    workflow,
+    /group: windows-recovery-\$\{\{ github\.event\.pull_request\.number \|\| github\.run_id \}\}/u,
+  );
+  assert.match(workflow, /\n {2}cancel-in-progress: true/u);
+});
+
+test('the recovery lane filters pull requests by the workspaces its steps execute', () => {
+  const workflow = readWorkflow('windows-recovery.yml');
+  const filtered = new Set(pullRequestPathFilter('windows-recovery.yml'));
+
+  // Derived from the dist paths the steps run, then widened along the workspace
+  // dependency graph the planner selects with. The separator class matches the
+  // backslash form too, because these steps run under pwsh where both are
+  // legal. A new workspace on this lane, or a new dependency under one of them,
+  // fails here until the filter admits its sources and project file.
+  const executed = [
+    ...new Set(
+      [...workflow.matchAll(/packages[/\\]([^/\\]+)[/\\]dist[/\\]/gu)].map((match) => match[1]),
+    ),
+  ].sort();
+  assert.deepEqual(executed, ['runtime', 'runtime-host', 'storage']);
+
+  const closure = dependencyClosure(executed.map((workspace) => `packages/${workspace}`));
+  assert.ok(closure.includes('packages/core'), 'dependency closure must reach core');
+  for (const dir of closure) {
+    assert.ok(filtered.has(`${dir}/src/**`), `${dir}: sources`);
+    assert.ok(filtered.has(`${dir}/tsconfig.json`), `${dir}: project file`);
+    assert.ok(filtered.has(`${dir}/package.json`), `${dir}: manifest`);
+  }
+});
+
+test('the recovery lane filters pull requests by what its install and clean steps consume', () => {
+  const filtered = new Set(pullRequestPathFilter('windows-recovery.yml'));
+
+  // `npm.cmd ci` and `npm.cmd run build:test` run unconditionally, so these are
+  // first-class inputs of the lane rather than transitive edits the nightly can
+  // be left to cover. A grouped dependabot bump touches only the manifests, and
+  // the crash gates sit on a native file lock the Linux `test` lane never sees.
+  for (const path of [
+    'package.json',
+    'package-lock.json',
+    'patches/**',
+    'scripts/apply-dependency-patches.mjs',
+    'scripts/install-electron-with-retry.mjs',
+    'scripts/clean-build.mjs',
+    'scripts/clean-paths.mjs',
+    'scripts/windows-runtime-host-local-ipc-trust.ps1',
+    'tsconfig.base.json',
+    'tsconfig.lib.json',
+    'packages/runtime/scripts/**',
+    '.github/workflows/windows-recovery.yml',
+  ]) {
+    assert.ok(filtered.has(path), path);
+  }
 });
 
 test('the sandbox lane pairs its path filter with a nightly run', () => {
@@ -551,6 +572,56 @@ test('core CI runs the live Eval proxy lifecycle when Eval is selected', () => {
 });
 
 const WORKFLOW_DIR = new URL('../.github/workflows/', import.meta.url);
+
+/**
+ * Reads the `paths` list belonging to a workflow's `pull_request` trigger.
+ * Anchoring to the trigger, instead of matching entry text anywhere in the
+ * file, is what makes the filter assertions fail when entries move under
+ * `paths-ignore`, under another trigger, or out of `on:` altogether.
+ */
+function pullRequestPathFilter(name) {
+  // Reads the `on:` block with comments already stripped, so a comment between
+  // the trigger and its list cannot end the scan, and accepts the quoting and
+  // spacing YAML allows, so a legal rewrite reports the entries it really has
+  // instead of an empty list that reads as a missing filter.
+  const lines = triggerBlock(name).split('\n');
+  const start = lines.findIndex((line) => /^ {2}pull_request:\s*$/u.test(line));
+  assert.ok(start >= 0, `${name}: no pull_request trigger`);
+
+  const paths = [];
+  let inPaths = false;
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === '') continue;
+    if (/^ {0,2}\S/u.test(line)) break;
+    if (/^ {4}\S/u.test(line)) {
+      inPaths = /^ {4}paths:\s*$/u.test(line);
+      continue;
+    }
+    const entry = inPaths ? /^\s+-\s+['"]?(.+?)['"]?\s*$/u.exec(line) : null;
+    if (entry) paths.push(entry[1]);
+  }
+  return paths;
+}
+
+/**
+ * Workspace dirs `seeds` depend on, transitively, read off the same graph the
+ * planner selects with rather than a second definition of the same edges. The
+ * graph stores dependents, so a dependency is any dir listing one of ours.
+ */
+function dependencyClosure(seeds) {
+  const graph = loadWorkspaceGraph();
+  const selected = new Set(seeds);
+  const pending = [...seeds];
+  while (pending.length > 0) {
+    const dir = pending.shift();
+    for (const [dependency, dependents] of graph.dependents) {
+      if (!dependents.has(dir) || selected.has(dependency)) continue;
+      selected.add(dependency);
+      pending.push(dependency);
+    }
+  }
+  return [...selected].sort();
+}
 
 function readWorkflow(name) {
   return readFileSync(new URL(name, WORKFLOW_DIR), 'utf8');

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -352,27 +352,64 @@ test('pull request triggers stay on an explicit allowlist', () => {
   ]);
 });
 
-test('the recovery lane pairs its path filter with a nightly run', () => {
+test('the recovery lane pairs its path filter with a nightly run and a main push', () => {
   const workflow = readWorkflow('windows-recovery.yml');
 
   // Same contract as the sandbox lane: the filter is a pre-filter, not the
   // lane's import closure, so dropping the schedule would silently lose every
   // transitive edit it cannot match, and dropping the filter would put every
-  // Windows recovery run back on every pull request.
+  // Windows recovery run back on every pull request. The main push carries no
+  // filter because `strict: false` lets a stale-base pull request go green,
+  // and only the merged result proves two green halves still agree.
   assert.match(workflow, /\n {2}pull_request:\n {4}paths:/u);
+  assert.match(workflow, /\n {2}push:\n {4}branches: \[main\]/u);
   assert.match(workflow, /\n {2}schedule:/u);
   assert.match(workflow, /\n {2}workflow_dispatch:/u);
   assert.match(workflow, /\n {4}name: windows_recovery/u);
-  assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/u);
 });
 
-test('the recovery lane filter names the authorities its steps execute', () => {
+test('the recovery lane keeps scheduled and manual runs out of one shared group', () => {
   const workflow = readWorkflow('windows-recovery.yml');
 
+  // github.ref is refs/heads/main for the nightly, a dispatch and a main push
+  // alike, so a ref-keyed group made a dispatch queue behind the nightly for
+  // up to the job timeout and let the next dispatch discard it while pending.
+  assert.match(
+    workflow,
+    /group: windows-recovery-\$\{\{ github\.head_ref \|\| github\.run_id \}\}/u,
+  );
+  assert.match(workflow, /\n {2}cancel-in-progress: true/u);
+});
+
+test('the recovery lane filter covers every workspace its steps execute', () => {
+  const workflow = readWorkflow('windows-recovery.yml');
+  // Derived from the dist paths the steps actually run, so adding a workspace
+  // to this lane fails here until its sources and project file are filtered.
+  const executed = [
+    ...new Set([...workflow.matchAll(/packages\/([^/]+)\/dist\//gu)].map((match) => match[1])),
+  ].sort();
+
+  assert.deepEqual(executed, ['runtime', 'runtime-host', 'storage']);
+  for (const workspace of executed) {
+    assert.ok(workflow.includes(`      - 'packages/${workspace}/src/**'`), workspace);
+    assert.ok(workflow.includes(`      - 'packages/${workspace}/tsconfig.json'`), workspace);
+  }
+});
+
+test('the recovery lane filter names what its install and build steps consume', () => {
+  const workflow = readWorkflow('windows-recovery.yml');
+
+  // `npm.cmd ci` and `npm.cmd run build:test` run unconditionally, so their
+  // inputs are first-class inputs of this lane rather than transitive edits
+  // the nightly can be left to cover. A grouped dependabot bump touches only
+  // the manifests, and the crash gates below sit on a native file lock that
+  // the Linux `test` lane cannot observe at all.
   for (const path of [
-    'packages/storage/src/**',
-    'packages/runtime/src/**',
-    'packages/runtime-host/src/**',
+    'package.json',
+    'package-lock.json',
+    'patches/**',
+    'tsconfig.base.json',
+    'tsconfig.lib.json',
     'scripts/windows-runtime-host-local-ipc-trust.ps1',
     '.github/workflows/windows-recovery.yml',
   ]) {

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -362,7 +362,7 @@ test('the recovery lane pairs its path filter with a nightly run and a main push
   // transitive edit it cannot match, and dropping the filter would put every
   // Windows recovery run back on every pull request. The main push carries no
   // filter because `strict: false` lets a stale-base pull request go green,
-  // and because a diff over 3,000 files can skip a paths filter outright.
+  // and because a paths filter only sees the first 300 files of a diff.
   // Stripped comment lines survive as blank ones, so the gap between the
   // trigger and its list is any mix of blank and four-space lines.
   assert.match(triggers, /\n {2}pull_request:\n(?:(?: {4}[^\n]*)?\n)* {4}paths:/u);

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -416,6 +416,26 @@ test('the recovery lane filters pull requests by the workspaces its steps execut
   }
 });
 
+test('the recovery lane filter follows the postinstall launcher chain', () => {
+  const filtered = new Set(pullRequestPathFilter('windows-recovery.yml'));
+  const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+  // Derived from postinstall itself, then one hop into whatever those entry
+  // points launch, because a launcher the filter cannot see still decides what
+  // `npm ci` produces on Windows. A restated list missed exactly that hop.
+  const entrypoints = [...manifest.scripts.postinstall.matchAll(/node (scripts\/[\w.-]+)/gu)].map(
+    (match) => match[1],
+  );
+  assert.ok(entrypoints.length > 0, 'postinstall runs no script');
+
+  for (const entrypoint of entrypoints) {
+    assert.ok(filtered.has(entrypoint), entrypoint);
+    const source = readFileSync(new URL(`../${entrypoint}`, import.meta.url), 'utf8');
+    for (const launched of source.matchAll(/new URL\('\.\/([\w.-]+)'/gu)) {
+      assert.ok(filtered.has(`scripts/${launched[1]}`), `${entrypoint} launches ${launched[1]}`);
+    }
+  }
+});
+
 test('the recovery lane filters pull requests by what its install and clean steps consume', () => {
   const filtered = new Set(pullRequestPathFilter('windows-recovery.yml'));
 

--- a/scripts/product-release.test.mjs
+++ b/scripts/product-release.test.mjs
@@ -724,10 +724,7 @@ test('one product workflow gates one draft release on every required artifact', 
 
 test('repository control plane admits only reviewed immutable release tags', async () => {
   const config = parseYaml(await readFile(new URL('../.asf.yaml', import.meta.url), 'utf8'));
-  assert.deepEqual(config.github.protected_branches.main.required_status_checks.contexts, [
-    'test',
-    'windows_recovery',
-  ]);
+  assert.deepEqual(config.github.protected_branches.main.required_status_checks.contexts, ['test']);
   const environments = config.github.environments;
   for (const [name, tagPattern] of [
     ['release', 'v*-incubating-rc*'],

--- a/scripts/product-release.test.mjs
+++ b/scripts/product-release.test.mjs
@@ -724,7 +724,10 @@ test('one product workflow gates one draft release on every required artifact', 
 
 test('repository control plane admits only reviewed immutable release tags', async () => {
   const config = parseYaml(await readFile(new URL('../.asf.yaml', import.meta.url), 'utf8'));
-  assert.deepEqual(config.github.protected_branches.main.required_status_checks.contexts, ['test']);
+  assert.deepEqual(config.github.protected_branches.main.required_status_checks.contexts, [
+    'test',
+    'windows_recovery',
+  ]);
   const environments = config.github.environments;
   for (const [name, tagPattern] of [
     ['release', 'v*-incubating-rc*'],


### PR DESCRIPTION
## Summary

`windows_recovery` became a required context in #3789, so every pull request starts a Windows runner whether or not it can observe the change. That reverses the automatic-runner-start reduction from #3261, and it does not scale: Windows is one of four platforms this project is heading for.

This scopes the lane to its own inputs with a `pull_request` paths filter, keeps an unfiltered `push` on `main`, adds a nightly run, and removes `windows_recovery` from the ASF-managed required contexts. Measured against the last 30 merged pull requests, the filter selects 18 and skips 12.

Refs #3789. Refs #3261.

### Why the required context goes away

A paths filter and a required context cannot coexist: a filtered workflow never starts, so the check never reports and the pull request stays pending with no way for a committer to override it. `.asf.yaml` gains a comment recording that.

Dropping it is the point, not a side effect. No other platform holds a required gate today — `runtime-host-owner-platform` covers macOS and Windows, `release-windows-check` and `windows-sandbox-w0` cover Windows, and none of them blocks a merge. Requiring one platform out of four is the asymmetry being removed.

What takes over the blocking role is the unfiltered main push: it observes the merged result immediately and attributes a regression to a single commit, rather than leaving it for a nightly that faces a batch. The nightly still covers the transitive edits a static list cannot match, and the concurrency key gives each main push its own group so no merge supersedes another's evidence.

## Verification

- `node --test --test-concurrency=1 scripts/ci-test-plan.test.mjs` — 41 passed, 0 failed
- `node --test --test-name-pattern="repository control plane" scripts/product-release.test.mjs` — 1 passed, 0 failed
- `actionlint` on both changed workflows, `npx biome check` on the changed scripts — clean

Each contract test was checked in both directions. Reversals that must fail, and do: renaming `paths` to `paths-ignore`; adding a filter to the `push` trigger; deleting the nightly; deleting `packages/core/src/**`; deleting a workspace manifest. Legal rewrites that must stay green, and do: a comment inside the trigger block, a comment between `paths:` and its first entry, and an entry requoted with double quotes.

The filter's contract derives the workspace set from the `dist` paths the steps run and widens it with `loadWorkspaceGraph` — the same graph the planner selects with — so the filter is checked against the dependency edges rather than against a second copy of them. That is what makes `packages/core` required in the filter without being named in the test.

## Review focus

The paths list is a pre-filter, not the lane's import closure. The nightly and the unfiltered main push are what make that safe, so all three must stay paired; the contract test asserts it.

GitHub evaluates a paths filter against the first 300 files of the diff only, so a wider pull request can skip the filter outright; that is the other reason the main push carries none.

`.asf.yaml` is applied by ASF infrastructure after merge. Between the merge and that reconcile the required context still exists while the filter is already live, so a pull request pushed in that window touching none of the filtered paths shows `windows_recovery` as pending, and clears itself once the reconcile lands.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Opus traced the required-context and trigger history, measured lane timings and filter selectivity against merged pull requests, wrote the workflow, config and contract test changes, and ran three rounds of adversarial review. An intermediate commit implemented the alternative — keeping the context required and selecting inside the job — and it is reverted in the final commit for the reason given above.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

