### PR TITLE
fix(runtime): persist contextRemaining on the stored TokenUsageMessage

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -9038,6 +9038,108 @@ describe('AiSdkBackend RunTrace', () => {
     );
   });
 
+  test('persists contextRemaining on the stored token_usage message (#4019)', async () => {
+    const messages: StoredMessage[] = [];
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                inputTokens: { total: 4, noCache: 4, cacheRead: 0, cacheWrite: undefined },
+                outputTokens: { total: 2, text: 2, reasoning: 0 },
+              },
+            },
+          ],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      }),
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message: StoredMessage) => {
+        messages.push(message);
+      },
+      connection: {
+        ...connection(),
+        models: [{ id: 'mock-model-id', contextWindow: 200_000 }],
+      },
+      apiKey: '[redacted]',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+    }
+
+    // The single step consumed 4 prompt tokens of the 200k window.
+    const expected = 200_000 - 4;
+    const stored = messages.find((message) => message.type === 'token_usage');
+    assert.equal(
+      stored?.type === 'token_usage' ? stored.contextRemaining : undefined,
+      expected,
+      'stored TokenUsageMessage must carry contextRemaining so transcript rebuilds keep the ctx segment',
+    );
+    const live = events.find((event) => event.type === 'token_usage');
+    assert.equal(live?.contextRemaining, expected);
+  });
+
+  test('omits contextRemaining from the stored token_usage message when the window is unknown', async () => {
+    const messages: StoredMessage[] = [];
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                inputTokens: { total: 4, noCache: 4, cacheRead: 0, cacheWrite: undefined },
+                outputTokens: { total: 2, text: 2, reasoning: 0 },
+              },
+            },
+          ],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      }),
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message: StoredMessage) => {
+        messages.push(message);
+      },
+      // No declared/fetched window for mock-model-id: degrade, never invent one.
+      connection: connection(),
+      apiKey: '[redacted]',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      void event;
+    }
+
+    const stored = messages.find((message) => message.type === 'token_usage');
+    assert.equal(stored?.type, 'token_usage');
+    assert.equal(stored?.type === 'token_usage' && 'contextRemaining' in stored, false);
+  });
+
   test('does not call the provider when prepared-request persistence fails', async () => {
     const model = completionModel();
     const backend = createTestAiSdkBackend({

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2863,6 +2863,19 @@ export class AiSdkBackend implements AgentBackend {
               activeToolResultPruneDiagnosticPatch,
               midTurnCompactDiagnosticPatch,
             );
+            // Persisted alongside the live event so transcript rebuilds from
+            // stored messages keep the TUI ctx segment instead of degrading to
+            // `?/<window>` (#4019). Computed once; both writers share it.
+            const contextRemainingForUsage = (() => {
+              const contextWindow = resolveSelectedModelContextWindow(
+                this.input.connection,
+                this.input.modelId,
+              );
+              if (lastStepInputTokens !== undefined && contextWindow !== undefined) {
+                return Math.max(0, contextWindow - lastStepInputTokens);
+              }
+              return undefined;
+            })();
             const tu: TokenUsageMessage = {
               type: 'token_usage',
               id: this.newId(),
@@ -2894,6 +2907,9 @@ export class AiSdkBackend implements AgentBackend {
               requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
               promptSegments: turnDiagnostics.promptSegments,
               ...(contextBudgetForUsage ? { contextBudget: contextBudgetForUsage } : {}),
+              ...(contextRemainingForUsage !== undefined
+                ? { contextRemaining: contextRemainingForUsage }
+                : {}),
               ...(providerRequestTraceId ? { providerRequestTraceId } : {}),
             };
             await this.input.appendMessage(tu).catch(() => {});
@@ -2925,16 +2941,6 @@ export class AiSdkBackend implements AgentBackend {
               };
               await this.input.appendMessage(note).catch(() => {});
             }
-            const contextRemainingForUsage = (() => {
-              const contextWindow = resolveSelectedModelContextWindow(
-                this.input.connection,
-                this.input.modelId,
-              );
-              if (lastStepInputTokens !== undefined && contextWindow !== undefined) {
-                return Math.max(0, contextWindow - lastStepInputTokens);
-              }
-              return undefined;
-            })();
             queue.push({
               type: 'token_usage',
               id: this.newId(),

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2876,11 +2876,10 @@ export class AiSdkBackend implements AgentBackend {
               }
               return undefined;
             })();
-            const tu: TokenUsageMessage = {
-              type: 'token_usage',
-              id: this.newId(),
-              turnId,
-              ts: this.now(),
+            // One shared usage payload for the durable message and the live
+            // event: twin per-field literals drifted before (#4019), so a field
+            // now has exactly one definition site.
+            const usageFields = {
               input: tokenUsage.inputTokens,
               output: tokenUsage.outputTokens,
               cacheHitInput: tokenUsage.cacheHitInputTokens,
@@ -2911,6 +2910,13 @@ export class AiSdkBackend implements AgentBackend {
                 ? { contextRemaining: contextRemainingForUsage }
                 : {}),
               ...(providerRequestTraceId ? { providerRequestTraceId } : {}),
+            };
+            const tu: TokenUsageMessage = {
+              type: 'token_usage',
+              id: this.newId(),
+              turnId,
+              ts: this.now(),
+              ...usageFields,
             };
             await this.input.appendMessage(tu).catch(() => {});
             if (
@@ -2946,36 +2952,7 @@ export class AiSdkBackend implements AgentBackend {
               id: this.newId(),
               turnId,
               ts: this.now(),
-              input: tokenUsage.inputTokens,
-              output: tokenUsage.outputTokens,
-              cacheHitInput: tokenUsage.cacheHitInputTokens,
-              cacheMissInput: tokenUsage.cacheMissInputTokens,
-              cacheMissInputSource: tokenUsage.cacheMissInputSource,
-              cacheWriteInput: tokenUsage.cacheWriteInputTokens,
-              reasoning: tokenUsage.reasoningTokens,
-              total: tokenUsage.totalTokens,
-              ...(tokenUsage.rawFinishReason !== undefined
-                ? { rawFinishReason: tokenUsage.rawFinishReason }
-                : {}),
-              ...(runtimeSteps > 0 ? { runtimeSteps } : {}),
-              ...(tokenUsage.cachedInputTokens > 0
-                ? { cacheRead: tokenUsage.cachedInputTokens }
-                : {}),
-              ...(tokenUsage.cacheWriteInputTokens > 0
-                ? { cacheCreation: tokenUsage.cacheWriteInputTokens }
-                : {}),
-              ...(tokenUsageCostUsd !== undefined ? { costUsd: tokenUsageCostUsd } : {}),
-              systemPromptHash,
-              prefixHash: turnDiagnostics.requestShape.prefixHash,
-              prefixChangeReason: turnDiagnostics.requestShape.prefixChangeReason,
-              requestShapeHash: turnDiagnostics.requestShape.requestShapeHash,
-              requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
-              promptSegments: turnDiagnostics.promptSegments,
-              ...(contextBudgetForUsage ? { contextBudget: contextBudgetForUsage } : {}),
-              ...(contextRemainingForUsage !== undefined
-                ? { contextRemaining: contextRemainingForUsage }
-                : {}),
-              ...(providerRequestTraceId ? { providerRequestTraceId } : {}),
+              ...usageFields,
             } satisfies TokenUsageEvent);
           }
         } catch {


### PR DESCRIPTION
## Summary

The turn-end usage write had two asymmetric paths: the live `TokenUsageEvent` carried `contextRemaining` (#1072), but the durable `TokenUsageMessage` written via `appendMessage` did not. The TUI rebuilds `usage` from stored messages in `replaceTranscriptWithStoredMessages`, so after any transcript reload (abort refresh, resume, reconnect) `contextRemaining` was washed back to `undefined` and the status line fell back to the #3371 `ctx ?/<window>` degrade — even for providers that report per-step usage, and even though the runtime event ledger proves the value was computed.

The fix computes `contextRemainingForUsage` once and shares one `usageFields` payload between the stored message and the live event, so a usage field now has exactly one definition site and cannot drift between the two writers again. Ids and timestamps stay per-writer: the stored message and the live event are distinct facts.

No behavior change for providers without per-step usage or without a known context window: the field stays absent and the `?/<window>` degrade still applies.

Fixes #4019

## Verification

- `packages/runtime` `ai-sdk-backend.test.js`: 201/201 pass, including two new tests —
  - `persists contextRemaining on the stored token_usage message (#4019)` asserts the stored message and the live event both carry `contextRemaining` (`200_000 - 4`), and fails without the fix;
  - `omits contextRemaining from the stored token_usage message when the window is unknown` pins the degrade path.
- `runtime-event-read-model.test.js` + `session-manager.test.js`: 265/265 pass (replay/read-model already preserved the field; #1422).
- `packages/cli` `pi-transcript.test.js`: 92/92 pass.
- Full `runtime` dist suite: 3028/3048 pass; the 13 failures are pre-existing environment issues on this machine (missing `rg`, bubblewrap sandbox), reproduced identically on unmodified `origin/main`.
- `biome check` on touched files: clean. `tsc --noEmit` for `@maka/runtime`: clean. ASF header check: clean.

## Root cause

#1072 added `contextRemaining` only to the live event; the stored message is the one the TUI rebuild reads, so the field never survived a transcript rebuild. Local evidence: `runtime_events.actions.tokenUsage` carried `contextRemaining: 230068` while the corresponding `session_messages` record had none.

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka (k3-256k) — root-cause analysis from local runtime DBs, the fix, the single-definition-site refactor, and the tests. Commits carry `Generated-by: Maka`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
