### PR TITLE
fix(desktop): observe the first turn before admission

### DIFF
--- a/apps/desktop/e2e/streaming-remount.spec.ts
+++ b/apps/desktop/e2e/streaming-remount.spec.ts
@@ -25,6 +25,13 @@ import {
 import type { Locator } from '@playwright/test';
 import { COMPOSER_INPUT, ensureSidebarExpanded, expect, test } from './fixtures';
 
+interface SessionObservationLatchWindow extends Window {
+  /** E2E-only preload affordance; see the MAKA_E2E block in preload.ts. */
+  makaE2eLatch?: {
+    rejectNextSessionObservation(message: string): void;
+  };
+}
+
 function sessionRow(sidebar: Locator, sessionId: string): Locator {
   return sidebar.locator(`[data-session-id=${JSON.stringify(sessionId)}]`);
 }
@@ -35,6 +42,28 @@ async function steerActiveTurn(composer: Locator, text: string): Promise<void> {
   await composer.fill(text);
   await composer.press('Shift+Enter');
 }
+
+test('a failed first observation seed reconnects to the live Turn', async ({ window: page }) => {
+  const latchInstalled = await page.evaluate(() => {
+    const latch = (window as SessionObservationLatchWindow).makaE2eLatch;
+    if (!latch) return false;
+    latch.rejectNextSessionObservation('forced first observation failure');
+    return true;
+  });
+  expect(latchInstalled, 'the preload E2E latch is installed').toBe(true);
+
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill(FAKE_HOLD_OPEN_PROMPT);
+  await composer.press('Enter');
+
+  await expect(page.locator('.maka-bubble-streaming')).toContainText(
+    'Fake backend waiting',
+  );
+  await page.getByRole('button', { name: '停止' }).click();
+  await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, {
+    timeout: 20_000,
+  });
+});
 
 test('remounting a live surface leaves accumulated output settled', async ({
   window: page,
@@ -130,7 +159,7 @@ test('keeps a completed reply after an interrupted turn and conversation remount
   await composer.fill(FAKE_HOLD_OPEN_PROMPT);
   await composer.press('Enter');
   await expect(page.locator('.maka-bubble-streaming')).toContainText(
-    'Fake backend waiting for the test to stop the Turn.',
+    'Fake backend waiting',
   );
   const originalSessionId = await sidebar
     .locator('[data-session-id]:has([aria-current="page"])')

--- a/apps/desktop/src/main/__tests__/app-shell-busy-race-settlement.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-busy-race-settlement.test.ts
@@ -459,8 +459,11 @@ describe('busy-raced send settlement', () => {
       const actions = createAppShellChatActions({
         ...createActionsDeps(),
         activeIdRef,
+        activateSessionForFirstSend: async (sessionId) => {
+          activated.push(sessionId);
+          activeIdRef.current = sessionId;
+        },
         setActiveId: (sessionId: string | undefined) => {
-          if (sessionId !== undefined) activated.push(sessionId);
           activeIdRef.current = sessionId;
         },
         setLiveTurnBySession: turnState.setLiveTurnBySession,
@@ -500,6 +503,9 @@ describe('busy-raced send settlement', () => {
       const actions = createAppShellChatActions({
         ...createActionsDeps(),
         activeIdRef,
+        activateSessionForFirstSend: async (sessionId) => {
+          activeIdRef.current = sessionId;
+        },
         setActiveId: (sessionId: string | undefined) => {
           activeIdRef.current = sessionId;
         },

--- a/apps/desktop/src/main/__tests__/app-shell-chat-actions-fixture.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-chat-actions-fixture.ts
@@ -92,9 +92,10 @@ export function createTransientState() {
 }
 
 export function createActionsDeps() {
+  const activeIdRef = { current: undefined as string | undefined };
   return {
     uiLocale: 'en' as const,
-    activeIdRef: { current: undefined as string | undefined },
+    activeIdRef,
     addPendingSessionAction: () => true,
     captureComposerImportOwner: () => ({
       sessionId: undefined,
@@ -107,6 +108,9 @@ export function createActionsDeps() {
     markSessionReadLocally: () => undefined,
     messageRetryPendingRef: { current: new Set<string>() },
     refreshSessions: async () => [],
+    activateSessionForFirstSend: async (sessionId: string) => {
+      activeIdRef.current = sessionId;
+    },
     setActiveId: () => undefined,
     setMessageLoadErrorBySession: () => undefined,
     setMessageRetryPendingBySession: () => undefined,
@@ -115,7 +119,6 @@ export function createActionsDeps() {
     updateTransientMessage: () => undefined,
     removeTransientMessage: () => undefined,
     transcriptRangeRef: { current: undefined },
-    setNavSelection: () => undefined,
     setLiveTurnBySession: () => undefined,
     setInteractionBySession: () => undefined,
     showModelSetupToast: () => undefined,

--- a/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
@@ -342,6 +342,56 @@ describe('composer first-send cleanup', () => {
     }
   });
 
+  it('removes the unsent session and surfaces an observation barrier failure', async () => {
+    const activeIdRef = { current: undefined as string | undefined };
+    const removed: string[] = [];
+    const errors: string[] = [];
+    let submissions = 0;
+    const restoreWindow = installWindow({
+      newTasks: { create: async () => ({ id: 'session-1' }) },
+      sessions: {
+        submitMessage: async () => {
+          submissions += 1;
+          return { ok: true, attachments: [], skillInvocation: { loaded: [], failed: [] } };
+        },
+        remove: async (sessionId: string) => {
+          removed.push(sessionId);
+        },
+      },
+    });
+
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef,
+        activateSessionForFirstSend: async (sessionId) => {
+          activeIdRef.current = sessionId;
+          throw new Error('Timed out while preparing the new Session event stream');
+        },
+        setActiveId: (sessionId) => {
+          activeIdRef.current = sessionId;
+        },
+        isNewChatSendSurfaceActive: () => activeIdRef.current === undefined,
+        isShellSurfaceOwnerActive: (owner) =>
+          owner.navSection === 'sessions' && owner.sessionId === activeIdRef.current,
+        toastApi: {
+          error: (_title, description) => {
+            if (description) errors.push(description);
+          },
+          info: () => undefined,
+        },
+      });
+      assert.equal(await actions.send('hello'), false);
+    } finally {
+      restoreWindow();
+    }
+
+    assert.equal(submissions, 0);
+    assert.deepEqual(removed, ['session-1']);
+    assert.equal(activeIdRef.current, undefined);
+    assert.deepEqual(errors, ['The message could not be sent. Try again later.']);
+  });
+
   it('leaves an EXISTING session alone when its send rejects', async () => {
     // Only the session this send created is disposable. A send that fails in
     // an open conversation must not delete the conversation.

--- a/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
@@ -301,6 +301,47 @@ describe('composer first-send cleanup', () => {
     assert.deepEqual(removed, []);
   });
 
+  it('waits for the new session observation before submitting its first message', async () => {
+    const observation = deferred<void>();
+    const order: string[] = [];
+    const activeIdRef = { current: undefined as string | undefined };
+    const restoreWindow = installWindow({
+      newTasks: {
+        create: async () => {
+          order.push('create');
+          return { id: 'session-1' };
+        },
+      },
+      sessions: {
+        submitMessage: async () => {
+          order.push('submit');
+          return { ok: true, attachments: [], skillInvocation: { loaded: [], failed: [] } };
+        },
+      },
+    });
+
+    try {
+      const sending = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef,
+        activateSessionForFirstSend: async (sessionId) => {
+          order.push('observe');
+          activeIdRef.current = sessionId;
+          await observation.promise;
+          order.push('seeded');
+        },
+      }).send('hello');
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.deepEqual(order, ['create', 'observe']);
+
+      observation.resolve();
+      assert.equal(await sending, true);
+      assert.deepEqual(order, ['create', 'observe', 'seeded', 'submit']);
+    } finally {
+      restoreWindow();
+    }
+  });
+
   it('leaves an EXISTING session alone when its send rejects', async () => {
     // Only the session this send created is disposable. A send that fails in
     // an open conversation must not delete the conversation.

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3320,6 +3320,7 @@ if (process.env.MAKA_E2E === '1' && process.env.MAKA_E2E_USER_DATA_DIR) {
   type LatchKey = 'newTasks.listInvocableSkills' | 'sessions.list' | 'settings.chunk';
   const gates = new Map<LatchKey, { promise: Promise<void>; oneShot: boolean }>();
   const releases = new Map<LatchKey, { resolve: () => void; reject: (error: Error) => void }>();
+  let nextSessionObservationError: Error | undefined;
   const invocableSkillsWaiters = new Map<string, Array<() => void>>();
   const waitForLatch = async (key: LatchKey): Promise<void> => {
     const gate = gates.get(key);
@@ -3342,6 +3343,33 @@ if (process.env.MAKA_E2E === '1' && process.env.MAKA_E2E_USER_DATA_DIR) {
     makaBridge.sessions.list.bind(makaBridge.sessions),
     'sessions.list',
   );
+  const subscribeSessionEvents = makaBridge.sessions.subscribeEvents.bind(makaBridge.sessions);
+  makaBridge.sessions.subscribeEvents = (
+    sessionId,
+    handler,
+    onSeeded,
+    onObservationSeed,
+    onSeedError,
+  ) => {
+    const nextError = nextSessionObservationError;
+    nextSessionObservationError = undefined;
+    if (!nextError) {
+      return subscribeSessionEvents(
+        sessionId,
+        handler,
+        onSeeded,
+        onObservationSeed,
+        onSeedError,
+      );
+    }
+    let disposed = false;
+    void Promise.resolve().then(() => {
+      if (!disposed) onSeedError?.(nextError);
+    });
+    return () => {
+      disposed = true;
+    };
+  };
   const listInvocableSkills = makaBridge.skills.listInvocable.bind(makaBridge.skills);
   makaBridge.skills.listInvocable = async (...args) => {
     try {
@@ -3380,6 +3408,9 @@ if (process.env.MAKA_E2E === '1' && process.env.MAKA_E2E_USER_DATA_DIR) {
         waiters.push(resolve);
         invocableSkillsWaiters.set(sessionId, waiters);
       });
+    },
+    rejectNextSessionObservation(message: string) {
+      nextSessionObservationError = new Error(message);
     },
     release(key: LatchKey) {
       releases.get(key)?.resolve();

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -157,6 +157,7 @@ export function createAppShellChatActions(deps: {
   isShellSurfaceOwnerActive: (owner: ComposerImportOwner) => boolean;
   messageRetryPendingRef: RefBox<Set<string>>;
   refreshSessions: () => Promise<DesktopSessionSummary[]>;
+  activateSessionForFirstSend: (sessionId: string) => Promise<void>;
   setActiveId: (sessionId: string | undefined) => void;
   setMessageLoadErrorBySession: MessageLoadErrorUpdater;
   setMessageRetryPendingBySession: BooleanRecordUpdater;
@@ -171,7 +172,6 @@ export function createAppShellChatActions(deps: {
   ) => void;
   removeTransientMessage: (sessionId: string, messageId: string) => void;
   transcriptRangeRef: RefBox<DesktopTranscriptRangeController | undefined>;
-  setNavSelection: (selection: NavSelection) => void;
   /** #646: arm the "正在处理…" indicator locally at send() — the model-wait
    * window opens before any SessionEvent arrives (turn_started is not one). */
   setLiveTurnBySession: LiveTurnRecordUpdater;
@@ -214,6 +214,7 @@ export function createAppShellChatActions(deps: {
     isShellSurfaceOwnerActive,
     messageRetryPendingRef,
     refreshSessions,
+    activateSessionForFirstSend,
     setActiveId,
     setMessageLoadErrorBySession,
     setMessageRetryPendingBySession,
@@ -222,7 +223,6 @@ export function createAppShellChatActions(deps: {
     updateTransientMessage,
     removeTransientMessage,
     transcriptRangeRef,
-    setNavSelection,
     setLiveTurnBySession,
     setInteractionBySession,
     onInteractionChanged,
@@ -449,6 +449,7 @@ export function createAppShellChatActions(deps: {
       unsentSessionId = undefined;
       try {
         await window.maka.sessions.remove(sessionId);
+        if (activeIdRef.current === sessionId) setActiveId(undefined);
         await refreshSessions();
       } catch {
         // Best-effort: a failed cleanup must not replace the real error.
@@ -473,10 +474,19 @@ export function createAppShellChatActions(deps: {
           orchestrationMode: newChatOrchestrationMode,
         });
         unsentSessionId = session.id;
+        optimisticSessionId = session.id;
         // Consumed: the choice is now the created Session's, not the next
         // draft's. A failed create leaves it in place so a retry keeps it.
         if (newChatPermissionChoice) clearNewChatPermissionChoice();
-        optimisticSessionId = session.id;
+        // The first Turn must not outrun the only renderer observation that
+        // can identify its live assistant stream. Activating the new Session
+        // is only a render request; the explicit seed barrier is what makes
+        // the subscription ready before Runtime Host admits the Message.
+        await activateSessionForFirstSend(session.id);
+        if (activeIdRef.current !== session.id) {
+          await discardUnsentSession();
+          return false;
+        }
         optimisticMessageId = messageId;
         showTransientUserMessage(
           session.id,
@@ -522,8 +532,7 @@ export function createAppShellChatActions(deps: {
           ...(options.displayText ? { displayText: options.displayText } : {}),
           ...(quotes && quotes.length > 0 ? { quotes } : {}),
           exactTurn,
-          isSurfaceVisible: () =>
-            Boolean(newChatOwner && isNewChatSendSurfaceActive(newChatOwner)),
+          isSurfaceVisible: () => activeIdRef.current === session.id,
         });
         if (submitted.kind === 'refused') {
           await discardUnsentSession();
@@ -531,10 +540,6 @@ export function createAppShellChatActions(deps: {
         }
         unsentSessionId = undefined;
         options.onSessionResolved?.(session.id);
-        if (newChatOwner && isNewChatSendSurfaceActive(newChatOwner)) {
-          setNavSelection({ section: 'sessions' });
-          setActiveId(session.id);
-        }
         await refreshSessions();
         return true;
       }

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -478,10 +478,10 @@ export function createAppShellChatActions(deps: {
         // Consumed: the choice is now the created Session's, not the next
         // draft's. A failed create leaves it in place so a retry keeps it.
         if (newChatPermissionChoice) clearNewChatPermissionChoice();
-        // The first Turn must not outrun the only renderer observation that
-        // can identify its live assistant stream. Activating the new Session
-        // is only a render request; the explicit seed barrier is what makes
-        // the subscription ready before Runtime Host admits the Message.
+        // Active-stream snapshots can only restore assistant segments that
+        // are still streaming. Wait until the observer is ready before the
+        // first admission so a completed segment in a still-running Turn
+        // cannot become durable text without live identity.
         await activateSessionForFirstSend(session.id);
         if (activeIdRef.current !== session.id) {
           await discardUnsentSession();
@@ -612,6 +612,22 @@ export function createAppShellChatActions(deps: {
       options.onSessionResolved?.(sessionId);
       return true;
     } catch (error) {
+      // Capture ownership before cleanup clears the optimistic Session. A
+      // barrier timeout belongs to the surface that was waiting for it, while
+      // navigation away still suppresses feedback.
+      const feedbackSessionId = optimisticSessionId ?? initialSessionId;
+      const diagnosticTarget = feedbackSessionId
+        ? { sessionId: feedbackSessionId }
+        : initialNewTaskTarget
+          ? { profileId: initialNewTaskTarget.profileId }
+          : undefined;
+      const sendStillOwnsCurrentSurface =
+        (feedbackSessionId !== undefined &&
+          isShellSurfaceOwnerActive({
+            ...sendOwner,
+            sessionId: feedbackSessionId,
+          })) ||
+        (newChatOwner !== null && isNewChatSendSurfaceActive(newChatOwner));
       await discardUnsentSession();
       if (optimisticSessionId && optimisticMessageId) {
         removeOptimisticUserMessage(optimisticSessionId, optimisticMessageId);
@@ -635,19 +651,6 @@ export function createAppShellChatActions(deps: {
       // The owner MOVES on an optimistic create: the send began on the new-chat
       // surface and the app is now on the session it just made, so the id is
       // taken from the flight and only the section comes from the capture.
-      const feedbackSessionId = optimisticSessionId ?? initialSessionId;
-      const diagnosticTarget = feedbackSessionId
-        ? { sessionId: feedbackSessionId }
-        : initialNewTaskTarget
-          ? { profileId: initialNewTaskTarget.profileId }
-          : undefined;
-      const sendStillOwnsCurrentSurface =
-        (feedbackSessionId !== undefined &&
-          isShellSurfaceOwnerActive({
-            ...sendOwner,
-            sessionId: feedbackSessionId,
-          })) ||
-        (newChatOwner !== null && isNewChatSendSurfaceActive(newChatOwner));
       if (!sendStillOwnsCurrentSurface) return false;
       if (isNoRealConnectionError(error)) {
         const reason = noRealConnectionReasonFromError(error);

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -425,8 +425,11 @@ export function useActiveSessionEvents(options: {
 
   useLayoutEffect(() => {
     if (!activeId) return;
-    const observationGeneration = beginObservationSeed(activeId);
     let disposed = false;
+    let observationAttempt = 0;
+    let observationFailures = 0;
+    let observationRetryTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+    let unsubscribeSessionEvents = () => {};
     const transcript = new DesktopTranscriptRangeStore(activeId);
     const subscribedAt = Date.now();
     options.setMessageLoadErrorBySession((current) => {
@@ -465,24 +468,56 @@ export function useActiveSessionEvents(options: {
       applyReadError(activeId, error, () => disposed);
     });
     options.transcriptRangeRef.current = controller;
-    const unsubscribe = window.maka.sessions.subscribeEvents(
-      activeId,
-      (event) => {
-        handleSessionEvent(activeId, event);
-      },
-      () => completeObservationSeed(activeId, observationGeneration),
-      (phase) => {
-        if (phase === 'pending') beginObservationSeed(activeId);
-        else completeObservationSeed(activeId);
-      },
-    );
+    const subscribeSessionEvents = () => {
+      const attempt = ++observationAttempt;
+      const observationGeneration = beginObservationSeed(activeId);
+      let unsubscribeRequested = false;
+      let unsubscribeCurrent = () => {
+        unsubscribeRequested = true;
+      };
+      const unsubscribe = window.maka.sessions.subscribeEvents(
+        activeId,
+        (event) => {
+          if (attempt !== observationAttempt) return;
+          handleSessionEvent(activeId, event);
+        },
+        () => {
+          if (attempt !== observationAttempt) return;
+          observationFailures = 0;
+          completeObservationSeed(activeId, observationGeneration);
+        },
+        (phase) => {
+          if (attempt !== observationAttempt) return;
+          if (phase === 'pending') beginObservationSeed(activeId);
+          else completeObservationSeed(activeId);
+        },
+        () => {
+          if (disposed || attempt !== observationAttempt) return;
+          unsubscribeCurrent();
+          observationFailures += 1;
+          const retryDelayMs = Math.min(100 * (2 ** (observationFailures - 1)), 2_000);
+          observationRetryTimer = globalThis.setTimeout(() => {
+            observationRetryTimer = undefined;
+            if (!disposed && attempt === observationAttempt) subscribeSessionEvents();
+          }, retryDelayMs);
+        },
+      );
+      unsubscribeCurrent = unsubscribe;
+      unsubscribeSessionEvents = unsubscribe;
+      if (unsubscribeRequested) unsubscribe();
+    };
+    subscribeSessionEvents();
     return () => {
       disposed = true;
+      observationAttempt += 1;
+      if (observationRetryTimer !== undefined) {
+        globalThis.clearTimeout(observationRetryTimer);
+      }
       if (options.transcriptRangeRef.current?.store === transcript) {
         options.transcriptRangeRef.current = undefined;
       }
       void controller.close();
-      unsubscribe();
+      unsubscribeSessionEvents();
       markSessionEventStreamClosed(activeId);
     };
   }, [activeId]);

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1744,6 +1744,35 @@ function AppShellContent({
     [sessions, localProjects, sessionNavigation.commands],
   );
 
+  const firstSendObservationWaitersRef = useRef(new Map<string, {
+    promise: Promise<void>;
+    resolve: () => void;
+    reject: (error: Error) => void;
+  }>());
+  const activateSessionForFirstSend = useCallback((sessionId: string): Promise<void> => {
+    let waiter = firstSendObservationWaitersRef.current.get(sessionId);
+    if (!waiter) {
+      let resolve!: () => void;
+      let reject!: (error: Error) => void;
+      const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+      });
+      waiter = { promise, resolve, reject };
+      firstSendObservationWaitersRef.current.set(sessionId, waiter);
+    }
+    setNavSelection({ section: 'sessions' });
+    setActiveId(sessionId);
+    return waiter.promise;
+  }, [setActiveId, setNavSelection]);
+  useEffect(() => {
+    for (const [sessionId, waiter] of firstSendObservationWaitersRef.current) {
+      if (sessionId === activeId) continue;
+      firstSendObservationWaitersRef.current.delete(sessionId);
+      waiter.reject(new Error('The new Session was left before its event stream became ready'));
+    }
+  }, [activeId]);
+
   const { applyE2eFixture } = useStableActions(createAppShellE2eFixtureActions, {
     openSettingsSection,
     refreshSessions,
@@ -1778,6 +1807,7 @@ function AppShellContent({
     isShellSurfaceOwnerActive,
     messageRetryPendingRef,
     refreshSessions,
+    activateSessionForFirstSend,
     setActiveId,
     setMessageLoadErrorBySession,
     setMessageRetryPendingBySession,
@@ -1786,7 +1816,6 @@ function AppShellContent({
     updateTransientMessage,
     removeTransientMessage,
     transcriptRangeRef,
-    setNavSelection,
     setLiveTurnBySession,
     setInteractionBySession,
     onInteractionChanged: markInteractionChanged,
@@ -2312,6 +2341,11 @@ function AppShellContent({
     const next = completeLiveContentSeed(current, sessionId, expected);
     activeEventSeedRef.current = next;
     setActiveEventSeed(next);
+    const firstSendWaiter = firstSendObservationWaitersRef.current.get(sessionId);
+    if (firstSendWaiter) {
+      firstSendObservationWaitersRef.current.delete(sessionId);
+      firstSendWaiter.resolve();
+    }
     void retireCancelledTransientMessages(sessionId);
   };
   useActiveSessionEvents({

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -258,6 +258,13 @@ function newTaskDraftKey(target: {
  * assistant stream slot when the primary post-commit signal is missed.
  */
 const SETTLE_FALLBACK_GRACE_MS = 1000;
+const FIRST_SEND_OBSERVATION_TIMEOUT_MS = 30_000;
+type FirstSendObservationWaiter = {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timeoutId: ReturnType<typeof globalThis.setTimeout>;
+};
 /**
  * Module surfaces that own their whole column and render no workspace toolbar.
  * This used to be a `display: none` rule keyed on the detail panel's
@@ -1744,11 +1751,9 @@ function AppShellContent({
     [sessions, localProjects, sessionNavigation.commands],
   );
 
-  const firstSendObservationWaitersRef = useRef(new Map<string, {
-    promise: Promise<void>;
-    resolve: () => void;
-    reject: (error: Error) => void;
-  }>());
+  const firstSendObservationWaitersRef = useRef(
+    new Map<string, FirstSendObservationWaiter>(),
+  );
   const activateSessionForFirstSend = useCallback((sessionId: string): Promise<void> => {
     let waiter = firstSendObservationWaitersRef.current.get(sessionId);
     if (!waiter) {
@@ -1758,7 +1763,14 @@ function AppShellContent({
         resolve = resolvePromise;
         reject = rejectPromise;
       });
-      waiter = { promise, resolve, reject };
+      let created!: FirstSendObservationWaiter;
+      const timeoutId = globalThis.setTimeout(() => {
+        if (firstSendObservationWaitersRef.current.get(sessionId) !== created) return;
+        firstSendObservationWaitersRef.current.delete(sessionId);
+        created.reject(new Error('Timed out while preparing the new Session event stream'));
+      }, FIRST_SEND_OBSERVATION_TIMEOUT_MS);
+      created = { promise, resolve, reject, timeoutId };
+      waiter = created;
       firstSendObservationWaitersRef.current.set(sessionId, waiter);
     }
     setNavSelection({ section: 'sessions' });
@@ -1769,9 +1781,17 @@ function AppShellContent({
     for (const [sessionId, waiter] of firstSendObservationWaitersRef.current) {
       if (sessionId === activeId) continue;
       firstSendObservationWaitersRef.current.delete(sessionId);
+      globalThis.clearTimeout(waiter.timeoutId);
       waiter.reject(new Error('The new Session was left before its event stream became ready'));
     }
   }, [activeId]);
+  useEffect(() => () => {
+    for (const [sessionId, waiter] of firstSendObservationWaitersRef.current) {
+      firstSendObservationWaitersRef.current.delete(sessionId);
+      globalThis.clearTimeout(waiter.timeoutId);
+      waiter.reject(new Error('The app closed before the new Session event stream became ready'));
+    }
+  }, []);
 
   const { applyE2eFixture } = useStableActions(createAppShellE2eFixtureActions, {
     openSettingsSection,
@@ -2344,6 +2364,7 @@ function AppShellContent({
     const firstSendWaiter = firstSendObservationWaitersRef.current.get(sessionId);
     if (firstSendWaiter) {
       firstSendObservationWaitersRef.current.delete(sessionId);
+      globalThis.clearTimeout(firstSendWaiter.timeoutId);
       firstSendWaiter.resolve();
     }
     void retireCancelledTransientMessages(sessionId);


### PR DESCRIPTION
<details open><summary>English</summary>

## Summary

- establish the new Session's event observation before admitting its first Message
- reconnect after a failed observation seed while fencing stale callbacks and subscriptions
- bound the first-send wait at 30 seconds and fail without losing the user's draft
- add a deterministic Electron regression that fails the first seed and still requires a live streaming bubble

## Root cause

The original #3177 fix protected live projection during Stop and remount. The recurrence happens earlier: the first Message could reach Runtime Host before React activated the new Session and subscribed to its event stream. If that first observation seed failed, the durable transcript eventually showed the assistant text and the Session remained running, but the renderer never learned the live Turn identity. The result looked like a completed historical bubble, so `.maka-bubble-streaming` was absent even though Stop was still available.

This change makes a completed observation seed a prerequisite for only the first Message of a newly created Session. A transient seed failure reconnects with generation fencing. The barrier is bounded at 30 seconds; leaving the Session or timing out cancels the wait and removes the still-unsent Session while preserving the draft. Runtime Host remains the sole owner of Message admission and Turn identity.

## Verification

- `streaming-remount.spec.ts`: 4/4
- deterministic failed-seed regression repeated 10 times: 10/10
- Desktop unit suite: 1592/1592
- Desktop typecheck and production build
- Biome and `git diff --check`

Closes #3177.

## Generative AI disclosure

OpenAI Codex made a substantive contribution by investigating the race, implementing the fix and regression coverage, and running the verification above. The commit includes the required `Generated-by: OpenAI Codex` trailer.

</details>

<details><summary>简体中文</summary>

## 摘要

- 在新 Session 的首条 Message 进入 Runtime Host 前，先建立该 Session 的事件观察
- observation seed 失败后自动重连，并用 generation 隔离过期回调与订阅
- 将首条发送的等待限制为 30 秒，失败时不丢失用户草稿
- 新增确定性的 Electron 回归测试：强制第一次 seed 失败后，仍必须出现 live streaming bubble

## 根因

原先针对 #3177 的修复保护的是 Stop 和 remount 期间的 live projection。本次复发发生得更早：首条 Message 可能在 React 激活新 Session、订阅事件流之前就进入 Runtime Host。若第一次 observation seed 失败，持久 transcript 最终仍会显示助手文本，Session 也仍处于运行状态，但 renderer 永远拿不到 live Turn 身份。因此界面把回复显示成历史消息，`.maka-bubble-streaming` 不存在，Stop 却仍可见。

本次修改只对新建 Session 的首条 Message 增加 observation seed 屏障。临时 seed 失败会带 generation 隔离地重连；屏障最长等待 30 秒，用户离开 Session 或等待超时时都会取消等待并删除尚未发送成功的 Session，同时保留草稿。Message admission 与 Turn 身份仍只有 Runtime Host 一个权威来源。

## 验证

- `streaming-remount.spec.ts`：4/4
- 确定性 seed 失败回归连续运行 10 次：10/10
- Desktop 单元测试：1592/1592
- Desktop typecheck 与生产构建通过
- Biome 与 `git diff --check` 通过

关闭 #3177。

## 生成式 AI 披露

OpenAI Codex 对根因调查、修复实现、回归测试和上述验证作出了实质贡献。提交中包含所要求的 `Generated-by: OpenAI Codex` trailer。

</details>

---
_Posted by an automated development agent operated by @M4n5ter. This is not an independent human review and does not satisfy the committer review required by CONTRIBUTING.md. A human is accountable for this pull request — please push back if anything here is wrong._

<details><summary>简体中文</summary>

_本 PR 由 @M4n5ter 运行的自动化开发程序发布。它不构成 CONTRIBUTING.md 所要求的独立人类审查，也不能替代人类审查。有人类对此 PR 负责，如有错误请直接指出。_

</details>
