### PR TITLE
fix(runtime-host): handle question cancellation during drain

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-host-queue.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host-queue.test.ts
@@ -51,6 +51,7 @@ import {
   commitTerminalRunWithRuntimeFact,
 } from '@maka/runtime/terminal-run-commit';
 import {
+  FAKE_ASK_USER_QUESTION_DURING_DRAIN_PROMPT,
   FAKE_ASK_USER_QUESTION_PROMPT,
   FAKE_WAIT_FOR_STEERING_PROMPT,
 } from '@maka/runtime/test-only/fake-backend';
@@ -554,6 +555,50 @@ test('graceful Host shutdown stops and drains an active Turn before releasing ow
     assert.equal(stable.status, 'cancelled');
     await observer.close();
     await fixture.stopHost(successor);
+
+    const ledger = await fixture.readTurn(turnId);
+    assert.equal(ledger.terminalEvents.length, 1);
+    assert.equal(ledger.classification.kind, 'fact');
+    if (ledger.classification.kind === 'fact') {
+      assert.equal(ledger.classification.fact.runStatus, 'cancelled');
+      assert.notEqual(ledger.classification.fact.failureClass, 'app_restarted');
+    }
+  });
+});
+
+test('Host shutdown contains a user-question admission rejected by Interaction drain', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root);
+    const subscription = await client.openSessionSubscription({
+      sessionId: fixture.sessionId,
+      transcript: { kind: 'none' },
+    });
+    const probe = new SubscriptionProbe(subscription);
+    const turnId = randomUUID();
+    const started = requireStartedTurn(
+      await client.request('turn.start', {
+        sessionId: fixture.sessionId,
+        turnId,
+        content: { text: FAKE_ASK_USER_QUESTION_DURING_DRAIN_PROMPT },
+      }),
+    );
+
+    await probe.waitFor(
+      (frame) =>
+        frame.kind === 'subscription.session_event' &&
+        frame.runId === started.runId &&
+        frame.event.type === 'tool_start' &&
+        frame.event.toolName === 'AskUserQuestion',
+      'question scenario did not reach its admission checkpoint',
+    );
+
+    const exit = await fixture.stopHost(host, { type: 'shutdown_question_admission' });
+    assert.deepEqual(exit, { code: 0, signal: null });
+    await client.closed;
+    await probe.waitForFailure('connection_closed');
+    await fixture.assertOwnerAvailable();
+    assert.equal(await fixture.readPendingInteractionCount(), 0);
 
     const ledger = await fixture.readTurn(turnId);
     assert.equal(ledger.terminalEvents.length, 1);

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
@@ -934,9 +934,10 @@ export class ExecutionFixture {
 
   async stopHost(
     host: ExecutionHostHandle,
+    shutdownMessage: { type: 'shutdown' | 'shutdown_question_admission' } = { type: 'shutdown' },
   ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
     if (host.child.exitCode === null && host.child.signalCode === null) {
-      host.child.send({ type: 'shutdown' });
+      host.child.send(shutdownMessage);
     }
     const exit = await withTimeout(
       waitForExitResult(host.child),
@@ -994,6 +995,18 @@ export class ExecutionFixture {
         terminalEvents: runtimeEvents.filter(isTerminalRuntimeEvent),
         classification: classifyTerminalRuntimeLedger(run, runtimeEvents),
       };
+    } finally {
+      await stores?.sessionStore.close?.();
+      await reader.close();
+    }
+  }
+
+  async readPendingInteractionCount(): Promise<number> {
+    const reader = await acquireReader(this.capability);
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForRead>> | undefined;
+    try {
+      stores = await openInteractiveExecutionStoresForRead(reader.lease);
+      return (await stores.interactionStore.listSessionPending(this.sessionId)).length;
     } finally {
       await stores?.sessionStore.close?.();
       await reader.close();

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
@@ -44,6 +44,7 @@ if (!Number.isSafeInteger(idleGraceMs) || idleGraceMs < 0) {
 // candidate host in its own right, so it supplies the deterministic one through
 // the composition's `primaryBackendFactory` seam — the same path Desktop E2E
 // takes — and its sessions declare the real `ai-sdk` backend kind.
+const fakeBackends = new Set<FakeBackend>();
 const result = await startExecutionRuntimeHostCandidate(
   {
     rootPath,
@@ -53,7 +54,11 @@ const result = await startExecutionRuntimeHostCandidate(
   {
     createComposition: (context, compositionOptions) =>
       createExecutionRuntimeHostComposition(context, compositionOptions, {
-        primaryBackendFactory: (backendContext) => new FakeBackend(backendContext),
+        primaryBackendFactory: (backendContext) => {
+          const backend = new FakeBackend(backendContext);
+          fakeBackends.add(backend);
+          return backend;
+        },
       }),
   },
 );
@@ -72,11 +77,20 @@ if (recoverySessionId && recoveryRunId) {
 }
 
 process.on('message', (message: unknown) => {
-  if (
-    message &&
-    typeof message === 'object' &&
-    (message as { type?: unknown }).type === 'shutdown'
-  ) {
+  const type =
+    message && typeof message === 'object' ? (message as { type?: unknown }).type : undefined;
+  if (type === 'shutdown_question_admission') {
+    void (async () => {
+      await Promise.all(
+        [...fakeBackends].map((backend) => backend.waitForQuestionAdmissionCheckpoint()),
+      );
+      // Host.close() synchronously drains every authority before returning.
+      void result.host.close();
+      for (const backend of fakeBackends) backend.releaseQuestionAdmission();
+    })();
+    return;
+  }
+  if (type === 'shutdown') {
     void result.host.close();
   }
 });

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -455,7 +455,8 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
         ...results
           .filter(
             (result): result is PromiseRejectedResult =>
-              result.status === 'rejected' && !isShutdownCancelledBackendStart(result.reason),
+              result.status === 'rejected' &&
+              !isShutdownCancelledInteractionAdmission(result.reason),
           )
           .map((result) => result.reason),
       );
@@ -2970,13 +2971,15 @@ function isTerminalSnapshot(
   );
 }
 
-function isShutdownCancelledBackendStart(error: unknown): boolean {
-  // The Host began draining while a Turn was still starting its backend, so
-  // the interaction bind was rejected with authority_draining. The Turn never
-  // ran; its drain rejects with this FailStopError and the Host is already
-  // shutting down. Treating it as a shutdown failure would fail the whole
-  // Host close — it is the expected consequence of stopping mid-start, not a
-  // resource that failed to close.
+function isShutdownCancelledInteractionAdmission(error: unknown): boolean {
+  // Drain can reach a running question admission before the Turn's stop fence
+  // closes its Interaction Run, so this expected cancellation is direct.
+  if (
+    error instanceof RuntimeInteractionAdmissionRejectedError &&
+    error.reason === 'authority_draining'
+  ) {
+    return true;
+  }
   return (
     error instanceof RuntimeInteractionFailStopError &&
     error.authorityFailure instanceof RuntimeInteractionAdmissionRejectedError &&

--- a/packages/runtime/src/test-only/fake-backend.ts
+++ b/packages/runtime/src/test-only/fake-backend.ts
@@ -40,6 +40,7 @@ import type { SessionStore } from '../session-manager.js';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 export const FAKE_ASK_USER_QUESTION_PROMPT = '__e2e_ask_user_question__';
+export const FAKE_ASK_USER_QUESTION_DURING_DRAIN_PROMPT = '__e2e_ask_user_question_during_drain__';
 export const FAKE_ASK_SANDBOX_BOUNDARY_PROMPT = '__e2e_ask_sandbox_boundary__';
 export const FAKE_WAIT_FOR_STEERING_PROMPT = '__e2e_wait_for_steering__';
 export const FAKE_WAIT_FOR_STEERING_LARGE_RESPONSE_PROMPT =
@@ -70,6 +71,10 @@ export class FakeBackend implements AgentBackend {
   private stopped = false;
   private pendingQuestion: PendingQuestion | undefined;
   private pendingSandboxBoundary: PendingSandboxBoundary | undefined;
+  private readonly questionAdmissionWaiters: Array<() => void> = [];
+  private readonly questionAdmissionCheckpointWaiters: Array<() => void> = [];
+  private readonly stopWaiters: Array<() => void> = [];
+  private questionAdmissionWaiting = false;
 
   constructor(
     private readonly ctx: {
@@ -84,7 +89,10 @@ export class FakeBackend implements AgentBackend {
 
   async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
     this.stopped = false;
-    if (input.text === FAKE_ASK_USER_QUESTION_PROMPT) {
+    if (
+      input.text === FAKE_ASK_USER_QUESTION_PROMPT ||
+      input.text === FAKE_ASK_USER_QUESTION_DURING_DRAIN_PROMPT
+    ) {
       yield* this.sendQuestionScenario(input);
       return;
     }
@@ -326,6 +334,8 @@ export class FakeBackend implements AgentBackend {
 
   async stop(): Promise<void> {
     this.stopped = true;
+    this.releaseQuestionAdmission();
+    for (const resolve of this.stopWaiters.splice(0)) resolve();
     if (this.pendingQuestion && !this.pendingQuestion.hosted) {
       this.pendingQuestion.resolve(null);
       this.pendingQuestion = undefined;
@@ -349,6 +359,15 @@ export class FakeBackend implements AgentBackend {
   }
 
   async dispose(): Promise<void> {}
+
+  releaseQuestionAdmission(): void {
+    for (const resolve of this.questionAdmissionWaiters.splice(0)) resolve();
+  }
+
+  waitForQuestionAdmissionCheckpoint(): Promise<void> {
+    if (this.questionAdmissionWaiting) return Promise.resolve();
+    return new Promise((resolve) => this.questionAdmissionCheckpointWaiters.push(resolve));
+  }
 
   private async *sendErrorScenario(
     input: BackendSendInput,
@@ -440,6 +459,10 @@ export class FakeBackend implements AgentBackend {
       args: { questions },
     };
 
+    if (input.text === FAKE_ASK_USER_QUESTION_DURING_DRAIN_PROMPT) {
+      await this.waitForQuestionAdmissionRelease();
+    }
+
     let resolveResponse!: (response: UserQuestionResponse | null) => void;
     const responsePromise = new Promise<UserQuestionResponse | null>((resolve) => {
       resolveResponse = resolve;
@@ -465,6 +488,7 @@ export class FakeBackend implements AgentBackend {
         await input.hostedInteraction.admitUserQuestionRequest({ request, settlement });
       } catch (error) {
         this.takePendingQuestion(turnId, requestId).resolve(null);
+        if (input.text === FAKE_ASK_USER_QUESTION_DURING_DRAIN_PROMPT) await this.waitForStop();
         throw error;
       }
     }
@@ -537,6 +561,22 @@ export class FakeBackend implements AgentBackend {
     });
     yield { type: 'text_complete', id: randomUUID(), turnId, ts: completedAt, messageId, text };
     yield { type: 'complete', id: randomUUID(), turnId, ts: Date.now(), stopReason: 'end_turn' };
+  }
+
+  private async waitForQuestionAdmissionRelease(): Promise<void> {
+    if (this.stopped) return Promise.resolve();
+    this.questionAdmissionWaiting = true;
+    for (const resolve of this.questionAdmissionCheckpointWaiters.splice(0)) resolve();
+    try {
+      await new Promise<void>((resolve) => this.questionAdmissionWaiters.push(resolve));
+    } finally {
+      this.questionAdmissionWaiting = false;
+    }
+  }
+
+  private waitForStop(): Promise<void> {
+    if (this.stopped) return Promise.resolve();
+    return new Promise((resolve) => this.stopWaiters.push(resolve));
   }
 
   private async *sendSandboxBoundaryScenario(input: BackendSendInput): AsyncIterable<SessionEvent> {


### PR DESCRIPTION
## Summary

Treat a direct RuntimeInteractionAdmissionRejectedError with reason authority_draining as expected cancellation while RootTurnCoordinator is closing. The existing wrapped cancellation remains supported, and unrelated Interaction, invariant, cleanup, and resource failures still propagate.

Add a deterministic process-level checkpoint that reproduces the active AskUserQuestion admission race and verifies clean Host exit, terminal cancellation, no pending Interaction, and released ownership.

Fixes #3992

## Verification

- RED: temporarily removed the direct-error branch; the focused test failed with Host exit code 1 and a direct authority_draining admission rejection.
- Focused regression test repeated 10/10 successfully after restoration.
- execution-host-queue.test.js: 13 passed.
- fake-backend.test.js: 4 passed.
- npm run lint
- npm run format:check
- npm run build
- npm run typecheck
- npx knip --workspace apps/desktop
- npx knip --workspace packages/ui
- npm run check:asf-headers

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with repository analysis, implementation, tests, verification, and PR drafting. The human contributor reviewed the change and remains responsible for it.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No