### PR TITLE
test(skills): cover Windows catalog

### DIFF
--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -145,6 +145,24 @@ jobs:
           node.exe --test packages/runtime-host/dist/__tests__/control-endpoint.test.js
           ./scripts/windows-runtime-host-local-ipc-trust.ps1
 
+      - name: Verify Skill catalog on Windows
+        shell: pwsh
+        run: |
+          node.exe --test --test-reporter=tap --test-concurrency=1 `
+            packages/runtime-host/dist/__tests__/skill-catalog-coordinator.test.js `
+            packages/runtime-host/dist/__tests__/skill-catalog-protocol.test.js `
+            packages/runtime-host/dist/__tests__/skill-catalog-repository.test.js `
+            packages/runtime-host/dist/__tests__/skill-catalog-transaction.test.js `
+            packages/runtime-host/dist/__tests__/skill-catalog-two-client-uds.test.js `
+            2>&1 | Tee-Object -FilePath "$env:RUNNER_TEMP/skill-catalog.tap"
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -ne 0) { exit $exitCode }
+          $output = Get-Content "$env:RUNNER_TEMP/skill-catalog.tap"
+          if ($output -notcontains '# tests 90' -or $output -notcontains '# pass 90' -or $output -notcontains '# skipped 0') {
+            Write-Error 'Skill catalog gate did not run exactly 90 passing Windows tests'
+            exit 1
+          }
+
       - name: Verify SQLite crash recovery
         shell: pwsh
         run: |

--- a/docs/windows-test-inventory.md
+++ b/docs/windows-test-inventory.md
@@ -15,11 +15,11 @@ Locations intentionally omit line numbers so unrelated edits do not invalidate t
 
 | Classification | Count |
 |---|---:|
-| windows-backend-gap | 24 |
+| windows-backend-gap | 23 |
 | portable-candidate | 8 |
 | platform-contract | 35 |
 
-Total Windows-excluded declarations: **67**
+Total Windows-excluded declarations: **66**
 
 ## Inventory
 
@@ -53,7 +53,6 @@ Total Windows-excluded declarations: **67**
 | windows-backend-gap | `packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts` two Clients share stable Session creation, CAS configuration, and catalog continuity | `process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts` stable Session creation survives response loss and Host restart | `process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts` two Clients share exact retryable Session branch and revision authority | `process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/skill-catalog-two-client-uds.test.ts` two UDS clients converge on one lease-bound Skill catalog authority | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts` fails the connection for a canonical response with mismatched ${mismatch.name} | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts` rejects local invalid input without poisoning transport and correlates a private canonical copy | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/usage-pricing-two-client-uds.test.ts` two clients share usage projection and one revision-CAS pricing authority | `process.platform === 'win32'` |

--- a/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
@@ -19,11 +19,13 @@
 
 import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, test } from 'node:test';
+import { promisify } from 'node:util';
 import {
   BUNDLED_SKILL_CATALOG,
   buildStarterSkillTemplate,
@@ -47,6 +49,7 @@ import {
 } from '../server/skill-catalog-transaction.js';
 
 const roots = new Set<string>();
+const execFileAsync = promisify(execFile);
 
 afterEach(async () => {
   await Promise.all([...roots].map((root) => rm(root, { recursive: true, force: true })));
@@ -317,7 +320,7 @@ test('noncanonical external ids remain wire-safe governance entries', async () =
   );
   await createSkill(
     join(fixture.project, '.maka', 'skills'),
-    'bad\nskill',
+    'bad\u007Fskill',
     skillBody('Control Skill', 'control directory id'),
   );
   const repository = fixture.repository();
@@ -444,10 +447,9 @@ test('repository preserves filesystem-safe ids and codec preserves the 256-byte 
 });
 
 test('managed source read failures are not projected as an empty catalog', async () => {
-  if (process.platform === 'win32') return;
   const fixture = await createFixture();
   await createSkill(fixture.sources, 'restricted', skillBody('Restricted', 'unreadable'));
-  await chmod(fixture.sources, 0o000);
+  const restoreReadAccess = await makeUnreadable(fixture.sources, 0o700);
   try {
     await assert.rejects(
       start(fixture.repository(), fixture.project, 'managed_sources'),
@@ -458,12 +460,11 @@ test('managed source read failures are not projected as an empty catalog', async
       },
     );
   } finally {
-    await chmod(fixture.sources, 0o700);
+    await restoreReadAccess();
   }
 });
 
 test('one unreadable managed source child makes the Host catalog fail closed', async () => {
-  if (process.platform === 'win32') return;
   const fixture = await createFixture();
   await createSkill(fixture.sources, 'readable', skillBody('Readable', 'valid source'));
   const unreadable = await createSkill(
@@ -472,7 +473,7 @@ test('one unreadable managed source child makes the Host catalog fail closed', a
     skillBody('Unreadable', 'restricted source'),
   );
   const unreadableFile = join(unreadable, 'SKILL.md');
-  await chmod(unreadableFile, 0o000);
+  const restoreReadAccess = await makeUnreadable(unreadableFile, 0o600);
   try {
     await assert.rejects(
       start(fixture.repository(), fixture.project, 'managed_sources'),
@@ -483,7 +484,7 @@ test('one unreadable managed source child makes the Host catalog fail closed', a
       },
     );
   } finally {
-    await chmod(unreadableFile, 0o600);
+    await restoreReadAccess();
   }
 });
 
@@ -1224,6 +1225,19 @@ async function tempDirectory(prefix: string): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), prefix));
   roots.add(root);
   return root;
+}
+
+async function makeUnreadable(target: string, restoreMode: number): Promise<() => Promise<void>> {
+  if (process.platform !== 'win32') {
+    await chmod(target, 0o000);
+    return () => chmod(target, restoreMode);
+  }
+  const principal = process.env.USERNAME;
+  assert.ok(principal, 'Windows test identity must be available');
+  await execFileAsync('icacls.exe', [target, '/deny', `${principal}:(R)`]);
+  return async () => {
+    await execFileAsync('icacls.exe', [target, '/remove:d', principal]);
+  };
 }
 
 async function createSkill(parent: string, id: string, content: string): Promise<string> {

--- a/packages/runtime-host/src/__tests__/skill-catalog-transaction.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-transaction.test.ts
@@ -19,7 +19,7 @@
 
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { closeSync, fsyncSync, openSync, writeSync } from 'node:fs';
+import { closeSync, fsyncSync, openSync, readdirSync, writeFileSync, writeSync } from 'node:fs';
 import { mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
@@ -213,7 +213,6 @@ test('intent body write failure cleans staging and does not poison recovery', as
 });
 
 test('a process killed before intent publication leaves only a GC-safe pre-intent transaction', async () => {
-  if (process.platform === 'win32') return;
   const root = await tempRoot();
   const moduleUrl = new URL('../server/skill-catalog-transaction.js', import.meta.url).href;
   const script = `
@@ -236,7 +235,8 @@ test('a process killed before intent publication leaves only a GC-safe pre-inten
       child.once('exit', (code, signal) => resolve({ code, signal }));
     },
   );
-  assert.equal(exit.signal, 'SIGKILL');
+  if (process.platform === 'win32') assert.notEqual(exit.code, 0);
+  else assert.equal(exit.signal, 'SIGKILL');
   const transaction = await onlyTransaction(root);
   assert.deepEqual((await readdir(transaction)).sort(), ['intent.json.tmp', 'next']);
   await writer(root).recover();
@@ -536,18 +536,25 @@ test('managed recovery fails closed without overwriting a third-party edit', asy
   assert.deepEqual(await transactionEntries(root), entries);
 });
 
-test('managed replacement preserves a pre-GC open-fd save and fails before transaction completion', async () => {
-  if (process.platform === 'win32') return;
+test('managed replacement preserves a pre-GC stale save and fails before transaction completion', async () => {
   const root = await tempRoot();
   const expected = managedArtifacts('old');
   const next = managedArtifacts('new');
   await createManaged(root, 'managed', expected);
-  const fd = openSync(join(root, 'skills', 'managed', 'SKILL.md'), 'r+');
+  const fd =
+    process.platform === 'win32'
+      ? undefined
+      : openSync(join(root, 'skills', 'managed', 'SKILL.md'), 'r+');
   const transactionWriter = new SkillCatalogTransactionWriter(
     async (operation) => operation(root),
     {
       failpoint(point) {
         if (point !== 'after_managed_publish') return;
+        if (fd === undefined) {
+          // Windows cannot freeze a directory with an open child, so inject the same stale save after the rename.
+          writeFileSync(frozenSkillPath(root), '# open fd edit\n', { flush: true });
+          return;
+        }
         writeSync(fd, Buffer.from('# open fd edit\n'), 0, 15, 0);
         fsyncSync(fd);
       },
@@ -559,7 +566,7 @@ test('managed replacement preserves a pre-GC open-fd save and fails before trans
       isTransactionError('commit_outcome_unknown'),
     );
   } finally {
-    closeSync(fd);
+    if (fd !== undefined) closeSync(fd);
   }
 
   assert.deepEqual(await readManaged(root, 'managed'), next);
@@ -569,6 +576,13 @@ test('managed replacement preserves a pre-GC open-fd save and fails before trans
   assert.deepEqual(await readManaged(root, 'managed'), next);
   assert.match(await readFile(join(frozen, 'SKILL.md'), 'utf8'), /^# open fd edit/);
 });
+
+function frozenSkillPath(root: string): string {
+  const skills = join(root, 'skills');
+  const frozen = readdirSync(skills).filter((entry) => entry.startsWith('.maka-frozen-'));
+  assert.equal(frozen.length, 1);
+  return join(skills, frozen[0], 'SKILL.md');
+}
 
 test('managed replacement rejects a stale expected set before creating an intent', async () => {
   const root = await tempRoot();
@@ -622,7 +636,6 @@ test('recovery rejects modified intents by the digest bound into the transaction
 });
 
 test('managed recovery rejects symlinks without following them', async () => {
-  if (process.platform === 'win32') return;
   const root = await tempRoot();
   const expected = managedArtifacts('old');
   const next = managedArtifacts('new');

--- a/packages/runtime-host/src/__tests__/skill-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-two-client-uds.test.ts
@@ -40,8 +40,7 @@ const PROTOCOL = {
 } as const;
 const REQUEST_TIMEOUT_MS = 5_000;
 
-test('two UDS clients converge on one lease-bound Skill catalog authority', {
-  skip: process.platform === 'win32',
+test('two local IPC clients converge on one lease-bound Skill catalog authority', {
   timeout: 20_000,
 }, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-skill-catalog-two-client-'));
@@ -85,7 +84,9 @@ Keep ${privateMarker} inside the lazy-loaded body.
     host = await RuntimeHostKernel.start({
       owner,
       idleGraceMs: 30_000,
-      composition: defineInteractiveRuntimeHostComposition(createExecutionRuntimeHostComposition),
+      composition: defineInteractiveRuntimeHostComposition((context) =>
+        createExecutionRuntimeHostComposition(context, { skillHomeDirectory: isolatedHome }),
+      ),
     });
     endpoint = host.endpoint;
 
@@ -197,7 +198,7 @@ Keep ${privateMarker} inside the lazy-loaded body.
       if (closure.status === 'rejected') cleanupErrors.push(closure.reason);
     }
     await host?.close().catch((error: unknown) => cleanupErrors.push(error));
-    if (endpoint)
+    if (endpoint && process.platform !== 'win32')
       await assert.rejects(lstat(endpoint), { code: 'ENOENT' }).catch((error: unknown) => {
         cleanupErrors.push(error);
       });

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -579,6 +579,19 @@ test('Windows recovery executes the root initialization replacement race', () =>
   assert.match(recovery, /# skipped 0/u);
 });
 
+test('Windows recovery executes the complete Skill catalog suite', () => {
+  const recovery = readWorkflow('windows-recovery.yml');
+
+  assert.match(recovery, /skill-catalog-coordinator\.test\.js/u);
+  assert.match(recovery, /skill-catalog-protocol\.test\.js/u);
+  assert.match(recovery, /skill-catalog-repository\.test\.js/u);
+  assert.match(recovery, /skill-catalog-transaction\.test\.js/u);
+  assert.match(recovery, /skill-catalog-two-client-uds\.test\.js/u);
+  assert.match(recovery, /# tests 90/u);
+  assert.match(recovery, /# pass 90/u);
+  assert.match(recovery, /# skipped 0/u);
+});
+
 test('workflows never persist the job credential into the checkout', () => {
   for (const name of readdirSync(WORKFLOW_DIR)) {
     for (const step of checkoutSteps(name)) {


### PR DESCRIPTION
Fixes #3901

## Summary

Windows could report a healthy Skill Catalog suite while six filesystem, recovery, and multi-client contracts never ran.

Five tests returned before their assertions on Windows, while the real two-client transport test carried an explicit Windows skip. The tests now use Windows ACLs for unreadable fixtures, accept the Windows process-termination representation, exercise the existing named-pipe transport with an isolated skill home, and retain the open-handle and symlink recovery assertions.

The blocking Windows recovery lane runs every Skill Catalog test file and requires exactly 90 passes with zero skips; its CI contract prevents the file list or count from silently shrinking.

## Verification

Before:
```text
447:  if (process.platform === 'win32') return;
466:  if (process.platform === 'win32') return;
216:  if (process.platform === 'win32') return;
540:  if (process.platform === 'win32') return;
625:  if (process.platform === 'win32') return;
44:  skip: process.platform === 'win32',
```

After ([Windows recovery run](https://github.com/apache/maka/actions/runs/33035646370)):
```text
# tests 90
# suites 1
# pass 90
# fail 0
# cancelled 0
# skipped 0
# todo 0
```

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the cross-platform test fixtures and Windows CI gate, then performed local validation and an independent subagent review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

