### PR TITLE
fix(desktop): allow current npm for local CLI builds

### DIFF
--- a/scripts/release-cli-package.mjs
+++ b/scripts/release-cli-package.mjs
@@ -89,7 +89,8 @@ try {
 }
 
 function main() {
-  validateToolchain();
+  validateNodeVersion();
+  if (!developmentBuild) validateReleaseNpmVersion();
   if (developmentBuild) {
     if (allowDirty || preparedTree) {
       throw new Error('--development cannot be combined with release build options');
@@ -239,11 +240,14 @@ function copyPeerPrebuildInputToCleanTree(cleanRoot) {
   return destination;
 }
 
-function validateToolchain() {
+function validateNodeVersion() {
   const [major = 0, minor = 0] = process.versions.node.split('.').map(Number);
   if (major < 22 || (major === 22 && minor < 19)) {
     throw new Error(`Node.js >=22.19.0 is required; found ${process.versions.node}`);
   }
+}
+
+function validateReleaseNpmVersion() {
   const packageManager = readJson(join(repoRoot, 'package.json')).packageManager;
   const requiredNpmVersion = /^npm@(.+)$/.exec(packageManager)?.[1];
   if (!requiredNpmVersion) {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Allow private development CLI archives to use the developer's installed npm version. Publishable release builds continue to require the exact npm version pinned by the repository.

This prevents Desktop development from failing while preparing its local Runtime Host CLI merely because the installed npm is newer than the release toolchain.

## Verification

- `node --check scripts/release-cli-package.mjs`
- Biome format and lint for the changed script
- Temporarily changed `packageManager` to `npm@12.0.2`; `--development` passed the former version gate and entered the workspace build
- Full repository typecheck is deferred to CI; the changed file is JavaScript

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the release/development boundary and implemented the change under human direction and review

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

允许私有开发版 CLI 归档使用开发者当前安装的 npm 版本。可发布的正式构建仍要求使用仓库固定的精确 npm 版本。

这避免了 Desktop 开发环境仅因 npm 比发布工具链更新，就无法准备本地 Runtime Host CLI。

## 验证

- `node --check scripts/release-cli-package.mjs`
- 对变更脚本执行 Biome 格式与 lint 检查
- 临时将 `packageManager` 改为 `npm@12.0.2`；`--development` 已越过原版本检查并进入 workspace build
- 完整仓库 typecheck 交由 CI；本次变更文件为 JavaScript

## AI 使用

- [ ] 没有生成式工具作出实质贡献
- [x] 生成式工具作出了实质贡献

工具及范围：OpenAI Codex 在人工指导和审核下调查发布/开发边界并实现本次修改

## 检查清单

- [x] 测试覆盖该变更，且修改前会失败
- [ ] lint、格式、typecheck 与受影响测试套件均在本地通过

本 PR 是否改变行为？

- [x] 是——已在概要中说明
- [ ] 否

</details>
