### PR TITLE
fix(runtime-host): break reconnect failure cascades

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -141,6 +141,43 @@ test('quiesces reconnect and waits for the Host process before update install', 
   await owner.close();
 });
 
+test('waits through a reconnect gap before quiescing Host retirement', async () => {
+  const first = candidateHarness();
+  const replacement = candidateHarness({ disconnectOnPrepare: true });
+  let starts = 0;
+  let reportReplacementStart!: () => void;
+  let releaseReplacement!: () => void;
+  const replacementStarted = new Promise<void>((resolve) => {
+    reportReplacementStart = resolve;
+  });
+  const replacementReleased = new Promise<void>((resolve) => {
+    releaseReplacement = resolve;
+  });
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async () => {
+      starts += 1;
+      if (starts === 1) return ready(first.candidate);
+      reportReplacementStart();
+      await replacementReleased;
+      return ready(replacement.candidate);
+    },
+    waitForHostExit: async () => {},
+  });
+
+  first.disconnect();
+  await replacementStarted;
+  const retirement = owner.retireOwnedLocalHost('interrupt_active_work');
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(replacement.prepareRetirementCalls, 0);
+
+  releaseReplacement();
+  assert.equal((await retirement).kind, 'retired');
+  assert.equal(replacement.prepareRetirementCalls, 1);
+  assert.deepEqual(replacement.retirementModes, ['interrupt_active_work']);
+  assert.equal(starts, 2);
+  await owner.close();
+});
+
 test('retires the owned ephemeral Host before Desktop quit', async () => {
   const events: string[] = [];
   const current = candidateHarness({

--- a/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
@@ -386,6 +386,42 @@ test("bounds reconnectable reads when no replacement handler becomes available",
   router.close();
 });
 
+test("settles concurrent invocations after one bounded replacement window", async () => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc, {
+    replacementWaitTimeoutMs: 5,
+  });
+  const target = router.createTarget("target-a");
+  target.handleReconnectableRead?.("projects:getSnapshot", async () => ({ projects: [] }));
+  router.activate("target-a");
+  target.removeHandler("projects:getSnapshot");
+
+  const reads = Array.from({ length: 200 }, (_, index) =>
+    ipc.invoke("projects:getSnapshot", scope("target-a"), { index }).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    ),
+  );
+  const settled = Promise.all(reads);
+  try {
+    const result = await Promise.race([
+      settled,
+      new Promise<{ readonly timedOut: true }>((resolve) =>
+        setTimeout(() => resolve({ timedOut: true }), 100),
+      ),
+    ]);
+    assert.ok(Array.isArray(result), "Runtime Host invocations did not settle");
+    assert.equal(result.length, 200);
+    for (const read of result) {
+      assert.equal(read.ok, false);
+      if (!read.ok) assert.ok(read.error instanceof RuntimeHostHandlerUnavailableError);
+    }
+  } finally {
+    router.close();
+    await settled;
+  }
+});
+
 test("does not reset one reconnectable read deadline across failed replacements", async (t) => {
   const ipc = ipcHarness();
   const router = new RuntimeHostReconnectingIpcMain(ipc, {

--- a/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
@@ -128,7 +128,7 @@ test("reconciles a dispatched control on a replacement without replaying it", as
 test("bounds reconciliation when no replacement candidate becomes available", async () => {
   const ipc = ipcHarness();
   const router = new RuntimeHostReconnectingIpcMain(ipc, {
-    reconciliationWaitTimeoutMs: 5,
+    replacementWaitTimeoutMs: 5,
   });
   const firstTarget = router.createTarget("target-a") as ReconciledControlTarget;
   let dispatches = 0;
@@ -339,10 +339,10 @@ test("holds an invocation across a Runtime Host candidate replacement", async ()
   assert.equal(ipc.size, 0);
 });
 
-test("bounds invocation while an active Runtime Host has no handler", async () => {
+test("bounds an invocation while an active Runtime Host has no handler", async () => {
   const ipc = ipcHarness();
   const router = new RuntimeHostReconnectingIpcMain(ipc, {
-    handlerWaitTimeoutMs: 5,
+    replacementWaitTimeoutMs: 5,
   });
   const target = router.createTarget("target-a");
   target.handle("sessions:send", async () => "sent");
@@ -354,17 +354,14 @@ test("bounds invocation while an active Runtime Host has no handler", async () =
     RuntimeHostHandlerUnavailableError,
   );
   target.handle("sessions:send", async () => "retried");
-  assert.equal(
-    await ipc.invoke("sessions:send", scope("target-a")),
-    "retried",
-  );
+  assert.equal(await ipc.invoke("sessions:send", scope("target-a")), "retried");
   router.close();
 });
 
 test("bounds reconnectable reads when no replacement handler becomes available", async () => {
   const ipc = ipcHarness();
   const router = new RuntimeHostReconnectingIpcMain(ipc, {
-    handlerWaitTimeoutMs: 5,
+    replacementWaitTimeoutMs: 5,
   });
   const target = router.createTarget("target-a");
   const failRead = deferred();
@@ -387,6 +384,43 @@ test("bounds reconnectable reads when no replacement handler becomes available",
     RuntimeHostHandlerUnavailableError,
   );
   router.close();
+});
+
+test("does not reset one reconnectable read deadline across failed replacements", async (t) => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc, {
+    replacementWaitTimeoutMs: 15,
+  });
+  let monotonicNow = 0;
+  t.mock.method(performance, "now", () => monotonicNow);
+  router.activate("target-a");
+  let attempts = 0;
+  const maximumAttempts = 20;
+  const installFailingTarget = (): void => {
+    const target = router.createTarget("target-a");
+    target.handleReconnectableRead?.("projects:getSnapshot", async () => {
+      attempts += 1;
+      monotonicNow += 5;
+      target.removeHandler("projects:getSnapshot");
+      if (attempts < maximumAttempts) installFailingTarget();
+      throw new RuntimeHostOperationError(
+        "project.catalog.query",
+        "host_draining",
+        "Runtime Host is draining",
+      );
+    });
+  };
+  installFailingTarget();
+
+  try {
+    await assert.rejects(
+      () => ipc.invoke("projects:getSnapshot", scope("target-a")),
+      RuntimeHostHandlerUnavailableError,
+    );
+    assert.equal(attempts, 4);
+  } finally {
+    router.close();
+  }
 });
 
 test("does not return a late read from a replaced Runtime Host candidate", async () => {

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -557,7 +557,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     const lifecycle = this.#requireLifecycle(
       this.#requireTarget(LOCAL_RUNTIME_HOST_PROFILE.id),
     );
-    const quiescence = lifecycle.quiesce();
+    const quiescence = await lifecycle.quiesce();
     let hostPid = quiescence.current.hostPid;
     let launchBarrierPaused = false;
     const resume = () => {

--- a/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
@@ -33,18 +33,16 @@ type ReconcileIpcHandler = (
 
 type ReconciliationUnavailableIpcHandler = ReconcileIpcHandler;
 
-const DEFAULT_RECONCILIATION_WAIT_TIMEOUT_MS = 15_000;
-const DEFAULT_HANDLER_WAIT_TIMEOUT_MS = 5_000;
+const DEFAULT_REPLACEMENT_WAIT_TIMEOUT_MS = 15_000;
 
 export interface RuntimeHostReconnectingIpcMainOptions {
-  readonly reconciliationWaitTimeoutMs?: number;
-  readonly handlerWaitTimeoutMs?: number;
+  readonly replacementWaitTimeoutMs?: number;
 }
 
-class ReconciliationWaitExpiredError extends Error {
+class HandlerWaitExpiredError extends Error {
   constructor() {
-    super("Runtime Host reconciliation replacement wait expired");
-    this.name = "ReconciliationWaitExpiredError";
+    super("Runtime Host replacement wait expired");
+    this.name = "HandlerWaitExpiredError";
   }
 }
 
@@ -99,8 +97,7 @@ export class RuntimeHostReconnectingIpcMain {
   readonly #ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
   readonly #slots = new Map<string, HandlerSlot>();
   readonly #activeEpochs = new Set<string>();
-  readonly #reconciliationWaitTimeoutMs: number;
-  readonly #handlerWaitTimeoutMs: number;
+  readonly #replacementWaitTimeoutMs: number;
   #closed = false;
 
   constructor(
@@ -108,18 +105,12 @@ export class RuntimeHostReconnectingIpcMain {
     options: RuntimeHostReconnectingIpcMainOptions = {},
   ) {
     this.#ipcMain = ipcMain;
-    const reconciliationWaitTimeoutMs =
-      options.reconciliationWaitTimeoutMs ?? DEFAULT_RECONCILIATION_WAIT_TIMEOUT_MS;
-    if (!Number.isSafeInteger(reconciliationWaitTimeoutMs) || reconciliationWaitTimeoutMs <= 0) {
-      throw new TypeError("Runtime Host reconciliation wait timeout must be positive");
+    const replacementWaitTimeoutMs =
+      options.replacementWaitTimeoutMs ?? DEFAULT_REPLACEMENT_WAIT_TIMEOUT_MS;
+    if (!Number.isSafeInteger(replacementWaitTimeoutMs) || replacementWaitTimeoutMs <= 0) {
+      throw new TypeError("Runtime Host replacement wait timeout must be positive");
     }
-    this.#reconciliationWaitTimeoutMs = reconciliationWaitTimeoutMs;
-    const handlerWaitTimeoutMs =
-      options.handlerWaitTimeoutMs ?? DEFAULT_HANDLER_WAIT_TIMEOUT_MS;
-    if (!Number.isSafeInteger(handlerWaitTimeoutMs) || handlerWaitTimeoutMs <= 0) {
-      throw new TypeError("Runtime Host handler wait timeout must be positive");
-    }
-    this.#handlerWaitTimeoutMs = handlerWaitTimeoutMs;
+    this.#replacementWaitTimeoutMs = replacementWaitTimeoutMs;
   }
 
   createTarget(epoch: string): RuntimeHostTargetIpcMain {
@@ -248,41 +239,28 @@ export class RuntimeHostReconnectingIpcMain {
     args: readonly unknown[],
   ): Promise<unknown> {
     const epoch = this.#requireTargetEpoch(args[0]);
-    let handler: BoundHandler =
-      slot.handlers.get(epoch) ??
-      await this.#waitForHandler(
-        slot,
-        epoch,
-        undefined,
-        this.#handlerWaitTimeoutMs,
-        () => new RuntimeHostHandlerUnavailableError(),
-      );
-    let reconciliationContext: unknown;
     let reconciling = false;
-    let reconciliationDeadline: number | undefined;
+    let replacementDeadline: number | undefined;
     const waitForReplacement = async (
-      previous: BoundHandler,
+      previous?: BoundHandler,
     ): Promise<BoundHandler | undefined> => {
-      if (!reconciling) {
-        return this.#waitForHandler(
-          slot,
-          epoch,
-          previous,
-          this.#handlerWaitTimeoutMs,
-          () => new RuntimeHostHandlerUnavailableError(),
-        );
-      }
-      const remainingMs = Math.max(
-        0,
-        (reconciliationDeadline ?? Date.now()) - Date.now(),
-      );
+      // One invocation gets one monotonic replacement window across every
+      // candidate it visits; flapping must not restart its lifetime.
+      replacementDeadline ??= performance.now() + this.#replacementWaitTimeoutMs;
+      const remainingMs = Math.max(0, replacementDeadline - performance.now());
       try {
+        if (remainingMs <= 0) throw new HandlerWaitExpiredError();
         return await this.#waitForHandler(slot, epoch, previous, remainingMs);
       } catch (error) {
-        if (error instanceof ReconciliationWaitExpiredError) return undefined;
-        throw error;
+        if (!(error instanceof HandlerWaitExpiredError)) throw error;
+        if (reconciling) return undefined;
+        throw new RuntimeHostHandlerUnavailableError();
       }
     };
+    const initialHandler = slot.handlers.get(epoch) ?? await waitForReplacement();
+    if (!initialHandler) throw new RuntimeHostHandlerUnavailableError();
+    let handler: BoundHandler = initialHandler;
+    let reconciliationContext: unknown;
     const unavailable = (): Promise<unknown> =>
       requireReconciliationUnavailableHandler(handler)(
         reconciliationContext,
@@ -309,7 +287,6 @@ export class RuntimeHostReconnectingIpcMain {
           if (step.kind === "completed") return step.value;
           reconciliationContext = step.context;
           reconciling = true;
-          reconciliationDeadline = Date.now() + this.#reconciliationWaitTimeoutMs;
           const replacement = await waitForReplacement(handler);
           if (!replacement) return unavailable();
           handler = replacement;
@@ -345,7 +322,6 @@ export class RuntimeHostReconnectingIpcMain {
     epoch: string,
     previous?: BoundHandler,
     timeoutMs?: number,
-    timeoutError: () => Error = () => new ReconciliationWaitExpiredError(),
   ): Promise<BoundHandler> {
     try {
       this.#assertActive(epoch);
@@ -357,7 +333,7 @@ export class RuntimeHostReconnectingIpcMain {
       return Promise.resolve(current);
     }
     if (timeoutMs !== undefined && timeoutMs <= 0) {
-      return Promise.reject(timeoutError());
+      return Promise.reject(new HandlerWaitExpiredError());
     }
     return new Promise((resolve, reject) => {
       let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -376,7 +352,7 @@ export class RuntimeHostReconnectingIpcMain {
       if (timeoutMs !== undefined) {
         timeout = setTimeout(() => {
           if (!slot.waiters.delete(waiter)) return;
-          waiter.reject(timeoutError());
+          waiter.reject(new HandlerWaitExpiredError());
         }, timeoutMs);
       }
     });

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -41,7 +41,9 @@ import {
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS,
   RUNTIME_HOST_PROTOCOL_VERSION,
+  SESSION_CONTINUITY_SCHEMA_VERSION,
   type ClientFrame,
+  type EncodedProtocolMessage,
   type HostFrame,
   type ResponseFrame,
   type TurnSnapshot,
@@ -53,6 +55,7 @@ import type {
   ClientCapabilityService,
 } from '../server/client-capability-service.js';
 import { RuntimeHostConnectionSession } from '../server/connection-session.js';
+import type { SessionContinuityService } from '../server/session-continuity-service.js';
 import {
   createUnavailableAccessAuthorityOperationHandlers,
   createUnavailableDomainOperationHandlers,
@@ -68,6 +71,7 @@ import {
   RuntimeHostOutboundQueueError,
 } from '../server/serial-outbound-writer.js';
 import { FramedTransport } from '../transport/framed-transport.js';
+import type { RuntimeHostMessageTransport } from '../transport/message-transport.js';
 
 const CURRENT_PROTOCOL = {
   min: RUNTIME_HOST_PROTOCOL_VERSION,
@@ -358,6 +362,191 @@ test('serial outbound writer reports its 2 MiB byte bound before its frame bound
   } finally {
     writer.close();
     await pair.close();
+  }
+});
+
+test('flushes concurrent subscription opens before activating their live frame streams', async () => {
+  const releaseWrites = deferred();
+  const requestsEntered = deferred();
+  const allWrites = deferred();
+  const inbound = Array.from({ length: 16 }, (_, index) => ({
+    requestId: `open-${index}`,
+    operation: 'subscription.open',
+    input: { sessionId: `session-${index}`, transcript: { kind: 'none' } },
+  }));
+  const written: EncodedProtocolMessage[] = [];
+  let aborted = false;
+  let resolveClosed!: () => void;
+  let rejectRead: ((error: Error) => void) | undefined;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const transport: RuntimeHostMessageTransport = {
+    closed,
+    read: async () => {
+      const frame = inbound.shift();
+      if (frame) return frame;
+      return new Promise<never>((_resolve, reject) => {
+        rejectRead = reject;
+      });
+    },
+    write: async (message) => {
+      await releaseWrites.promise;
+      written.push(message);
+      if (written.length === 32) allWrites.resolve();
+    },
+    closeAfterFlush: () => {
+      resolveClosed();
+    },
+    abort: (error) => {
+      if (aborted) return;
+      aborted = true;
+      rejectRead?.(error ?? new Error('in-memory transport aborted'));
+      resolveClosed();
+    },
+  };
+  let openCalls = 0;
+  let sink: Parameters<SessionContinuityService['attachConnection']>[1] | undefined;
+  const largeSnapshot = (sessionId: string) => {
+    const snapshot = canonicalProjection(sessionId);
+    return {
+      ...snapshot,
+      schemaVersion: SESSION_CONTINUITY_SCHEMA_VERSION,
+      projectionRevision: 1,
+      queue: {
+        ...snapshot.queue,
+        followup: Array.from({ length: 2 }, (_, index) => ({
+          entryId: `entry-${sessionId}-${index}`,
+          messageId: `message-${sessionId}-${index}`,
+          content: { text: 'q'.repeat(25 * 1024), quotes: [] },
+          placement: 'next_turn' as const,
+          state: 'queued' as const,
+        })),
+      },
+    };
+  };
+  const continuity: SessionContinuityService = {
+    handlers: {
+      'subscription.open': async (input) => {
+        openCalls += 1;
+        if (openCalls === 16) requestsEntered.resolve();
+        return {
+          ok: true,
+          result: {
+            hostEpoch: 'host-epoch',
+            subscriptionId: `subscription-${input.sessionId}`,
+            nextSequence: 1,
+            snapshot: largeSnapshot(input.sessionId),
+            activeAssistantStreams: Array.from({ length: 180 }, (_, index) => ({
+              kind: 'text' as const,
+              turnId: `turn-${input.sessionId}`,
+              messageId: `stream-${input.sessionId}-${index}`,
+            })),
+            transcript: transcriptBootstrapFor(input.sessionId),
+          },
+        };
+      },
+      'subscription.close': async (input) => ({
+        ok: true,
+        result: { subscriptionId: input.subscriptionId },
+      }),
+      'session.transcript.overlay.release': async () => ({
+        ok: false,
+        error: { code: 'operation_unavailable', message: 'not used' },
+      }),
+      'session.transcript.page': async () => ({
+        ok: false,
+        error: { code: 'operation_unavailable', message: 'not used' },
+      }),
+    },
+    attachConnection: (_connectionId, attachedSink) => {
+      sink = attachedSink;
+      return {
+        activate: (subscriptionId) => {
+          const sessionId = subscriptionId.slice('subscription-'.length);
+          void sink
+            ?.send({
+              kind: 'subscription.session_projection',
+              hostEpoch: 'host-epoch',
+              subscriptionId,
+              sequence: 1,
+              snapshot: largeSnapshot(sessionId),
+            })
+            .catch(() => undefined);
+        },
+        abort() {},
+        close() {},
+      };
+    },
+  };
+  const handlers: OperationHandlerMap = {
+    'host.status': async () => ({
+      ok: true,
+      result: {
+        hostEpoch: 'host-epoch',
+        compositionId: 'maka.interactive',
+        compositionRevision: '1',
+        state: 'ready',
+        connections: 1,
+        activeOperations: 0,
+        activeResidencies: 0,
+      },
+    }),
+    ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
+    ...createUnavailableAccessAuthorityOperationHandlers(),
+    ...createHandlers(async (input) => ({
+      ok: true,
+      result: runningSnapshot(input.sessionId, input.turnId),
+    })),
+    ...continuity.handlers,
+  };
+  const session = new RuntimeHostConnectionSession({
+    transport,
+    connection: acceptedConnection('concurrent-subscription-opens'),
+    resolveHandlers: () => handlers,
+    resolveContinuity: () => continuity,
+    beginOperation: async () => ({
+      acquireResidency: () => ({ release() {} }),
+      seal() {},
+      finish() {},
+    }),
+    onTeardown() {},
+  });
+  const run = session.run();
+  try {
+    await withTimeout(requestsEntered.promise, 1_000, 'subscription opens were not dispatched');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(aborted, false);
+
+    releaseWrites.resolve();
+    await withTimeout(allWrites.promise, 2_000, 'subscription frames were not flushed');
+    const frames = written.map((message) =>
+      decodeHostFrame(JSON.parse(message.toString('utf8')) as unknown),
+    );
+    const openResponseBytes = written.reduce(
+      (total, message, index) =>
+        !('kind' in frames[index]!) && frames[index]!.operation === 'subscription.open'
+          ? total + message.byteLength
+          : total,
+      0,
+    );
+    assert.ok(openResponseBytes < 2 * 1024 * 1024);
+    assert.ok(written.reduce((total, message) => total + message.byteLength, 0) > 2 * 1024 * 1024);
+    assert.equal(
+      frames.filter((frame) => !('kind' in frame) && frame.operation === 'subscription.open')
+        .length,
+      16,
+    );
+    assert.equal(
+      frames.filter((frame) => 'kind' in frame && frame.kind === 'subscription.session_projection')
+        .length,
+      16,
+    );
+    assert.equal(aborted, false);
+  } finally {
+    releaseWrites.resolve();
+    transport.abort();
+    await run;
   }
 });
 
@@ -1436,6 +1625,43 @@ function canonicalProjection(sessionId: string): CanonicalSessionProjection {
       followup: [],
     },
     interactions: { pending: [] },
+  };
+}
+
+function transcriptBootstrapFor(sessionId: string) {
+  const contents = Buffer.from('t'.repeat(16 * 1024));
+  return {
+    throughSequence: 0,
+    overlayMessageCount: 0,
+    durable: {
+      kind: 'page' as const,
+      sessionId,
+      source: 'durable' as const,
+      direction: 'older' as const,
+      throughSequence: 0,
+      rawBytes: contents.byteLength,
+      fragments: [
+        {
+          kind: 'durable' as const,
+          sequence: 0,
+          byteOffset: 0,
+          totalBytes: contents.byteLength,
+          payloadDigest: null,
+          data: contents.toString('base64'),
+        },
+      ],
+      nextCursor: null,
+    },
+    overlay: {
+      kind: 'page' as const,
+      sessionId,
+      source: 'overlay' as const,
+      direction: 'older' as const,
+      throughSequence: 0,
+      rawBytes: 0,
+      fragments: [],
+      nextCursor: null,
+    },
   };
 }
 

--- a/packages/runtime-host/src/__tests__/reconnecting-connection.test.ts
+++ b/packages/runtime-host/src/__tests__/reconnecting-connection.test.ts
@@ -399,7 +399,7 @@ test('reconnect lifecycle quiescence suppresses replacement until it is resumed'
     },
   });
 
-  const quiescence = lifecycle.quiesce();
+  const quiescence = await lifecycle.quiesce();
   assert.equal(quiescence.current, first.connection);
   first.disconnect();
   await new Promise<void>((resolve) => setImmediate(resolve));
@@ -408,6 +408,35 @@ test('reconnect lifecycle quiescence suppresses replacement until it is resumed'
   quiescence.resume();
   await connected.promise;
   assert.equal(connectCalls, 1);
+  await lifecycle.close();
+});
+
+test('reconnect lifecycle quiescence waits through a connection gap before freezing', async () => {
+  const first = connectionHarness('first', () => undefined);
+  const replacement = connectionHarness('replacement', () => undefined);
+  const reconnecting = deferredValue<RuntimeHostConnection>();
+  const connectStarted = deferred();
+  let connectCalls = 0;
+  const lifecycle = await startRuntimeHostReconnectLifecycle({
+    initial: first.connection,
+    connect: async () => {
+      connectCalls += 1;
+      connectStarted.resolve();
+      return reconnecting.promise;
+    },
+  });
+
+  first.disconnect();
+  await connectStarted.promise;
+  const quiescenceTask = lifecycle.quiesce();
+  reconnecting.resolve(replacement.connection);
+  const quiescence = await quiescenceTask;
+  assert.equal(quiescence.current, replacement.connection);
+
+  replacement.disconnect();
+  await yieldToEventLoop();
+  assert.equal(connectCalls, 1);
+  quiescence.resume();
   await lifecycle.close();
 });
 

--- a/packages/runtime-host/src/client/reconnect-lifecycle.ts
+++ b/packages/runtime-host/src/client/reconnect-lifecycle.ts
@@ -49,7 +49,7 @@ export interface RuntimeHostReconnectLifecycle<T extends RuntimeHostReconnectRes
   readonly current: T | undefined;
   waitForCurrent(previous?: T, signal?: AbortSignal): Promise<T>;
   subscribe(listener: (current: T | undefined) => void): () => void;
-  quiesce(): RuntimeHostReconnectQuiescence<T>;
+  quiesce(): Promise<RuntimeHostReconnectQuiescence<T>>;
   close(): Promise<void>;
 }
 
@@ -190,13 +190,21 @@ class RuntimeHostReconnectLifecycleImpl<T extends RuntimeHostReconnectResource>
     return () => this.#listeners.delete(listener);
   }
 
-  quiesce(): RuntimeHostReconnectQuiescence<T> {
+  async quiesce(): Promise<RuntimeHostReconnectQuiescence<T>> {
+    while (!this.#current) {
+      if (this.#closed || this.#terminalError) {
+        throw new Error('Runtime Host reconnect lifecycle is closed');
+      }
+      if (this.#quiesced) {
+        throw new Error('Runtime Host reconnect lifecycle is already quiesced');
+      }
+      await this.waitForCurrent();
+    }
     if (this.#closed || this.#terminalError) {
       throw new Error('Runtime Host reconnect lifecycle is closed');
     }
     if (this.#quiesced) throw new Error('Runtime Host reconnect lifecycle is already quiesced');
     const current = this.#current;
-    if (!current) throw new Error('Runtime Host has no current connection to quiesce');
     this.#quiesced = true;
     let active = true;
     return {

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -233,9 +233,12 @@ export class RuntimeHostConnectionSession {
         response.ok && response.operation === 'subscription.open'
           ? response.result.subscriptionId
           : undefined;
-      if (openedSubscriptionId) continuity?.activate(openedSubscriptionId);
       try {
         await receipt.flushed;
+        // Subscriber-local queues retain pre-activation events. Expose them
+        // only after the open result leaves the connection-wide writer, or a
+        // restore fan-out can make legal responses and first frames overflow it.
+        if (openedSubscriptionId) continuity?.activate(openedSubscriptionId);
       } catch (error) {
         if (openedSubscriptionId) continuity?.abort(openedSubscriptionId);
         throw error;


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

This change removes three independent causes that turned an ordinary Runtime Host replacement into a prolonged failure cascade:

- a reconnect restoring many subscriptions could abort a healthy server connection because each live stream was activated before its `subscription.open` response had left the connection-wide writer;
- Desktop retirement could fail solely because it called `quiesce()` during the short interval with no current candidate;
- renderer IPC invocations could remain alive across unlimited candidate replacements because handler waits had no invocation-wide lifetime.

The repair does not increase queue capacity, add another retry loop, or weaken the liveness watchdog. It changes ownership and ordering at the three earliest faulty boundaries.

## Root causes and fixes

### Flush subscription ownership before activating live streams

All subscription responses and live frames share one writer bounded at 2 MiB. The previous order enqueued an open response, activated that subscription immediately, and only then waited for the response to flush. During restoration, sixteen legal large subscriptions could therefore place sixteen open responses and sixteen first live snapshots in the same queue. The writer treated that as overload and closed the socket; the client observed `read_eof`, reconnected, restored the same subscriptions, and could repeat the same abort.

The server now flushes each open response before activating its stream. Subscriber-local queues already retain events before activation, so this removes the overlap without losing data or adding buffering.

### Quiesce the candidate that reconnects

`quiesce()` previously required a current candidate and threw during a reconnect gap. It is now asynchronous: it reuses the lifecycle's existing `waitForCurrent()` authority, then freezes replacement synchronously around the recovered candidate. Desktop retirement simply awaits that lease.

### Give one IPC invocation one replacement lifetime

The router previously bounded reconciliation only. Initial handler absence could hold a non-replayable command forever, and every failed reconnectable-read replacement could begin another unbounded wait.

All handler replacement paths now share one lazy, monotonic deadline per renderer invocation. The budget starts only when a replacement is first required and never resets as candidates flap. Reconciled controls retain their existing unavailable fallback; reads and commands that never reach a handler fail explicitly.

This consolidates the bounded-handler work from #3795 and the shared monotonic read deadline from #3847 into one replacement authority. Their authors are credited in the commit trailers.

Closes #3458. Folds in the now-merged #3795 and supersedes #3847.

## Relationship to #3280

#3280 fixes the downstream transcript identity defect: durable transcript ranges are scoped by Session and Host epoch rather than a Desktop replica generation. This PR addresses the upstream disconnect/reconnect causes and the independent quit-time race that #3280 intentionally did not cover.

I did not change the `host.status` watchdog. After removing the proven server-side abort and the unbounded retained invocations, the captured timeout is explained as a liveness signal inside the cascade; I did not find evidence that a healthy, normally draining local Host independently exceeds that deadline.

## Validation

- A production-session regression constructs sixteen wire-valid large subscription restores entirely in memory. Restoring the old activate-before-flush order makes the transport abort; the fixed order stays open and flushes all 16 responses plus all 16 first projections. The hypothetical simultaneous population is larger than 2 MiB, while the response-only population is below the bound.
- 16/16 reconnecting-client lifecycle tests pass.
- 49/49 Desktop manager and reconnecting IPC tests pass. A committed regression
  verifies that 200 concurrent invocations all settle after the same bounded
  replacement window instead of remaining rooted while the target stays active.
- The new reconnect-gap retirement test reaches the replacement candidate exactly once.
- A synthetic 15 ms monotonic budget stops a twenty-candidate read-flapping sequence after four attempts, proving that candidate replacement cannot reset the invocation lifetime.
- A local, in-memory forced-GC probe ran 20 flapping rounds with 200 large-argument
  invocations per round (4,000 total). All 4,000 settled, zero argument markers
  remained reachable after collection, and the post-GC heap peak changed by about
  148 KiB between the first and final five rounds. This directly validates the
  retained-waiter path that made prolonged reconnect churn accumulate heap.
- Core, Storage, MCP, Runtime, Runtime Host, Computer Use, UI, and Desktop main builds pass.
- Biome and `git diff --check` pass.

The socket-backed remainder of the Runtime Host connection-session suite is left to hosted CI; the new regression itself uses an in-memory transport.

## Generative tool disclosure

Codex made substantive contributions: it traced the failure chain, implemented the three repairs, and wrote the regression tests. Every contributed commit includes a `Generated-by: Codex` trailer.

</details>

<details>
<summary>简体中文</summary>

## 概要

这次修改移除了三个相互独立的根因，它们会把一次普通的 Runtime Host 替换放大成长时间故障：

- 重连恢复多个订阅时，服务端会在 `subscription.open` 响应真正写出前启动直播流，合法的大恢复集合因此可能击穿连接级 2 MiB 写队列并主动断开连接；
- Desktop 在短暂没有当前候选者时调用 `quiesce()` 会直接失败，退出或更新流程因此与重连窗口竞争；
- renderer IPC 没有统一的调用生命周期，候选者不断替换时，同一次调用可以无限等待并长期保留参数、事件和 Promise。

修复没有提高队列容量、没有增加新的重试循环，也没有削弱存活探针。它在三个最早出错的边界上改正了顺序和权威。

## 修复

1. 服务端先冲刷订阅打开响应，再激活对应直播流。订阅自己的队列本来就会保存激活前事件，因此不丢数据，也不需要第二份缓冲。
2. `quiesce()` 改为异步复用现有 `waitForCurrent()`：连接恢复后立刻冻结该候选者，Desktop 退休流程只需等待这份 lease。
3. 所有 IPC handler 替换路径共享同一个按调用建立的单调时钟 deadline。它只在第一次需要替换时开始，并且不会随候选者反复失败而重置。该设计把 #3795 与 #3847 的关键修复合并为一份 replacement authority，并在 commit trailer 中保留作者署名。

本 PR 关闭 #3458，吸收已经合并的 #3795，并取代 #3847。

#3280 已修复下游 transcript 身份问题；本 PR 修复它没有覆盖的上游断连/重连根因以及退出竞态。

验证包括：旧顺序下可稳定触发 transport abort、修复后 16 个打开响应和 16 个首帧全部写出；16/16 reconnecting-client 测试、49/49 Desktop manager/router 测试以及八个 workspace 构建全部通过。提交的并发回归确认 200 个调用都会在同一个窗口内结束。另一个本地纯内存 forced-GC 探针执行了 20 轮、每轮 200 个大参数调用，共 4,000 次；回收后没有参数 marker 仍可达，首尾五轮的 GC 后 heap 峰值只相差约 148 KiB。这个结果直接验证了持续重连时会累积 heap 的 retained-waiter 路径。新回归使用纯内存 transport；其余依赖 socket 的 connection-session 测试交给 hosted CI。

Codex 对本 PR 做了实质贡献，包括故障链追踪、三处修复和回归测试；所有相关 commit 都带有 `Generated-by: Codex` trailer。

</details>

---
_Posted by an automated review agent operated by @M4n5ter. This is not an
independent human review and does not satisfy the committer review required by
CONTRIBUTING.md. A human is accountable for this pull request — please push back
if anything here is wrong._

<details><summary>简体中文</summary>

_本 PR 由 @M4n5ter 运行的自动化审查程序发出。它不构成 CONTRIBUTING.md
所要求的独立人类审查，也不能替代人类审查。有人类对本 PR 负责，如有错误请直接指出。_

</details>
