### PR TITLE
test(desktop): wait for ready WorkHub layout surface

### DIFF
--- a/apps/desktop/e2e/workhub-layout.spec.ts
+++ b/apps/desktop/e2e/workhub-layout.spec.ts
@@ -36,7 +36,7 @@ test('WorkHub target metadata does not overlap the submitted Session result', as
   await page.evaluate(async () => {
     await window.maka.settings.updateClient({ workHub: { enabled: true } });
   });
-  await expect(page.getByRole('main', { name: 'WorkHub' })).toBeVisible();
+  await expect(page.getByText('1 项工作', { exact: true })).toBeVisible();
 
   const workHubComposer = page.locator(
     '.workhub-surface .maka-composer-editor [contenteditable="true"]',


### PR DESCRIPTION
## Summary

Wait for the ready WorkHub surface's exact `1 项工作` projection before filling and submitting through its Composer. This prevents the layout E2E from treating the resolving Coordination status surface as submission-ready while preserving the existing result and non-overlap assertions.

Closes #3961

## Verification

- Baseline stress loop before the change: 9 failed, 51 passed (`--repeat-each=60 --workers=4`)
- Focused layout E2E after the change: 20 passed (`--repeat-each=20 --workers=1`)
- Coordination startup failure/recovery E2E: 1 passed
- `npx biome check apps/desktop/e2e/workhub-layout.spec.ts`
- `npm --workspace @maka/desktop run typecheck`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex analyzed and reproduced the race, implemented the E2E synchronization change, and ran verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
