### PR TITLE
fix(desktop): keep Agent Graph results label from shrinking

### DIFF
--- a/apps/desktop/src/renderer/styles/agent-graph.css
+++ b/apps/desktop/src/renderer/styles/agent-graph.css
@@ -176,7 +176,18 @@
   margin-top: var(--space-2);
 }
 
+/* The label is a fixed cost of the row, not a share of it: leave it shrinkable
+   and flex takes it down to min-content, which in a script without break
+   opportunities is one glyph wide — the label stacks vertically while the id
+   list it names keeps its single line. The ids are the part with room to give,
+   so they take the whole remainder and ellipsis out of it. */
+.maka-agent-graph-results > span {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .maka-agent-graph-results code {
+  flex: 1 1 0;
   font: var(--maka-text-supporting);
   min-width: 0;
   overflow: hidden;


### PR DESCRIPTION
## Summary

`.maka-agent-graph-results` is a flex row, and the label `<span>` inside it had
neither `flex-shrink: 0` nor `white-space: nowrap`. Flex therefore shrinks the
label to min-content whenever the id list needs room — and min-content in a
script with no break opportunities is one glyph, which is how `已选择结果`
degrades into `已选 / 择结 / 果`.

This is not zh-only. The same missing constraint breaks `Selected results` into
two lines, and it does so at the panel's full 680px measure, not just when the
window is narrow — the English label is long enough that two `graph_record_*`
ids already push it over. So the fix reads better as *the label never shrinks*
than as *add nowrap for Chinese*: the ids are the part of the row with room to
give, and they already truncate.

Fixes #3966

## Verification

`npm run lint && npm run format:check && npm run build && npm run typecheck` —
all pass locally.

Captured in Storybook per `apps/desktop/stories/FIDELITY.md`, which names it as
ground truth for pixel work, driving the real `AgentGraphPanel` in its real
frame (`ChatSurfaceLayout`, the host at `app-shell.tsx:2848`) with a
`snapshot.finish` carrying two `graph_record_*` ids. The story itself is not
committed: FIDELITY.md puts responsive behaviour outside the story lane (CI
mounts every story once at 1280 wide), and a narrower version of a state
already on screen is not its own story. A permanent guard for this belongs
with the agent-graph slice of #3944.

Two viewports × both shipped locales. The wide column is the control — it shows
the fix did not disturb the case that was already correct.

| | before | after |
|---|---|---|
| **zh · 430px** | ![](https://github.com/user-attachments/assets/fa1f12be-aa6f-4811-8d71-eb2b99482f30) | ![](https://github.com/user-attachments/assets/7c30c7ee-cef2-4b1d-92ca-cd4979cb6a49) |
| **en · 430px** | ![](https://github.com/user-attachments/assets/0f8b4728-e7a5-460b-b9a2-b96f6e537d12) | ![](https://github.com/user-attachments/assets/ef7bd5c7-c0ee-4c61-9c63-d4e5b6b5310f) |
| **zh · 980px** | ![](https://github.com/user-attachments/assets/350876bb-3d7e-40db-982b-57d1a7f6e124) | ![](https://github.com/user-attachments/assets/a95b18ad-6e56-4a85-ade6-c4b7be3a452d) |
| **en · 980px** | ![](https://github.com/user-attachments/assets/eac08b58-48d4-4fb4-a5b8-96e2f29ce4e2) | ![](https://github.com/user-attachments/assets/99e5f999-a44c-4fea-9a26-06b4547a89ad) |

Not run: `npm run test`, and the desktop e2e suite — this changes no behaviour
either one asserts.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Claude Opus 5) wrote the CSS rules and this
description, built the local Storybook harness, and captured the screenshots.
Root cause and scope came from the issue reporter and from my own reproduction.
The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Tests: none added. The repo has no computed-style contract for this panel, and
FIDELITY.md routes responsive behaviour to a `packages/ui` contract or the
desktop e2e harness rather than to a story — see the #3944 note above.

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
