### PR TITLE
fix(desktop): signal liveness in the Agent Graph panel

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
@@ -18,13 +18,18 @@
  */
 
 import { strict as assert } from 'node:assert';
+import { existsSync, readFileSync } from 'node:fs';
 import { afterEach, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { act, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { AgentGraphClientSnapshot } from '@maka/runtime/stream-graph-read-model';
 import type { AgentGraphEpochSummary } from '@maka/runtime-host/protocol';
-import { AgentGraphPanel } from '../../renderer/agent-graph-panel.js';
+import {
+  AgentGraphPanel,
+  formatAgentGraphRunClock,
+  getAgentGraphPanelCopy,
+} from '../../renderer/agent-graph-panel.js';
 
 type GraphListener = () => void;
 
@@ -694,5 +699,83 @@ describe('AgentGraphPanel dismiss', () => {
     await harness.renderSession('session-a');
     assert.equal(harness.container.querySelector('.maka-agent-graph-panel'), null);
     await act(async () => harness.root.unmount());
+  });
+});
+
+const agentGraphCssUrl = [
+  new URL('../../renderer/styles/agent-graph.css', import.meta.url),
+  new URL('../../../src/renderer/styles/agent-graph.css', import.meta.url),
+].find((candidate) => existsSync(candidate));
+
+if (!agentGraphCssUrl) throw new Error('Could not locate renderer/styles/agent-graph.css');
+
+const agentGraphCss = readFileSync(agentGraphCssUrl, 'utf8');
+
+describe('AgentGraphPanel liveness', () => {
+  it('animates the status dot only for operators that are still working', () => {
+    const runningDotRule = agentGraphCss.match(
+      /li\[data-status="running"\][^{]*li\[data-status="runnable"\][^{]*\{([^}]*)\}/,
+    );
+    assert.ok(runningDotRule, 'running and runnable dots must share one rule');
+    // A homogeneous fan-out settles all at once, so colour alone leaves the
+    // list looking frozen for the whole run.
+    assert.match(runningDotRule[1] ?? '', /background:\s*var\(--status-running\)/);
+    assert.match(runningDotRule[1] ?? '', /animation:\s*maka-agent-graph-status-pulse 1\.5s/);
+    assert.match(agentGraphCss, /@keyframes maka-agent-graph-status-pulse/);
+
+    for (const settled of ['completed', 'failed', 'aborted']) {
+      const rule = agentGraphCss.match(
+        new RegExp(`li\\[data-status="${settled}"\\][^{]*\\{([^}]*)\\}`),
+      );
+      assert.ok(rule, settled);
+      assert.doesNotMatch(rule[1] ?? '', /animation/, settled);
+    }
+  });
+
+  it('keeps a header heartbeat for every unsettled graph status', async () => {
+    for (const status of ['active', 'waiting', 'closing'] as const) {
+      const harness = await renderPanel(snapshot({ graphId: `graph-${status}`, status }));
+      assert.ok(harness.container.querySelector('.maka-agent-graph-heartbeat'), status);
+      await act(async () => harness.root.unmount());
+    }
+  });
+
+  it('drops the heartbeat and the clock once the graph settles', async () => {
+    const harness = await renderPanel(snapshot({ graphId: 'graph-1', status: 'active' }));
+    assert.ok(harness.container.querySelector('.maka-agent-graph-heartbeat'));
+    assert.match(harness.container.textContent ?? '', /Running · 0\/0 settled · Elapsed 00:00/);
+
+    await harness.setSnapshot(snapshot({ graphId: 'graph-1', status: 'completed' }));
+    assert.equal(harness.container.querySelector('.maka-agent-graph-heartbeat'), null);
+    assert.equal(harness.container.querySelector('.maka-agent-graph-elapsed'), null);
+    assert.doesNotMatch(harness.container.textContent ?? '', /Elapsed/);
+    await act(async () => harness.root.unmount());
+  });
+
+  it('restarts the clock when the graph rolls over to a new epoch', async () => {
+    const harness = await renderPanel(snapshot({ graphId: 'graph-1', status: 'active' }));
+    const firstClock = harness.container.querySelector('.maka-agent-graph-elapsed');
+    assert.ok(firstClock);
+
+    await harness.setSnapshot(snapshot({ graphId: 'graph-2', status: 'active' }));
+    const secondClock = harness.container.querySelector('.maka-agent-graph-elapsed');
+    assert.ok(secondClock);
+    // A new epoch is a new run: reusing the element would carry the previous
+    // run's start time into it.
+    assert.notEqual(secondClock, firstClock);
+    await act(async () => harness.root.unmount());
+  });
+
+  it('formats the run clock in both locales', () => {
+    assert.equal(formatAgentGraphRunClock(0), '00:00');
+    assert.equal(formatAgentGraphRunClock(23), '00:23');
+    assert.equal(formatAgentGraphRunClock(59.9), '00:59');
+    assert.equal(formatAgentGraphRunClock(600), '10:00');
+    assert.equal(formatAgentGraphRunClock(3_599), '59:59');
+    assert.equal(formatAgentGraphRunClock(3_661), '1:01:01');
+    assert.equal(formatAgentGraphRunClock(-5), '00:00');
+
+    assert.equal(getAgentGraphPanelCopy('en').elapsed('00:23'), 'Elapsed 00:23');
+    assert.equal(getAgentGraphPanelCopy('zh').elapsed('00:23'), '已运行 00:23');
   });
 });

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -71,6 +71,7 @@ type GraphPanelCopy = {
   noOperators: string;
   hiddenOperators(count: number): string;
   progress(settled: number, total: number, hasOmitted: boolean): string;
+  elapsed(clock: string): string;
   status(status: AgentGraphClientSnapshot['status']): string;
   operatorStatus(status: AgentGraphClientOperator['status']): string;
   wait(operator: AgentGraphClientOperator): string | undefined;
@@ -100,6 +101,7 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
       hiddenOperators: (count) => `另有 ${count} 个 operator`,
       progress: (settled, total, hasOmitted) =>
         hasOmitted ? `可见 ${settled}/${total} 已结束` : `${settled}/${total} 已结束`,
+      elapsed: (clock) => `已运行 ${clock}`,
       status: (status) =>
         ({
           empty: '等待调度',
@@ -147,6 +149,7 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
     hiddenOperators: (count) => `${count} more operator${count === 1 ? '' : 's'}`,
     progress: (settled, total, hasOmitted) =>
       hasOmitted ? `${settled}/${total} visible settled` : `${settled}/${total} settled`,
+    elapsed: (clock) => `Elapsed ${clock}`,
     status: (status) =>
       ({
         empty: 'Awaiting schedule',
@@ -345,12 +348,13 @@ export function AgentGraphPanel(props: {
       );
     }
   };
+  const graphRunning = snapshot !== undefined && isRunningGraphStatus(snapshot.status);
   const stopAvailable =
     selectedEpoch?.current === true &&
     !loading &&
     snapshot !== undefined &&
     snapshot.graphId === selectedGraphId &&
-    ['active', 'waiting', 'closing'].includes(snapshot.status);
+    graphRunning;
   const dismissAvailable =
     selectedEpoch?.current === true &&
     !loading &&
@@ -391,6 +395,14 @@ export function AgentGraphPanel(props: {
           {epochsTruncated ? (
             <span className="maka-agent-graph-epoch-capped">{copy.cappedEpochs(epochs.length)}</span>
           ) : null}
+          {graphRunning ? (
+            <Spinner
+              size="sm"
+              shade="subtle"
+              className="maka-agent-graph-heartbeat"
+              aria-hidden="true"
+            />
+          ) : null}
           {snapshot ? (
             <span className="maka-agent-graph-progress">
               {copy.status(snapshot.status)} ·{' '}
@@ -399,6 +411,12 @@ export function AgentGraphPanel(props: {
                 progress.total,
                 snapshot.omitted.operators > 0,
               )}
+              {graphRunning ? (
+                <>
+                  {' · '}
+                  <AgentGraphRunClock key={snapshot.graphId} format={copy.elapsed} />
+                </>
+              ) : null}
             </span>
           ) : null}
         </div>
@@ -522,6 +540,45 @@ export function AgentGraphPanel(props: {
       ) : null}
     </section>
   );
+}
+
+function isRunningGraphStatus(status: AgentGraphClientSnapshot['status']): boolean {
+  return status === 'active' || status === 'waiting' || status === 'closing';
+}
+
+/**
+ * Age of the panel's own observation of a running graph.
+ *
+ * The settled counter can hold at `0/7` for an entire fan-out, so the header
+ * needs one number that always moves. The count starts from the render that
+ * first showed this graph running rather than from the epoch binding's
+ * `createdAt`, which is `0` for sessions that no epoch store backs — an
+ * "elapsed" derived from that would read as decades. Remount on `graphId`
+ * restarts it, so an epoch rollover does not inherit the previous run's clock.
+ */
+function AgentGraphRunClock(props: { format(clock: string): string }): JSX.Element {
+  const [seconds, setSeconds] = useState(0);
+  useEffect(() => {
+    const startedAt = Date.now();
+    const tick = globalThis.setInterval(() => {
+      setSeconds(Math.floor((Date.now() - startedAt) / 1_000));
+    }, 1_000);
+    return () => globalThis.clearInterval(tick);
+  }, []);
+  return (
+    <span className="maka-agent-graph-elapsed">
+      {props.format(formatAgentGraphRunClock(seconds))}
+    </span>
+  );
+}
+
+export function formatAgentGraphRunClock(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(seconds / 60);
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return minutes < 60
+    ? `${pad(minutes)}:${pad(seconds % 60)}`
+    : `${Math.floor(minutes / 60)}:${pad(minutes % 60)}:${pad(seconds % 60)}`;
 }
 
 function sameEpochPage(

--- a/apps/desktop/src/renderer/styles/agent-graph.css
+++ b/apps/desktop/src/renderer/styles/agent-graph.css
@@ -84,6 +84,19 @@
   color: var(--muted-foreground);
 }
 
+/* Both halves of the header line can hold still for a whole fan-out — the
+   status word stays "Running" and the settled counter stays `0/7` — so the
+   heading carries one element that is always moving while the graph is alive.
+   The status text beside it names the state, so the ring is decoration. */
+.maka-agent-graph-heartbeat {
+  flex: 0 0 auto;
+}
+
+/* Tabular figures keep the ticking clock from reflowing the counter beside it. */
+.maka-agent-graph-elapsed {
+  font-variant-numeric: tabular-nums;
+}
+
 .maka-agent-graph-empty {
   margin: var(--space-2) 0 0;
 }
@@ -125,9 +138,23 @@
   background: var(--muted-foreground);
 }
 
+/* A homogeneous fan-out settles all at once: seven `local-read` operators hold
+   at `running` for tens of seconds and the rows change nothing on screen, which
+   reads as a frozen list. Motion is the row's liveness signal; the hue stays
+   `--status-running` so colour keeps meaning status and only movement means
+   "still working". Reduced motion is handled by the global cap in
+   maka-tokens.css, which runs a single iteration back to the resting dot. */
+@keyframes maka-agent-graph-status-pulse {
+  50% {
+    opacity: 0.4;
+    transform: scale(1.5);
+  }
+}
+
 .maka-agent-graph-operators li[data-status="running"] .maka-agent-graph-status-dot,
 .maka-agent-graph-operators li[data-status="runnable"] .maka-agent-graph-status-dot {
   background: var(--status-running);
+  animation: maka-agent-graph-status-pulse 1.5s ease-in-out infinite;
 }
 
 .maka-agent-graph-operators li[data-status="completed"] .maka-agent-graph-status-dot {


### PR DESCRIPTION
Fixes #3878.

When an Agent Graph fans out, the desktop panel looks frozen: settled/total stays at 0/7, operator dots only change color, and the Spinner disappears once a snapshot exists. Users think Maka is idle and hit Stop graph.

This adds three liveness signals while the graph is unsettled:
- running/runnable status dots pulse
- header Spinner (heartbeat) for active/waiting/closing
- elapsed clock next to the counter (panel observation time, not createdAt)

Per-operator live preview and header progress bar are out of scope.

AI use: generative tooling made a substantive contribution.