### PR TITLE
docs(readme): complete repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,20 +190,20 @@ Start with [ARCHITECTURE.md](./ARCHITECTURE.md). It provides the system map, cod
 ## Repository layout
 
 ```text
-apps/desktop/       Electron main / preload / React renderer
+apps/desktop/          Electron main / preload / React renderer
 
-packages/core/      Pure contracts for Sessions, Events, Permissions, and Connections
-packages/storage/   SQLite operational state, configuration, and payload stores
-packages/mcp/       Provider-neutral Model Context Protocol client integration
-packages/runtime/   AgentRun, model adapters, tools, context, and recovery
+packages/core/         Pure contracts for Sessions, Events, Permissions, and Connections
+packages/storage/      SQLite operational state, configuration, and payload stores
+packages/mcp/          Provider-neutral Model Context Protocol client integration
+packages/runtime/      AgentRun, model adapters, tools, context, and recovery
 packages/runtime-host/ Single-owner Runtime Host lifecycle, protocol, and client bootstrap
-packages/eval/      Experiment cells, attempts, results, and executor/subject adapters
+packages/eval/         Experiment cells, attempts, results, and executor/subject adapters
 packages/computer-use/ Computer-use backend selection, host lifecycle, and protocol adapters
-packages/cli/       TUI and non-interactive CLI
-packages/ui/        Shared conversation, Markdown, Artifact, and UI primitives
+packages/cli/          TUI and non-interactive CLI
+packages/ui/           Shared conversation, Markdown, Artifact, and UI primitives
 
-docs/               Architecture, product, security, privacy, and test contracts
-scripts/            Build hygiene, visual checks, smoke tests, and release helpers
+docs/                  Architecture, product, security, privacy, and test contracts
+scripts/               Build hygiene, visual checks, smoke tests, and release helpers
 ```
 
 ## Local data and recovery

--- a/README.md
+++ b/README.md
@@ -194,8 +194,11 @@ apps/desktop/       Electron main / preload / React renderer
 
 packages/core/      Pure contracts for Sessions, Events, Permissions, and Connections
 packages/storage/   SQLite operational state, configuration, and payload stores
+packages/mcp/       Provider-neutral Model Context Protocol client integration
 packages/runtime/   AgentRun, model adapters, tools, context, and recovery
+packages/runtime-host/ Single-owner Runtime Host lifecycle, protocol, and client bootstrap
 packages/eval/      Experiment cells, attempts, results, and executor/subject adapters
+packages/computer-use/ Computer-use backend selection, host lifecycle, and protocol adapters
 packages/cli/       TUI and non-interactive CLI
 packages/ui/        Shared conversation, Markdown, Artifact, and UI primitives
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -187,20 +187,20 @@ Experiment → Cells → Attempts → Results
 ## 仓库结构
 
 ```text
-apps/desktop/       Electron main / preload / React renderer
+apps/desktop/          Electron main / preload / React renderer
 
-packages/core/      Session、Event、Permission、Connection 等纯 contracts
-packages/storage/   SQLite 运行状态、配置与 payload stores
-packages/mcp/       与提供商无关的 Model Context Protocol 客户端集成
-packages/runtime/   AgentRun、模型适配、工具、上下文和恢复
+packages/core/         Session、Event、Permission、Connection 等纯 contracts
+packages/storage/      SQLite 运行状态、配置与 payload stores
+packages/mcp/          与提供商无关的 Model Context Protocol 客户端集成
+packages/runtime/      AgentRun、模型适配、工具、上下文和恢复
 packages/runtime-host/ 单一所有者的 Runtime Host 生命周期、协议和客户端启动
-packages/eval/      Experiment cell、attempt、result 与 executor/subject adapter
+packages/eval/         Experiment cell、attempt、result 与 executor/subject adapter
 packages/computer-use/ Computer Use 后端选择、Host 生命周期和协议适配
-packages/cli/       TUI 和非交互 CLI
-packages/ui/        共享对话、Markdown、Artifact 与 UI primitives
+packages/cli/          TUI 和非交互 CLI
+packages/ui/           共享对话、Markdown、Artifact 与 UI primitives
 
-docs/               架构、产品、安全、隐私和测试契约
-scripts/            Build hygiene、视觉检查、smoke 和 release helpers
+docs/                  架构、产品、安全、隐私和测试契约
+scripts/               Build hygiene、视觉检查、smoke 和 release helpers
 ```
 
 ## 本地数据与恢复

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -191,8 +191,11 @@ apps/desktop/       Electron main / preload / React renderer
 
 packages/core/      Session、Event、Permission、Connection 等纯 contracts
 packages/storage/   SQLite 运行状态、配置与 payload stores
+packages/mcp/       与提供商无关的 Model Context Protocol 客户端集成
 packages/runtime/   AgentRun、模型适配、工具、上下文和恢复
+packages/runtime-host/ 单一所有者的 Runtime Host 生命周期、协议和客户端启动
 packages/eval/      Experiment cell、attempt、result 与 executor/subject adapter
+packages/computer-use/ Computer Use 后端选择、Host 生命周期和协议适配
 packages/cli/       TUI 和非交互 CLI
 packages/ui/        共享对话、Markdown、Artifact 与 UI primitives
 


### PR DESCRIPTION
## Summary

Complete the bilingual repository layout with the three npm workspaces that were missing from both root READMEs: `packages/mcp`, `packages/runtime-host`, and `packages/computer-use`.

The descriptions follow each package's current manifest and public responsibilities. This changes documentation only.

## Verification

- `biome format .` — pass; 1,698 supported files checked with no fixes needed
- `node scripts/asf-license-headers.mjs check` — pass
- A PowerShell consistency check confirmed that every root npm workspace appears in both `README.md` and `README.zh-CN.md`
- `git diff --check` — pass
- Build, typecheck, and runtime tests were not rerun because this PR changes only Markdown

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex compared the root workspaces with both repository layouts, drafted the English and Chinese descriptions, and ran the verification above. This automated submission is opened as a draft for final human review.

## Before ready for review

- [ ] Human contributor of record reviews both language versions and the verification evidence.

## Checklist

- [x] Tests cover the change and fail without it — not applicable to this documentation-only change; the workspace consistency check covers the omission
- [x] Lint, format, typecheck and the affected suites pass locally — format and source-header checks pass; code checks are not affected

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No