### PR TITLE
test(desktop): story-cover the renderer crash fallback

### DIFF
--- a/apps/desktop/src/renderer/error-boundary.tsx
+++ b/apps/desktop/src/renderer/error-boundary.tsx
@@ -151,10 +151,10 @@ export class ErrorBoundary extends Component<{ children: ReactNode; locale: UiLo
   }
 }
 
-// The fallback face, split out of the class so its four `copyState` values and
-// the repeat-error path can be rendered directly in Storybook — the crash
-// surface is otherwise reachable only by actually crashing the renderer (and
-// the failed-copy state only by additionally failing the clipboard bridge).
+// The fallback face, split out of the class so its four `copyState` values can
+// be rendered directly in Storybook — the crash surface is otherwise reachable
+// only by actually crashing the renderer (and the failed-copy state only by
+// additionally failing the clipboard bridge).
 // The class owns all state and side effects; this component only paints.
 export function ErrorBoundaryFallback({
   error,

--- a/apps/desktop/src/renderer/error-boundary.tsx
+++ b/apps/desktop/src/renderer/error-boundary.tsx
@@ -32,10 +32,12 @@ import { ICON_SIZE, AlertTriangle, Check, Clipboard, RotateCw } from '@maka/ui/i
 import { Button as UiButton, Card, redactSecrets } from '@maka/ui';
 import { getShellCopy } from './locales/shell-copy.js';
 
+export type ErrorBoundaryCopyState = 'idle' | 'pending' | 'copied' | 'failed';
+
 type State = {
   error: Error | null;
   errorInfo: ErrorInfo | null;
-  copyState: 'idle' | 'pending' | 'copied' | 'failed';
+  copyState: ErrorBoundaryCopyState;
 };
 
 const RENDERER_ERROR_DETAILS_MAX_BYTES = 24 * 1024;
@@ -135,66 +137,101 @@ export class ErrorBoundary extends Component<{ children: ReactNode; locale: UiLo
   render(): ReactNode {
     const { error, errorInfo, copyState } = this.state;
     if (!error) return this.props.children;
-    const safeStack = redactSecrets(`${error.name}: ${error.message}${error.stack ? `\n\n${error.stack}` : ''}`);
-    const copyPending = copyState === 'pending';
-    const copy = getShellCopy(this.props.locale).errorBoundary;
-    const copyLabel = copyPending
-      ? copy.copyPending
-      : copyState === 'copied'
-        ? copy.copied
-        : copyState === 'failed'
-          ? copy.copyFailed
-          : copy.copyReport;
-    const CopyIcon = copyState === 'copied' ? Check : Clipboard;
-
     return (
-      <div className="maka-error-surface" role="alert" aria-live="assertive">
-        {/* Astryx Card owns the card face: red tint for the destructive
-            surface, high elevation for the former shadow-modal. The class
-            keeps only the icon/copy grid geometry. */}
-        <Card variant="red" elevation="high" padding={0} className="maka-error-card">
-          <span className="maka-error-icon" aria-hidden="true">
-            <AlertTriangle size={ICON_SIZE.empty} /> {/* 20 in the 32px plate — the ladder's fill convention */}
-          </span>
-          <div className="maka-error-copy">
-            <h2>{copy.title}</h2>
-            <p>
-              {copy.descriptionBeforeRetry} <strong>{copy.retry}</strong> {copy.descriptionBeforeReload}{' '}
-              <strong>{copy.reload}</strong> {copy.descriptionAfterReload}
-            </p>
-            <pre className="maka-error-stack" role="group" aria-label={copy.errorDetails}>
-              {safeStack}
-            </pre>
-            {errorInfo?.componentStack && (
-              <pre className="maka-error-stack" role="group" aria-label={copy.componentStack}>
-                {redactSecrets(errorInfo.componentStack.trim())}
-              </pre>
-            )}
-            <div className="maka-error-actions">
-              <UiButton
-                variant="secondary"
-                className="maka-error-copy-action"
-                data-copy-state={copyState}
-                isDisabled={copyPending}
-                aria-busy={copyPending ? 'true' : undefined}
-                onClick={this.handleCopyReport}
-                icon={<CopyIcon size={ICON_SIZE.control} aria-hidden="true" />}
-                label={copyLabel}
-              />
-              <UiButton
-                variant="secondary"
-                onClick={this.handleReset}
-                icon={<RotateCw size={ICON_SIZE.control} aria-hidden="true" />}
-                label={copy.retry}
-              />
-              <UiButton variant="primary" onClick={this.handleReload} label={copy.reload} />
-            </div>
-            {copyState === 'failed' && <p className="maka-error-copy-status">{copy.clipboardFailure}</p>}
-          </div>
-        </Card>
-      </div>
+      <ErrorBoundaryFallback
+        error={error}
+        errorInfo={errorInfo}
+        copyState={copyState}
+        locale={this.props.locale}
+        onCopyReport={this.handleCopyReport}
+        onReset={this.handleReset}
+        onReload={this.handleReload}
+      />
     );
   }
+}
+
+// The fallback face, split out of the class so its four `copyState` values and
+// the repeat-error path can be rendered directly in Storybook — the crash
+// surface is otherwise reachable only by actually crashing the renderer (and
+// the failed-copy state only by additionally failing the clipboard bridge).
+// The class owns all state and side effects; this component only paints.
+export function ErrorBoundaryFallback({
+  error,
+  errorInfo,
+  copyState,
+  locale,
+  onCopyReport,
+  onReset,
+  onReload,
+}: {
+  error: Error;
+  errorInfo?: ErrorInfo | null;
+  copyState: ErrorBoundaryCopyState;
+  locale: UiLocale;
+  onCopyReport: () => void;
+  onReset: () => void;
+  onReload: () => void;
+}): ReactNode {
+  const safeStack = redactSecrets(`${error.name}: ${error.message}${error.stack ? `\n\n${error.stack}` : ''}`);
+  const copyPending = copyState === 'pending';
+  const copy = getShellCopy(locale).errorBoundary;
+  const copyLabel = copyPending
+    ? copy.copyPending
+    : copyState === 'copied'
+      ? copy.copied
+      : copyState === 'failed'
+        ? copy.copyFailed
+        : copy.copyReport;
+  const CopyIcon = copyState === 'copied' ? Check : Clipboard;
+
+  return (
+    <div className="maka-error-surface" role="alert" aria-live="assertive">
+      {/* Astryx Card owns the card face: red tint for the destructive
+          surface, high elevation for the former shadow-modal. The class
+          keeps only the icon/copy grid geometry. */}
+      <Card variant="red" elevation="high" padding={0} className="maka-error-card">
+        <span className="maka-error-icon" aria-hidden="true">
+          <AlertTriangle size={ICON_SIZE.empty} /> {/* 20 in the 32px plate — the ladder's fill convention */}
+        </span>
+        <div className="maka-error-copy">
+          <h2>{copy.title}</h2>
+          <p>
+            {copy.descriptionBeforeRetry} <strong>{copy.retry}</strong> {copy.descriptionBeforeReload}{' '}
+            <strong>{copy.reload}</strong> {copy.descriptionAfterReload}
+          </p>
+          <pre className="maka-error-stack" role="group" aria-label={copy.errorDetails}>
+            {safeStack}
+          </pre>
+          {errorInfo?.componentStack && (
+            <pre className="maka-error-stack" role="group" aria-label={copy.componentStack}>
+              {redactSecrets(errorInfo.componentStack.trim())}
+            </pre>
+          )}
+          <div className="maka-error-actions">
+            <UiButton
+              variant="secondary"
+              className="maka-error-copy-action"
+              data-copy-state={copyState}
+              isDisabled={copyPending}
+              aria-busy={copyPending ? 'true' : undefined}
+              onClick={onCopyReport}
+              icon={<CopyIcon size={ICON_SIZE.control} aria-hidden="true" />}
+              label={copyLabel}
+            />
+            <UiButton
+              variant="secondary"
+              onClick={onReset}
+              icon={<RotateCw size={ICON_SIZE.control} aria-hidden="true" />}
+              label={copy.retry}
+            />
+            <UiButton variant="primary" onClick={onReload} label={copy.reload} />
+          </div>
+          {copyState === 'failed' && <p className="maka-error-copy-status">{copy.clipboardFailure}</p>}
+        </div>
+      </Card>
+    </div>
+  );
 }
 
 function formatRendererErrorDetails(error: Error, info?: ErrorInfo | null): string {

--- a/apps/desktop/stories/error-boundary.stories.tsx
+++ b/apps/desktop/stories/error-boundary.stories.tsx
@@ -39,8 +39,8 @@ const onCopyReport = fn();
 const onReset = fn();
 const onReload = fn();
 
-// A representative renderer crash: a real Error carrying a synthetic renderer
-// stack + React component stack, the same shape componentDidCatch hands render().
+// Explicitly synthetic diagnostics used only to exercise the fallback layout.
+// The generic fixture names do not represent a Maka product call chain.
 function buildRendererError(name: string, message: string, frames: string[]): Error {
   const error = new Error(message);
   error.name = name;
@@ -48,42 +48,23 @@ function buildRendererError(name: string, message: string, frames: string[]): Er
   return error;
 }
 
-const transcriptError = buildRendererError(
+const syntheticError = buildRendererError(
   'TypeError',
   "Cannot read properties of undefined (reading 'messages')",
   [
-    'SessionTranscript (src/renderer/features/workbar/session-transcript.tsx:142:31)',
+    'SyntheticCrashFixture (<synthetic-storybook-fixture>:42:7)',
     'renderWithHooks (react-dom.development.js:15486:18)',
     'mountIndeterminateComponent (react-dom.development.js:20103:13)',
     'beginWork (react-dom.development.js:21626:16)',
   ],
 );
 
-const transcriptComponentStack: ErrorInfo = {
+const syntheticComponentStack: ErrorInfo = {
   componentStack: [
     '',
-    '    at SessionTranscript (src/renderer/features/workbar/session-transcript.tsx:142:31)',
-    '    at WorkbarPanel',
-    '    at AppShell',
-    '    at ErrorBoundary (src/renderer/error-boundary.tsx:73:1)',
-  ].join('\n'),
-};
-
-// A second, different error — what the boundary catches when the still-broken
-// subtree throws again after 重试.
-const retryError = buildRendererError('RangeError', 'Maximum call stack size exceeded', [
-  'toTreeNode (src/renderer/features/workbar/plan-tree.tsx:88:12)',
-  'toTreeNode (src/renderer/features/workbar/plan-tree.tsx:91:20)',
-  'toTreeNode (src/renderer/features/workbar/plan-tree.tsx:91:20)',
-]);
-
-const retryComponentStack: ErrorInfo = {
-  componentStack: [
-    '',
-    '    at PlanTree (src/renderer/features/workbar/plan-tree.tsx:88:12)',
-    '    at WorkbarPanel',
-    '    at AppShell',
-    '    at ErrorBoundary (src/renderer/error-boundary.tsx:73:1)',
+    '    at SyntheticCrashFixture (<synthetic-storybook-fixture>:42:7)',
+    '    at SyntheticParentFixture (<synthetic-storybook-fixture>:18:3)',
+    '    at ErrorBoundary',
   ].join('\n'),
 };
 
@@ -103,36 +84,23 @@ function fallback(copyState: ErrorBoundaryCopyState, error: Error, errorInfo: Er
   );
 }
 
-// Real path: the renderer throws during render; ErrorBoundary.getDerivedStateFromError
-// + componentDidCatch capture the error and React component stack, and render() paints
-// this fallback with copyState 'idle'.
+// Visual snapshot of the fallback's idle state. In production, ErrorBoundary supplies
+// this Error/ErrorInfo shape after catching a renderer crash.
 export const DefaultFallback: Story = {
-  render: fallback('idle', transcriptError, transcriptComponentStack),
+  render: fallback('idle', syntheticError, syntheticComponentStack),
 };
 
-// Real path: on the crash screen the user clicks 复制诊断信息; handleCopyReport sets
-// copyState 'pending' while window.maka.diagnostics.copyReport is in flight, disabling
-// the button (isDisabled + aria-busy).
+// Visual snapshot of the fallback's pending state; it does not exercise the copy transition.
 export const CopyPending: Story = {
-  render: fallback('pending', transcriptError, transcriptComponentStack),
+  render: fallback('pending', syntheticError, syntheticComponentStack),
 };
 
-// Real path: continues from copy pending — diagnostics.copyReport resolves, handleCopyReport
-// sets copyState 'copied' and the copy button swaps to the check glyph.
+// Visual snapshot of the fallback's copied state; it does not exercise the copy transition.
 export const Copied: Story = {
-  render: fallback('copied', transcriptError, transcriptComponentStack),
+  render: fallback('copied', syntheticError, syntheticComponentStack),
 };
 
-// Real path: continues from copy pending — the clipboard bridge (diagnostics.copyReport, or
-// the navigator.clipboard fallback) rejects, handleCopyReport sets copyState 'failed', and the
-// manual-select hint appears below the actions.
+// Visual snapshot of the fallback's failed state; it does not exercise the copy transition.
 export const CopyFailed: Story = {
-  render: fallback('failed', transcriptError, transcriptComponentStack),
-};
-
-// Real path: after 重试 (handleReset clears the error) the still-broken subtree throws a
-// second, different error; the boundary re-catches and render() shows the new report — proving
-// the fallback reflects the current error, not the first one.
-export const RepeatError: Story = {
-  render: fallback('idle', retryError, retryComponentStack),
+  render: fallback('failed', syntheticError, syntheticComponentStack),
 };

--- a/apps/desktop/stories/error-boundary.stories.tsx
+++ b/apps/desktop/stories/error-boundary.stories.tsx
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import type { ErrorInfo } from 'react';
+import {
+  ErrorBoundaryFallback,
+  type ErrorBoundaryCopyState,
+} from '../src/renderer/error-boundary';
+
+const meta = {
+  title: 'Product/Shell/Error Boundary',
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// The class owns the copy/reset/reload side effects; the fallback only paints,
+// so these mocks stand in for the wired handlers without touching state.
+const onCopyReport = fn();
+const onReset = fn();
+const onReload = fn();
+
+// A representative renderer crash: a real Error carrying a synthetic renderer
+// stack + React component stack, the same shape componentDidCatch hands render().
+function buildRendererError(name: string, message: string, frames: string[]): Error {
+  const error = new Error(message);
+  error.name = name;
+  error.stack = [`${name}: ${message}`, ...frames.map((frame) => `    at ${frame}`)].join('\n');
+  return error;
+}
+
+const transcriptError = buildRendererError(
+  'TypeError',
+  "Cannot read properties of undefined (reading 'messages')",
+  [
+    'SessionTranscript (src/renderer/features/workbar/session-transcript.tsx:142:31)',
+    'renderWithHooks (react-dom.development.js:15486:18)',
+    'mountIndeterminateComponent (react-dom.development.js:20103:13)',
+    'beginWork (react-dom.development.js:21626:16)',
+  ],
+);
+
+const transcriptComponentStack: ErrorInfo = {
+  componentStack: [
+    '',
+    '    at SessionTranscript (src/renderer/features/workbar/session-transcript.tsx:142:31)',
+    '    at WorkbarPanel',
+    '    at AppShell',
+    '    at ErrorBoundary (src/renderer/error-boundary.tsx:73:1)',
+  ].join('\n'),
+};
+
+// A second, different error — what the boundary catches when the still-broken
+// subtree throws again after 重试.
+const retryError = buildRendererError('RangeError', 'Maximum call stack size exceeded', [
+  'toTreeNode (src/renderer/features/workbar/plan-tree.tsx:88:12)',
+  'toTreeNode (src/renderer/features/workbar/plan-tree.tsx:91:20)',
+  'toTreeNode (src/renderer/features/workbar/plan-tree.tsx:91:20)',
+]);
+
+const retryComponentStack: ErrorInfo = {
+  componentStack: [
+    '',
+    '    at PlanTree (src/renderer/features/workbar/plan-tree.tsx:88:12)',
+    '    at WorkbarPanel',
+    '    at AppShell',
+    '    at ErrorBoundary (src/renderer/error-boundary.tsx:73:1)',
+  ].join('\n'),
+};
+
+const resolveLocale = (globals: Record<string, unknown>) => (globals.locale === 'en' ? 'en' : 'zh');
+
+function fallback(copyState: ErrorBoundaryCopyState, error: Error, errorInfo: ErrorInfo) {
+  return (_args: unknown, { globals }: { globals: Record<string, unknown> }) => (
+    <ErrorBoundaryFallback
+      error={error}
+      errorInfo={errorInfo}
+      copyState={copyState}
+      locale={resolveLocale(globals)}
+      onCopyReport={onCopyReport}
+      onReset={onReset}
+      onReload={onReload}
+    />
+  );
+}
+
+// Real path: the renderer throws during render; ErrorBoundary.getDerivedStateFromError
+// + componentDidCatch capture the error and React component stack, and render() paints
+// this fallback with copyState 'idle'.
+export const DefaultFallback: Story = {
+  render: fallback('idle', transcriptError, transcriptComponentStack),
+};
+
+// Real path: on the crash screen the user clicks 复制诊断信息; handleCopyReport sets
+// copyState 'pending' while window.maka.diagnostics.copyReport is in flight, disabling
+// the button (isDisabled + aria-busy).
+export const CopyPending: Story = {
+  render: fallback('pending', transcriptError, transcriptComponentStack),
+};
+
+// Real path: continues from copy pending — diagnostics.copyReport resolves, handleCopyReport
+// sets copyState 'copied' and the copy button swaps to the check glyph.
+export const Copied: Story = {
+  render: fallback('copied', transcriptError, transcriptComponentStack),
+};
+
+// Real path: continues from copy pending — the clipboard bridge (diagnostics.copyReport, or
+// the navigator.clipboard fallback) rejects, handleCopyReport sets copyState 'failed', and the
+// manual-select hint appears below the actions.
+export const CopyFailed: Story = {
+  render: fallback('failed', transcriptError, transcriptComponentStack),
+};
+
+// Real path: after 重试 (handleReset clears the error) the still-broken subtree throws a
+// second, different error; the boundary re-catches and render() shows the new report — proving
+// the fallback reflects the current error, not the first one.
+export const RepeatError: Story = {
+  render: fallback('idle', retryError, retryComponentStack),
+};


### PR DESCRIPTION
## Summary

The top-level renderer `ErrorBoundary` (`apps/desktop/src/renderer/error-boundary.tsx`) had no Storybook coverage — it is the surface hardest to reach in normal use and the one whose correctness matters most when reached, so its four `copyState` values and the repeat-error path could only be seen by actually crashing the app.

This PR extracts the fallback face into a pure presentational `ErrorBoundaryFallback` component (the class still owns all state and side effects, so behavior is unchanged), then adds one story per state — default fallback, copy pending, copied, copy failed, repeat error — each with a `// Real path:` annotation per `stories/FIDELITY.md`. Rendering the fallback directly rather than triggering a real throw keeps the render smoke free of the `console.error` that `componentDidCatch` would otherwise emit.

Fixes #3943

## Verification

Ran locally, all passing:

- `biome lint` — clean
- `tsc` (`tsconfig.storybook.json` + `tsconfig.renderer.json`)
- `npm run build-storybook` — all five `product-shell-error-boundary--*` in the index
- `npm run smoke:storybook` — `Storybook render smoke passed (200 stories).`, all five new stories render clean

The five states are visible in Storybook under **Product/Shell/Error Boundary**; the render smoke above is the command-output evidence that each mounts without runtime, console, or AX errors.


<img width="1280" height="900" alt="error-boundary--default-fallback" src="https://github.com/user-attachments/assets/2f885b81-c2cd-4837-bce5-f606f666ff86" />

<img width="1280" height="900" alt="error-boundary--repeat-error" src="https://github.com/user-attachments/assets/ae8980e4-4fc0-4199-882c-a7e5ef46c053" />


## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code assisted with the `ErrorBoundaryFallback` extraction and the story authoring; the design decisions and verification are my own. The affected commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

<!-- The added stories are the coverage: the render smoke mounts each state, so a regression in the extracted fallback surfaces as a smoke failure. -->

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No