### PR TITLE
fix(core): tolerate legacy ShellRun visibility for safe upgrade

### DIFF
--- a/packages/core/src/shell-run.ts
+++ b/packages/core/src/shell-run.ts
@@ -350,7 +350,23 @@ export function normalizeShellRunRecord(
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error(`Invalid ShellRun record for ${shellRunId}: expected an object`);
   }
-  const record = value as Partial<ShellRunRecord>;
+  // Legacy `visibility` (`model`|`user`) was briefly persisted around 2026-08 before
+  // being removed. Retain read-compatibility by stripping it (after validating its
+  // shape) so a workspace that was written by that build can still recover.
+  const rawRecord = value as Partial<ShellRunRecord> & Record<string, unknown>;
+  let record: Partial<ShellRunRecord> = rawRecord;
+  if ('visibility' in rawRecord) {
+    const visibility = rawRecord.visibility;
+    if (
+      visibility !== undefined &&
+      visibility !== 'model' &&
+      visibility !== 'user'
+    ) {
+      throw new Error(`Invalid ShellRun record for ${shellRunId}: malformed fields`);
+    }
+    const { visibility: _stripped, ...withoutVisibility } = rawRecord;
+    record = withoutVisibility as Partial<ShellRunRecord>;
+  }
   const requiredStrings = [
     record.shellRunId,
     record.sessionId,


### PR DESCRIPTION
### 动机

fa1c2cf36 为 ShellRunRecord 增加 visibility?: 'model'|'user'，随后在 HEAD 移除但未提供迁移或容错。该窗口期写入的工作区会在 core_shell_runs.record_json 中留下顶层 visibility（本次用户库中 6 条，含 8849e999-b167-4239-bf1d-912aeec07f9c），normalizeShellRunRecord (packages/core/src/shell-run.ts:345) 以 hasOnlyKeys 严格校验失败，抛 Invalid ShellRun record ... malformed fields，经 candidate-entry.ts:71 归为 internal_startup_failure (70)，host 永远 recovering，诊断仅见 INTERNAL_STARTUP_FAILURE。

### 修复

在 normalizeShellRunRecord 入口剥离 legacy visibility（先校验 model|user，非法仍拒绝），后续严格校验与 canonicalShellRunRecord 均基于剥离后对象，旧库可恢复且字段在下次写入时自然丢弃。已在 1.1G 现库（5143 runs）及合成用例验证。

### 验证

- 合成：visibility=user/model 可读且被剥除，非法值仍拒绝
- 现库：json_extract(visibility) IS NOT NULL 6→0 后 host ready
- npm --workspace @maka/core run build && npm run build 通过

### 风险

仅放宽读取，白名单外其他未知字段仍 fail-closed。