### PR TITLE
fix(runtime): avoid OpenAI tool_search name collision

### DIFF
--- a/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
@@ -39,6 +39,7 @@ import { ModelAdapter } from '../model-adapter.js';
 import type { ModelStreamEvent, ModelToolSet } from '../model-protocol.js';
 import { canonicalizeToolSet } from '../request-shape.js';
 import type { MakaTool } from '../tool-runtime.js';
+import { TOOL_SEARCH_PROVIDER_NAME, ToolAvailabilityRuntime } from '../tool-availability.js';
 
 // A tool with a real (non-trivial) zod schema so the AI SDK actually serializes it.
 function tool(name: string): MakaTool {
@@ -119,6 +120,113 @@ describe('hidden tools are trimmed from the provider request (wire-level)', () =
 });
 
 describe('ModelAdapter provider-step boundary', () => {
+  test('uses a provider-safe alias for Maka tool_search on OpenAI Responses', async () => {
+    const adapter = new ModelAdapter({
+      connection: {
+        slug: 'codex-subscription',
+        providerType: 'openai-codex',
+        defaultModel: 'gpt-5.6-sol',
+      } as never,
+      apiKey: 'test',
+      modelId: 'gpt-5.6-sol',
+      modelFactory: () => ({}),
+      providerOptions: {},
+      newId: () => 'id',
+      now: () => 0,
+    });
+    const modelTools: ModelToolSet = {
+      tool_search: {
+        description: 'Search Maka deferred tools',
+        inputSchema: z.object({ query: z.string() }),
+      },
+    };
+    let seenTools: string[] = [];
+    const model = new MockLanguageModelV4({
+      doStream: async ({ tools }) => {
+        seenTools = (tools ?? []).map((tool) => tool.name);
+        return {
+          stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'tool-call',
+              toolCallId: 'next-search-call',
+              toolName: TOOL_SEARCH_PROVIDER_NAME,
+              input: JSON.stringify({ query: 'settings' }),
+            },
+            {
+              type: 'tool-result',
+              providerExecuted: true,
+              toolCallId: 'provider-result',
+              toolName: TOOL_SEARCH_PROVIDER_NAME,
+              result: { activated: [] },
+            } as unknown as LanguageModelV4StreamPart,
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+              usage: ZERO_USAGE,
+            },
+          ]),
+        };
+      },
+    });
+
+    const result = await adapter.startStream({
+      model,
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'search-call',
+              toolName: 'tool_search',
+              input: { query: 'browser' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'search-call',
+              toolName: 'tool_search',
+              output: {
+                type: 'json',
+                value: { activated: ['browser_click'] },
+              },
+            },
+          ],
+        },
+      ],
+      tools: modelTools,
+      activeTools: ['tool_search'],
+      onStreamActivity: () => {},
+      abortSignal: new AbortController().signal,
+      repairToolCall: async () => null,
+    });
+
+    const events: ModelStreamEvent[] = [];
+    for await (const event of result.events) events.push(event);
+    assert.deepEqual(seenTools, [TOOL_SEARCH_PROVIDER_NAME]);
+    assert.equal(
+      events.find((event) => event.kind === 'tool-call')?.toolCall.toolName,
+      'tool_search',
+    );
+    assert.equal(
+      events.find((event) => event.kind === 'provider-tool-result')?.toolName,
+      'tool_search',
+    );
+  });
+
+  test('rejects a real tool that collides with the provider-safe alias', () => {
+    assert.throws(
+      () =>
+        new ToolAvailabilityRuntime([tool(TOOL_SEARCH_PROVIDER_NAME)], undefined, tool('invalid')),
+      /reserved by Runtime/,
+    );
+  });
+
   test('returns provider tool calls without executing tool behavior inside the SDK', async () => {
     let executeCalls = 0;
     const toolsWithExecutableBehavior = {

--- a/packages/runtime/src/__tests__/responses-wire-contract.test.ts
+++ b/packages/runtime/src/__tests__/responses-wire-contract.test.ts
@@ -21,10 +21,13 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { z } from 'zod';
 import { modelMetadataIdsForProvider } from '@maka/core/model-metadata';
 import { PROVIDER_REGISTRY } from '@maka/core/llm-connections';
 import { thinkingVariantsForModel } from '@maka/core/model-thinking';
 import { buildProviderOptions, getAIModel } from '../model-factory.js';
+import { ModelAdapter } from '../model-adapter.js';
+import { TOOL_SEARCH_PROVIDER_NAME } from '../tool-availability.js';
 import { resolveModelRuntime } from '../model-runtime.js';
 import { lowerModelTools } from '../model-adapter.js';
 import { openAiCodexCompactionMessages } from '../openai-codex-history-compactor.js';
@@ -51,6 +54,89 @@ function openAiNamespace(options: Record<string, unknown>): Record<string, unkno
 }
 
 describe('responses wire contract', () => {
+  test('does not route Maka tool_search history through OpenAI native tool_search validation', async () => {
+    const connection = conn('openai-codex', 'codex-subscription');
+    connection.defaultModel = 'gpt-5.6-sol';
+    const requestBodies: Record<string, unknown>[] = [];
+    const fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return Response.json({
+        id: 'response-tool-search-alias',
+        object: 'response',
+        status: 'completed',
+        output: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    const adapter = new ModelAdapter({
+      connection,
+      apiKey: 'test-token',
+      modelId: connection.defaultModel,
+      modelFactory: (input) =>
+        getAIModel({
+          connection,
+          apiKey: input.apiKey,
+          modelId: connection.defaultModel,
+          fetch,
+        }),
+      newId: () => 'test-id',
+      now: () => 0,
+    });
+    const result = await adapter.startStream({
+      model: adapter.resolveModel(),
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'search-call',
+              toolName: 'tool_search',
+              input: { query: 'browser' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'search-call',
+              toolName: 'tool_search',
+              output: { type: 'json', value: { activated: ['browser_click'] } },
+            },
+          ],
+        },
+      ],
+      tools: {
+        tool_search: {
+          description: 'Search Maka deferred tools',
+          inputSchema: z.object({ query: z.string() }),
+        },
+      },
+      activeTools: ['tool_search'],
+      system: 'Call tool_search; keep existing maka_tool_search text unchanged.',
+      onStreamActivity: () => {},
+      abortSignal: new AbortController().signal,
+      repairToolCall: async () => null,
+    });
+    for await (const _event of result.events) void _event;
+    const body = requestBodies[0];
+    const input = body?.input as Array<Record<string, unknown>>;
+    assert.equal(
+      input?.find((item) => item.type === 'function_call')?.name,
+      TOOL_SEARCH_PROVIDER_NAME,
+    );
+    assert.equal(
+      input?.find((item) => item.type === 'function_call_output')?.call_id,
+      'search-call',
+    );
+    assert.equal(
+      input?.find((item) => item.role === 'developer')?.content,
+      'Call maka_tool_search; keep existing maka_tool_search text unchanged.',
+    );
+  });
+
   test('keeps Qwen3.8 Max on Token Plan Chat until the provider adapter supports Responses', () => {
     for (const providerType of ['alibaba-token-plan-cn', 'alibaba-token-plan'] as const) {
       assert.equal(

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -81,6 +81,7 @@ import {
   type OpenAiResponsesTransportState,
 } from './openai-responses-websocket.js';
 import { openAiApplyPatchProviderTool } from './openai-apply-patch.js';
+import { TOOL_SEARCH_NAME, TOOL_SEARCH_PROVIDER_NAME } from './tool-availability.js';
 
 /**
  * Build an ai-sdk LanguageModel from a single input object.
@@ -254,7 +255,16 @@ export class ModelAdapter {
           },
         })
       : input.model;
+    const usesOpenAiResponsesAdapter = hasOpenAiResponsesAdapter(this.runtime);
+    const providerToolName = (name: string): string =>
+      usesOpenAiResponsesAdapter && name === TOOL_SEARCH_NAME ? TOOL_SEARCH_PROVIDER_NAME : name;
+    const runtimeToolName = (name: string): string =>
+      usesOpenAiResponsesAdapter && name === TOOL_SEARCH_PROVIDER_NAME ? TOOL_SEARCH_NAME : name;
     const sdkTools = lowerModelTools(input.tools);
+    if (usesOpenAiResponsesAdapter && sdkTools[TOOL_SEARCH_NAME] !== undefined) {
+      sdkTools[TOOL_SEARCH_PROVIDER_NAME] = sdkTools[TOOL_SEARCH_NAME];
+      delete sdkTools[TOOL_SEARCH_NAME];
+    }
     const fullMessages = input.messages;
     const responsesLane =
       input.continuationKey && usesNativeOpenAiResponses(this.input.connection, this.runtime)
@@ -266,6 +276,10 @@ export class ModelAdapter {
           this.openAiResponsesTransportState.semanticBaseline(responsesLane),
         )
       : { messages: fullMessages };
+    const providerMessages = remapModelMessageToolNames(continuation.messages, providerToolName);
+    const providerSystem = input.system
+      ? remapProviderToolNamesInText(input.system, providerToolName)
+      : undefined;
     const providerOptions = usesNativeOpenAiResponses(this.input.connection, this.runtime)
       ? mergeOpenAiResponsesProviderOptions(
           this.input.providerOptions,
@@ -275,9 +289,9 @@ export class ModelAdapter {
       : this.input.providerOptions;
     const sdkResult = streamText({
       model: trackedModel,
-      messages: continuation.messages,
+      messages: providerMessages,
       tools: sdkTools,
-      activeTools: input.activeTools,
+      activeTools: input.activeTools.map(providerToolName),
       // An empty active set is an authoritative tool-free request (not merely
       // an empty provider schema).  Some OpenAI-compatible models, including
       // DeepSeek, otherwise keep emitting their native tool-call envelope as
@@ -285,8 +299,20 @@ export class ModelAdapter {
       // The child-agent finalization step relies on this boundary to spend its
       // last budgeted request on a summary instead of one more unusable call.
       ...(input.activeTools.length === 0 ? { toolChoice: 'none' } : {}),
-      repairToolCall: input.repairToolCall,
-      ...(input.system ? { instructions: input.system } : {}),
+      repairToolCall: async ({
+        toolCall,
+        error,
+      }: {
+        toolCall: RepairableAiSdkToolCall;
+        error: unknown;
+      }) => {
+        const repaired = await input.repairToolCall({
+          toolCall: { ...toolCall, toolName: runtimeToolName(toolCall.toolName) },
+          error,
+        });
+        return repaired ? { ...repaired, toolName: providerToolName(repaired.toolName) } : repaired;
+      },
+      ...(providerSystem ? { instructions: providerSystem } : {}),
       ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
       providerOptions,
       ...(responsesLane ? { headers: { [OPENAI_RESPONSES_LANE_HEADER]: responsesLane } } : {}),
@@ -308,6 +334,7 @@ export class ModelAdapter {
       ...(responsesLane ? { lane: responsesLane } : {}),
       requestMessages: fullMessages,
       abortSignal: input.abortSignal,
+      runtimeToolName,
     });
   }
 
@@ -320,7 +347,12 @@ export class ModelAdapter {
   private toModelStreamResult(
     sdk: SdkStreamResult,
     onStreamActivity: () => void,
-    continuation: { lane?: string; requestMessages: ModelMessage[]; abortSignal: AbortSignal },
+    continuation: {
+      lane?: string;
+      requestMessages: ModelMessage[];
+      abortSignal: AbortSignal;
+      runtimeToolName?: (name: string) => string;
+    },
   ): ModelStreamResult {
     const openAiChatReasoningTransportState =
       this.runtime.reasoningReplay.kind === 'openai-chat-plaintext'
@@ -340,7 +372,11 @@ export class ModelAdapter {
         try {
           for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
             onStreamActivity();
-            for (const event of translateChunk(chunk, openAiChatReasoningTransportState)) {
+            for (const event of translateChunk(
+              chunk,
+              openAiChatReasoningTransportState,
+              continuation.runtimeToolName,
+            )) {
               if (event.kind === 'error') failure = event.failure;
               if (event.kind === 'finish') sawFinish = true;
               if (event.kind === 'finish' || event.kind === 'step-finish') {
@@ -573,6 +609,14 @@ function usesNativeOpenAiResponses(
   return connection.providerType === 'openai' && runtime.wire === 'openai-responses';
 }
 
+function hasOpenAiResponsesAdapter(runtime: ResolvedModelRuntime): boolean {
+  return (
+    runtime.wire === 'openai-responses' &&
+    runtime.reasoningReplay.kind === 'responses' &&
+    runtime.reasoningReplay.contract.adapter === 'openai'
+  );
+}
+
 function fixedAnthropicThinkingBudget(
   providerOptions: Record<string, unknown> | undefined,
 ): number {
@@ -697,6 +741,7 @@ function openAiResponsesReasoningProviderOptionsFromChunk(
 function translateChunk(
   chunk: AiSdkStreamChunk,
   openAiChatReasoningTransportState?: OpenAiChatReasoningTransportState,
+  runtimeToolName?: (name: string) => string,
 ): ModelStreamEvent[] {
   switch (chunk.type) {
     case 'text-start':
@@ -801,7 +846,7 @@ function translateChunk(
         {
           kind: 'provider-tool-result',
           toolCallId: chunk.toolCallId,
-          toolName: chunk.toolName,
+          toolName: runtimeToolName?.(chunk.toolName) ?? chunk.toolName,
           output: chunk.type === 'tool-error' ? chunk.error : (chunk.output ?? chunk.result),
           ...(chunk.type === 'tool-error' || chunk.isError === true ? { isError: true } : {}),
         },
@@ -812,7 +857,7 @@ function translateChunk(
       const toolCall: ToolCallPart = {
         type: 'tool-call',
         toolCallId: chunk.toolCallId,
-        toolName: chunk.toolName,
+        toolName: runtimeToolName?.(chunk.toolName) ?? chunk.toolName,
         input:
           chunk.providerExecuted === true
             ? parseProviderExecutedToolInput(chunk.input ?? chunk.args)
@@ -831,6 +876,58 @@ function translateChunk(
     default:
       return [];
   }
+}
+
+/**
+ * OpenAI Responses reserves the provider name `tool_search`. Keep Maka's
+ * persisted/history name intact and translate only the provider-bound copy.
+ */
+function remapModelMessageToolNames(
+  messages: readonly ModelMessage[],
+  providerToolName: (name: string) => string,
+): ModelMessage[] {
+  const remapContent = <T extends { type: string }>(content: readonly T[]): T[] =>
+    content.map((part) => {
+      if (
+        (part.type === 'tool-call' || part.type === 'tool-result') &&
+        'toolName' in part &&
+        typeof part.toolName === 'string'
+      ) {
+        const remapped = { ...part, toolName: providerToolName(part.toolName) } as T & {
+          output?: { type?: string; value?: unknown };
+        };
+        if (part.type === 'tool-result' && remapped.output) {
+          if (
+            (remapped.output.type === 'text' || remapped.output.type === 'error-text') &&
+            typeof remapped.output.value === 'string'
+          ) {
+            remapped.output = {
+              ...remapped.output,
+              value: remapProviderToolNamesInText(remapped.output.value, providerToolName),
+            };
+          }
+        }
+        return remapped as T;
+      }
+      return part;
+    });
+
+  return messages.map((message) => {
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      return { ...message, content: remapContent(message.content) };
+    }
+    if (message.role === 'tool') {
+      return { ...message, content: remapContent(message.content) };
+    }
+    return message;
+  });
+}
+
+function remapProviderToolNamesInText(
+  text: string,
+  providerToolName: (name: string) => string,
+): string {
+  return text.replace(/\btool_search\b/gu, providerToolName(TOOL_SEARCH_NAME));
 }
 
 function parseProviderExecutedToolInput(input: unknown): unknown {

--- a/packages/runtime/src/tool-availability.ts
+++ b/packages/runtime/src/tool-availability.ts
@@ -27,6 +27,8 @@ import type { MakaTool, ToolGating } from './tool-runtime.js';
 
 /** Canonical name of Maka's provider-independent deferred-tool search connector. */
 export const TOOL_SEARCH_NAME = 'tool_search';
+/** Provider-safe alias used because OpenAI Responses reserves `tool_search`. */
+export const TOOL_SEARCH_PROVIDER_NAME = 'maka_tool_search';
 export const TOOL_SEARCH_DEFAULT_LIMIT = 8;
 export const TOOL_SEARCH_MAX_LIMIT = 20;
 export const TOOL_SEARCH_MAX_SCHEMA_CHARS = 64 * 1024;
@@ -135,6 +137,9 @@ export class ToolAvailabilityRuntime {
   ) {
     if (tools.some((tool) => tool.name === TOOL_SEARCH_NAME)) {
       throw new Error(`Tool name "${TOOL_SEARCH_NAME}" is reserved by Runtime`);
+    }
+    if (tools.some((tool) => tool.name === TOOL_SEARCH_PROVIDER_NAME)) {
+      throw new Error(`Tool name "${TOOL_SEARCH_PROVIDER_NAME}" is reserved by Runtime`);
     }
     this.tools = [...tools];
     this.toolsByName = new Map(tools.map((tool) => [tool.name, tool]));


### PR DESCRIPTION
## Summary

Fixes #3939

Maka's deferred-tool connector keeps the internal name `tool_search`, but the provider-bound OpenAI Responses request uses the collision-free alias `maka_tool_search`. Provider-facing system text, replayed tool call/result names, repair callbacks, and streamed provider tool results are mapped consistently at the adapter boundary. The alias is reserved so a real tool cannot shadow it.

## Verification

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/mcp run build`
- `npm --workspace @maka/computer-use run build`
- `npm --workspace @maka/runtime run build`
- `node --test "packages/runtime/dist/__tests__/deferred-tools-wire.test.js" "packages/runtime/dist/__tests__/responses-wire-contract.test.js"` (20 passed)
- Biome format/check passed for all changed files

The Responses wire regression uses the real `openai-codex` / `gpt-5.6-sol` adapter and `@ai-sdk/openai` converter. It proves the historical `{ activated: [...] }` result is sent as a generic function output under `maka_tool_search`, and that provider tool calls/results map back to Maka's internal `tool_search` identity.

## Review focus

The provider alias is a transport-only projection. Runtime persistence, UI copy, activation payloads, and existing history remain on the internal name. A real `maka_tool_search` tool is rejected at catalog construction to preserve bijective mapping.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex authored the implementation, tests, and review follow-up; the human contributor reviewed the changes and owns the submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — provider-bound tool naming changes to avoid an SDK reserved-name collision; internal behavior is unchanged.
- [ ] No
