### PR TITLE
test(runtime-host): cover canonical WebSocket paths

### DIFF
--- a/packages/runtime-host/src/__tests__/websocket-path.test.ts
+++ b/packages/runtime-host/src/__tests__/websocket-path.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  isCanonicalRuntimeHostWebSocketPath,
+  RUNTIME_HOST_WEBSOCKET_PATH_MAX_BYTES,
+} from '../protocol/index.js';
+
+describe('Runtime Host WebSocket path', () => {
+  test('accepts canonical absolute paths', () => {
+    assert.equal(isCanonicalRuntimeHostWebSocketPath('/'), true);
+    assert.equal(isCanonicalRuntimeHostWebSocketPath('/runtime-host'), true);
+    assert.equal(isCanonicalRuntimeHostWebSocketPath('/runtime-host/%E2%9C%93'), true);
+  });
+
+  test('rejects values that are not canonical same-origin paths', () => {
+    const invalidPaths: unknown[] = [
+      undefined,
+      null,
+      0,
+      '',
+      'runtime-host',
+      '//attacker.example',
+      '/runtime-host?token=secret',
+      '/runtime-host#fragment',
+      '/runtime-host/../admin',
+      '/runtime-host\u0000',
+    ];
+
+    for (const path of invalidPaths) {
+      assert.equal(isCanonicalRuntimeHostWebSocketPath(path), false);
+    }
+  });
+
+  test('enforces the encoded path byte limit at the exact boundary', () => {
+    // The leading slash counts toward the wire-size budget.
+    const maximumPath = `/${'a'.repeat(RUNTIME_HOST_WEBSOCKET_PATH_MAX_BYTES - 1)}`;
+    const oversizedPath = `${maximumPath}a`;
+
+    assert.equal(new TextEncoder().encode(maximumPath).byteLength, 1_000);
+    assert.equal(isCanonicalRuntimeHostWebSocketPath(maximumPath), true);
+    assert.equal(isCanonicalRuntimeHostWebSocketPath(oversizedPath), false);
+  });
+});


### PR DESCRIPTION
## Summary

Add direct contract coverage for the Runtime Host WebSocket path validator.

The tests cover canonical absolute paths, cross-origin and normalized path rejection, query, fragment, and control-character rejection, plus the exact 1,000-byte boundary. This changes no production behavior.

## Verification

- `npx --yes npm@11.19.0 --workspace @maka/runtime-host run build` — pass
- `npx --yes npm@11.19.0 --workspace @maka/runtime-host run typecheck` — pass
- `node --test packages/runtime-host/dist/__tests__/websocket-path.test.js` — 3/3 pass
- `biome check packages/runtime-host/src/__tests__/websocket-path.test.ts` — pass
- `node scripts/asf-license-headers.mjs check` — pass
- Sensitivity check: temporarily changing the exported limit from 1,000 to 1,001 bytes made the boundary test fail; the implementation was then restored and the focused suite passed.
- The full Runtime Host suite is not reported as passing: on the unmodified base, seven existing `canonical-session-projection.test.ts` cases failed and the runner did not exit after teardown.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex audited the validator and contribution rules, authored the contract tests, and ran the verification above. This automated submission is opened as a draft for final human review.

## Before ready for review

- [ ] Human contributor of record reviews the diff and verification evidence.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally — focused lint, build, typecheck, and tests pass; the unrelated full-suite baseline failures are recorded above

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No