### PR TITLE
docs(runtime): correct storage authority

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -38,7 +38,7 @@ Desktop composition lives in `apps/desktop/src/main/main.ts`. Other clients exec
 
 - Add backend behavior behind `AgentBackend` and register it through the existing registry.
 - Add tools through the builtin/tool composition seams; keep filesystem and shell effects behind `WorkspaceExecutor`.
-- Put shared pure contracts in `packages/core` and durable JSONL state in `packages/storage`.
+- Put shared pure contracts in `packages/core` and interactive Runtime state in the SQLite control plane owned by `packages/storage`.
 - Expose supported package APIs through the root barrel or a declared `package.json` subpath rather than importing internal files from another package.
 - Keep provider credentials and Electron IPC outside this package. The product shell resolves credentials and passes only the dependencies required for execution.
 


### PR DESCRIPTION
## Summary

Correct the Runtime package extension guidance so it points contributors to the current SQLite control plane in `packages/storage` instead of the retired durable JSONL state model.

This aligns the package README with `ARCHITECTURE.md` and the current `runtime.sqlite` implementation. This changes documentation only.

## Verification

- `biome format .` — pass; 1,698 supported files checked with no fixes needed
- `node scripts/asf-license-headers.mjs check` — pass
- A focused wording check confirmed that the stale `durable JSONL state` guidance is absent and the SQLite control-plane guidance is present
- `git diff --check` — pass
- Build, typecheck, and runtime tests were not rerun because this PR changes only Markdown

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex traced the storage authority through the architecture documentation and current storage implementation, corrected the wording, and ran the verification above. This automated submission is opened as a draft for final human review.

## Before ready for review

- [ ] Human contributor of record reviews the wording and verification evidence.

## Checklist

- [x] Tests cover the change and fail without it — not applicable to this documentation-only change; the focused wording check covers the stale statement
- [x] Lint, format, typecheck and the affected suites pass locally — format and source-header checks pass; code checks are not affected

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No