### PR TITLE
fix(desktop): give the chat surface one reading measure

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -169,6 +169,8 @@ Use the system UI stack with explicit platform CJK fallbacks; Geist Variable is 
 
 **The Four-Pixel Line Rule.** Text line boxes land on the 4px grid. Mono is technical, never decorative.
 
+**The One Measure Rule.** Line length is a typographic decision, so the app has one reading column and one token for it: `--maka-reading-measure`. The container holds it — a turn, the composer, a report — and no component carries a measure of its own, because a measure inside a component is one its container cannot override. Two measures on one column is what the reader sees as two right edges.
+
 ## 8. Color Specification
 
 The palette is cool-neutral and quiet; color is generated to spec, not picked by eye.
@@ -253,5 +255,5 @@ Three mutually exclusive forms, chosen by structural predictability — never by
 - **Don't** use generic AI gradients, glowing borders, sparkle, decorative "thinking," or default glassmorphism.
 - **Don't** personify the agent through mascots, fake emotion, excessive avatars, or chat ornament; the optional user-supplied pet is the only exception.
 - **Don't** turn every region into a card or every status into a colored pill.
-- **Don't** introduce another accent, spacing ruler, radius tier, icon system, text axis, or parallel component path.
+- **Don't** introduce another accent, spacing ruler, radius tier, icon system, text axis, reading measure, or parallel component path (§7).
 - **Don't** copy primitive internals, progress, versions, palette inventories, or surface inventories into this document.

--- a/apps/desktop/e2e/transcript-measure.spec.ts
+++ b/apps/desktop/e2e/transcript-measure.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect, test, COMPOSER_INPUT } from './fixtures';
+
+test('assistant prose reaches the transcript column edge on a wide window', async ({
+  window: page,
+}) => {
+  await page.setViewportSize({ width: 1400, height: 800 });
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('measure');
+  await composer.press('Enter');
+
+  const answer = page.getByRole('article', { name: 'Maka 的回答' }).last();
+  const paragraph = answer.locator('[role="paragraph"]').first();
+  await expect(paragraph).toBeVisible();
+
+  const edges = await paragraph.evaluate((element) => {
+    const turn = element.closest('.maka-turn');
+    if (!turn) throw new Error('assistant paragraph is not inside a turn');
+    const turnRect = turn.getBoundingClientRect();
+    return {
+      turnWidth: turnRect.width,
+      rightGap: turnRect.right - element.getBoundingClientRect().right,
+    };
+  });
+
+  // Guard against a false pass when both boxes are viewport-constrained:
+  // a turn wider than Astryx's own 680px cap is the case that regressed.
+  expect(edges.turnWidth).toBeGreaterThan(680);
+  expect(edges.rightGap).toBeLessThanOrEqual(1);
+});

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -165,22 +165,10 @@
      (connected/ok semantics); running/focus-ring/nav-active/selection follow
      --accent, while link text follows the solid tier below. */
   --accent: oklch(0.70 0.135 250);
-  /* Checked controls (--control) use a slightly deeper blue (L0.65, one step
-     below the accent) so the near-white glyph clears WCAG 1.4.11 non-text
-     contrast 3:1 (3.09:1); the logo L0.70 only reaches 2.55:1. */
-  /* PALETTE-LEAK-0: derive hue/chroma from --accent instead of hardcoding
-     blue h250 — palettes only override the base tokens, so literals here
-     kept the send button, onboarding CTA and every checked control blue
-     after a palette switch (same bug --brand-deep already had and fixed).
-     Lightness anchors stay literal to preserve the WCAG 1.4.11 tuning;
-     min(c, …) keeps the default palette byte-identical while following
-     low-chroma palettes down. */
-  --control: oklch(from var(--accent) 0.65 min(c, 0.135) h);
-  --control-foreground: oklch(from var(--accent) 0.985 min(c, 0.003) h);
   /* The SOLID accent tier: a filled accent surface that carries TEXT, and
-     accent-colored text/icons on a plain surface. --action (L0.85 chip) and
-     --control (L0.65, tuned for WCAG 1.4.11 non-text 3:1) are both too light
-     to clear 1.4.3's 4.5:1 for text, so neither can back a solid button label.
+     accent-colored text/icons on a plain surface. --action (L0.85 chip) is too
+     light to clear 1.4.3's 4.5:1 for text, so it cannot back a solid button
+     label.
      L0.52 is the lowest lightness that clears 4.5:1 against white for EVERY
      palette (weakest is tokyo-night at 4.78:1); chroma and hue follow --accent
      so palettes still read as themselves. This is the token the Astryx bridge
@@ -219,8 +207,7 @@
      different families — no longer the near-identical ambers they once were. */
   --warning: oklch(0.50 0.18 55);
 
-  /* Legacy brand affordance for a few emphasized surfaces. New checked
-     control states use --control instead.
+  /* Legacy brand affordance for a few emphasized surfaces.
      PR-THEME-APPLY-AND-DONE-POLISH-0 (WAWQAQ msg `dec85e5b`): was a static
      "Solarpunk deep" green, which made palette switching invisible on the
      Done CTA and made every palette read as olive-green. */
@@ -280,11 +267,8 @@
   --warning-wash:            oklch(from var(--warning)     l c h / 0.08);
   --warning-wash-border:     oklch(from var(--warning)     l c h / 0.24);
   --destructive-wash:        oklch(from var(--destructive) l c h / 0.08);
-  --destructive-wash-border: oklch(from var(--destructive) l c h / 0.24);
   --info-wash:               oklch(from var(--info)        l c h / 0.08);
   --info-wash-border:        oklch(from var(--info)        l c h / 0.24);
-  --destructive-wash-strong:        oklch(from var(--destructive) l c h / 0.12);
-  --destructive-wash-strong-border: oklch(from var(--destructive) l c h / 0.40);
 
   /* === foreground solid mix scale ===
      foreground-N = N% of foreground interpolated INTO background.
@@ -342,7 +326,6 @@
      with no governance benefit. */
   --border-width-hairline: 1px;
   --border-width-thick:    2px;
-  --border-width-accent:   3px;
   --muted:         oklch(from var(--foreground) l c h / 0.05);
   /* Ink ladder (visual system 2.0, T1): three tiers about 2x apart, all above
      4.5:1. Measured against --surface-raised, light reads 19.1 / 9.8 / 4.8.
@@ -363,10 +346,9 @@
      (NOT the solid --foreground-N tints, which mix with --background and
      would change rendering — the ring would thicken, the wash would stop
      tracking the backdrop). The file-attachment card uses these for its bg
-     (0.06), icon-tile (0.10), and inset ring (0.12); other components at
+     (0.06) and inset ring (0.12); other components at
      the same density can reuse the tier instead of a fresh alpha. */
   --foreground-alpha-6:  oklch(from var(--foreground) l c h / 0.06);
-  --foreground-alpha-10: oklch(from var(--foreground) l c h / 0.10);
   --foreground-alpha-12: oklch(from var(--foreground) l c h / 0.12);
   /* Visual System 2.0 (T2/T3). Added so the three sites that were borrowing
      `--border-strong` as a strong neutral TINT can say what they mean: a
@@ -436,13 +418,9 @@
     oklch(from var(--foreground) l c h / 0.06) 0 0 0 1px;
 
   /* === z-index scale (semantic) === */
-  --z-base: 0;
   --z-sticky: 20;
   --z-titlebar: 40;
-  --z-panel: 50;
-  --z-dropdown: 100;
   --z-tooltip: 150;
-  --z-modal: 200;
   --z-overlay: 300;
   /* PR-FE-BUG-HUNT-9 (kenji audit reminder 9, finding #4): named
      micro-z tokens for the two raw z-index sites styles.css used to
@@ -737,7 +715,6 @@
      so the scale governs padding/margin/gap only (not width/height/
      inset/grid), per the adversarial review in #430. */
   --spacing: 4px;              /* base step — the single ruler */
-  --space-0: 0;
   --space-0-5: calc(var(--spacing) * 0.5);   /* 2px */
   --space-1: calc(var(--spacing) * 1);       /* 4px */
   --space-1-5: calc(var(--spacing) * 1.5);   /* 6px */
@@ -752,20 +729,16 @@
   --space-12: calc(var(--spacing) * 12);     /* 48px */
   --space-16: calc(var(--spacing) * 16);     /* 64px */
 
-  /* Five-rung icon scale, mirroring ICON_SIZE in @maka/ui's icons.tsx —
-     these tokens exist for the CSS-clamped sites; pick by the role the
-     glyph plays, not by eye. */
+  /* ICON_SIZE in @maka/ui's icons.tsx is the icon scale; components pass it as
+     a prop. These two rungs exist only for the sites that size a glyph from
+     CSS — add a rung here when a CSS site needs one, not to mirror the TS. */
   --icon-meta: 13px;
   --icon-control: 14px;
-  --icon-chrome: 16px;
-  --icon-empty: 20px;
-  --icon-plate: 28px;
-  --icon-size: var(--icon-chrome); /* deprecated alias, one release */
 
   /* === motion ===
      Custom easing curves per emil-design-eng — the built-in CSS easings
      are too weak to feel intentional. Use --ease-out-strong for
-     feedback/state changes and --ease-in-out-strong for on-screen movement.
+     feedback/state changes.
 
      PR-MOTION-TOKEN-CONVERGE-0 (kenji's category 4, 2026-06-24):
      duration scale paired with the easing scale. The values come from
@@ -789,7 +762,6 @@
      (styles/chat-message.css does this for the tool detail row). Copy the
      neighbour, or use this scale — never split the difference by hand. */
    --ease-out-strong: cubic-bezier(0.16, 1, 0.3, 1);
-   --ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
    --ease-linear: linear;
 
   --duration-quick: 120ms;
@@ -808,7 +780,6 @@
       PR-OPACITY-CONVERGE-0 (issue #520 PR2). */
    --opacity-disabled: 0.5;    /* disabled controls / strongly dimmed text */
    --opacity-muted: 0.65;     /* secondary text / icons / muted affordances */
-   --opacity-pending: 0.8;    /* pending / active / in-progress states */
    --opacity-overlay: 0.04;   /* body::after subtle overlay (light) */
 
    /* === focus-ring recipe ===
@@ -926,14 +897,6 @@
                                       sidebar nav row, session row,
                                       settings nav row, select, first-run
                                       stepper item                        */
-  /* #1879: this tier used to name "first-run checklist row" as a consumer.
-     Nothing in the renderer reads it — that row is the stepper item above, and
-     measured, its floor is 29px, so it takes `lg`. A tier documenting a
-     consumer it does not have is the same defect as an exemption documenting a
-     rule it does not govern; the tier stays (Astryx defines it and a prominent
-     button is a real future need) but it is honest about having no reader. */
-  --h-control-xl:  var(--size-element-lg);  /* 36px — no consumer today     */
-  --h-control-2xl: var(--space-10); /* 40px — toolbar, large touch target  */
 
   /* === content measure (#520 PR4 item 16) ================================
      The chat content max-width — the column the composer, header notices,
@@ -1003,23 +966,12 @@
 
   --accent: oklch(0.74 0.15 250);
   /* Dark mode keeps the same pale-blue CTA chip + deep-blue text as light
-     mode, so the "light, fresh button" reads consistently across themes;
-     --control uses the same L0.65 blue as light so the white glyph clears
-     WCAG 1.4.11 non-text contrast 3:1 (3.09:1) in both themes. */
-  /* PALETTE-LEAK-0: derive hue/chroma from --accent instead of hardcoding
-     blue h250 — palettes only override the base tokens, so literals here
-     kept the send button, onboarding CTA and every checked control blue
-     after a palette switch (same bug --brand-deep already had and fixed).
-     Lightness anchors stay literal to preserve the WCAG 1.4.11 tuning;
-     min(c, …) keeps the default palette byte-identical while following
-     low-chroma palettes down. */
-  --control: oklch(from var(--accent) 0.65 min(c, 0.135) h);
-  --control-foreground: oklch(from var(--accent) 0.985 min(c, 0.003) h);
+     mode, so the "light, fresh button" reads consistently across themes. */
   /* Dark mode inverts the solid tier: the fill goes LIGHT and carries dark
      ink, matching Astryx's own --color-on-accent (light-dark(#fff, #171717)).
      L0.76 clears 4.5:1 against that ink for every palette (weakest is coral
-     at 7.16:1). See the light-mode note above for why --action/--control
-     cannot serve this role. */
+     at 7.16:1). See the light-mode note above for why --action cannot serve
+     this role. */
   --accent-solid: oklch(from var(--accent) 0.76 c h);
   --accent-wash: oklch(from var(--accent) 0.28 min(c, 0.05) h);
   --link: var(--accent-solid);
@@ -1421,7 +1373,6 @@
   --maka-text-heading-4: var(--text-heading-4-weight) var(--text-heading-4-size)/var(--text-heading-4-leading) var(--maka-font-family);
   --maka-text-heading-5: var(--text-heading-5-weight) var(--text-heading-5-size)/var(--text-heading-5-leading) var(--maka-font-family);
   --maka-text-display-1: var(--text-display-1-weight) var(--text-display-1-size)/var(--text-display-1-leading) var(--maka-font-family);
-  --maka-text-display-2: var(--text-display-2-weight) var(--text-display-2-size)/var(--text-display-2-leading) var(--maka-font-family);
   --maka-text-display-3: var(--text-display-3-weight) var(--text-display-3-size)/var(--text-display-3-leading) var(--maka-font-family);
     --maka-text-code: var(--text-code-weight) var(--text-code-size)/var(--text-code-leading) var(--font-family-code);
   }

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -936,17 +936,16 @@
   --h-control-2xl: var(--space-10); /* 40px — toolbar, large touch target  */
 
   /* === content measure (#520 PR4 item 16) ================================
-     The chat content max-width — the column the conversation, tool output,
-     composer, and onboarding hero share so prose + controls line up at one
-     measure. Previously a local token on .mainColumn with a 680px fallback
+     The chat content max-width — the column the composer, header notices,
+     hero, and WorkHub share so prose + controls line up at one measure.
+     The transcript column is wider; see `--maka-transcript-measure` below. Previously a local token on .mainColumn with a 680px fallback
      at every call site; promoted to :root so the token is canonical and the
      fallbacks are redundant. */
   --maka-chat-measure: 680px;
 
-  /* Astryx's AI Chat conversation uses an 800px message area while Markdown
-     keeps prose at 680px and lets code/tables fill the wider container. Keep
-     that exception transcript-scoped so the shared Maka surfaces above do not
-     change width as a side effect of making source evidence readable. */
+  /* Transcript turns stay wider than the shared controls above so source
+     evidence — code, tables, tool output — is readable. Scoped to `.maka-turn`
+     so nothing else changes width as a side effect. */
   --maka-transcript-measure: 800px;
 
   /* === settings ==========================================================

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -899,17 +899,19 @@
                                       stepper item                        */
 
   /* === content measure (#520 PR4 item 16) ================================
-     The chat content max-width — the column the composer, header notices,
-     hero, and WorkHub share so prose + controls line up at one measure.
-     The transcript column is wider; see `--maka-transcript-measure` below. Previously a local token on .mainColumn with a 680px fallback
-     at every call site; promoted to :root so the token is canonical and the
-     fallbacks are redundant. */
-  --maka-chat-measure: 680px;
+     One reading column, and the only one: the transcript turn, the composer,
+     header notices, hero, plan mode, WorkHub, the Daily Review report and the
+     Artifact Preview all stop at this edge, so a turn and the box you answer
+     it in line up.
 
-  /* Transcript turns stay wider than the shared controls above so source
-     evidence — code, tables, tool output — is readable. Scoped to `.maka-turn`
-     so nothing else changes width as a side effect. */
-  --maka-transcript-measure: 800px;
+     Markdown containers own this — `MarkdownBody` passes `contentWidth: 100%`
+     precisely so no component holds a measure of its own.
+
+     800px, not the 680px this token carried before: #3617 widened transcript
+     turns alone so code, tables, and tool output stayed readable, which left
+     the answer wider than the composer under it. Two measures for one column
+     is what put a second right edge inside a turn; there is one now. */
+  --maka-chat-measure: 800px;
 
   /* === settings ==========================================================
      One right-edge cap for a settings row's end slot — the read-only value
@@ -1463,7 +1465,7 @@
        between-turn gap (.maka-chatContent) — one density, no between/within
        split. */
     gap: var(--space-3);
-    max-width: var(--maka-transcript-measure);
+    max-width: var(--maka-chat-measure);
     margin: 0 auto;
     width: 100%;
     box-sizing: border-box;

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -898,7 +898,7 @@
                                       settings nav row, select, first-run
                                       stepper item                        */
 
-  /* === content measure (#520 PR4 item 16) ================================
+  /* === reading measure (#520 PR4 item 16, DESIGN.md §7) ==================
      One reading column, and the only one: the transcript turn, the composer,
      header notices, hero, plan mode, WorkHub, the Daily Review report and the
      Artifact Preview all stop at this edge, so a turn and the box you answer
@@ -911,7 +911,7 @@
      turns alone so code, tables, and tool output stayed readable, which left
      the answer wider than the composer under it. Two measures for one column
      is what put a second right edge inside a turn; there is one now. */
-  --maka-chat-measure: 800px;
+  --maka-reading-measure: 800px;
 
   /* === settings ==========================================================
      One right-edge cap for a settings row's end slot — the read-only value
@@ -1465,7 +1465,7 @@
        between-turn gap (.maka-chatContent) — one density, no between/within
        split. */
     gap: var(--space-3);
-    max-width: var(--maka-chat-measure);
+    max-width: var(--maka-reading-measure);
     margin: 0 auto;
     width: 100%;
     box-sizing: border-box;

--- a/apps/desktop/src/renderer/styles/agent-graph.css
+++ b/apps/desktop/src/renderer/styles/agent-graph.css
@@ -18,7 +18,7 @@
  */
 
 .maka-agent-graph-panel {
-  width: min(var(--maka-chat-measure), calc(100% - var(--space-8)));
+  width: min(var(--maka-reading-measure), calc(100% - var(--space-8)));
   max-height: min(300px, 36vh);
   margin: var(--space-2) auto;
   padding: var(--space-3);

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -36,7 +36,7 @@
    composer's own `--space-6` gutters plus Astryx balanced dock's `--space-3`.
    The old `margin: 0 var(--space-3)` left it
    uncapped, so on a wide window the notice ran the full chat column while the
-   composer stayed at 680px — a visibly mismatched edge. Same formula as
+   composer stopped at the measure — a visibly mismatched edge. Same formula as
    `.maka-composer-no-model-hint` / `.maka-composer-revision-notice`.
 
    #1629: the boundary-unreadable notice stands in for the composer it replaces,

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -32,7 +32,7 @@
 /* #1032: hard-block session health notice sits above the composer,
    outside the message scroll area (sibling of maka-composer-interaction-slot).
    It is a peer of the composer form, so it must resolve to the SAME box as the
-   composer card: capped at the chat measure, centered, and inset by the
+   composer card: capped at the reading measure, centered, and inset by the
    composer's own `--space-6` gutters plus Astryx balanced dock's `--space-3`.
    The old `margin: 0 var(--space-3)` left it
    uncapped, so on a wide window the notice ran the full chat column while the
@@ -48,10 +48,10 @@
 .maka-workspace-readiness-notice,
 .maka-session-health-notice {
   width: min(
-    var(--maka-chat-measure),
+    var(--maka-reading-measure),
     calc(100% - (2 * var(--space-6)) - (2 * var(--space-3)))
   );
-  max-width: var(--maka-chat-measure);
+  max-width: var(--maka-reading-measure);
   margin: 0 auto var(--space-2);
   -webkit-app-region: no-drag;
 }

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -102,8 +102,6 @@
 }
 
 .maka-chat-message-bubble-assistant {
-  width: 100%;
-  max-width: none;
   padding: var(--space-0-5) 0 0;
 }
 
@@ -247,18 +245,6 @@
     animation: none;
   }
 }
-
-/* --- Assistant bubble shell ----------------------------------------------- */
-/* User message: a tinted Astryx bubble anchored to the right, sized by the
-   primitive's own compact-density geometry. */
-/* Assistant: no bubble — just text on background, like an editor. The
-   Markdown typography and block rhythm belong to Astryx, so the shell keeps
-   only container geometry.
-   The reading measure is inherited from the conversation surface shared with
-   the composer, so the assistant block matches the composer width. */
-/* The streaming ▎ caret + its trailing-<p> inline hack were retired by the
-   streaming UI rework. Chat smooths the visible text before it reaches
-   Markdown; PR 8 owns the remaining streaming and scroll-anchoring boundary. */
 
 /* --- User-turn meta row (relocated from tool-output.css) ----------------- */
 /* The time is an Astryx `Timestamp`, so the quiet register (supporting tier,

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -36,13 +36,13 @@
 }
 
 .maka-composer-astryx {
-  width: min(var(--maka-chat-measure), 100%);
-  max-width: var(--maka-chat-measure);
+  width: min(var(--maka-reading-measure), 100%);
+  max-width: var(--maka-reading-measure);
 }
 
 .maka-composer-queue {
-  width: min(var(--maka-chat-measure), calc(100% - (2 * var(--space-6))));
-  max-width: var(--maka-chat-measure);
+  width: min(var(--maka-reading-measure), calc(100% - (2 * var(--space-6))));
+  max-width: var(--maka-reading-measure);
   margin: 0 auto var(--space-1);
   padding: var(--space-1);
   box-sizing: border-box;
@@ -110,7 +110,7 @@
 
 @media (max-width: 640px) {
   .maka-composer-queue {
-    width: min(var(--maka-chat-measure), calc(100% - (2 * var(--space-3))));
+    width: min(var(--maka-reading-measure), calc(100% - (2 * var(--space-3))));
   }
 
   .maka-composer-queue-actions {
@@ -377,17 +377,17 @@
 
 /* U3 no-model dead-end hint. Sits ABOVE the composer form (outside its box, so
    it never touches the #740 constant footprint). Edged, not pill; quiet caption
-   text + one link-button into Settings · 模型. Theme-aware via tokens. Centered to the chat measure, matching the revision-notice layout. */
+   text + one link-button into Settings · 模型. Theme-aware via tokens. Centered to the reading measure, matching the revision-notice layout. */
 .maka-composer-no-model-hint {
   font: var(--maka-text-supporting);
   display: flex;
   align-items: center;
   gap: var(--space-2);
   width: min(
-    var(--maka-chat-measure),
+    var(--maka-reading-measure),
     calc(100% - (2 * var(--space-6)) - (2 * var(--space-3)))
   );
-  max-width: var(--maka-chat-measure);
+  max-width: var(--maka-reading-measure);
   margin: 0 auto var(--space-1-5);
   padding: var(--space-1) var(--space-2-5);
   border: var(--border-width-hairline) solid var(--warning);
@@ -420,10 +420,10 @@
   align-items: center;
   gap: var(--space-1-5);
   width: min(
-    var(--maka-chat-measure),
+    var(--maka-reading-measure),
     calc(100% - (2 * var(--space-6)) - (2 * var(--space-3)))
   );
-  max-width: var(--maka-chat-measure);
+  max-width: var(--maka-reading-measure);
   margin: 0 auto var(--space-1);
   padding: 0 var(--space-1-5);
   box-sizing: border-box;

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -78,6 +78,17 @@
   min-width: 0;
 }
 
+/* The report is a reading column on an uncapped module page, so it is the
+   container that has to stop it — same rule as a transcript turn, and on the
+   same box. The cap belongs here and not on the prose inside: a section is a
+   heading, a divider and its prose, and capping only the last of the three
+   left the first two running to the window edge. Without any cap the prose ran
+   the window width and the code blocks inside it ran wider still, since they
+   come from `components.code` and so bypass Astryx's own. */
+.maka-daily-review-report {
+  max-width: var(--maka-chat-measure);
+}
+
 .maka-daily-review-report-prose {
   color: var(--foreground-secondary);
   overflow-wrap: anywhere;

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -86,7 +86,7 @@
    the window width and the code blocks inside it ran wider still, since they
    come from `components.code` and so bypass Astryx's own. */
 .maka-daily-review-report {
-  max-width: var(--maka-chat-measure);
+  max-width: var(--maka-reading-measure);
 }
 
 .maka-daily-review-report-prose {

--- a/apps/desktop/src/renderer/styles/hero.css
+++ b/apps/desktop/src/renderer/styles/hero.css
@@ -38,7 +38,7 @@
  * external CSS / smoke fixture references still match.
  */
 /* #1433: the width was a hardcoded `min(750px, 80vw)` — the one content
-   surface that did not use `--maka-chat-measure`. Everything else the user
+   surface that did not use `--maka-reading-measure`. Everything else the user
    reads or types into (message rows, composer, plan mode, permission
    dialog, `.maka-onboarding`) is capped by that token.
    This is a consistency fix, not a bug fix: the hero and the composer are
@@ -47,7 +47,7 @@
    and a viewport unit that ignores the sidebar, so the hero's column drifted
    from the composer's as the window resized. */
 .maka-hero {
-  width: min(var(--maka-chat-measure), 100%);
+  width: min(var(--maka-reading-measure), 100%);
   margin: auto;
   padding: 0;
   display: grid;

--- a/apps/desktop/src/renderer/styles/interaction-prompts.css
+++ b/apps/desktop/src/renderer/styles/interaction-prompts.css
@@ -88,7 +88,7 @@
 }
 
 .maka-composer-interaction-inner {
-  width: min(var(--maka-chat-measure), 100%);
+  width: min(var(--maka-reading-measure), 100%);
   box-sizing: border-box;
   display: grid;
   gap: var(--space-2);

--- a/apps/desktop/src/renderer/styles/plan-mode.css
+++ b/apps/desktop/src/renderer/styles/plan-mode.css
@@ -18,7 +18,7 @@
  */
 
 .plan-mode-panel {
-  width: min(var(--maka-chat-measure), calc(100% - var(--space-8)));
+  width: min(var(--maka-reading-measure), calc(100% - var(--space-8)));
   margin: var(--space-3) auto var(--space-2);
   color: var(--foreground);
 }
@@ -181,7 +181,7 @@
 }
 
 .plan-execution-panel {
-  width: min(var(--maka-chat-measure), calc(100% - var(--space-8)));
+  width: min(var(--maka-reading-measure), calc(100% - var(--space-8)));
   display: grid;
   gap: var(--space-2);
   margin: 0 auto var(--space-2);

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -30,7 +30,7 @@
      centered. Once React mounts, `.appFrame` is that flex container's
      only child, and without an explicit main-axis size a flex item
      shrinks to its content width and gets centered — so on the
-     first-run hero (onboarding content max-content ~680px) the whole
+     first-run hero (onboarding content is narrower than the window) the whole
      app frame floated mid-window with large left/right gutters, while
      long-message sessions filled the width. Pin `width:100%` so the
      frame always spans the window regardless of inner content's

--- a/apps/desktop/src/renderer/styles/workbar/artifacts.css
+++ b/apps/desktop/src/renderer/styles/workbar/artifacts.css
@@ -199,12 +199,12 @@
   background: var(--background);
 }
 
-/* The pane caps itself at 600px, so this only binds in the stacked layout a
-   narrow window switches to, where the workbar drops its width cap and the
-   preview can run the width of the window. Prose needs a measure there; the
-   pane's own width is one everywhere else. */
+/* The workbar caps its own width (`SESSION_WORKBAR_MAX_WIDTH`), so this only
+   binds in the stacked layout a narrow window switches to, where that cap is
+   dropped and the preview can run the width of the window. Prose needs a
+   measure there; the pane's own width is one everywhere else. */
 .maka-artifact-preview-markdown {
-  max-width: var(--maka-chat-measure);
+  max-width: var(--maka-reading-measure);
   min-width: 0;
   padding-inline: var(--space-1);
 }

--- a/apps/desktop/src/renderer/styles/workbar/artifacts.css
+++ b/apps/desktop/src/renderer/styles/workbar/artifacts.css
@@ -199,7 +199,12 @@
   background: var(--background);
 }
 
+/* The pane caps itself at 600px, so this only binds in the stacked layout a
+   narrow window switches to, where the workbar drops its width cap and the
+   preview can run the width of the window. Prose needs a measure there; the
+   pane's own width is one everywhere else. */
 .maka-artifact-preview-markdown {
+  max-width: var(--maka-chat-measure);
   min-width: 0;
   padding-inline: var(--space-1);
 }

--- a/apps/desktop/src/renderer/styles/workhub.css
+++ b/apps/desktop/src/renderer/styles/workhub.css
@@ -42,8 +42,8 @@
 .workhub-header,
 .workhub-empty,
 .workhub-turns {
-  width: min(var(--maka-chat-measure), 100%);
-  max-width: var(--maka-chat-measure);
+  width: min(var(--maka-reading-measure), 100%);
+  max-width: var(--maka-reading-measure);
   margin-inline: auto;
 }
 
@@ -223,7 +223,7 @@
 
 .workhub-return {
   display: block;
-  width: min(var(--maka-chat-measure), calc(100% - var(--space-8)));
+  width: min(var(--maka-reading-measure), calc(100% - var(--space-8)));
   margin: 0 auto 8px;
   padding: 7px 12px;
   border: 1px solid var(--color-border-subtle, var(--border));

--- a/apps/desktop/src/renderer/styles/workhub.css
+++ b/apps/desktop/src/renderer/styles/workhub.css
@@ -125,12 +125,6 @@
   overflow-wrap: anywhere;
 }
 
-.workhub-assistant-bubble.maka-chat-message-bubble-assistant {
-  box-sizing: border-box;
-  width: 100%;
-  max-width: none;
-}
-
 .workhub-assistant-bubble > small,
 .workhub-status {
   color: var(--color-text-secondary, var(--muted-foreground));

--- a/apps/desktop/src/renderer/styles/workhub.css
+++ b/apps/desktop/src/renderer/styles/workhub.css
@@ -229,7 +229,7 @@
 
 .workhub-return {
   display: block;
-  width: min(680px, calc(100% - 48px));
+  width: min(var(--maka-chat-measure), calc(100% - var(--space-8)));
   margin: 0 auto 8px;
   padding: 7px 12px;
   border: 1px solid var(--color-border-subtle, var(--border));

--- a/apps/desktop/src/renderer/workhub-surface.tsx
+++ b/apps/desktop/src/renderer/workhub-surface.tsx
@@ -576,7 +576,11 @@ function WorkHubMessageFrame(props: {
         </ChatMessageBubble>
       </ChatMessage>
       <ChatMessage sender="assistant" density="compact" className="workhub-message">
-        <ChatMessageBubble variant="ghost" className="maka-chat-message-bubble maka-chat-message-bubble-assistant workhub-assistant-bubble">
+        <ChatMessageBubble
+          variant="ghost"
+          width="100%"
+          className="maka-chat-message-bubble maka-chat-message-bubble-assistant workhub-assistant-bubble"
+        >
           {props.children}
         </ChatMessageBubble>
       </ChatMessage>

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -1165,6 +1165,9 @@ const AssistantAnswerBubble = memo(function AssistantAnswerBubble(props: Assista
   return (
     <ChatMessageBubble
       variant="ghost"
+      // Astryx's own seam for a bubble that spans the message column: it sets
+      // the width and drops the default max(80%, 280px) cap in one prop.
+      width="100%"
       className={
         props.phase === 'historical'
           ? 'maka-chat-message-bubble maka-chat-message-bubble-assistant'

--- a/packages/ui/src/markdown-body.tsx
+++ b/packages/ui/src/markdown-body.tsx
@@ -151,6 +151,15 @@ export function MarkdownBody(props: {
     >
       <AstryxMarkdown
         autolink="gfm"
+        // Markdown holds no reading measure; the container it lands in does.
+        //
+        // Astryx caps prose at 680px by default but renders a supplied
+        // `components.code` bare — no spacing, no width, no alignment. Maka
+        // always supplies one, so any container that leans on the default gets
+        // prose at 680 and code blocks at whatever the container is: two right
+        // edges, which is the defect this whole change exists to remove. One
+        // authority per column, and it is the container.
+        contentWidth="100%"
         // Chosen by the caller, and defaulting to document rhythm.
         //
         // The transcript passes `compact`: Astryx's default heading spacing

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -32,10 +32,9 @@ import { cn } from "../utils.js";
  * onto package-owned semantic classes.
  *
  * The measure-column geometry the old `tool-output.css` re-anchor applied to
- * the summary / lineage rows / footer (`max-width:var(--maka-chat-measure)`,
- * `margin-right:auto`) is folded directly into those container variants here,
- * so the layout is location-independent instead of coupled to a
- * `[data-role="assistant"]` descendant selector.
+ * the summary / lineage rows / footer is gone rather than moved: `.maka-turn`
+ * is the column, and every `Marker` renders inside one, so a second cap on the
+ * chrome could only ever be the same edge stated twice.
  *
  * `markerVariants` is exported from THIS module as a local variant recipe
  * so the lineage badge + footer action — which render as `UiButton` and can't

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -779,7 +779,7 @@
 .maka-turn-footer {
   display: flex;
   width: 100%;
-  max-width: var(--maka-chat-measure, 680px);
+  max-width: var(--maka-chat-measure, 800px);
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -779,13 +779,10 @@
 .maka-turn-footer {
   display: flex;
   width: 100%;
-  max-width: var(--maka-chat-measure, 800px);
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
   gap: var(--space-0-5);
-  margin-left: 0;
-  margin-right: auto;
 }
 
 .maka-turn-lineage-row {

--- a/packages/ui/stories/markdown.stories.tsx
+++ b/packages/ui/stories/markdown.stories.tsx
@@ -70,7 +70,7 @@ export const TranscriptTurn: Story = {
   render: () => (
     <ProseFrame>
       <div className="maka-turn">
-        <ChatMessageBubble variant="ghost" className="maka-chat-message-bubble maka-chat-message-bubble-assistant">
+        <ChatMessageBubble variant="ghost" width="100%" className="maka-chat-message-bubble maka-chat-message-bubble-assistant">
           <Markdown
             density="compact"
             text={[
@@ -108,7 +108,7 @@ export const TranscriptCodeBlock: Story = {
   render: () => (
     <ProseFrame width={1040}>
       <div className="maka-turn">
-        <ChatMessageBubble variant="ghost" className="maka-chat-message-bubble maka-chat-message-bubble-assistant">
+        <ChatMessageBubble variant="ghost" width="100%" className="maka-chat-message-bubble maka-chat-message-bubble-assistant">
           <Markdown
             density="compact"
             text={[
@@ -135,7 +135,7 @@ export const TranscriptCodeBlock: Story = {
 export const RichAssistantAnswer: Story = {
   render: () => (
     <ProseFrame>
-      <ChatMessageBubble variant="ghost" className="maka-chat-message-bubble maka-chat-message-bubble-assistant">
+      <ChatMessageBubble variant="ghost" width="100%" className="maka-chat-message-bubble maka-chat-message-bubble-assistant">
         <Markdown
           text={[
             '## 改动思路',
@@ -170,7 +170,7 @@ export const RichAssistantAnswer: Story = {
 export const LongFormArticle: Story = {
   render: () => (
     <ProseFrame width={680}>
-      <ChatMessageBubble variant="ghost" className="maka-chat-message-bubble maka-chat-message-bubble-assistant">
+      <ChatMessageBubble variant="ghost" width="100%" className="maka-chat-message-bubble maka-chat-message-bubble-assistant">
         <Markdown
           text={[
             '# Storybook 表面覆盖：为什么单独可看很重要',


### PR DESCRIPTION
## Summary

An assistant turn had two right edges. The turn column is `--maka-transcript-measure` (800px), and the tool cards, code blocks and the user bubble all reach it — but every paragraph stopped 120px short, leaving a band of whitespace down the right side of the transcript that is wider on a wider window.

The cause is two reading-measure authorities. Maka's column owns one, and Astryx's `Markdown` owns another: `contentWidth` defaults to 680px with `contentAlign: 'start'`, while code and tables are left to fill the container. #3617 raised the column from 680 to 800 so source evidence could be read, which made the second authority visible for the first time.

`MarkdownBody` now passes `contentWidth: 100%`, which is a disclaimer rather than a width: Markdown holds no measure, and the container it lands in is the only one that does.

That rule only works if every container has one, and the two document callers did not. Astryx renders a supplied `components.code` bare — no spacing, no width, no alignment — and Maka always supplies one, so on the Daily Review report, which sits on an uncapped module page, prose stopped at 680 while the code blocks inside it ran the width of the window. That is the same two edges, one surface over, and it is live on `main` today. The report column holds the measure now — the column and not the prose inside it, since a section is a heading, a divider and its prose, and capping only the prose would have left the other two running past it. The Artifact Preview pane caps itself at 600px and so never showed this in the normal layout; it holds the measure for the stacked layout a narrow window switches to, where the workbar drops that cap.

The 680 is deliberately not mirrored into a Maka token. A token would make Astryx's default ours to keep in sync, which is the same two-authority defect wearing a token's name.

Three commits follow it, taking the same defect to its root.

**One reading measure.** `--maka-reading-measure` (680px) and `--maka-transcript-measure` (800px) split one column in two, so the answer was wider than the box you type into, and turn chrome (`.maka-turn-footer`, `.maka-turn-lineage-row`) stopped at 680 inside an 800px turn — three right edges down one conversation. `--maka-reading-measure` is now 800px and is the only measure; the transcript token is deleted and `@maka/ui`'s fallback follows it, since that package does not load `maka-tokens.css`. `.workhub-return` had written the old 680 as a literal and reads the measure now, like the panels above it. 800px because the alternative undoes #3617: at 680 the code and tables it widened go back into a column too tight to read.

This widens surfaces beyond the transcript by 18%: the composer, header notices, the hero, plan mode, WorkHub, the agent graph, the Daily Review report and the Artifact Preview all move from 680 to 800. That is the point rather than a side effect — those are the surfaces whose edge was failing to line up with the answer above them — but it is the visible part of this PR and the reason for the second screenshot.

**Tokens nothing reads.** The audit behind the measure merge also found 21 custom properties with no `var()` consumer anywhere — not in renderer CSS, `@maka/ui`, stories, or Astryx, which reads some Maka properties through its own theme bridge and was checked separately. Two groups are more than single tokens: the CSS icon scale mirrored `ICON_SIZE` in `icons.tsx` (209 consumers there, two here) and keeps only its two CSS-clamped rungs; the z-index ladder listed four rungs no layer sits on. Four comments naming a deleted token as live are corrected with it. The unread `--elevation-raised` / `--elevation-drag` stay: DESIGN.md §5 names the three-step tier as the vocabulary product CSS must use and the Floating Recipe requires `--elevation-overlay` by name, so retiring part of a published tier is a design decision rather than a sweep. `--foreground-8` stays beside `--foreground-alpha-*` — the first mixes into the background and is opaque, the second is a real alpha channel.

**What the merge made redundant.** Two comments elsewhere stated the old split as current — the composer "stayed at 680px", and the first-run hero's content was pinned at "~680px" to explain a flex bug whose argument does not need the number; a number repeated in prose is the same second authority in a form no search finds. The assistant bubble set `width: 100%; max-width: none` from product CSS, in `chat-message.css` and again at higher specificity in `workhub.css`; Astryx's published `width` prop does exactly that, and both call sites already pass the `variant="ghost"` its docs pair it with, so the two CSS blocks become two props, and the markdown stories pass it too. Turn chrome's `max-width: var(--maka-chat-measure, 800px)` and its auto margins bound while the chrome was 680 inside an 800px turn; under one measure a descendant of an 800px box cannot exceed 800, so they can never apply, and the 800px fallback leaves with them, along with the `Marker` doc comment that promised that geometry. A documentation block in `chat-message.css` with no rules under it, restating geometry documented where those rules live, goes too.

**One name.** `--maka-chat-measure` stopped being about chat once it governed the Daily Review report and the Artifact Preview too, and a name that describes a subset of what a token governs is how the next surface concludes the token is not for it and writes a second one. It is `--maka-reading-measure` at all twenty-four call sites. DESIGN.md gains the rule in §7, where the other two named typography rules live — one reading column, one token, held by the container and never by a component — and §11's list of rulers nobody may duplicate gains "reading measure" beside spacing, radius, icons and the text axis.

Refs #3617

## Screenshots

Same conversation, same 1400px viewport.

Before — three right edges: the paragraph wraps 120px inside the code card, and the composer stops 120px inside both:

<img width="1400" height="800" alt="image" src="https://github.com/user-attachments/assets/af9cf015-a0b3-44c8-8d18-bf10c9148a99" />

After — one: prose, code card, user bubble and composer all stop at the same edge:

<img width="1400" height="800" alt="image" src="https://github.com/user-attachments/assets/118c0d9c-b220-471c-aa93-3f1c939abad7" />

## Verification

All of the following on the final tree.

- `e2e/transcript-measure.spec.ts`, `e2e/session-workbar.spec.ts` — 8 passed. The second renders the WorkHub assistant bubble, whose product CSS this replaces with the `width` prop.
- `e2e/composer-plus-menu-stability.spec.ts`, `e2e/prompt-rail.spec.ts`, `e2e/link-color-contract.spec.ts`, `e2e/settings-row-focus-ring.spec.ts` — 19 passed. The first two cover the composer at the widened measure; the last two assert computed color and focus-ring geometry, the surfaces closest to the removed color and shadow tiers.
- New E2E `apps/desktop/e2e/transcript-measure.spec.ts`: sends a message at a 1400px viewport and asserts the assistant paragraph's right edge meets the turn column's right edge. Reverting `contentWidth` to `680` fails it at exactly `120`.
- Token consumer search covered `apps`, `packages`, `native`, `scripts` (css/ts/tsx/js/mjs/html) plus `@astryxdesign/core/dist` and `theme-neutral`, excluding build output and caches; re-run after the deletions and after the rename, no `var()` reference and no bare mention of a removed or old name survives. Dynamic access checked separately: only `--background` and `--maka-drawer-tooltip-x` go through `setProperty` / `getPropertyValue`.
- `@maka/ui` and `@maka/desktop` typecheck, `npm --workspace @maka/desktop run build:with-deps`, and `npm run format` — all clean.
- Not run: the repository-wide suite and Storybook visual smoke. CI covers both.
- No test covers the two document containers' caps. The invariant that regresses loudly — Markdown carrying a measure of its own — is what `transcript-measure.spec.ts` asserts; losing a container cap degrades line length rather than breaking behavior, and driving E2E to the Daily Review report to assert it was judged not worth its cost.

## Root cause

The defect reproduces in Astryx alone, with no Maka code: `ChatLayout density="spacious"` gives an 800px message area, `ChatMessageBubble variant="ghost" width="100%"` (the documented pattern for rich content) fills it, and a default `Markdown` inside stops its prose at 680px while its code blocks fill the bubble.

Astryx already solves exactly this in `Layout`, which publishes its `contentWidth` as the inheritable `--layout-content-width` and has `LayoutHeader` / `LayoutFooter` read it back as `var(--layout-content-width, none)`. Neither `Markdown` nor `ChatLayout` participates: both carry hardcoded values instead. Reported upstream as facebook/astryx#5598. If Astryx adopts the inheritance, this prop can be deleted.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — diagnosis, the fix, the token audit, the E2E, and this description. Reviewed and verified by the contributor before opening.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
