### PR TITLE
fix(tui): preserve legacy editor undo

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -6399,6 +6399,31 @@ describe('Maka Pi TUI runner', () => {
     await run;
   });
 
+  test('preserves legacy editor undo before a side conversation exists', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SideConversationDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    try {
+      terminal.input('draft');
+      await waitFor(() => editorInputText(terminal) === 'draft');
+      terminal.input('\x1f');
+      await waitFor(() => editorInputText(terminal) === '');
+      assert.equal(driver.getSessionId(), 'session-1');
+    } finally {
+      exitMaka(terminal);
+      await run;
+    }
+  });
+
   test('Ctrl+/ toggles side views, preserves drafts, and projects parent status in English', async () => {
     const terminal = new FakeTerminal();
     const driver = new SideConversationDriver();

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -3593,7 +3593,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return { consume: true };
     }
     if (tui.hasOverlay()) return undefined;
-    if (matchesSideConversationToggle(data)) {
+    if (sideConversation && matchesSideConversationToggle(data)) {
       if (!isKeyRepeat(data)) void toggleSideConversation();
       return { consume: true };
     }


### PR DESCRIPTION
## Summary

Preserve the editor's legacy `Ctrl+-` undo path until a side conversation exists.

The TUI now reserves the ambiguous `0x1f` byte for side switching only while a side pair is active. Enhanced keyboard-protocol shortcuts and active side switching keep their existing behavior.

Fixes #3928

## Verification

- Regression test fails on `origin/main` and passes with this fix
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npm --workspace maka-agent run test:dist` — 514 passed
- `npm run check:asf-headers`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- `git diff --check`

Additional check: `npx knip --workspace packages/cli` reports five unused exported types that are already present on `origin/main`; this PR adds none of them.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex reproduced the legacy key collision, implemented the state-scoped interception, added the regression, and performed first-principles, adversarial, and simplification reviews.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
