### PR TITLE
fix(cli): split MCP capability provider to avoid pulling runtime-host/server into TUI

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-capability-provider-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-capability-provider-command.test.ts
@@ -18,10 +18,24 @@
  */
 
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { test } from 'node:test';
 import type { McpToolBinding } from '@maka/core/mcp';
 import type { McpClientManager } from '@maka/mcp';
+import { createMcpCapabilityProvider as createPureMcpCapabilityProvider } from '../mcp-capability-provider.js';
 import { createMcpCapabilityProvider } from '../runtime-host-capability-provider-command.js';
+
+test('TUI MCP control keeps its capability provider on the pure import boundary', async () => {
+  const [tuiSource, providerSource] = await Promise.all([
+    readFile(new URL('../tui-mcp-control.js', import.meta.url), 'utf8'),
+    readFile(new URL('../mcp-capability-provider.js', import.meta.url), 'utf8'),
+  ]);
+
+  assert.equal(createMcpCapabilityProvider, createPureMcpCapabilityProvider);
+  assert.match(tuiSource, /from ['"]\.\/mcp-capability-provider\.js['"]/u);
+  assert.doesNotMatch(tuiSource, /@maka\/runtime-host\/server/u);
+  assert.doesNotMatch(providerSource, /@maka\/runtime-host\/server/u);
+});
 
 test('MCP capability publication freezes an accepted callable tool snapshot', async () => {
   let accepted = false;

--- a/packages/cli/src/mcp-capability-provider.ts
+++ b/packages/cli/src/mcp-capability-provider.ts
@@ -18,10 +18,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import type {
-  McpBoundTool,
-  McpToolBinding,
-} from '@maka/core/mcp';
+import type { McpBoundTool, McpToolBinding } from '@maka/core/mcp';
 import type { McpClientManager } from '@maka/mcp';
 import type { ClientCapabilityProvider } from '@maka/runtime-host/client';
 import {

--- a/packages/cli/src/mcp-capability-provider.ts
+++ b/packages/cli/src/mcp-capability-provider.ts
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createHash } from 'node:crypto';
+import type {
+  McpBoundTool,
+  McpToolBinding,
+} from '@maka/core/mcp';
+import type { McpClientManager } from '@maka/mcp';
+import type { ClientCapabilityProvider } from '@maka/runtime-host/client';
+import {
+  CLIENT_CAPABILITY_MAX_TOOLS,
+  CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER,
+  decodeClientCapabilityReplaceInput,
+  type ClientCapabilityCallResult,
+  type ClientCapabilityOffer,
+} from '@maka/runtime-host/protocol';
+import type { McpCallResult, McpToolDescriptor } from '@maka/core/mcp';
+
+const CAPABILITY_VERSION = '0';
+
+export function createMcpCapabilityProvider(
+  manager: Pick<McpClientManager, 'toolSnapshot' | 'callTool'>,
+): ClientCapabilityProvider | undefined {
+  const toolSnapshot = manager.toolSnapshot();
+  const tools = [...toolSnapshot.tools].sort(
+    (left, right) =>
+      left.descriptor.serverId.localeCompare(right.descriptor.serverId) ||
+      left.descriptor.name.localeCompare(right.descriptor.name),
+  );
+  const toolCount = tools.length;
+  if (toolCount === 0) return undefined;
+  if (toolCount > CLIENT_CAPABILITY_MAX_TOOLS) {
+    throw new Error(
+      `MCP capability provider exposes ${toolCount} tools; the limit is ${CLIENT_CAPABILITY_MAX_TOOLS}`,
+    );
+  }
+
+  const projectedIdentities = new Set<string>();
+  const projected: Array<{
+    readonly source: McpBoundTool;
+    readonly descriptor: ReturnType<typeof projectMcpTool>;
+  }> = [];
+  for (const source of tools) {
+    const descriptor = projectMcpTool(
+      source.descriptor,
+      capabilityEntityId(source.descriptor.serverId),
+    );
+    const identity = `${descriptor.serverId}\0${descriptor.name}`;
+    if (projectedIdentities.has(identity)) {
+      throw new Error('MCP tools collide after Client Capability identity normalization');
+    }
+    projectedIdentities.add(identity);
+    projected.push({ source, descriptor });
+  }
+
+  const bindings = new Map<string, McpToolBinding>();
+  const offers: ClientCapabilityOffer[] = [];
+  for (let offset = 0; offset < projected.length; offset += CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER) {
+    const chunk = projected.slice(offset, offset + CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER);
+    const offerId = mcpOfferId(chunk, offset / CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER);
+    const servers = new Set(chunk.map(({ source }) => source.descriptor.serverId));
+    offers.push({
+      offerId,
+      version: CAPABILITY_VERSION,
+      affinity: 'session',
+      hostPathAccess: 'none',
+      label:
+        servers.size === 1
+          ? `MCP: ${chunk[0]?.source.descriptor.serverId ?? 'tools'}`.slice(0, 128)
+          : `MCP tools (${servers.size} servers)`,
+      description: 'Use tools provided by connected MCP servers.',
+      tools: chunk.map(({ descriptor }) => descriptor),
+    });
+    for (const { source, descriptor } of chunk) {
+      bindings.set(
+        capabilityBindingKey(offerId, descriptor.serverId, descriptor.name),
+        source.binding,
+      );
+    }
+  }
+  const canonical = decodeClientCapabilityReplaceInput({
+    registrationId: '00000000-0000-4000-8000-000000000000',
+    offers,
+  });
+
+  return {
+    offers: () => canonical.offers,
+    call: async (frame, options) => {
+      const binding = bindings.get(
+        capabilityBindingKey(frame.offerId, frame.serverId, frame.toolName),
+      );
+      if (!binding) throw new Error('MCP capability is not part of the published snapshot');
+      await options.accept();
+      return projectMcpResult(
+        await manager.callTool(binding, frame.arguments, { signal: options.signal }),
+      );
+    },
+  };
+}
+
+function projectMcpTool(tool: McpToolDescriptor, wireServerId: string) {
+  return {
+    serverId: wireServerId,
+    name: capabilityEntityId(tool.name),
+    ...(tool.description ? { description: tool.description } : {}),
+    inputSchema: structuredClone(tool.inputSchema),
+    ...(tool.annotations ? { annotations: { ...tool.annotations } } : {}),
+  };
+}
+
+function capabilityEntityId(value: string): string {
+  if (/^[A-Za-z0-9_-]{1,128}$/u.test(value)) return value;
+  const label = value.replace(/[^A-Za-z0-9_-]+/gu, '_').slice(0, 103) || 'mcp';
+  const digest = createHash('sha256').update(value).digest('hex').slice(0, 24);
+  return `${label}_${digest}`;
+}
+
+function projectMcpResult(result: McpCallResult): ClientCapabilityCallResult {
+  return {
+    content: result.content.map((block) => structuredClone(block)),
+    ...(result.structuredContent === undefined
+      ? {}
+      : { structuredContent: structuredClone(result.structuredContent) }),
+  };
+}
+
+function mcpOfferId(tools: readonly { readonly source: McpBoundTool }[], chunk: number): string {
+  const hash = createHash('sha256').update(`mcp-capability-offer-v0\0${chunk}`);
+  for (const { source } of tools)
+    hash
+      .update('\0')
+      .update(source.descriptor.serverId)
+      .update('\0')
+      .update(source.descriptor.name);
+  return `mcp_${hash.digest('hex').slice(0, 24)}_${chunk}`;
+}
+
+function capabilityBindingKey(offerId: string, serverId: string, toolName: string): string {
+  return `${offerId}\0${serverId}\0${toolName}`;
+}

--- a/packages/cli/src/runtime-host-capability-provider-command.ts
+++ b/packages/cli/src/runtime-host-capability-provider-command.ts
@@ -21,12 +21,6 @@ import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import type {
-  McpBoundTool,
-  McpCallResult,
-  McpToolBinding,
-  McpToolDescriptor,
-} from '@maka/core/mcp';
 import { createCredentialMcpOAuthStorage, McpClientManager } from '@maka/mcp';
 import { createFileCredentialStore } from '@maka/storage/credential-store';
 import { normalizeMcpConfig } from '@maka/storage/mcp-config-store';
@@ -36,20 +30,15 @@ import {
   remoteRuntimeHostUnavailableError,
   RuntimeHostPermanentReconnectError,
   startRuntimeHostCapabilityProviderService,
-  type ClientCapabilityProvider,
   type RuntimeHostConnection,
 } from '@maka/runtime-host/client';
 import {
-  CLIENT_CAPABILITY_MAX_TOOLS,
-  CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER,
-  decodeClientCapabilityReplaceInput,
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
-  type ClientCapabilityCallResult,
-  type ClientCapabilityOffer,
 } from '@maka/runtime-host/protocol';
 import { runRuntimeHostProcessLifecycle } from '@maka/runtime-host/server';
+import { createMcpCapabilityProvider } from './mcp-capability-provider.js';
 
 const DEFAULT_CREDENTIAL_ENV = 'MAKA_RUNTIME_HOST_ACCESS_CREDENTIAL';
 const CAPABILITY_VERSION = '0';
@@ -199,126 +188,7 @@ async function connectRemoteCapabilityProvider(input: {
   throw new Error('Runtime Host is draining');
 }
 
-export function createMcpCapabilityProvider(
-  manager: Pick<McpClientManager, 'toolSnapshot' | 'callTool'>,
-): ClientCapabilityProvider | undefined {
-  const toolSnapshot = manager.toolSnapshot();
-  const tools = [...toolSnapshot.tools].sort(
-    (left, right) =>
-      left.descriptor.serverId.localeCompare(right.descriptor.serverId) ||
-      left.descriptor.name.localeCompare(right.descriptor.name),
-  );
-  const toolCount = tools.length;
-  if (toolCount === 0) return undefined;
-  if (toolCount > CLIENT_CAPABILITY_MAX_TOOLS) {
-    throw new Error(
-      `MCP capability provider exposes ${toolCount} tools; the limit is ${CLIENT_CAPABILITY_MAX_TOOLS}`,
-    );
-  }
-
-  const projectedIdentities = new Set<string>();
-  const projected: Array<{
-    readonly source: McpBoundTool;
-    readonly descriptor: ReturnType<typeof projectMcpTool>;
-  }> = [];
-  for (const source of tools) {
-    const descriptor = projectMcpTool(
-      source.descriptor,
-      capabilityEntityId(source.descriptor.serverId),
-    );
-    const identity = `${descriptor.serverId}\0${descriptor.name}`;
-    if (projectedIdentities.has(identity)) {
-      throw new Error('MCP tools collide after Client Capability identity normalization');
-    }
-    projectedIdentities.add(identity);
-    projected.push({ source, descriptor });
-  }
-
-  const bindings = new Map<string, McpToolBinding>();
-  const offers: ClientCapabilityOffer[] = [];
-  for (let offset = 0; offset < projected.length; offset += CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER) {
-    const chunk = projected.slice(offset, offset + CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER);
-    const offerId = mcpOfferId(chunk, offset / CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER);
-    const servers = new Set(chunk.map(({ source }) => source.descriptor.serverId));
-    offers.push({
-      offerId,
-      version: CAPABILITY_VERSION,
-      affinity: 'session',
-      hostPathAccess: 'none',
-      label:
-        servers.size === 1
-          ? `MCP: ${chunk[0]?.source.descriptor.serverId ?? 'tools'}`.slice(0, 128)
-          : `MCP tools (${servers.size} servers)`,
-      description: 'Use tools provided by connected MCP servers.',
-      tools: chunk.map(({ descriptor }) => descriptor),
-    });
-    for (const { source, descriptor } of chunk) {
-      bindings.set(
-        capabilityBindingKey(offerId, descriptor.serverId, descriptor.name),
-        source.binding,
-      );
-    }
-  }
-  const canonical = decodeClientCapabilityReplaceInput({
-    registrationId: '00000000-0000-4000-8000-000000000000',
-    offers,
-  });
-
-  return {
-    offers: () => canonical.offers,
-    call: async (frame, options) => {
-      const binding = bindings.get(
-        capabilityBindingKey(frame.offerId, frame.serverId, frame.toolName),
-      );
-      if (!binding) throw new Error('MCP capability is not part of the published snapshot');
-      await options.accept();
-      return projectMcpResult(
-        await manager.callTool(binding, frame.arguments, { signal: options.signal }),
-      );
-    },
-  };
-}
-
-function projectMcpTool(tool: McpToolDescriptor, wireServerId: string) {
-  return {
-    serverId: wireServerId,
-    name: capabilityEntityId(tool.name),
-    ...(tool.description ? { description: tool.description } : {}),
-    inputSchema: structuredClone(tool.inputSchema),
-    ...(tool.annotations ? { annotations: { ...tool.annotations } } : {}),
-  };
-}
-
-function capabilityEntityId(value: string): string {
-  if (/^[A-Za-z0-9_-]{1,128}$/u.test(value)) return value;
-  const label = value.replace(/[^A-Za-z0-9_-]+/gu, '_').slice(0, 103) || 'mcp';
-  const digest = createHash('sha256').update(value).digest('hex').slice(0, 24);
-  return `${label}_${digest}`;
-}
-
-function projectMcpResult(result: McpCallResult): ClientCapabilityCallResult {
-  return {
-    content: result.content.map((block) => structuredClone(block)),
-    ...(result.structuredContent === undefined
-      ? {}
-      : { structuredContent: structuredClone(result.structuredContent) }),
-  };
-}
-
-function mcpOfferId(tools: readonly { readonly source: McpBoundTool }[], chunk: number): string {
-  const hash = createHash('sha256').update(`mcp-capability-offer-v0\0${chunk}`);
-  for (const { source } of tools)
-    hash
-      .update('\0')
-      .update(source.descriptor.serverId)
-      .update('\0')
-      .update(source.descriptor.name);
-  return `mcp_${hash.digest('hex').slice(0, 24)}_${chunk}`;
-}
-
-function capabilityBindingKey(offerId: string, serverId: string, toolName: string): string {
-  return `${offerId}\0${serverId}\0${toolName}`;
-}
+export { createMcpCapabilityProvider } from './mcp-capability-provider.js';
 
 function reportRefreshFailure(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/tui-mcp-control.ts
+++ b/packages/cli/src/tui-mcp-control.ts
@@ -26,7 +26,7 @@ import type {
   RuntimeHostConnectionAvailability,
   RuntimeHostReconnectingConnection,
 } from '@maka/runtime-host/client';
-import { createMcpCapabilityProvider } from './runtime-host-capability-provider-command.js';
+import { createMcpCapabilityProvider } from './mcp-capability-provider.js';
 
 const RUNTIME_HOST_CREDENTIAL_ENV = 'MAKA_RUNTIME_HOST_ACCESS_CREDENTIAL';
 


### PR DESCRIPTION
## Summary

Fixes #4005.

The CLI TUI previously reached `createMcpCapabilityProvider` through a command module that also imports `@maka/runtime-host/server`. This keeps the provider implementation in `mcp-capability-provider.ts`, lets `tui-mcp-control` import that pure module directly, and retains the command-module re-export for existing callers. The follow-up test guards the emitted TUI-to-provider boundary so it cannot silently regain the Runtime Host server dependency.

## Verification

- `mise exec node@24.18.1 -- npm --workspace maka-agent run build`
- `mise exec node@24.18.1 -- node --test packages/cli/dist/__tests__/runtime-host-capability-provider-command.test.js` — 3 passed
- The previous exact-head hosted `test` check passed before this follow-up; this push reruns CI.
- Not rerun locally: the complete repository suite and import-performance measurement.

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Muse Spark was declared for the initial provider extraction. Codex added the emitted-module import-boundary regression test and restored this PR template metadata. The follow-up commit carries a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No