### PR TITLE
fix(runtime): reject malformed bypass CIDRs

### DIFF
--- a/packages/runtime/src/network/__tests__/bypass-matcher.test.ts
+++ b/packages/runtime/src/network/__tests__/bypass-matcher.test.ts
@@ -45,4 +45,11 @@ describe('matchesBypassList', () => {
     expect(matchesBypassList('LocalHost', list)).toBe(true);
     expect(matchesBypassList('anything', ['*'])).toBe(true);
   });
+
+  test('rejects malformed CIDR entries', () => {
+    expect(matchesBypassList('10.0.0.1', ['10.0.0.0/24.5'])).toBe(false);
+    expect(matchesBypassList('10.0.0.1', ['10.0.0.0/24/ignored'])).toBe(false);
+    expect(matchesBypassList('10.0.0.1', ['10.0.0.0/'])).toBe(false);
+    expect(matchesBypassList('10.0.0.1', ['1e1.0.0.0/8'])).toBe(false);
+  });
 });

--- a/packages/runtime/src/network/bypass-matcher.ts
+++ b/packages/runtime/src/network/bypass-matcher.ts
@@ -34,9 +34,12 @@ export function matchesBypassList(host: string, bypassList: string[]): boolean {
 }
 
 function matchesCidr(ip: string, cidr: string): boolean {
-  const [base, prefixRaw] = cidr.split('/');
+  const parts = cidr.split('/');
+  if (parts.length !== 2) return false;
+  const [base, prefixRaw] = parts;
+  if (isIP(base) !== 4 || !/^\d+$/.test(prefixRaw)) return false;
   const prefix = Number(prefixRaw);
-  if (!Number.isFinite(prefix) || prefix < 0 || prefix > 32) return false;
+  if (prefix > 32) return false;
   const ipInt = ipv4ToInt(ip);
   const baseInt = ipv4ToInt(base);
   if (ipInt === null || baseInt === null) return false;


### PR DESCRIPTION
Fixes #3915

## Summary

Malformed proxy bypass CIDRs can match provider, Bot, and WebSocket requests, routing them directly instead of through the configured proxy.

The matcher lets JavaScript coerce fractional or empty prefixes before bit shifting, ignores extra slash components, and parses non-address base syntax with `Number()`. It now requires exactly one slash, a valid IPv4 base, and a decimal integer prefix from 0 through 32 before applying the mask.

The boundary remains IPv4-only, matching the existing capability; valid CIDRs, host wildcards, and exact entries are unchanged.

## Verification

```text
Before
10.0.0.0/24.5       => true
10.0.0.0/24/ignored => true
10.0.0.0/            => true
1e1.0.0.0/8          => true

After
10.0.0.0/24.5       => false
10.0.0.0/24/ignored => false
10.0.0.0/            => false
1e1.0.0.0/8          => false
```

Biome and Runtime typecheck pass. A clean Runtime build passes all 3,040 executed tests, with 13 existing skips and no failures.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the proxy routing defect, implemented the validation and regression coverage, and ran verification. The human contributor remains responsible for the contribution.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
