### PR TITLE
feat(desktop): share the Local Runtime Host

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -141,6 +141,41 @@ test('quiesces reconnect and waits for the Host process before update install', 
   await owner.close();
 });
 
+test('quiesces Local reconnect while a managed service changes', async () => {
+  const current = candidateHarness({ lifecycleMode: 'service' });
+  const replacement = candidateHarness({
+    lifecycleMode: 'service',
+    hostEpoch: 'service-after',
+  });
+  let starts = 0;
+  let finishChange!: () => void;
+  const change = new Promise<void>((resolve) => {
+    finishChange = resolve;
+  });
+  const owner = await startRuntimeHostDesktopManager(
+    {} as DesktopRuntimeHostCandidateStartInput,
+    {
+      startCandidate: async () => {
+        starts += 1;
+        return ready(starts === 1 ? current.candidate : replacement.candidate);
+      },
+    },
+  );
+
+  const changing = owner.runManagedLocalHostChange(async () => {
+    current.disconnect();
+    await change;
+  });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(starts, 1);
+
+  finishChange();
+  await changing;
+  await owner.waitUntilReady('local', 'test-host-epoch');
+  assert.equal(starts, 2);
+  await owner.close();
+});
+
 test('waits through a reconnect gap before quiescing Host retirement', async () => {
   const first = candidateHarness();
   const replacement = candidateHarness({ disconnectOnPrepare: true });

--- a/apps/desktop/src/main/__tests__/runtime-host-local-operator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-local-operator.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runtimeHostLocalSetupCommand } from '../runtime-host-local-operator.js';
+
+test('local setup installs one managed service for the Desktop root with Direct peer enabled', () => {
+  assert.deepEqual(
+    runtimeHostLocalSetupCommand({
+      packageSpecifier: 'maka-agent@0.2.0',
+      clientDataRoot: '/Users/ada/Library/Application Support/Maka',
+      rootPath: '/Users/ada/Library/Application Support/Maka/workspaces/default',
+      principalId: 'desktop-owner:pairing',
+      coordinationRelays: ['/dns4/discovery.example/udp/443/quic-v1'],
+    }),
+    {
+      executable: 'npm',
+      args: [
+        'exec', '--yes', '--package', 'maka-agent@0.2.0', '--',
+        'maka', 'runtime-host', 'setup',
+        '--client-data-root', '/Users/ada/Library/Application Support/Maka',
+        '--root', '/Users/ada/Library/Application Support/Maka/workspaces/default',
+        '--principal', 'desktop-owner:pairing',
+        '--preset', 'desktop-client',
+        '--defer-pairing-commit',
+        '--enable-direct-peer',
+        '--coordination-relay', '/dns4/discovery.example/udp/443/quic-v1',
+        '--json',
+      ],
+    },
+  );
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-local-remote-access.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-local-remote-access.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { decodeRuntimeHostOwnerConnectionCode } from '@maka/runtime-host/client';
+import type { RuntimeHostDesktopManager } from '../runtime-host-desktop-manager.js';
+import { createDesktopLocalRuntimeHostRemoteAccess } from '../runtime-host-local-remote-access.js';
+import type { createDesktopRuntimeHostLocalOperator } from '../runtime-host-local-operator.js';
+
+test('enabling remote access hands the same root to one managed service before Desktop resumes', async (t) => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-local-remote-access-'));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const clientDataRoot = join(base, 'client');
+  const rootPath = join(clientDataRoot, 'workspaces', 'default');
+  await mkdir(rootPath, { recursive: true });
+  const handlers = new Map<string, Parameters<Electron.IpcMain['handle']>[1]>();
+  let retired = false;
+  let resumed = false;
+  const manager = {
+    async retireOwnedLocalHost() {
+      retired = true;
+      return { kind: 'retired' as const, resume: () => { resumed = true; } };
+    },
+  } as unknown as RuntimeHostDesktopManager;
+  const peer = {
+    peerId: '12D3KooWpeer',
+    routeHints: ['/ip4/192.0.2.1/udp/41000/quic-v1'],
+    coordinationRelays: [],
+  };
+  const operator = {
+    async runSetup(input: { readonly rootPath: string }) {
+      assert.equal(retired, true);
+      assert.equal(input.rootPath, rootPath);
+      return {
+        serviceId: 'b'.repeat(64),
+        operatorPath: join(base, 'operator'),
+        rootPath,
+        rootId: 'a'.repeat(64),
+        credential: 'pending-credential',
+        directPeer: peer,
+      };
+    },
+    async runPeer() {
+      return {
+        kind: 'result' as const,
+        action: 'status' as const,
+        status: {
+          state: 'enabled' as const,
+          serviceState: 'running',
+          rootId: 'a'.repeat(64),
+          ...peer,
+        },
+      };
+    },
+    async runService() {
+      throw new Error('rollback is not expected');
+    },
+    async close() {},
+  } as unknown as ReturnType<typeof createDesktopRuntimeHostLocalOperator>;
+  const service = createDesktopLocalRuntimeHostRemoteAccess({
+    ipcMain: {
+      handle: (channel, handler) => { handlers.set(channel, handler); },
+      removeHandler: (channel) => { handlers.delete(channel); },
+    },
+    clientDataRoot,
+    rootPath,
+    directPeerAvailable: true,
+    manager: () => manager,
+    resolveSetupPackage: async () => ({ kind: 'npm', specifier: 'maka-agent@0.2.0' }),
+    operator,
+  });
+  t.after(() => service.close());
+
+  const enable = handlers.get('local-runtime-host-remote-access:enable');
+  assert.ok(enable);
+  const result = await enable({} as Electron.IpcMainInvokeEvent, {
+    allowInterruptActiveTasks: false,
+    coordinationRelays: [],
+  }) as { readonly kind: string; readonly connectionCode: string };
+  assert.equal(result.kind, 'enabled');
+  assert.equal(resumed, true);
+  assert.deepEqual(decodeRuntimeHostOwnerConnectionCode(result.connectionCode), {
+    name: decodeRuntimeHostOwnerConnectionCode(result.connectionCode).name,
+    rootId: 'a'.repeat(64),
+    transport: { kind: 'libp2p-direct', ...peer },
+    credential: 'pending-credential',
+  });
+  assert.equal(
+    JSON.parse(await readFile(join(clientDataRoot, 'runtime-host-local-service.json'), 'utf8'))
+      .rootPath,
+    rootPath,
+  );
+});

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -170,6 +170,8 @@ import {
 } from "./runtime-host-ssh-terminal.js";
 import { createRuntimeHostSetupPackageResolver } from "./runtime-host-setup-package.js";
 import { configureDesktopRuntimeHostPeerClient } from './runtime-host-peer-client.js';
+import { createDesktopRuntimeHostLocalOperator } from './runtime-host-local-operator.js';
+import { createDesktopLocalRuntimeHostRemoteAccess } from './runtime-host-local-remote-access.js';
 import { createDesktopRuntimeHostOnboarding } from "./runtime-host-onboarding.js";
 import { createDesktopRuntimeHostManagement } from "./runtime-host-management.js";
 import { registerRuntimeHostOAuthIpc } from "./runtime-host-oauth-ipc-main.js";
@@ -385,6 +387,16 @@ const runtimeHostSetupPackage = createRuntimeHostSetupPackageResolver({
   isPackaged: app.isPackaged,
   appPath: app.getAppPath(),
   environment: process.env,
+});
+const localRuntimeHostOperator = createDesktopRuntimeHostLocalOperator();
+const localRuntimeHostRemoteAccess = createDesktopLocalRuntimeHostRemoteAccess({
+  ipcMain,
+  clientDataRoot: userDataDir,
+  rootPath: startupLocalStorageRoot.canonicalPath,
+  directPeerAvailable: runtimeHostDirectPeerAvailable,
+  manager: () => runtimeHostManager,
+  resolveSetupPackage: runtimeHostSetupPackage.resolve,
+  operator: localRuntimeHostOperator,
 });
 const native = assembleDesktopNativeCapabilities({
   isComputerUseRealModelE2e,
@@ -1602,6 +1614,7 @@ async function closeRuntimeHostDesktop(): Promise<void> {
     Promise.resolve().then(() => runtimeHostManagement.close()),
     runtimeHostManager?.close(),
     runtimeHostOnboarding.close(),
+    localRuntimeHostRemoteAccess.close(),
     runtimeHostSetupPackage.close(),
     Promise.resolve().then(() => workBoardIpc.close()),
     runtimeHostSshTerminal.close(),

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -71,6 +71,7 @@ export interface RuntimeHostDesktopManager {
     previousHostEpoch?: string,
     signal?: AbortSignal,
   ): Promise<void>;
+  runManagedLocalHostChange<T>(change: () => Promise<T>): Promise<T>;
   setDefaultProfile(profileId: string): void;
   retireOwnedLocalHost(mode: RuntimeHostRetirementMode): Promise<DesktopLocalHostRetirement>;
   close(): Promise<void>;
@@ -517,6 +518,23 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     await this.#removeTarget(target);
   }
 
+  runManagedLocalHostChange<T>(change: () => Promise<T>): Promise<T> {
+    return this.#mutateTarget(LOCAL_RUNTIME_HOST_PROFILE.id, async () => {
+      const lifecycle = this.#requireLifecycle(
+        this.#requireTarget(LOCAL_RUNTIME_HOST_PROFILE.id),
+      );
+      const quiescence = await lifecycle.quiesce();
+      try {
+        if (quiescence.current.hostLifecycleMode !== 'service') {
+          throw new Error('The Local Runtime Host is not managed by a background service');
+        }
+        return await change();
+      } finally {
+        quiescence.resume();
+      }
+    });
+  }
+
   setDefaultProfile(profileId: string): void {
     this.#defaultProfileId = profileId;
     this.onDefaultProfileChanged?.(profileId);
@@ -842,19 +860,22 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     }
   }
 
-  #mutateTarget(profileId: string, operation: () => Promise<void>): Promise<void> {
+  #mutateTarget<T>(profileId: string, operation: () => Promise<T>): Promise<T> {
     if (this.#closed) {
       return Promise.reject(new Error('Desktop Runtime Host manager is closed'));
     }
     const previous = this.#targetMutations.get(profileId) ?? Promise.resolve();
     const pending = previous.catch(() => undefined).then(operation);
-    const settled = pending.finally(() => {
+    const settled = pending.then(
+      () => undefined,
+      () => undefined,
+    ).finally(() => {
       if (this.#targetMutations.get(profileId) === settled) {
         this.#targetMutations.delete(profileId);
       }
     });
     this.#targetMutations.set(profileId, settled);
-    return settled;
+    return pending;
   }
 
   #activate(target: DesktopRuntimeHostTargetGeneration): void {

--- a/apps/desktop/src/main/runtime-host-framed-output.ts
+++ b/apps/desktop/src/main/runtime-host-framed-output.ts
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export function createRuntimeHostFramedOutputFilter<Frame>(input: {
+  readonly prefix: string;
+  readonly pendingMaxBytes: number;
+  readonly decode: (line: string) => Frame | undefined;
+  readonly label: string;
+  readonly onFrame: (frame: Frame) => void;
+  readonly onError: (error: Error) => void;
+}): { push(data: string): string; finish(): string } {
+  let pending = '';
+  let discardReservedLine = false;
+  const drain = (finished: boolean): string => {
+    let visible = '';
+    while (pending) {
+      if (discardReservedLine) {
+        const newline = pending.indexOf('\n');
+        if (newline < 0) {
+          pending = '';
+          break;
+        }
+        pending = pending.slice(newline + 1);
+        discardReservedLine = false;
+        continue;
+      }
+      const marker = pending.indexOf(input.prefix);
+      if (marker >= 0) {
+        visible += pending.slice(0, marker);
+        pending = pending.slice(marker);
+        const newline = pending.indexOf('\n');
+        if (newline < 0) {
+          if (finished) {
+            input.onError(new Error(`${input.label} returned an incomplete result`));
+            pending = '';
+          } else if (pending.length > input.pendingMaxBytes) {
+            input.onError(new Error(`${input.label} returned an oversized result`));
+            pending = '';
+            discardReservedLine = true;
+          }
+          break;
+        }
+        const line = pending.slice(0, newline + 1);
+        pending = pending.slice(newline + 1);
+        const frame = input.decode(line);
+        if (frame) input.onFrame(frame);
+        else input.onError(new Error(`${input.label} returned an invalid result`));
+        continue;
+      }
+      if (finished) {
+        visible += pending;
+        pending = '';
+        break;
+      }
+      const retained = markerSuffixLength(pending, input.prefix);
+      visible += pending.slice(0, pending.length - retained);
+      pending = pending.slice(pending.length - retained);
+      break;
+    }
+    return visible;
+  };
+  return {
+    push(data) {
+      pending += data;
+      return drain(false);
+    },
+    finish() {
+      return drain(true);
+    },
+  };
+}
+
+function markerSuffixLength(value: string, prefix: string): number {
+  const limit = Math.min(value.length, prefix.length - 1);
+  for (let length = limit; length > 0; length -= 1) {
+    if (prefix.startsWith(value.slice(-length))) return length;
+  }
+  return 0;
+}

--- a/apps/desktop/src/main/runtime-host-local-operator.ts
+++ b/apps/desktop/src/main/runtime-host-local-operator.ts
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtemp, realpath, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { redactSecrets } from '@maka/core/redaction';
+import {
+  DEFAULT_PROCESS_TERMINATION_GRACE_MS,
+  terminateChildProcessTree,
+} from '@maka/runtime/process-tree-terminator';
+import {
+  decodeRuntimeHostPeerManagementFrame,
+  decodeRuntimeHostServiceManagementFrame,
+  decodeRuntimeHostSetupFrame,
+  RUNTIME_HOST_PEER_MANAGEMENT_FRAME_PREFIX,
+  RUNTIME_HOST_SERVICE_MANAGEMENT_FRAME_PREFIX,
+  RUNTIME_HOST_SETUP_FRAME_PREFIX,
+  type RuntimeHostPeerManagementFrame,
+  type RuntimeHostServiceManagementFrame,
+  type RuntimeHostSetupFrame,
+} from '@maka/runtime-host/operator';
+import { createRuntimeHostFramedOutputFilter } from './runtime-host-framed-output.js';
+import {
+  isExactRuntimeHostSetupPackageSpecifier,
+  type DesktopRuntimeHostSetupPackage,
+} from './runtime-host-ssh-terminal.js';
+
+const SETUP_TIMEOUT_MS = 10 * 60_000;
+const SETUP_FRAME_PENDING_MAX = 20 * 1024;
+const STDERR_MAX_BYTES = 64 * 1024;
+
+type RuntimeHostSetupCompleteFrame = Extract<RuntimeHostSetupFrame, { kind: 'complete' }>;
+
+export interface DesktopRuntimeHostLocalServiceTarget {
+  readonly serviceId: string;
+  readonly rootPath: string;
+  readonly rootId: string;
+}
+
+export interface DesktopRuntimeHostLocalSetupInput {
+  readonly setupPackage: DesktopRuntimeHostSetupPackage;
+  readonly clientDataRoot: string;
+  readonly rootPath: string;
+  readonly principalId: string;
+  readonly projectDirectoryRoots?: readonly { readonly label: string; readonly path: string }[];
+  readonly coordinationRelays?: readonly string[];
+  readonly signal?: AbortSignal;
+}
+
+export interface DesktopRuntimeHostLocalSetupCommand {
+  readonly executable: string;
+  readonly args: readonly string[];
+}
+
+export function runtimeHostLocalSetupCommand(input: {
+  readonly packageSpecifier: string;
+  readonly clientDataRoot: string;
+  readonly rootPath: string;
+  readonly principalId: string;
+  readonly projectDirectoryRoots?: readonly { readonly label: string; readonly path: string }[];
+  readonly coordinationRelays?: readonly string[];
+}): DesktopRuntimeHostLocalSetupCommand {
+  if (!/^[A-Za-z0-9_.:-]{1,128}$/u.test(input.principalId)) {
+    throw new Error('Runtime Host setup principal is invalid');
+  }
+  return {
+    executable: 'npm',
+    args: [
+      'exec',
+      '--yes',
+      '--package',
+      input.packageSpecifier,
+      '--',
+      'maka',
+      'runtime-host',
+      'setup',
+      '--client-data-root',
+      input.clientDataRoot,
+      '--root',
+      input.rootPath,
+      '--principal',
+      input.principalId,
+      '--preset',
+      'desktop-client',
+      '--defer-pairing-commit',
+      '--enable-direct-peer',
+      ...(input.coordinationRelays ?? []).flatMap((relay) => [
+        '--coordination-relay',
+        relay,
+      ]),
+      ...(input.projectDirectoryRoots === undefined
+        ? []
+        : input.projectDirectoryRoots.length === 0
+          ? ['--no-project-roots']
+          : input.projectDirectoryRoots.flatMap(({ label, path }) => [
+              '--project-root-json',
+              JSON.stringify({ label, path }),
+            ])),
+      '--json',
+    ],
+  };
+}
+
+export function createDesktopRuntimeHostLocalOperator(input: {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly spawnProcess?: typeof spawn;
+  readonly setupTimeoutMs?: number;
+  readonly terminateProcess?: typeof terminateChildProcessTree;
+} = {}): {
+  runSetup(
+    setup: DesktopRuntimeHostLocalSetupInput,
+    onProgress: (frame: Extract<RuntimeHostSetupFrame, { kind: 'progress' }>) => void,
+  ): Promise<RuntimeHostSetupCompleteFrame>;
+  runPeer(input: {
+    readonly operatorPath: string;
+    readonly action: 'enable' | 'disable' | 'status';
+    readonly target: DesktopRuntimeHostLocalServiceTarget;
+    readonly coordinationRelays?: readonly string[];
+    readonly signal?: AbortSignal;
+  }): Promise<RuntimeHostPeerManagementFrame>;
+  runService(input: {
+    readonly operatorPath: string;
+    readonly action: 'status' | 'retire' | 'uninstall';
+    readonly target: DesktopRuntimeHostLocalServiceTarget;
+    readonly allowInterruptActiveTasks?: boolean;
+    readonly signal?: AbortSignal;
+  }): Promise<RuntimeHostServiceManagementFrame>;
+  close(): Promise<void>;
+} {
+  const active = new Set<ChildProcess>();
+  let closed = false;
+  const terminate = input.terminateProcess ?? terminateChildProcessTree;
+
+  return {
+    async runSetup(setup, onProgress) {
+      if (closed) throw new Error('Local Runtime Host operator is closed');
+      setup.signal?.throwIfAborted();
+      const packageSpecifier = await resolveLocalSetupPackage(setup.setupPackage);
+      const command = runtimeHostLocalSetupCommand({ ...setup, packageSpecifier });
+      const workingDirectory = await mkdtemp(join(tmpdir(), 'maka-runtime-host-local-setup-'));
+      try {
+        return await runSetupProcess({
+          command,
+          cwd: workingDirectory,
+          environment: input.environment ?? process.env,
+          spawnProcess: input.spawnProcess ?? spawn,
+          timeoutMs: input.setupTimeoutMs ?? SETUP_TIMEOUT_MS,
+          terminate,
+          signal: setup.signal,
+          onProgress,
+          active,
+        });
+      } finally {
+        await rm(workingDirectory, { recursive: true, force: true });
+      }
+    },
+    runPeer(command) {
+      if (closed) throw new Error('Local Runtime Host operator is closed');
+      return runSingleFrameProcess({
+        command: {
+          executable: command.operatorPath,
+          args: [
+            'peer',
+            command.action,
+            '--framed',
+            ...(command.action === 'enable'
+              ? command.coordinationRelays?.length
+                ? command.coordinationRelays.flatMap((relay) => [
+                    '--coordination-relay',
+                    relay,
+                  ])
+                : ['--clear-coordination-relays']
+              : []),
+            ...managedTargetArgs(command.target),
+          ],
+        },
+        prefix: RUNTIME_HOST_PEER_MANAGEMENT_FRAME_PREFIX,
+        decode: decodeRuntimeHostPeerManagementFrame,
+        label: 'Local Runtime Host peer management',
+        environment: input.environment ?? process.env,
+        spawnProcess: input.spawnProcess ?? spawn,
+        timeoutMs: input.setupTimeoutMs ?? SETUP_TIMEOUT_MS,
+        terminate,
+        signal: command.signal,
+        active,
+      });
+    },
+    runService(command) {
+      if (closed) throw new Error('Local Runtime Host operator is closed');
+      return runSingleFrameProcess({
+        command: {
+          executable: command.operatorPath,
+          args: [
+            command.action,
+            '--framed',
+            ...(command.allowInterruptActiveTasks ? ['--allow-interrupt-active-tasks'] : []),
+            ...managedTargetArgs(command.target),
+          ],
+        },
+        prefix: RUNTIME_HOST_SERVICE_MANAGEMENT_FRAME_PREFIX,
+        decode: decodeRuntimeHostServiceManagementFrame,
+        label: 'Local Runtime Host service management',
+        environment: input.environment ?? process.env,
+        spawnProcess: input.spawnProcess ?? spawn,
+        timeoutMs: input.setupTimeoutMs ?? SETUP_TIMEOUT_MS,
+        terminate,
+        signal: command.signal,
+        active,
+      });
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      await Promise.allSettled([...active].map((child) => stopProcess(child, terminate)));
+    },
+  };
+}
+
+async function resolveLocalSetupPackage(
+  setupPackage: DesktopRuntimeHostSetupPackage,
+): Promise<string> {
+  if (setupPackage.kind === 'npm') {
+    if (!isExactRuntimeHostSetupPackageSpecifier(setupPackage.specifier)) {
+      throw new Error('Runtime Host setup package is invalid');
+    }
+    return setupPackage.specifier;
+  }
+  const archive = await realpath(setupPackage.path);
+  if (!(await stat(archive)).isFile() || !archive.endsWith('.tgz')) {
+    throw new Error('Runtime Host development package must be a .tgz file');
+  }
+  return archive;
+}
+
+function managedTargetArgs(target: DesktopRuntimeHostLocalServiceTarget): string[] {
+  return [
+    '--expected-service-id',
+    target.serviceId,
+    '--expected-root-path',
+    target.rootPath,
+    '--expected-root-id',
+    target.rootId,
+  ];
+}
+
+function runSingleFrameProcess<Frame>(input: {
+  readonly command: DesktopRuntimeHostLocalSetupCommand;
+  readonly prefix: string;
+  readonly decode: (line: string) => Frame | undefined;
+  readonly label: string;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly spawnProcess: typeof spawn;
+  readonly timeoutMs: number;
+  readonly terminate: typeof terminateChildProcessTree;
+  readonly signal?: AbortSignal;
+  readonly active: Set<ChildProcess>;
+}): Promise<Frame> {
+  input.signal?.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const child = input.spawnProcess(input.command.executable, [...input.command.args], {
+      detached: process.platform !== 'win32',
+      env: input.environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    input.active.add(child);
+    let result: Frame | undefined;
+    let failure: Error | undefined;
+    let stderr = '';
+    let settled = false;
+    const filter = createRuntimeHostFramedOutputFilter({
+      prefix: input.prefix,
+      pendingMaxBytes: SETUP_FRAME_PENDING_MAX,
+      decode: input.decode,
+      label: input.label,
+      onFrame: (frame) => {
+        if (result) failure = new Error(`${input.label} returned multiple results`);
+        else result = frame;
+      },
+      onError: (error) => {
+        failure = error;
+      },
+    });
+    const cleanup = () => {
+      clearTimeout(timeout);
+      input.signal?.removeEventListener('abort', onAbort);
+      input.active.delete(child);
+    };
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error) reject(error);
+      else resolve(result!);
+    };
+    const stop = (error: Error) => {
+      void stopProcess(child, input.terminate).then(
+        () => finish(error),
+        (stopError) => finish(new AggregateError([error, stopError])),
+      );
+    };
+    const onAbort = () => stop(abortError(input.signal));
+    const timeout = setTimeout(() => stop(new Error(`${input.label} timed out`)), input.timeoutMs);
+    input.signal?.addEventListener('abort', onAbort, { once: true });
+    child.stdout?.on('data', (chunk: Buffer) => filter.push(chunk.toString('utf8')));
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr = appendBounded(stderr, chunk.toString('utf8'), STDERR_MAX_BYTES);
+    });
+    child.once('error', (error) => finish(error));
+    child.once('close', (code, signal) => {
+      filter.finish();
+      if (failure) return finish(failure);
+      if (result) return finish();
+      const status = code === null ? signal ?? 'an unknown status' : `code ${code}`;
+      const detail = redactSecrets(stderr.trim()).slice(-2_000);
+      finish(
+        new Error(
+          detail
+            ? `${input.label} exited with ${status}: ${detail}`
+            : `${input.label} exited with ${status}`,
+        ),
+      );
+    });
+    if (input.signal?.aborted) onAbort();
+  });
+}
+
+function runSetupProcess(input: {
+  readonly command: DesktopRuntimeHostLocalSetupCommand;
+  readonly cwd: string;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly spawnProcess: typeof spawn;
+  readonly timeoutMs: number;
+  readonly terminate: typeof terminateChildProcessTree;
+  readonly signal?: AbortSignal;
+  readonly onProgress: (frame: Extract<RuntimeHostSetupFrame, { kind: 'progress' }>) => void;
+  readonly active: Set<ChildProcess>;
+}): Promise<RuntimeHostSetupCompleteFrame> {
+  return new Promise((resolve, reject) => {
+    const child = input.spawnProcess(input.command.executable, [...input.command.args], {
+      cwd: input.cwd,
+      detached: process.platform !== 'win32',
+      env: input.environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    input.active.add(child);
+    let complete: RuntimeHostSetupCompleteFrame | undefined;
+    let failure: Error | undefined;
+    let stderr = '';
+    let settled = false;
+    const filter = createRuntimeHostFramedOutputFilter({
+      prefix: RUNTIME_HOST_SETUP_FRAME_PREFIX,
+      pendingMaxBytes: SETUP_FRAME_PENDING_MAX,
+      decode: decodeRuntimeHostSetupFrame,
+      label: 'Local Maka setup',
+      onFrame: (frame) => {
+        if (frame.kind === 'progress') input.onProgress(frame);
+        else if (frame.kind === 'error') failure = new Error(frame.error.message);
+        else if (complete) failure = new Error('Local Maka setup returned multiple results');
+        else complete = frame;
+      },
+      onError: (error) => {
+        failure = error;
+      },
+    });
+    const cleanup = () => {
+      clearTimeout(timeout);
+      input.signal?.removeEventListener('abort', onAbort);
+      input.active.delete(child);
+    };
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error) reject(error);
+      else resolve(complete!);
+    };
+    const stop = (error: Error) => {
+      void stopProcess(child, input.terminate).then(() => finish(error), finish);
+    };
+    const onAbort = () => stop(abortError(input.signal));
+    const timeout = setTimeout(
+      () => stop(new Error('Local Maka setup timed out')),
+      input.timeoutMs,
+    );
+    input.signal?.addEventListener('abort', onAbort, { once: true });
+    child.stdout?.on('data', (chunk: Buffer) => {
+      filter.push(chunk.toString('utf8'));
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr = appendBounded(stderr, chunk.toString('utf8'), STDERR_MAX_BYTES);
+    });
+    child.once('error', (error) => finish(error));
+    child.once('close', (code, signal) => {
+      filter.finish();
+      if (failure) return finish(failure);
+      if (complete && code === 0) return finish();
+      const status = code === null ? signal ?? 'an unknown status' : `code ${code}`;
+      const detail = redactSecrets(stderr.trim()).slice(-2_000);
+      finish(
+        new Error(
+          complete
+            ? `Local Maka setup exited with ${status}`
+            : detail
+              ? `Local Maka setup exited with ${status}: ${detail}`
+              : `Local Maka setup ended without a completion result (${status})`,
+        ),
+      );
+    });
+    if (input.signal?.aborted) onAbort();
+  });
+}
+
+async function stopProcess(
+  child: ChildProcess,
+  terminate: typeof terminateChildProcessTree,
+): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await terminate(child, 'SIGTERM');
+  if (await exitsWithin(child, DEFAULT_PROCESS_TERMINATION_GRACE_MS)) return;
+  await terminate(child, 'SIGKILL');
+  if (!(await exitsWithin(child, DEFAULT_PROCESS_TERMINATION_GRACE_MS))) {
+    throw new Error('Local Runtime Host operator did not exit after forced termination');
+  }
+}
+
+function exitsWithin(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      child.removeListener('close', onClose);
+      resolve(false);
+    }, timeoutMs);
+    const onClose = () => {
+      clearTimeout(timeout);
+      resolve(true);
+    };
+    child.once('close', onClose);
+  });
+}
+
+function appendBounded(current: string, chunk: string, maxBytes: number): string {
+  const next = current + chunk;
+  const encoded = Buffer.from(next);
+  return encoded.byteLength <= maxBytes
+    ? next
+    : encoded.subarray(encoded.byteLength - maxBytes).toString('utf8');
+}
+
+function abortError(signal: AbortSignal | undefined): Error {
+  return signal?.reason instanceof Error ? signal.reason : new Error('Local Maka setup was cancelled');
+}

--- a/apps/desktop/src/main/runtime-host-local-remote-access.ts
+++ b/apps/desktop/src/main/runtime-host-local-remote-access.ts
@@ -1,0 +1,477 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { open, readFile, rename, rm } from 'node:fs/promises';
+import { hostname } from 'node:os';
+import { dirname, isAbsolute, join } from 'node:path';
+import type { IpcMain } from 'electron';
+import {
+  consumeAccessCredentialDelivery,
+  encodeRuntimeHostOwnerConnectionCode,
+} from '@maka/runtime-host/client';
+import { REMOTE_OWNER_OPERATION_GRANTS } from '@maka/runtime-host/protocol';
+import type {
+  DesktopLocalRuntimeHostRemoteAccessEnableResult,
+  DesktopLocalRuntimeHostRemoteAccessSnapshot,
+} from '../preload/bridge-contract.js';
+import type { RuntimeHostDesktopManager } from './runtime-host-desktop-manager.js';
+import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
+import type {
+  createDesktopRuntimeHostLocalOperator,
+  DesktopRuntimeHostLocalServiceTarget,
+} from './runtime-host-local-operator.js';
+import type { DesktopRuntimeHostSetupPackage } from './runtime-host-ssh-terminal.js';
+
+const RECEIPT_FILE = 'runtime-host-local-service.json';
+const SERVICE_ID_PATTERN = /^[a-f0-9]{64}$/u;
+const ROOT_ID_PATTERN = /^[a-f0-9]{64}$/u;
+const ADDRESS_MAX_BYTES = 2 * 1024;
+const ADDRESS_MAX_COUNT = 16;
+
+interface LocalServiceReceipt extends DesktopRuntimeHostLocalServiceTarget {
+  readonly schemaVersion: 1;
+  readonly operatorPath: string;
+}
+
+interface LocalPeerDescriptor {
+  readonly peerId: string;
+  readonly routeHints: readonly string[];
+  readonly coordinationRelays: readonly string[];
+}
+
+type DesktopRuntimeHostLocalOperator = ReturnType<
+  typeof createDesktopRuntimeHostLocalOperator
+>;
+
+export function createDesktopLocalRuntimeHostRemoteAccess(input: {
+  readonly ipcMain: Pick<IpcMain, 'handle' | 'removeHandler'>;
+  readonly clientDataRoot: string;
+  readonly rootPath: string;
+  readonly directPeerAvailable: boolean;
+  readonly manager: () => RuntimeHostDesktopManager | undefined;
+  readonly resolveSetupPackage: (
+    signal?: AbortSignal,
+  ) => DesktopRuntimeHostSetupPackage | Promise<DesktopRuntimeHostSetupPackage>;
+  readonly operator: DesktopRuntimeHostLocalOperator;
+}): { close(): Promise<void> } {
+  const receiptPath = join(input.clientDataRoot, RECEIPT_FILE);
+  let mutation = Promise.resolve();
+  const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = mutation.then(operation);
+    mutation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  const getSnapshot = (): Promise<DesktopLocalRuntimeHostRemoteAccessSnapshot> =>
+    serialize(async () => {
+      if (!supported(input.directPeerAvailable)) return unsupportedSnapshot();
+      try {
+        const receipt = await readReceipt(receiptPath, input.rootPath);
+        if (!receipt) return { state: 'off' };
+        const peer = await readPeer(input.operator, receipt);
+        return peer ? onSnapshot(peer) : { state: 'off', managedService: true };
+      } catch (error) {
+        return { state: 'unavailable', message: errorMessage(error) };
+      }
+    });
+
+  const enable = (value: unknown): Promise<DesktopLocalRuntimeHostRemoteAccessEnableResult> =>
+    serialize(async () => {
+      const request = requireEnableInput(value);
+      if (!supported(input.directPeerAvailable)) throw new Error(unsupportedSnapshot().message);
+      const existing = await readReceipt(receiptPath, input.rootPath);
+      if (existing) {
+        const currentPeer = await readPeer(input.operator, existing);
+        if (
+          currentPeer &&
+          sameStrings(currentPeer.coordinationRelays, request.coordinationRelays)
+        ) {
+          return enabledResult(
+            currentPeer,
+            await issueConnectionCode(
+              input.rootPath,
+              existing.rootId,
+              currentPeer,
+              localClient(input.manager),
+            ),
+          );
+        }
+        const manager = requireManager(input.manager);
+        const previousHostEpoch = manager.current('local')?.candidate?.client.hostEpoch;
+        const response = await manager.runManagedLocalHostChange(() =>
+          input.operator.runPeer({
+            operatorPath: existing.operatorPath,
+            action: 'enable',
+            target: existing,
+            coordinationRelays: request.coordinationRelays,
+          }),
+        );
+        if (response.kind === 'error') {
+          if (response.error.code === 'active_tasks') return { kind: 'active_tasks' };
+          throw new Error(response.error.message);
+        }
+        const peer = requireEnabledPeer(response.status);
+        await manager.waitUntilReady('local', previousHostEpoch);
+        return enabledResult(
+          peer,
+          await issueConnectionCode(input.rootPath, existing.rootId, peer, localClient(input.manager)),
+        );
+      }
+
+      const setupPackage = await input.resolveSetupPackage();
+      const manager = requireManager(input.manager);
+      const retirement = await manager.retireOwnedLocalHost(
+        request.allowInterruptActiveTasks ? 'interrupt_active_work' : 'refuse_active_work',
+      );
+      if (retirement.kind === 'active_tasks') return { kind: 'active_tasks' };
+      if (retirement.kind === 'not_owned') {
+        throw new Error('The Local Runtime Host is already managed outside this Desktop');
+      }
+      try {
+        const complete = await input.operator.runSetup(
+          {
+            setupPackage,
+            clientDataRoot: input.clientDataRoot,
+            rootPath: input.rootPath,
+            principalId: `desktop-owner:${randomUUID()}`,
+            coordinationRelays: request.coordinationRelays,
+          },
+          () => undefined,
+        );
+        if (complete.rootPath !== input.rootPath || !complete.directPeer) {
+          throw new Error('Local Runtime Host setup returned an unrelated service');
+        }
+        const peer = requireEnabledPeer({ state: 'enabled', ...complete.directPeer });
+        const receipt = requireReceipt({
+          schemaVersion: 1,
+          serviceId: complete.serviceId,
+          operatorPath: complete.operatorPath,
+          rootPath: complete.rootPath,
+          rootId: complete.rootId,
+        }, input.rootPath);
+        try {
+          await writeReceipt(receiptPath, receipt);
+        } catch (error) {
+          await input.operator.runService({
+            operatorPath: receipt.operatorPath,
+            action: 'uninstall',
+            target: receipt,
+          }).catch((rollbackError) => {
+            throw new AggregateError([error, rollbackError], 'Local Runtime Host setup rollback failed');
+          });
+          throw error;
+        }
+        return enabledResult(
+          peer,
+          encodeRuntimeHostOwnerConnectionCode({
+            name: hostName(),
+            rootId: receipt.rootId,
+            transport: { kind: 'libp2p-direct', ...peer },
+            credential: complete.credential,
+          }),
+        );
+      } finally {
+        retirement.resume();
+      }
+    });
+
+  const createConnectionCode = (): Promise<string> =>
+    serialize(async () => {
+      const receipt = await requireStoredReceipt(receiptPath, input.rootPath);
+      const peer = await readPeer(input.operator, receipt);
+      if (!peer) throw new Error('Remote access is not enabled on this computer');
+      return issueConnectionCode(input.rootPath, receipt.rootId, peer, localClient(input.manager));
+    });
+
+  const disable = (): Promise<DesktopLocalRuntimeHostRemoteAccessSnapshot> =>
+    serialize(async () => {
+      const receipt = await requireStoredReceipt(receiptPath, input.rootPath);
+      const response = await requireManager(input.manager).runManagedLocalHostChange(() =>
+        input.operator.runPeer({
+          operatorPath: receipt.operatorPath,
+          action: 'disable',
+          target: receipt,
+        }),
+      );
+      if (response.kind === 'error') throw new Error(response.error.message);
+      return { state: 'off', managedService: true };
+    });
+
+  const uninstall = (
+    value: unknown,
+  ): Promise<{ readonly kind: 'active_tasks' | 'uninstalled' }> =>
+    serialize(async () => {
+      if (!isRecord(value) || typeof value.allowInterruptActiveTasks !== 'boolean') {
+        throw new Error('Local Runtime Host uninstall request is invalid');
+      }
+      const allowInterruptActiveTasks = value.allowInterruptActiveTasks;
+      const receipt = await requireStoredReceipt(receiptPath, input.rootPath);
+      return requireManager(input.manager).runManagedLocalHostChange(async () => {
+        const retired = await input.operator.runService({
+          operatorPath: receipt.operatorPath,
+          action: 'retire',
+          target: receipt,
+          allowInterruptActiveTasks,
+        });
+        if (retired.kind === 'error') throw new Error(retired.error.message);
+        if (retired.action !== 'retire') {
+          throw new Error('Local Runtime Host returned an unrelated service result');
+        }
+        if (retired.retirement.kind === 'active_tasks') return { kind: 'active_tasks' };
+        const removed = await input.operator.runService({
+          operatorPath: receipt.operatorPath,
+          action: 'uninstall',
+          target: receipt,
+        });
+        if (removed.kind === 'error') throw new Error(removed.error.message);
+        if (removed.action !== 'uninstall' || removed.service.state !== 'not_installed') {
+          throw new Error('Local Runtime Host service was not cleanly uninstalled');
+        }
+        await rm(receiptPath, { force: true });
+        return { kind: 'uninstalled' };
+      });
+    });
+
+  const channels = [
+    'local-runtime-host-remote-access:get-snapshot',
+    'local-runtime-host-remote-access:enable',
+    'local-runtime-host-remote-access:create-connection-code',
+    'local-runtime-host-remote-access:disable',
+    'local-runtime-host-remote-access:uninstall',
+  ] as const;
+  input.ipcMain.handle(channels[0], getSnapshot);
+  input.ipcMain.handle(channels[1], (_event, value: unknown) => enable(value));
+  input.ipcMain.handle(channels[2], createConnectionCode);
+  input.ipcMain.handle(channels[3], disable);
+  input.ipcMain.handle(channels[4], (_event, value: unknown) => uninstall(value));
+
+  return {
+    async close() {
+      for (const channel of channels) input.ipcMain.removeHandler(channel);
+      await input.operator.close();
+      await mutation;
+    },
+  };
+}
+
+function supported(directPeerAvailable: boolean): boolean {
+  return directPeerAvailable && (process.platform === 'darwin' || process.platform === 'linux');
+}
+
+function unsupportedSnapshot(): Extract<
+  DesktopLocalRuntimeHostRemoteAccessSnapshot,
+  { state: 'unsupported' }
+> {
+  return {
+    state: 'unsupported',
+    message:
+      process.platform === 'darwin' || process.platform === 'linux'
+        ? 'This Desktop build does not include Direct peer support'
+        : 'Remote access to this computer currently requires macOS or Linux',
+  };
+}
+
+function requireEnableInput(value: unknown): {
+  readonly allowInterruptActiveTasks: boolean;
+  readonly coordinationRelays: readonly string[];
+} {
+  if (!isRecord(value) || typeof value.allowInterruptActiveTasks !== 'boolean') {
+    throw new Error('Local Runtime Host remote-access request is invalid');
+  }
+  return {
+    allowInterruptActiveTasks: value.allowInterruptActiveTasks,
+    coordinationRelays: requireAddresses(value.coordinationRelays),
+  };
+}
+
+async function readPeer(
+  operator: DesktopRuntimeHostLocalOperator,
+  receipt: LocalServiceReceipt,
+): Promise<LocalPeerDescriptor | undefined> {
+  const response = await operator.runPeer({
+    operatorPath: receipt.operatorPath,
+    action: 'status',
+    target: receipt,
+  });
+  if (response.kind === 'error') throw new Error(response.error.message);
+  return response.status.state === 'enabled' ? requireEnabledPeer(response.status) : undefined;
+}
+
+function requireEnabledPeer(value: unknown): LocalPeerDescriptor {
+  if (!isRecord(value) || value.state !== 'enabled') {
+    throw new Error('Runtime Host Direct peer is not enabled');
+  }
+  if (typeof value.peerId !== 'string' || value.peerId.length === 0 || value.peerId.length > 160) {
+    throw new Error('Runtime Host returned an invalid peer identity');
+  }
+  return {
+    peerId: value.peerId,
+    routeHints: requireAddresses(value.routeHints),
+    coordinationRelays: requireAddresses(value.coordinationRelays),
+  };
+}
+
+function onSnapshot(peer: LocalPeerDescriptor): Extract<
+  DesktopLocalRuntimeHostRemoteAccessSnapshot,
+  { state: 'on' }
+> {
+  return { state: 'on', ...peer };
+}
+
+function enabledResult(
+  peer: LocalPeerDescriptor,
+  connectionCode: string,
+): Extract<DesktopLocalRuntimeHostRemoteAccessEnableResult, { kind: 'enabled' }> {
+  return { kind: 'enabled', connectionCode, snapshot: onSnapshot(peer) };
+}
+
+async function issueConnectionCode(
+  rootPath: string,
+  rootId: string,
+  peer: LocalPeerDescriptor,
+  client: DesktopRuntimeHostClient,
+): Promise<string> {
+  const prepared = await client.request('access.credential.prepare', {
+    principalKind: 'remote_owner',
+    principalId: `desktop-owner:${randomUUID()}`,
+    operationGrants: REMOTE_OWNER_OPERATION_GRANTS,
+    canPublishClientCapabilities: true,
+    canUseHostPaths: false,
+  });
+  const credential = await consumeAccessCredentialDelivery(
+    rootPath,
+    prepared.deliveryId,
+    prepared.credentialId,
+  );
+  return encodeRuntimeHostOwnerConnectionCode({
+    name: hostName(),
+    rootId,
+    transport: { kind: 'libp2p-direct', ...peer },
+    credential,
+  });
+}
+
+function localClient(manager: () => RuntimeHostDesktopManager | undefined): DesktopRuntimeHostClient {
+  const snapshot = requireManager(manager).current('local');
+  if (!snapshot?.candidate) throw new Error('The Local Runtime Host is reconnecting');
+  return snapshot.candidate.client;
+}
+
+function requireManager(
+  manager: () => RuntimeHostDesktopManager | undefined,
+): RuntimeHostDesktopManager {
+  const current = manager();
+  if (!current) throw new Error('Runtime Host manager is unavailable');
+  return current;
+}
+
+function hostName(): string {
+  return hostname().trim().slice(0, 128) || 'Remote computer';
+}
+
+async function requireStoredReceipt(path: string, rootPath: string): Promise<LocalServiceReceipt> {
+  const receipt = await readReceipt(path, rootPath);
+  if (!receipt) throw new Error('Remote access has not been set up on this computer');
+  return receipt;
+}
+
+async function readReceipt(path: string, rootPath: string): Promise<LocalServiceReceipt | undefined> {
+  try {
+    return requireReceipt(JSON.parse(await readFile(path, 'utf8')) as unknown, rootPath);
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) return undefined;
+    throw error;
+  }
+}
+
+function requireReceipt(value: unknown, rootPath: string): LocalServiceReceipt {
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== 1 ||
+    typeof value.serviceId !== 'string' ||
+    !SERVICE_ID_PATTERN.test(value.serviceId) ||
+    typeof value.rootId !== 'string' ||
+    !ROOT_ID_PATTERN.test(value.rootId) ||
+    value.rootPath !== rootPath ||
+    typeof value.operatorPath !== 'string' ||
+    !isAbsolute(value.operatorPath)
+  ) {
+    throw new Error('Local Runtime Host service receipt is invalid');
+  }
+  return {
+    schemaVersion: 1,
+    serviceId: value.serviceId,
+    rootPath,
+    rootId: value.rootId,
+    operatorPath: value.operatorPath,
+  };
+}
+
+async function writeReceipt(path: string, receipt: LocalServiceReceipt): Promise<void> {
+  const temporaryPath = join(dirname(path), `.runtime-host-local-service-${randomUUID()}.tmp`);
+  const handle = await open(temporaryPath, 'wx', 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await rename(temporaryPath, path);
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+function requireAddresses(value: unknown): readonly string[] {
+  if (!Array.isArray(value) || value.length > ADDRESS_MAX_COUNT) {
+    throw new Error('Runtime Host peer routes are invalid');
+  }
+  return value.map((entry) => {
+    if (
+      typeof entry !== 'string' ||
+      !entry.startsWith('/') ||
+      Buffer.byteLength(entry, 'utf8') > ADDRESS_MAX_BYTES ||
+      /[\s\u0000-\u001f\u007f]/u.test(entry)
+    ) {
+      throw new Error('Runtime Host peer route is invalid');
+    }
+    return entry;
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && error.code === code;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}

--- a/apps/desktop/src/main/runtime-host-profile-service.ts
+++ b/apps/desktop/src/main/runtime-host-profile-service.ts
@@ -23,6 +23,7 @@ import { dirname, join } from "node:path";
 import {
   createClientRuntimeHostCredentialStore,
   createClientRuntimeHostProfileCatalog,
+  decodeRuntimeHostOwnerConnectionCode,
   LOCAL_RUNTIME_HOST_PROFILE,
   RUNTIME_HOST_ACCESS_CREDENTIAL_MAX_BYTES,
   RuntimeHostOperationError,
@@ -93,6 +94,7 @@ export interface DesktopRuntimeHostProfileService {
       readonly managedService?: DesktopRuntimeHostManagedService;
     },
   ): Promise<{ readonly profileId: string }>;
+  importConnectionCode(code: string): Promise<{ readonly profileId: string }>;
   resolveManagedService(
     profileId: string,
   ): Promise<DesktopRuntimeHostManagedServiceBinding | undefined>;
@@ -652,6 +654,56 @@ export function createDesktopRuntimeHostProfileService(input: {
       }
     });
 
+  const addAndEnableVerified = (
+    value: DesktopRuntimeHostProfileAddInput & {
+      readonly credential: string;
+      readonly managedService?: DesktopRuntimeHostManagedService;
+    },
+  ): Promise<{ readonly profileId: string }> => {
+    requireSaveInput(value);
+    return mutateProfiles(async () => {
+      const currentDocument = await catalog.read();
+      const existing = currentDocument.profiles.find((profile) =>
+        profile.rootId === value.profile.rootId &&
+        sameRemoteRuntimeHostProfileTarget(profile, value.profile),
+      );
+      const previousTarget = existing ? await catalog.resolve(existing.id) : undefined;
+      const profile = existing ? { ...value.profile, id: existing.id } : value.profile;
+      const target = { profile, credential: value.credential } as const;
+      const intent = createDesktopRuntimeHostPairingIntent({
+        target,
+        ...(previousTarget ? { previous: previousTarget } : {}),
+        wasEnabled:
+          previousTarget !== undefined &&
+          preferences.enabledRemoteProfileIds.includes(previousTarget.profile.id),
+      });
+      await beginPairingIntent(intent);
+      try {
+        if (value.managedService) {
+          await managedServices.save(profile, value.managedService);
+        }
+        if (previousTarget) {
+          const rebound = await catalog.rebindIfCurrent(
+            previousTarget,
+            profile,
+            value.credential,
+          );
+          if (!rebound.rebound) {
+            throw new Error("Runtime Host profile changed before it could be updated");
+          }
+        } else {
+          await catalog.create(profile, value.credential);
+        }
+        await finishPairingIntent(intent);
+        return { profileId: profile.id };
+      } catch (failure) {
+        if (failure instanceof RuntimeHostPairingFinalizationInterruptedError) throw failure;
+        await rollbackPairingIntent(intent, failure);
+        throw failure;
+      }
+    });
+  };
+
   return {
     getSnapshot: () => mutate(snapshot),
     addAndEnable(value) {
@@ -676,48 +728,18 @@ export function createDesktopRuntimeHostProfileService(input: {
           : { kind: "connected", snapshot: await snapshot() };
       });
     },
-    addAndEnableVerified(value) {
-      requireSaveInput(value);
-      return mutateProfiles(async () => {
-        const currentDocument = await catalog.read();
-        const existing = currentDocument.profiles.find((profile) =>
-          profile.rootId === value.profile.rootId &&
-          sameRemoteRuntimeHostProfileTarget(profile, value.profile),
-        );
-        const previousTarget = existing ? await catalog.resolve(existing.id) : undefined;
-        const profile = existing ? { ...value.profile, id: existing.id } : value.profile;
-        const target = { profile, credential: value.credential } as const;
-        const intent = createDesktopRuntimeHostPairingIntent({
-          target,
-          ...(previousTarget ? { previous: previousTarget } : {}),
-          wasEnabled:
-            previousTarget !== undefined &&
-            preferences.enabledRemoteProfileIds.includes(previousTarget.profile.id),
-        });
-        await beginPairingIntent(intent);
-        try {
-          if (value.managedService) {
-            await managedServices.save(profile, value.managedService);
-          }
-          if (previousTarget) {
-            const rebound = await catalog.rebindIfCurrent(
-              previousTarget,
-              profile,
-              value.credential,
-            );
-            if (!rebound.rebound) {
-              throw new Error("Runtime Host profile changed before it could be updated");
-            }
-          } else {
-            await catalog.create(profile, value.credential);
-          }
-          await finishPairingIntent(intent);
-          return { profileId: profile.id };
-        } catch (failure) {
-          if (failure instanceof RuntimeHostPairingFinalizationInterruptedError) throw failure;
-          await rollbackPairingIntent(intent, failure);
-          throw failure;
-        }
+    addAndEnableVerified,
+    importConnectionCode(code) {
+      const decoded = decodeRuntimeHostOwnerConnectionCode(code);
+      return addAndEnableVerified({
+        profile: {
+          id: `remote-${randomUUID()}`,
+          name: decoded.name,
+          kind: 'remote',
+          rootId: decoded.rootId,
+          transport: decoded.transport,
+        },
+        credential: decoded.credential,
       });
     },
     rotateManagedCredential(expected, credential) {
@@ -1200,6 +1222,7 @@ export function registerDesktopRuntimeHostProfileIpc(
   const channels = [
     "runtime-host-profiles:getSnapshot",
     "runtime-host-profiles:add-and-enable",
+    "runtime-host-profiles:import-connection-code",
     "runtime-host-profiles:set-enabled",
     "runtime-host-profiles:set-default",
     "runtime-host-profiles:remove",
@@ -1209,12 +1232,13 @@ export function registerDesktopRuntimeHostProfileIpc(
   ipcMain.handle(channels[1], (_event, value: DesktopRuntimeHostProfileAddInput) =>
     service.addAndEnable(value),
   );
-  ipcMain.handle(channels[2], (_event, profileId: string, enabled: boolean) =>
+  ipcMain.handle(channels[2], (_event, code: string) => service.importConnectionCode(code));
+  ipcMain.handle(channels[3], (_event, profileId: string, enabled: boolean) =>
     service.setEnabled(profileId, enabled),
   );
-  ipcMain.handle(channels[3], (_event, profileId: string) => service.setDefault(profileId));
-  ipcMain.handle(channels[4], (_event, profileId: string) => service.remove(profileId));
-  ipcMain.handle(channels[5], () => service.resolvePairingRecovery());
+  ipcMain.handle(channels[4], (_event, profileId: string) => service.setDefault(profileId));
+  ipcMain.handle(channels[5], (_event, profileId: string) => service.remove(profileId));
+  ipcMain.handle(channels[6], () => service.resolvePairingRecovery());
   return () => {
     for (const channel of channels) ipcMain.removeHandler(channel);
   };

--- a/apps/desktop/src/main/runtime-host-ssh-terminal.ts
+++ b/apps/desktop/src/main/runtime-host-ssh-terminal.ts
@@ -60,6 +60,7 @@ import type {
   DesktopRuntimeHostSshTerminalEvent,
   DesktopRuntimeHostSshTerminalSnapshot,
 } from '../preload/bridge-contract.js';
+import { createRuntimeHostFramedOutputFilter } from './runtime-host-framed-output.js';
 
 interface ActiveTerminal {
   readonly sessionId: string;
@@ -497,7 +498,7 @@ export function createDesktopRuntimeHostSshTerminal(input: {
     let failure: Error | undefined;
     let activeTerminal: ActiveTerminal | undefined;
     let receivedProgress = false;
-    const filter = createFramedOutputFilter({
+    const filter = createRuntimeHostFramedOutputFilter({
       prefix: options.prefix,
       pendingMaxBytes: options.pendingMaxBytes,
       decode: options.decode,
@@ -592,7 +593,7 @@ export function createDesktopRuntimeHostSshTerminal(input: {
         let complete: RuntimeHostSetupCompleteFrame | undefined;
         let setupFailure: Error | undefined;
         let setupTerminal: ActiveTerminal | undefined;
-        const filter = createFramedOutputFilter({
+        const filter = createRuntimeHostFramedOutputFilter({
           prefix: RUNTIME_HOST_SETUP_FRAME_PREFIX,
           pendingMaxBytes: SETUP_FRAME_PENDING_MAX,
           decode: decodeRuntimeHostSetupFrame,
@@ -830,83 +831,6 @@ function cancellableUntilComplete(signal: AbortSignal | undefined): {
     },
     close,
   };
-}
-
-function createFramedOutputFilter<Frame>(input: {
-  readonly prefix: string;
-  readonly pendingMaxBytes: number;
-  readonly decode: (line: string) => Frame | undefined;
-  readonly label: string;
-  readonly onFrame: (frame: Frame) => void;
-  readonly onError: (error: Error) => void;
-}): { push(data: string): string; finish(): string } {
-  let pending = '';
-  let discardReservedLine = false;
-  const drain = (finished: boolean): string => {
-    let visible = '';
-    while (pending) {
-      if (discardReservedLine) {
-        const newline = pending.indexOf('\n');
-        if (newline < 0) {
-          pending = '';
-          break;
-        }
-        pending = pending.slice(newline + 1);
-        discardReservedLine = false;
-        continue;
-      }
-      const marker = pending.indexOf(input.prefix);
-      if (marker >= 0) {
-        visible += pending.slice(0, marker);
-        pending = pending.slice(marker);
-        const newline = pending.indexOf('\n');
-        if (newline < 0) {
-          if (finished) {
-            input.onError(new Error(`${input.label} returned an incomplete result`));
-            pending = '';
-          } else if (pending.length > input.pendingMaxBytes) {
-            input.onError(new Error(`${input.label} returned an oversized result`));
-            pending = '';
-            discardReservedLine = true;
-          }
-          break;
-        }
-        const line = pending.slice(0, newline + 1);
-        pending = pending.slice(newline + 1);
-        const frame = input.decode(line);
-        if (frame) input.onFrame(frame);
-        else input.onError(new Error(`${input.label} returned an invalid result`));
-        continue;
-      }
-      if (finished) {
-        visible += pending;
-        pending = '';
-        break;
-      }
-      const retained = markerSuffixLength(pending, input.prefix);
-      visible += pending.slice(0, pending.length - retained);
-      pending = pending.slice(pending.length - retained);
-      break;
-    }
-    return visible;
-  };
-  return {
-    push(data) {
-      pending += data;
-      return drain(false);
-    },
-    finish() {
-      return drain(true);
-    },
-  };
-}
-
-function markerSuffixLength(value: string, prefix: string): number {
-  const limit = Math.min(value.length, prefix.length - 1);
-  for (let length = limit; length > 0; length -= 1) {
-    if (prefix.startsWith(value.slice(-length))) return length;
-  }
-  return 0;
 }
 
 interface PreparedSetupPackage {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -381,6 +381,25 @@ export interface DesktopRuntimeHostProfileChangedEvent {
   readonly removed?: boolean;
 }
 
+export type DesktopLocalRuntimeHostRemoteAccessSnapshot =
+  | { readonly state: 'unsupported'; readonly message: string }
+  | { readonly state: 'off'; readonly managedService?: true }
+  | {
+      readonly state: 'on';
+      readonly peerId: string;
+      readonly routeHints: readonly string[];
+      readonly coordinationRelays: readonly string[];
+    }
+  | { readonly state: 'unavailable'; readonly message: string };
+
+export type DesktopLocalRuntimeHostRemoteAccessEnableResult =
+  | { readonly kind: 'active_tasks' }
+  | {
+      readonly kind: 'enabled';
+      readonly connectionCode: string;
+      readonly snapshot: Extract<DesktopLocalRuntimeHostRemoteAccessSnapshot, { state: 'on' }>;
+    };
+
 export type DesktopRuntimeHostSshTerminalEvent =
   | { readonly kind: 'opened'; readonly revision: number; readonly sessionId: string }
   | { readonly kind: 'data'; readonly revision: number; readonly sessionId: string; readonly data: string }
@@ -612,6 +631,7 @@ export interface MakaBridge {
     addAndEnable(
       input: DesktopRuntimeHostProfileAddInput,
     ): Promise<DesktopRuntimeHostProfileAddResult>;
+    importConnectionCode(code: string): Promise<{ readonly profileId: string }>;
     remove(profileId: string): Promise<DesktopRuntimeHostProfileSnapshot>;
     setEnabled(profileId: string, enabled: boolean): Promise<DesktopRuntimeHostProfileSnapshot>;
     setDefault(profileId: string): Promise<DesktopRuntimeHostProfileSnapshot>;
@@ -619,6 +639,19 @@ export interface MakaBridge {
     subscribeChanges(
       handler: (event: DesktopRuntimeHostProfileChangedEvent) => void,
     ): () => void;
+  };
+
+  localRuntimeHostRemoteAccess: {
+    getSnapshot(): Promise<DesktopLocalRuntimeHostRemoteAccessSnapshot>;
+    enable(input: {
+      readonly allowInterruptActiveTasks: boolean;
+      readonly coordinationRelays: readonly string[];
+    }): Promise<DesktopLocalRuntimeHostRemoteAccessEnableResult>;
+    createConnectionCode(): Promise<string>;
+    disable(): Promise<DesktopLocalRuntimeHostRemoteAccessSnapshot>;
+    uninstall(input: {
+      readonly allowInterruptActiveTasks: boolean;
+    }): Promise<{ readonly kind: 'active_tasks' | 'uninstalled' }>;
   };
 
   runtimeHostSshTerminal: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1176,6 +1176,9 @@ const makaBridge = {
     addAndEnable(input: DesktopRuntimeHostProfileAddInput) {
       return ipcRenderer.invoke('runtime-host-profiles:add-and-enable', input);
     },
+    importConnectionCode(code: string) {
+      return ipcRenderer.invoke('runtime-host-profiles:import-connection-code', code);
+    },
     remove(profileId: string) {
       return ipcRenderer.invoke('runtime-host-profiles:remove', profileId);
     },
@@ -1197,6 +1200,28 @@ const makaBridge = {
       };
       ipcRenderer.on('runtime-host-profiles:changed', listener);
       return () => ipcRenderer.off('runtime-host-profiles:changed', listener);
+    },
+  },
+  localRuntimeHostRemoteAccess: {
+    getSnapshot() {
+      return ipcRenderer.invoke('local-runtime-host-remote-access:get-snapshot');
+    },
+    enable(input: {
+      readonly allowInterruptActiveTasks: boolean;
+      readonly coordinationRelays: readonly string[];
+    }) {
+      return ipcRenderer.invoke('local-runtime-host-remote-access:enable', input);
+    },
+    createConnectionCode() {
+      return ipcRenderer.invoke(
+        'local-runtime-host-remote-access:create-connection-code',
+      );
+    },
+    disable() {
+      return ipcRenderer.invoke('local-runtime-host-remote-access:disable');
+    },
+    uninstall(input: { readonly allowInterruptActiveTasks: boolean }) {
+      return ipcRenderer.invoke('local-runtime-host-remote-access:uninstall', input);
     },
   },
   runtimeHostSshTerminal: {

--- a/apps/desktop/src/renderer/locales/settings-projects-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-projects-copy.ts
@@ -28,7 +28,33 @@ export type SettingsProjectsCopy = {
     remoteTitle: string;
     remoteDescription: string;
     addComputer: string;
+    useConnectionCode: string;
     configureManually: string;
+    thisComputerRemoteAccess: string;
+    thisComputerRemoteAccessHelp: string;
+    remoteAccessOn: string;
+    remoteAccessOff: string;
+    enableRemoteAccess: string;
+    disableRemoteAccess: string;
+    uninstallLocalService: string;
+    uninstallLocalServiceConfirm: string;
+    uninstallLocalServiceDescription: string;
+    uninstallLocalServiceDone: string;
+    createConnectionCode: string;
+    connectionCodeTitle: string;
+    connectionCodeDescription: string;
+    importConnectionCodeTitle: string;
+    importConnectionCodeDescription: string;
+    connectionCode: string;
+    copyConnectionCode: string;
+    connectionCodeCopied: string;
+    connectWithCode: string;
+    remoteAccessActiveTasks: string;
+    remoteAccessActiveTasksDescription: string;
+    uninstallActiveTasksDescription: string;
+    interruptAndEnable: string;
+    interruptAndUninstall: string;
+    remoteAccessFailed: string;
     setupTitle: string;
     setupDescription: string;
     setupName: string;
@@ -251,7 +277,33 @@ const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
       remoteTitle: '远程 Host',
       remoteDescription: '通过 SSH 自动设置一台电脑，或手动连接已有 Runtime Host。',
       addComputer: '添加电脑',
+      useConnectionCode: '使用连接码',
       configureManually: '手动配置',
+      thisComputerRemoteAccess: '远程访问',
+      thisComputerRemoteAccessHelp: '让其他 Maka Desktop 通过实验性 Direct peer 连接此 Host',
+      remoteAccessOn: '已开启',
+      remoteAccessOff: '未开启',
+      enableRemoteAccess: '开启',
+      disableRemoteAccess: '关闭',
+      uninstallLocalService: '移除后台服务',
+      uninstallLocalServiceConfirm: '移除 Runtime Host 后台服务？',
+      uninstallLocalServiceDescription: '数据会保留，Local Host 将恢复为仅在 Maka Desktop 运行时启动。',
+      uninstallLocalServiceDone: '后台服务已移除',
+      createConnectionCode: '新建连接码',
+      connectionCodeTitle: '连接这台电脑',
+      connectionCodeDescription: '在另一台 Maka Desktop 中粘贴此一次性连接码',
+      importConnectionCodeTitle: '使用连接码',
+      importConnectionCodeDescription: '粘贴另一台 Maka Desktop 生成的连接码',
+      connectionCode: '连接码',
+      copyConnectionCode: '复制连接码',
+      connectionCodeCopied: '连接码已复制',
+      connectWithCode: '连接',
+      remoteAccessActiveTasks: '这台电脑仍有正在运行的任务',
+      remoteAccessActiveTasksDescription: '开启远程访问需要把 Local Host 交给系统服务。是否中断当前任务并继续？',
+      uninstallActiveTasksDescription: '移除后台服务会停止当前任务。是否中断这些任务并继续？',
+      interruptAndEnable: '中断任务并开启',
+      interruptAndUninstall: '中断任务并移除',
+      remoteAccessFailed: '远程访问操作失败',
       setupTitle: '添加远程电脑',
       setupDescription: '通过 SSH 安装并连接 Runtime Host',
       setupName: '显示名称（可选）',
@@ -495,7 +547,33 @@ const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
       remoteDescription:
         'Set up a computer over SSH, or connect an existing Runtime Host manually.',
       addComputer: 'Add computer',
+      useConnectionCode: 'Use connection code',
       configureManually: 'Configure manually',
+      thisComputerRemoteAccess: 'Remote access',
+      thisComputerRemoteAccessHelp: 'Let another Maka Desktop reach this Host through experimental Direct peer',
+      remoteAccessOn: 'On',
+      remoteAccessOff: 'Off',
+      enableRemoteAccess: 'Enable',
+      disableRemoteAccess: 'Turn off',
+      uninstallLocalService: 'Remove background service',
+      uninstallLocalServiceConfirm: 'Remove the Runtime Host background service?',
+      uninstallLocalServiceDescription: 'Data is retained. The Local Host will return to running only while Maka Desktop is open.',
+      uninstallLocalServiceDone: 'Background service removed',
+      createConnectionCode: 'New connection code',
+      connectionCodeTitle: 'Connect to this computer',
+      connectionCodeDescription: 'Paste this one-time connection code into another Maka Desktop',
+      importConnectionCodeTitle: 'Use a connection code',
+      importConnectionCodeDescription: 'Paste a connection code created by another Maka Desktop',
+      connectionCode: 'Connection code',
+      copyConnectionCode: 'Copy connection code',
+      connectionCodeCopied: 'Connection code copied',
+      connectWithCode: 'Connect',
+      remoteAccessActiveTasks: 'This computer still has running tasks',
+      remoteAccessActiveTasksDescription: 'Enabling remote access hands the Local Host to a system service. Interrupt the current tasks and continue?',
+      uninstallActiveTasksDescription: 'Removing the background service stops the current tasks. Interrupt them and continue?',
+      interruptAndEnable: 'Interrupt and enable',
+      interruptAndUninstall: 'Interrupt and remove',
+      remoteAccessFailed: 'Remote access failed',
       setupTitle: 'Add remote computer',
       setupDescription: 'Install and connect Runtime Host over SSH',
       setupName: 'Display name (optional)',

--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -77,6 +77,7 @@ export function ProjectsSettingsPage(props: {
   ): Promise<UpdateAppSettingsResult>;
   onRetryRuntimeHost(): Promise<void>;
   onRemoteHostAdded(profileId: string): void;
+  onLocalConnectionCode(connectionCode: string): void;
 }) {
   const host = useOptionalRuntimeHostSettingsTarget();
   const locale = useUiLocale();
@@ -203,7 +204,10 @@ export function ProjectsSettingsPage(props: {
   if (!host) {
     return (
       <SettingsPage as="section" aria-label={copy.section}>
-        <RuntimeHostProfilesSection onRemoteHostAdded={props.onRemoteHostAdded} />
+        <RuntimeHostProfilesSection
+          onRemoteHostAdded={props.onRemoteHostAdded}
+          onLocalConnectionCode={props.onLocalConnectionCode}
+        />
         {props.runtimeHostStatus !== 'loading' ? (
           <Banner
             status={props.runtimeHostStatus === 'error' ? 'error' : 'warning'}
@@ -228,7 +232,10 @@ export function ProjectsSettingsPage(props: {
   }
   return (
     <SettingsPage as="section" aria-label={copy.section}>
-      <RuntimeHostProfilesSection onRemoteHostAdded={props.onRemoteHostAdded} />
+      <RuntimeHostProfilesSection
+        onRemoteHostAdded={props.onRemoteHostAdded}
+        onLocalConnectionCode={props.onLocalConnectionCode}
+      />
       {props.runtimeHostStatus === 'error' ? (
         <Banner
           status="error"

--- a/apps/desktop/src/renderer/settings/runtime-host-connection-code-dialog.tsx
+++ b/apps/desktop/src/renderer/settings/runtime-host-connection-code-dialog.tsx
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogHeader } from '@astryxdesign/core/Dialog';
+import { Layout, LayoutContent, LayoutFooter } from '@astryxdesign/core/Layout';
+import { Button, FormLayout, TextArea, useToast, useUiLocale } from '@maka/ui';
+import { getSettingsProjectsCopy } from '../locales/settings-projects-copy.js';
+import { settingsActionErrorMessage } from './settings-error-copy.js';
+
+export function RuntimeHostConnectionCodeDialog(props: {
+  readonly isOpen: boolean;
+  readonly mode: 'share' | 'import';
+  readonly connectionCode?: string;
+  readonly onClose: () => void;
+  readonly onImported?: (profileId: string) => void;
+}) {
+  const locale = useUiLocale();
+  const copy = getSettingsProjectsCopy(locale).runtimeHost;
+  const toast = useToast();
+  const [draft, setDraft] = useState('');
+  const [working, setWorking] = useState(false);
+
+  useEffect(() => {
+    if (!props.isOpen) setDraft('');
+  }, [props.isOpen]);
+
+  const value = props.mode === 'share' ? props.connectionCode ?? '' : draft;
+
+  async function copyCode(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(copy.connectionCodeCopied);
+    } catch (error) {
+      toast.error(copy.remoteAccessFailed, settingsActionErrorMessage(error, locale));
+    }
+  }
+
+  async function connect(): Promise<void> {
+    setWorking(true);
+    try {
+      const result = await window.maka.runtimeHostProfiles.importConnectionCode(draft.trim());
+      props.onImported?.(result.profileId);
+      props.onClose();
+    } catch (error) {
+      toast.error(copy.remoteAccessFailed, settingsActionErrorMessage(error, locale));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <Dialog
+      isOpen={props.isOpen}
+      onOpenChange={(open) => {
+        if (!open && !working) props.onClose();
+      }}
+      purpose="form"
+      width={520}
+    >
+      <Layout
+        header={(
+          <DialogHeader
+            title={
+              props.mode === 'share'
+                ? copy.connectionCodeTitle
+                : copy.importConnectionCodeTitle
+            }
+            subtitle={
+              props.mode === 'share'
+                ? copy.connectionCodeDescription
+                : copy.importConnectionCodeDescription
+            }
+            onOpenChange={(open) => {
+              if (!open && !working) props.onClose();
+            }}
+          />
+        )}
+        content={(
+          <LayoutContent padding={4}>
+            <FormLayout>
+              <TextArea
+                label={copy.connectionCode}
+                value={value}
+                rows={6}
+                hasSpellCheck={false}
+                isDisabled={working}
+                isReadOnly={props.mode === 'share'}
+                onChange={props.mode === 'import' ? setDraft : () => undefined}
+              />
+            </FormLayout>
+          </LayoutContent>
+        )}
+        footer={(
+          <LayoutFooter>
+            <Button
+              variant="secondary"
+              label={copy.cancel}
+              isDisabled={working}
+              onClick={props.onClose}
+            />
+            <Button
+              variant="primary"
+              label={
+                props.mode === 'share' ? copy.copyConnectionCode : copy.connectWithCode
+              }
+              isDisabled={working || value.trim().length === 0}
+              onClick={() => void (props.mode === 'share' ? copyCode() : connect())}
+            />
+          </LayoutFooter>
+        )}
+      />
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/renderer/settings/runtime-host-profiles-section.tsx
+++ b/apps/desktop/src/renderer/settings/runtime-host-profiles-section.tsx
@@ -28,6 +28,9 @@ import {
   Switch,
 } from "@astryxdesign/core";
 import type {
+  DesktopLocalRuntimeHostRemoteAccessSnapshot,
+} from '../../preload/bridge-contract.js';
+import type {
   RemoteRuntimeHostProfile,
   RuntimeHostRemoteTransport,
 } from "@maka/runtime-host/client";
@@ -49,6 +52,7 @@ import { settingsActionErrorMessage } from "./settings-error-copy.js";
 import { SettingsField, SettingsRow, SettingsSection } from "./settings-section.js";
 import { RuntimeHostOnboardingDialog } from './runtime-host-onboarding-dialog.js';
 import { RuntimeHostManagementDialog } from './runtime-host-management-dialog.js';
+import { RuntimeHostConnectionCodeDialog } from './runtime-host-connection-code-dialog.js';
 
 type RemoteTransportKind = RuntimeHostRemoteTransport["kind"];
 
@@ -70,6 +74,7 @@ function createRemoteHostDraft() {
 
 export function RuntimeHostProfilesSection(props: {
   readonly onRemoteHostAdded: (profileId: string) => void;
+  readonly onLocalConnectionCode: (connectionCode: string) => void;
 }) {
   const locale = useUiLocale();
   const copy = getSettingsProjectsCopy(locale).runtimeHost;
@@ -81,12 +86,20 @@ export function RuntimeHostProfilesSection(props: {
   const [showAdd, setShowAdd] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [managedProfile, setManagedProfile] = useState<RemoteRuntimeHostProfile>();
+  const [localAccess, setLocalAccess] = useState<DesktopLocalRuntimeHostRemoteAccessSnapshot>();
+  const [showConnectionCodeImport, setShowConnectionCodeImport] = useState(false);
   const [switching, setSwitching] = useState(false);
   const [draft, setDraft] = useState(createRemoteHostDraft);
 
   const reload = useCallback(async () => {
-    const next = await window.maka.runtimeHostProfiles.getSnapshot();
-    if (mountedRef.current) setSnapshot(next);
+    const [next, nextLocalAccess] = await Promise.all([
+      window.maka.runtimeHostProfiles.getSnapshot(),
+      window.maka.localRuntimeHostRemoteAccess.getSnapshot(),
+    ]);
+    if (mountedRef.current) {
+      setSnapshot(next);
+      setLocalAccess(nextLocalAccess);
+    }
   }, [mountedRef]);
 
   useEffect(() => {
@@ -228,6 +241,108 @@ export function RuntimeHostProfilesSection(props: {
     }
   }
 
+  async function enableLocalRemoteAccess(allowInterruptActiveTasks = false): Promise<void> {
+    setSwitching(true);
+    try {
+      const result = await window.maka.localRuntimeHostRemoteAccess.enable({
+        allowInterruptActiveTasks,
+        coordinationRelays: [],
+      });
+      if (result.kind === 'enabled') {
+        props.onLocalConnectionCode(result.connectionCode);
+      }
+      if (!mountedRef.current) return;
+      if (result.kind === 'active_tasks') {
+        const confirmed = await toast.confirm({
+          title: copy.remoteAccessActiveTasks,
+          description: copy.remoteAccessActiveTasksDescription,
+          confirmLabel: copy.interruptAndEnable,
+          cancelLabel: copy.cancel,
+          destructive: true,
+        });
+        if (confirmed) await enableLocalRemoteAccess(true);
+        return;
+      }
+      setLocalAccess(result.snapshot);
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(
+          copy.remoteAccessFailed,
+          settingsActionErrorMessage(error, locale),
+        );
+      }
+    } finally {
+      if (mountedRef.current) setSwitching(false);
+    }
+  }
+
+  async function createLocalConnectionCode(): Promise<void> {
+    setSwitching(true);
+    try {
+      const code = await window.maka.localRuntimeHostRemoteAccess.createConnectionCode();
+      if (mountedRef.current) props.onLocalConnectionCode(code);
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(copy.remoteAccessFailed, settingsActionErrorMessage(error, locale));
+      }
+    } finally {
+      if (mountedRef.current) setSwitching(false);
+    }
+  }
+
+  async function disableLocalRemoteAccess(): Promise<void> {
+    setSwitching(true);
+    try {
+      const next = await window.maka.localRuntimeHostRemoteAccess.disable();
+      if (mountedRef.current) setLocalAccess(next);
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(copy.remoteAccessFailed, settingsActionErrorMessage(error, locale));
+      }
+    } finally {
+      if (mountedRef.current) setSwitching(false);
+    }
+  }
+
+  async function uninstallLocalService(allowInterruptActiveTasks = false): Promise<void> {
+    if (!allowInterruptActiveTasks) {
+      const confirmed = await toast.confirm({
+        title: copy.uninstallLocalServiceConfirm,
+        description: copy.uninstallLocalServiceDescription,
+        confirmLabel: copy.uninstallLocalService,
+        cancelLabel: copy.cancel,
+        destructive: true,
+      });
+      if (!confirmed) return;
+    }
+    setSwitching(true);
+    try {
+      const result = await window.maka.localRuntimeHostRemoteAccess.uninstall({
+        allowInterruptActiveTasks,
+      });
+      if (!mountedRef.current) return;
+      if (result.kind === 'active_tasks') {
+        const confirmed = await toast.confirm({
+          title: copy.remoteAccessActiveTasks,
+          description: copy.uninstallActiveTasksDescription,
+          confirmLabel: copy.interruptAndUninstall,
+          cancelLabel: copy.cancel,
+          destructive: true,
+        });
+        if (confirmed) await uninstallLocalService(true);
+        return;
+      }
+      setLocalAccess({ state: 'off' });
+      toast.success(copy.uninstallLocalServiceDone);
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(copy.remoteAccessFailed, settingsActionErrorMessage(error, locale));
+      }
+    } finally {
+      if (mountedRef.current) setSwitching(false);
+    }
+  }
+
   const remoteEntries = snapshot?.entries.filter((entry) => entry.profile.kind === "remote") ?? [];
   const profileOptions = (snapshot?.entries ?? [])
     .filter((entry) => entry.enabled)
@@ -253,6 +368,75 @@ export function RuntimeHostProfilesSection(props: {
             />
           </HStack>}
         />
+        <SettingsRow
+          label={copy.thisComputerRemoteAccess}
+          description={
+            localAccess?.state === 'unsupported'
+              ? localAccess.message
+              : localAccess?.state === 'unavailable'
+                ? localAccess.message
+                : copy.thisComputerRemoteAccessHelp
+          }
+          end={(
+            <HStack gap={2} align="center">
+              <Badge
+                variant="neutral"
+                label={localAccess?.state === 'on' ? copy.remoteAccessOn : copy.remoteAccessOff}
+              />
+              {localAccess?.state === 'on' ? (
+                <MoreMenu
+                  label={copy.thisComputerRemoteAccess}
+                  size="sm"
+                  items={[
+                    {
+                      label: copy.createConnectionCode,
+                      isDisabled: switching,
+                      onClick: () => void createLocalConnectionCode(),
+                    },
+                    {
+                      label: copy.disableRemoteAccess,
+                      isDisabled: switching,
+                      onClick: () => void disableLocalRemoteAccess(),
+                    },
+                    {
+                      label: copy.uninstallLocalService,
+                      isDisabled: switching,
+                      onClick: () => void uninstallLocalService(),
+                    },
+                  ]}
+                />
+              ) : (
+                <>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    label={copy.enableRemoteAccess}
+                    isDisabled={
+                      switching ||
+                      !localAccess ||
+                      localAccess.state === 'unsupported' ||
+                      localAccess.state === 'unavailable'
+                    }
+                    onClick={() => void enableLocalRemoteAccess()}
+                  />
+                  {localAccess?.state === 'off' && localAccess.managedService ? (
+                    <MoreMenu
+                      label={copy.thisComputerRemoteAccess}
+                      size="sm"
+                      items={[
+                        {
+                          label: copy.uninstallLocalService,
+                          isDisabled: switching,
+                          onClick: () => void uninstallLocalService(),
+                        },
+                      ]}
+                    />
+                  ) : null}
+                </>
+              )}
+            </HStack>
+          )}
+        />
       </SettingsSection>
 
       <SettingsSection
@@ -269,12 +453,21 @@ export function RuntimeHostProfilesSection(props: {
                 setShowOnboarding(true);
               }}
             />
-            <Button
-              variant="secondary"
+            <MoreMenu
+              label={copy.moreActions(copy.remoteTitle)}
               size="sm"
-              label={showAdd ? copy.cancel : copy.configureManually}
-              isDisabled={switching}
-              onClick={toggleAdd}
+              items={[
+                {
+                  label: copy.useConnectionCode,
+                  isDisabled: switching,
+                  onClick: () => setShowConnectionCodeImport(true),
+                },
+                {
+                  label: showAdd ? copy.cancel : copy.configureManually,
+                  isDisabled: switching,
+                  onClick: toggleAdd,
+                },
+              ]}
             />
           </HStack>
         }
@@ -459,6 +652,15 @@ export function RuntimeHostProfilesSection(props: {
         profile={managedProfile}
         onClose={() => {
           setManagedProfile(undefined);
+          void reload();
+        }}
+      />
+      <RuntimeHostConnectionCodeDialog
+        isOpen={showConnectionCodeImport}
+        mode="import"
+        onClose={() => setShowConnectionCodeImport(false)}
+        onImported={(profileId) => {
+          props.onRemoteHostAdded(profileId);
           void reload();
         }}
       />

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -99,6 +99,7 @@ import {
   projectClientOwnedSettings,
 } from '../../shared/settings-ownership.js';
 import { RuntimeHostSettingsTarget } from './runtime-host-settings-target.js';
+import { RuntimeHostConnectionCodeDialog } from './runtime-host-connection-code-dialog.js';
 import {
   beginSettingsResourceLoad,
   completeSettingsResourceLoad,
@@ -295,6 +296,7 @@ export function SettingsSurface(props: {
     initialRuntimeHostCatalog?.defaultProfileId,
   );
   const [usageStats, setUsageStats] = useState<UsageStats | null>(null);
+  const [localConnectionCode, setLocalConnectionCode] = useState<string>();
   const [clientLoading, setClientLoading] = useState(initialClientSettings === undefined);
   const settingsModalMountedRef = useMountedRef();
   const clientSettingsTicketRef = useRef(0);
@@ -992,6 +994,7 @@ export function SettingsSurface(props: {
                             archivedTasks={props.archivedTasks}
                             onTaskImported={props.onTaskImported}
                             onRemoteHostAdded={props.onRemoteHostAdded}
+                            onLocalConnectionCode={setLocalConnectionCode}
                             openProviderCatalog={providerCatalogRequested}
                             initialConnectionSlug={props.initialConnectionSlug}
                             initialCreateProviderType={createProviderRequest}
@@ -1011,6 +1014,12 @@ export function SettingsSurface(props: {
             />
           </section>
         )}
+      />
+      <RuntimeHostConnectionCodeDialog
+        isOpen={localConnectionCode !== undefined}
+        mode="share"
+        connectionCode={localConnectionCode}
+        onClose={() => setLocalConnectionCode(undefined)}
       />
     </div>
   );
@@ -1047,6 +1056,7 @@ function SettingsPageBody(props: {
   archivedTasks: ArchivedTasksBridge;
   onTaskImported(session: DesktopSessionSummary): void;
   onRemoteHostAdded(profileId: string): void;
+  onLocalConnectionCode(connectionCode: string): void;
   openProviderCatalog?: boolean;
   initialConnectionSlug?: string;
   initialCreateProviderType?: ProviderType;
@@ -1134,6 +1144,7 @@ function SettingsPageBody(props: {
           onUpdate={props.onUpdateSettings}
           onRetryRuntimeHost={props.onRetryRuntimeHost}
           onRemoteHostAdded={props.onRemoteHostAdded}
+          onLocalConnectionCode={props.onLocalConnectionCode}
         />
       );
     case 'appearance':

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -5,7 +5,7 @@ Each row is one on-disk product surface file. Regenerated inventory must stay in
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 214 files — blocker 0, polish 1, aligned 213.
+**Totals:** 215 files — blocker 0, polish 1, aligned 214.
 
 ## Exclusions (explicit)
 
@@ -98,6 +98,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/settings/provider-oauth-section.tsx` | settings-module | Banner, Button, HStack, Text, VStack | aligned — uses Astryx (Banner, Button, HStack, Text, VStack) | aligned |
 | `apps/desktop/src/renderer/settings/providers-panel.tsx` | settings-module | Badge, Banner, Button, EmptyState, HStack, Heading, List, ListItem, Text, VStack | aligned — uses Astryx (Badge, Banner, Button, EmptyState, HStack, Heading, List, ListItem) | aligned |
 | `apps/desktop/src/renderer/settings/request-customization-editor.tsx` | settings-module | Button, HStack, IconButton, Text, VStack | aligned — uses Astryx (Button, HStack, IconButton, Text, VStack) | aligned |
+| `apps/desktop/src/renderer/settings/runtime-host-connection-code-dialog.tsx` | settings-module | Button, Dialog, DialogHeader, Layout, LayoutContent | aligned — uses Astryx (Button, Dialog, DialogHeader, Layout, LayoutContent) | aligned |
 | `apps/desktop/src/renderer/settings/runtime-host-interaction-boundary.tsx` | settings-module | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/settings/runtime-host-management-dialog.tsx` | settings-module | Badge, Banner, Button, Dialog, DialogHeader, Layout, LayoutContent, Selector, Spinner, Text | aligned — uses Astryx (Badge, Banner, Button, Dialog, DialogHeader, Layout, LayoutContent, Selector) | aligned |
 | `apps/desktop/src/renderer/settings/runtime-host-onboarding-dialog.tsx` | settings-module | Banner, Button, Dialog, DialogHeader, Layout, LayoutContent, Spinner, Text | aligned — uses Astryx (Banner, Button, Dialog, DialogHeader, Layout, LayoutContent, Spinner, Text) | aligned |

--- a/docs/astryx-surface-file-inventory.paths
+++ b/docs/astryx-surface-file-inventory.paths
@@ -70,6 +70,7 @@ apps/desktop/src/renderer/settings/provider-enabled-model-manager.tsx
 apps/desktop/src/renderer/settings/provider-oauth-section.tsx
 apps/desktop/src/renderer/settings/providers-panel.tsx
 apps/desktop/src/renderer/settings/request-customization-editor.tsx
+apps/desktop/src/renderer/settings/runtime-host-connection-code-dialog.tsx
 apps/desktop/src/renderer/settings/runtime-host-interaction-boundary.tsx
 apps/desktop/src/renderer/settings/runtime-host-management-dialog.tsx
 apps/desktop/src/renderer/settings/runtime-host-onboarding-dialog.tsx

--- a/docs/runtime-host-remote-access.md
+++ b/docs/runtime-host-remote-access.md
@@ -184,6 +184,12 @@ Open `Settings → Workspace → Runtime Host` and choose **Add computer**. Ente
 
 Use **Configure manually** for an existing TLS, SSH, or explicitly acknowledged plaintext endpoint.
 
+To reach the current computer from another Desktop, enable **Remote access** in the same settings
+page. Maka keeps the existing Local Host and State Root, moves that Host under the OS service
+manager, and adds a Direct peer listener alongside Local IPC. Share the one-time connection code
+with the other Desktop. Turning remote access off removes only the Direct peer listener; removing
+the background service returns Local Host ownership to Desktop and retains all data.
+
 The credential is stored separately from the Profile. Desktop keeps Local and every enabled remote Host connected independently. Choose one as the default for new Sessions; existing Sessions continue to use their owning Host. A failed remote connection remains visible without interrupting the other Hosts. After connecting, choose a Project registered on that Host; Client-local directory actions remain unavailable.
 
 During guided pairing, the delivered credential has the selected Client grants and expires after 15 minutes unless Desktop explicitly finalizes it after saving the local binding.

--- a/docs/runtime-host-remote-access.zh-CN.md
+++ b/docs/runtime-host-remote-access.zh-CN.md
@@ -170,6 +170,11 @@ Client Profile 还必须单独持久化明文风险确认。Maka 不会把 TLS �
 
 已有 TLS、SSH 或明确允许的明文 endpoint 可通过**手动配置**添加。
 
+如需从另一台 Desktop 访问当前电脑，可在同一设置页开启**远程访问**。Maka 会保留现有
+Local Host 和 State Root，将该 Host 交由操作系统服务管理，并在 Local IPC 之外同时启用 Direct
+peer listener。将一次性 connection code 提供给另一台 Desktop 即可连接。关闭远程访问只会停止
+Direct peer listener；移除后台服务后，Local Host 会重新由 Desktop 管理，所有数据均保留。
+
 Credential 与 Profile 分开存储。Desktop 会让 Local 与每个已启用的 remote Host 独立保持连接，并允许指定一个默认 Host 来创建新 Session；已有 Session 仍使用自己的 Host。Remote connection 失败时仍会显示，但不会中断其他 Host。连接后从该 Host 已注册的 Project 中选择一个；Client 本地目录操作不可用。
 
 对于通过 SSH 管理的电脑，可从其**管理**操作查看已安装版本、服务状态、可用目录和近期日志，也可以启动、重启、修复或卸载服务。卸载会保留远端 State Root，且不会删除 Desktop Profile；移除 Profile 也不会卸载远端服务。手动配置的 direct connection 仍可正常使用，但需要在 Host 机器上管理服务。

--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -437,7 +437,12 @@ describe('managed Runtime Host service', () => {
         'desktop.client-1',
         '--preset',
         'desktop-client',
+        '--client-data-root',
+        '/var/lib/maka-client',
         '--defer-pairing-commit',
+        '--enable-direct-peer',
+        '--coordination-relay',
+        '/dns4/discovery.example/udp/443/quic-v1',
         '--json',
       ]),
       {
@@ -445,7 +450,11 @@ describe('managed Runtime Host service', () => {
         json: true,
         principalId: 'desktop.client-1',
         preset: 'desktop-client',
+        clientDataRoot: '/var/lib/maka-client',
         deferPairingCommit: true,
+        directPeer: {
+          coordinationRelays: ['/dns4/discovery.example/udp/443/quic-v1'],
+        },
       },
     );
   });

--- a/packages/cli/src/__tests__/runtime-host-setup.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-setup.test.ts
@@ -84,6 +84,7 @@ test('managed setup converges on one exact package and verified Client pairing',
     version: '0.2.0',
     principalId: 'desktop.client-1',
     preset: 'desktop-client',
+    directPeer: { coordinationRelays: [] },
   } as const;
   const overrides = {
     createBackend: () => unusedBackend(),
@@ -97,6 +98,12 @@ test('managed setup converges on one exact package and verified Client pairing',
         projectDirectoryRoots: [],
         websocket: { host: '127.0.0.1', port: 42_111, path: '/runtime-host' },
         launch: { nodePath: process.execPath, cliPath: input.cliPath },
+        peer: {
+          enabled: true,
+          peerId: '12D3KooWpeer',
+          listenAddresses: ['/ip4/192.0.2.10/udp/41000/quic-v1'],
+          coordinationRelays: [],
+        },
       };
       return serviceResult('install', config, '0.2.0');
     },
@@ -160,6 +167,11 @@ test('managed setup converges on one exact package and verified Client pairing',
   assert.equal(frames.filter((frame) => frame?.kind === 'complete').length, 2);
   const complete = frames.find((frame) => frame?.kind === 'complete');
   assert.equal(complete?.kind === 'complete' ? complete.credential : undefined, 'secret-1');
+  assert.deepEqual(complete?.kind === 'complete' ? complete.directPeer : undefined, {
+    peerId: '12D3KooWpeer',
+    routeHints: ['/ip4/192.0.2.10/udp/41000/quic-v1'],
+    coordinationRelays: [],
+  });
   const operatorPath = complete?.kind === 'complete' ? complete.operatorPath : undefined;
   assert.equal(operatorPath, join(canonicalDeploymentRoot, 'operator'));
   const operator = await readFile(operatorPath!, 'utf8');

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -297,7 +297,7 @@ export async function runMakaCli(
       const { runRuntimeHostSetupCli } = await import('./runtime-host-setup-command.js');
       return runRuntimeHostSetupCli({
         json: command.json,
-        clientDataRoot: dataRoots.clientDataRoot,
+        clientDataRoot: command.clientDataRoot ?? dataRoots.clientDataRoot,
         defaultRootPath: dataRoots.workspaceRoot,
         sourcePackageRoot: fileURLToPath(new URL('..', import.meta.url)),
         version,
@@ -310,6 +310,7 @@ export async function runMakaCli(
           : {}),
         ...(command.websocketPort === undefined ? {} : { websocketPort: command.websocketPort }),
         ...(command.websocketPath ? { websocketPath: command.websocketPath } : {}),
+        ...(command.directPeer ? { directPeer: command.directPeer } : {}),
         ...(command.expectedTarget ? { expectedTarget: command.expectedTarget } : {}),
       });
     }

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -66,10 +66,14 @@ export type RuntimeHostCliCommand =
       principalId: string;
       preset: 'desktop-client' | 'terminal-client';
       deferPairingCommit: boolean;
+      clientDataRoot?: string;
       rootPath?: string;
       projectDirectoryRoots?: { label: string; path: string }[];
       websocketPort?: number;
       websocketPath?: string;
+      directPeer?: {
+        coordinationRelays: string[];
+      };
       expectedTarget?: RuntimeHostManagedServiceTarget;
     }
   | {
@@ -241,8 +245,19 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
   let principalId: string | undefined;
   let preset: 'desktop-client' | 'terminal-client' | undefined;
   let deferPairingCommit = false;
+  let clientDataRoot: string | undefined;
+  let enableDirectPeer = false;
+  const coordinationRelays: string[] = [];
   const options = parseManagedServiceOptions(argv, {
     valueOptions: {
+      '--client-data-root': (value) => {
+        if (clientDataRoot !== undefined) return error('Duplicate --client-data-root');
+        if (!isSafeAbsolutePath(value)) return error('--client-data-root must be an absolute path');
+        clientDataRoot = value;
+      },
+      '--coordination-relay': (value) => {
+        coordinationRelays.push(value);
+      },
       '--principal': (value) => {
         principalId = value;
       },
@@ -254,6 +269,10 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
       },
     },
     flagOptions: {
+      '--enable-direct-peer': () => {
+        if (enableDirectPeer) return error('Duplicate --enable-direct-peer');
+        enableDirectPeer = true;
+      },
       '--defer-pairing-commit': () => {
         if (deferPairingCommit) return error('Duplicate --defer-pairing-commit');
         deferPairingCommit = true;
@@ -265,12 +284,17 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
     return error('runtime-host setup requires a valid --principal');
   }
   if (!preset) return error('runtime-host setup requires --preset');
+  if (!enableDirectPeer && coordinationRelays.length > 0) {
+    return error('--coordination-relay requires --enable-direct-peer');
+  }
   return {
     kind: 'runtime-host-setup',
     ...options,
     principalId,
     preset,
     deferPairingCommit,
+    ...(clientDataRoot ? { clientDataRoot } : {}),
+    ...(enableDirectPeer ? { directPeer: { coordinationRelays } } : {}),
   };
 }
 

--- a/packages/cli/src/runtime-host-peer-management-command.ts
+++ b/packages/cli/src/runtime-host-peer-management-command.ts
@@ -269,7 +269,7 @@ async function readPeerStatus(
   };
 }
 
-function expandWildcardListenAddresses(addresses: readonly string[]): string[] {
+export function expandWildcardListenAddresses(addresses: readonly string[]): string[] {
   const interfaces = Object.values(networkInterfaces()).flatMap((entries) => entries ?? []);
   const ipv4 = interfaces
     .filter((entry) => entry.family === 'IPv4' && !entry.internal)

--- a/packages/cli/src/runtime-host-setup-command.ts
+++ b/packages/cli/src/runtime-host-setup-command.ts
@@ -55,6 +55,7 @@ import {
   type RuntimeHostManagedServiceTarget,
   type RuntimeHostServiceBackend,
 } from './runtime-host-service-manager.js';
+import { expandWildcardListenAddresses } from './runtime-host-peer-management-command.js';
 
 const SETUP_LOCK_TIMEOUT_MS = 5 * 60_000;
 
@@ -71,6 +72,9 @@ export interface RuntimeHostSetupCliOptions {
   readonly projectDirectoryRoots?: readonly { readonly label: string; readonly path: string }[];
   readonly websocketPort?: number;
   readonly websocketPath?: string;
+  readonly directPeer?: {
+    readonly coordinationRelays: readonly string[];
+  };
   readonly expectedTarget?: RuntimeHostManagedServiceTarget;
 }
 
@@ -184,6 +188,9 @@ async function runRuntimeHostSetupLocked(
           : {}),
         ...(options.websocketPort === undefined ? {} : { websocketPort: options.websocketPort }),
         ...(options.websocketPath ? { websocketPath: options.websocketPath } : {}),
+        ...(options.directPeer
+          ? { peer: { coordinationRelays: options.directPeer.coordinationRelays } }
+          : {}),
       },
       backend,
     );
@@ -250,6 +257,15 @@ async function runRuntimeHostSetupLocked(
       endpoint,
       credentialId: paired.credentialId,
       credential: paired.credential,
+      ...(config.peer?.enabled
+        ? {
+            directPeer: {
+              peerId: config.peer.peerId,
+              routeHints: expandWildcardListenAddresses(config.peer.listenAddresses),
+              coordinationRelays: [...config.peer.coordinationRelays],
+            },
+          }
+        : {}),
     });
   } catch (error) {
     if (options.deferPairingCommit) {

--- a/packages/runtime-host/src/__tests__/owner-connection-code.test.ts
+++ b/packages/runtime-host/src/__tests__/owner-connection-code.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  decodeRuntimeHostOwnerConnectionCode,
+  encodeRuntimeHostOwnerConnectionCode,
+} from '../client/owner-connection-code.js';
+
+test('owner connection code round-trips its bounded direct-peer pairing payload', () => {
+  const input = {
+    name: 'Office Mac',
+    rootId: 'a'.repeat(64),
+    transport: {
+      kind: 'libp2p-direct' as const,
+      peerId: '12D3KooWpeer',
+      routeHints: ['/ip4/192.0.2.1/udp/41000/quic-v1'],
+      coordinationRelays: [],
+    },
+    credential: 'pending-credential',
+  };
+  assert.deepEqual(
+    decodeRuntimeHostOwnerConnectionCode(encodeRuntimeHostOwnerConnectionCode(input)),
+    input,
+  );
+});
+
+test('owner connection code rejects unversioned and route-less payloads', () => {
+  assert.throws(() => decodeRuntimeHostOwnerConnectionCode('pending-credential'));
+  assert.throws(() =>
+    encodeRuntimeHostOwnerConnectionCode({
+      name: 'Office Mac',
+      rootId: 'a'.repeat(64),
+      transport: {
+        kind: 'libp2p-direct',
+        peerId: '12D3KooWpeer',
+        routeHints: [],
+        coordinationRelays: [],
+      },
+      credential: 'pending-credential',
+    }),
+  );
+});

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -120,6 +120,11 @@ export {
 export { loadOrCreateRuntimeHostClientInstanceId } from './client-instance-identity.js';
 export { projectSessionCatalogSummary } from './session-catalog-summary.js';
 export { consumeAccessCredentialDelivery } from '../control/access-credential-delivery.js';
+export {
+  decodeRuntimeHostOwnerConnectionCode,
+  encodeRuntimeHostOwnerConnectionCode,
+  type RuntimeHostOwnerConnectionCode,
+} from './owner-connection-code.js';
 export { ensureRuntimeHostPeerIdentity } from '../transport/peer-native.js';
 export {
   createOAuthPresentationClientProvider,

--- a/packages/runtime-host/src/client/owner-connection-code.ts
+++ b/packages/runtime-host/src/client/owner-connection-code.ts
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { z } from 'zod';
+import { requireHostRootId } from '../protocol/index.js';
+import {
+  RUNTIME_HOST_ACCESS_CREDENTIAL_MAX_BYTES,
+  type RuntimeHostRemoteTransport,
+} from './host-profile.js';
+
+const PREFIX = 'maka-runtime-host:connect:v1:';
+const ENCODED_MAX_BYTES = 48 * 1024;
+const FIELD_MAX_BYTES = 2 * 1024;
+const ROUTE_MAX = 16;
+
+const boundedString = (maxBytes: number) =>
+  z
+    .string()
+    .min(1)
+    .refine((value) => Buffer.byteLength(value, 'utf8') <= maxBytes);
+const peerAddress = boundedString(FIELD_MAX_BYTES).refine(
+  (value) => value.startsWith('/') && !/[\s\u0000-\u001f\u007f]/u.test(value),
+);
+const payloadSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    name: boundedString(128),
+    rootId: z.string().refine((value) => {
+      try {
+        requireHostRootId(value);
+        return true;
+      } catch {
+        return false;
+      }
+    }),
+    transport: z
+      .object({
+        kind: z.literal('libp2p-direct'),
+        peerId: boundedString(160),
+        routeHints: z.array(peerAddress).max(ROUTE_MAX),
+        coordinationRelays: z.array(peerAddress).max(ROUTE_MAX),
+      })
+      .strict()
+      .refine(
+        (transport) => transport.routeHints.length > 0 || transport.coordinationRelays.length > 0,
+      ),
+    credential: boundedString(RUNTIME_HOST_ACCESS_CREDENTIAL_MAX_BYTES),
+  })
+  .strict();
+
+export interface RuntimeHostOwnerConnectionCode {
+  readonly name: string;
+  readonly rootId: string;
+  readonly transport: Extract<RuntimeHostRemoteTransport, { kind: 'libp2p-direct' }>;
+  readonly credential: string;
+}
+
+export function encodeRuntimeHostOwnerConnectionCode(
+  input: RuntimeHostOwnerConnectionCode,
+): string {
+  const payload = payloadSchema.parse({ schemaVersion: 1, ...input });
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  if (Buffer.byteLength(encoded, 'utf8') > ENCODED_MAX_BYTES) {
+    throw new RangeError('Runtime Host connection code is too large');
+  }
+  return `${PREFIX}${encoded}`;
+}
+
+export function decodeRuntimeHostOwnerConnectionCode(
+  value: unknown,
+): RuntimeHostOwnerConnectionCode {
+  if (typeof value !== 'string' || !value.startsWith(PREFIX)) {
+    throw new Error('Runtime Host connection code is invalid');
+  }
+  const encoded = value.slice(PREFIX.length);
+  if (encoded.length === 0 || Buffer.byteLength(encoded, 'utf8') > ENCODED_MAX_BYTES) {
+    throw new Error('Runtime Host connection code is invalid');
+  }
+  try {
+    const payload = payloadSchema.parse(
+      JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8')),
+    );
+    return {
+      name: payload.name,
+      rootId: requireHostRootId(payload.rootId),
+      transport: payload.transport,
+      credential: payload.credential,
+    };
+  } catch (error) {
+    throw new Error('Runtime Host connection code is invalid', { cause: error });
+  }
+}

--- a/packages/runtime-host/src/operator/setup-frame.ts
+++ b/packages/runtime-host/src/operator/setup-frame.ts
@@ -24,6 +24,7 @@ export const RUNTIME_HOST_SETUP_FRAME_PREFIX = 'MAKA_RUNTIME_HOST_SETUP_V1 ';
 const SETUP_FRAME_MAX_BYTES = 32 * 1024;
 const SETUP_FIELD_MAX_BYTES = 1024;
 const SETUP_CREDENTIAL_MAX_BYTES = 8 * 1024;
+const SETUP_PEER_ADDRESS_MAX_BYTES = 2 * 1024;
 export const RUNTIME_HOST_SETUP_ERROR_CODE_MAX_BYTES = 128;
 export const RUNTIME_HOST_SETUP_ERROR_MESSAGE_MAX_BYTES = SETUP_FIELD_MAX_BYTES;
 const SETUP_PHASES = [
@@ -69,6 +70,14 @@ const SETUP_FRAME_SCHEMA = z.discriminatedUnion('kind', [
       ),
       credentialId: boundedString(SETUP_FIELD_MAX_BYTES),
       credential: boundedString(SETUP_CREDENTIAL_MAX_BYTES),
+      directPeer: z
+        .object({
+          peerId: boundedString(160),
+          routeHints: z.array(boundedString(SETUP_PEER_ADDRESS_MAX_BYTES)).max(16),
+          coordinationRelays: z.array(boundedString(SETUP_PEER_ADDRESS_MAX_BYTES)).max(16),
+        })
+        .strict()
+        .optional(),
     })
     .strict(),
   z


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Let a user expose the current computer's Local Runtime Host to another Maka Desktop without creating a second Host or copying its State Root

- hands the existing Local Host from the ephemeral Desktop child to the OS-managed service
- keeps Local IPC and experimental Direct peer active on the same Host
- adds versioned, one-time Owner connection codes and an atomic import flow
- keeps disabling connectivity separate from uninstalling the service or revoking credentials

This PR is stacked on #3950

Refs #3842

## Verification

- `npm run typecheck`
- `npm run lint -- --diagnostic-level=error`
- `npm run format:check`
- `npm run build`
- `npm run check:stale`
- `npm run check:asf-headers`
- `npm run astryx:surface-inventory`
- affected CLI, Runtime Host, and Desktop test suites
- real two-Desktop connection-code import over Direct peer, including disable, re-enable, and service uninstall
- Electron UI checked through CDP with isolated profiles

The full Runtime suite passes standalone; one parallel repository-wide test invocation exited while that suite was running, with no failing test reproduced

### UI

Before:

![](https://github.com/apache/maka/blob/dfa1f42ed8684080bd3b441544300465a8344950/maka-local-access-before.png?raw=true)

After:

![](https://github.com/apache/maka/blob/dfa1f42ed8684080bd3b441544300465a8344950/maka-local-access-after.png?raw=true)

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with implementation, tests, documentation, and verification under the contributor's direction

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 摘要

允许用户把当前电脑的 Local Runtime Host 提供给另一台 Maka Desktop 使用，同时不创建第二个 Host，也不复制 State Root

- 将现有 Local Host 从 Desktop 临时子进程交接给操作系统托管服务
- 同一个 Host 同时保留 Local IPC 与实验性的 Direct peer listener
- 增加版本化、一次性的 Owner 连接码和原子导入流程
- 明确区分关闭连接方式、卸载服务与撤销凭据

本 PR 堆叠在 #3950 之上

关联 #3842

## 验证

- `npm run typecheck`
- `npm run lint -- --diagnostic-level=error`
- `npm run format:check`
- `npm run build`
- `npm run check:stale`
- `npm run check:asf-headers`
- `npm run astryx:surface-inventory`
- 受影响的 CLI、Runtime Host 与 Desktop 测试套件
- 使用两个真实 Desktop 通过 Direct peer 导入连接码，并验证关闭、重新开启和卸载服务
- 使用隔离 profile 通过 CDP 检查 Electron UI

Runtime 完整测试单独运行通过；一次仓库级并行测试在该套件运行期间退出，未能复现具体失败测试

### 界面

修改前：

![](https://github.com/apache/maka/blob/dfa1f42ed8684080bd3b441544300465a8344950/maka-local-access-before.png?raw=true)

修改后：

![](https://github.com/apache/maka/blob/dfa1f42ed8684080bd3b441544300465a8344950/maka-local-access-after.png?raw=true)

## AI 使用

- [ ] 没有生成式工具作出实质贡献
- [x] 生成式工具作出了实质贡献

工具与范围：OpenAI Codex 在贡献者指导下协助实现、测试、文档与验证

## 检查清单

- [x] 测试覆盖本次变更，并会在缺少变更时失败
- [x] lint、format、typecheck 与受影响测试套件均已在本地通过

本 PR 是否改变行为？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
