### PR TITLE
feat(cli): confirmed second Ctrl+O/Ctrl+T collapses blocks stranded above the viewport (#4011)

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -26,10 +26,12 @@ import type { SessionEvent, ToolResultContent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import {
   appendUserPrompt,
+  applyExpansionDefaultToAll,
   applyShellRunViewUpdateToTranscript,
   applyMakaSessionEventToTranscript,
   applyShellRunUpdateToTranscript,
   createMakaPiTranscriptState,
+  hasExpandedEntriesAboveViewport,
   renderMakaPiActivityStrip,
   renderMakaPiPendingQueue,
   renderMakaPiStatusLine,
@@ -1642,6 +1644,235 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(state.expandAllTools, true);
     const third = state.entries[state.entries.length - 1];
     assert.match(third.kind === 'notice' ? third.text : '', /starts expanded/);
+  });
+
+  test('a collapse with mixed card positions names the stranded cards and offers the second press (#4011)', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_start',
+        toolUseId: 'tool-early',
+        toolName: 'Bash',
+        args: { command: 'early-build' },
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_result',
+        toolUseId: 'tool-early',
+        isError: false,
+        content: terminalResult(
+          `early-head\n${Array.from({ length: 30 }, (_, i) => `early-row-${i}`).join('\n')}`,
+        ),
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'text_delta',
+        messageId: 'message-1',
+        text: Array.from({ length: 20 }, (_, i) => `filler-${i}`).join('\n\n'),
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_start',
+        toolUseId: 'tool-late',
+        toolName: 'Bash',
+        args: { command: 'late-build' },
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_result',
+        toolUseId: 'tool-late',
+        isError: false,
+        content: terminalResult(
+          `late-head\n${Array.from({ length: 30 }, (_, i) => `late-row-${i}`).join('\n')}`,
+        ),
+      }),
+    );
+
+    // Expand both while everything is in view, then let the viewport scroll so
+    // the early card's head sits in scrollback and only the late card remains
+    // reachable.
+    assert.equal(toggleAllToolExpansion(state), true);
+    renderMakaPiTranscript(state, meta(), 100);
+    const early = state.entries.find(
+      (entry): entry is Extract<typeof entry, { kind: 'tool' }> =>
+        entry.kind === 'tool' && entry.toolUseId === 'tool-early',
+    );
+    const late = state.entries.find(
+      (entry): entry is Extract<typeof entry, { kind: 'tool' }> =>
+        entry.kind === 'tool' && entry.toolUseId === 'tool-late',
+    );
+    assert.ok(early && late);
+    const viewportTop = state.renderGeometry.entryFirstLine?.get(late);
+    assert.ok(viewportTop !== undefined && viewportTop > 0);
+    state.renderGeometry.viewportTop = viewportTop;
+
+    // The collapse reaches the late card but strands the early one, and the
+    // notice says so instead of staying silent (#4011).
+    assert.equal(toggleAllToolExpansion(state), true);
+    assert.equal(state.expandAllTools, false);
+    assert.equal(early.expanded, true);
+    assert.equal(late.expanded, false);
+    const notice = state.entries[state.entries.length - 1];
+    assert.equal(notice.kind, 'notice');
+    const text = notice.kind === 'notice' ? notice.text : '';
+    assert.match(text, /1 tool card above the view stayed expanded/);
+    assert.match(text, /press Ctrl\+O again within 2s/);
+    assert.match(text, /starts collapsed/);
+    assert.equal(hasExpandedEntriesAboveViewport(state, 'tool'), true);
+  });
+
+  test('the confirmed second press collapses the stranded card without flipping the default (#4011)', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_start',
+        toolUseId: 'tool-big',
+        toolName: 'Bash',
+        args: { command: 'big-diff' },
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_result',
+        toolUseId: 'tool-big',
+        isError: false,
+        content: terminalResult(
+          `big-head\n${Array.from({ length: 80 }, (_, i) => `big-row-${i}`).join('\n')}`,
+        ),
+      }),
+    );
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    renderMakaPiTranscript(state, meta(), 100);
+    const entry = state.entries.find(
+      (candidate): candidate is Extract<typeof candidate, { kind: 'tool' }> =>
+        candidate.kind === 'tool',
+    );
+    assert.ok(entry);
+    const firstLine = state.renderGeometry.entryFirstLine?.get(entry);
+    assert.ok(firstLine !== undefined);
+    state.renderGeometry.viewportTop = firstLine + 5;
+
+    // First press: viewport-scoped collapse strands the card; the state is
+    // confirmable (the runner owns the confirm window itself).
+    assert.equal(toggleAllToolExpansion(state), true);
+    assert.equal(state.expandAllTools, false);
+    assert.equal(entry.expanded, true);
+    assert.equal(hasExpandedEntriesAboveViewport(state, 'tool'), true);
+
+    // Confirmed second press: every candidate takes the collapsed default and
+    // the default itself does not move (a plain toggle would flip it back).
+    assert.equal(applyExpansionDefaultToAll(state, 'tool'), true);
+    assert.equal(state.expandAllTools, false);
+    assert.equal(entry.expanded, false);
+    assert.equal(hasExpandedEntriesAboveViewport(state, 'tool'), false);
+    // Idempotent once everything already matches the default.
+    assert.equal(applyExpansionDefaultToAll(state, 'tool'), false);
+  });
+
+  test('an expand toggle with collapsed cards above the viewport stays silent about them (#4011)', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_start',
+        toolUseId: 'tool-early',
+        toolName: 'Bash',
+        args: { command: 'early-build' },
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_result',
+        toolUseId: 'tool-early',
+        isError: false,
+        content: terminalResult(`early-head\nearly-row`),
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'text_delta',
+        messageId: 'message-1',
+        text: Array.from({ length: 20 }, (_, i) => `filler-${i}`).join('\n\n'),
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_start',
+        toolUseId: 'tool-late',
+        toolName: 'Bash',
+        args: { command: 'late-build' },
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_result',
+        toolUseId: 'tool-late',
+        isError: false,
+        content: terminalResult(`late-head\nlate-row`),
+      }),
+    );
+
+    renderMakaPiTranscript(state, meta(), 100);
+    const late = state.entries.find(
+      (entry): entry is Extract<typeof entry, { kind: 'tool' }> =>
+        entry.kind === 'tool' && entry.toolUseId === 'tool-late',
+    );
+    assert.ok(late);
+    const viewportTop = state.renderGeometry.entryFirstLine?.get(late);
+    assert.ok(viewportTop !== undefined && viewportTop > 0);
+    state.renderGeometry.viewportTop = viewportTop;
+
+    // Expanding the in-view card leaves the collapsed card above untouched —
+    // compact in scrollback, harmless — and offers no redraw for it.
+    assert.equal(toggleAllToolExpansion(state), true);
+    assert.equal(late.expanded, true);
+    assert.equal(
+      state.entries.some(
+        (entry) => entry.kind === 'notice' && entry.text.includes('again within 2s'),
+      ),
+      false,
+    );
+    // And nothing expanded sits above the viewport, so no confirm can arm.
+    assert.equal(hasExpandedEntriesAboveViewport(state, 'tool'), false);
+  });
+
+  test('hasExpandedEntriesAboveViewport is false while entry positions are unknown (#4011)', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_start',
+        toolUseId: 'tool-1',
+        toolName: 'Bash',
+        args: { command: 'build' },
+      }),
+    );
+    const entry = state.entries.find(
+      (candidate): candidate is Extract<typeof candidate, { kind: 'tool' }> =>
+        candidate.kind === 'tool',
+    );
+    assert.ok(entry);
+    entry.expanded = true;
+    // Wholesale-replacement window: no positions recorded, viewport scrolled.
+    state.renderGeometry.entryFirstLine = undefined;
+    state.renderGeometry.viewportTop = 10;
+    assert.equal(hasExpandedEntriesAboveViewport(state, 'tool'), false);
   });
 
   test('Ctrl+T leaves thinking entries above the live viewport untouched (#1097)', () => {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -74,6 +74,7 @@ import {
 } from '../pi-tui-runner.js';
 import { AUTO_RECAP_IDLE_MS } from '../session-recap.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
+import { EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS } from '../pi-transcript.js';
 import {
   autocompleteSuggestionLines,
   assertBottomPickerPlacement,
@@ -1611,6 +1612,64 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\x14');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Thinking…'));
     assert.equal(terminal.output().includes('\x1b[3J'), true);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('an expired Ctrl+T confirmation re-offers collapse instead of reversing it (#4011)', async (t) => {
+    const terminal = new FakeTerminal();
+    const driver = new ThinkingDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Thinking…'));
+
+    terminal.input('\x14');
+    await waitFor(() => terminal.output().includes('reason-row-0'));
+    terminal.input('\x14');
+    await waitFor(() =>
+      plainTerminalOutput(terminal.output()).includes('stayed expanded in scrollback'),
+    );
+
+    const beforeExpiredPress = terminal.output().length;
+    t.mock.timers.enable({ apis: ['Date'], now: Date.now() });
+    t.mock.timers.tick(EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS + 1);
+    terminal.input('\x14');
+    t.mock.timers.reset();
+
+    await waitFor(() => terminal.output().length > beforeExpiredPress);
+    const expiredPressOutput = terminal.output().slice(beforeExpiredPress);
+    assert.equal(expiredPressOutput.includes('\x1b[3J'), false);
+    assert.equal(
+      plainTerminalOutput(expiredPressOutput).includes('stayed expanded in scrollback'),
+      true,
+    );
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('reason-row-0'), false);
+    assert.equal(
+      plainTerminalOutput(terminal.screenOutput()).includes('stayed expanded in scrollback'),
+      true,
+    );
+
+    // The new offer arms a fresh window. This second press is the only one
+    // that clears scrollback and collapses the above-viewport block.
+    terminal.input('\x14');
+    await waitFor(() => terminal.output().slice(beforeExpiredPress).includes('\x1b[3J'));
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('Thinking…'), true);
 
     exitMaka(terminal);
     await Promise.race([

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1573,6 +1573,54 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('a confirmed second Ctrl+T collapses a head-scrolled block with one full redraw (#4011)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new ThinkingDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Thinking…'));
+
+    // Expand: the 80-line thinking block renders in full and pushes its own
+    // head above the 24-row viewport.
+    terminal.input('\x14');
+    await waitFor(() => terminal.output().includes('reason-row-0'));
+    assert.equal(terminal.output().includes('\x1b[3J'), false);
+
+    // First collapse press: the block's head is stranded in scrollback, so the
+    // toggle flips the default, names the stranded block, offers the second
+    // press — and does NOT redraw. (Match a wrap-safe early fragment: the
+    // notice line wraps at 80 columns.)
+    terminal.input('\x14');
+    await waitFor(() =>
+      plainTerminalOutput(terminal.output()).includes('stayed expanded in scrollback'),
+    );
+    assert.equal(terminal.output().includes('\x1b[3J'), false);
+
+    // Confirmed second press inside the window: one deliberate
+    // scrollback-clearing full redraw collapses the stranded block.
+    terminal.input('\x14');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Thinking…'));
+    assert.equal(terminal.output().includes('\x1b[3J'), true);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('does not treat a kitty Escape press+release as a double Escape', async () => {
     const terminal = new FakeTerminal();
     const driver = new InterruptibleTurnDriver();
@@ -7172,6 +7220,28 @@ class ToolOutputDriver extends FakeSessionDriver {
       id: 'event-complete',
       turnId: 'turn-1',
       ts: 3,
+      stopReason: 'end_turn',
+    };
+  }
+}
+
+// #4011: an 80-line thinking block renders in full when expanded, so one
+// Ctrl+T pushes its head above the 24-row viewport into scrollback.
+class ThinkingDriver extends ToolOutputDriver {
+  override async *promptEvents(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'thinking_delta',
+      id: 'event-thinking-1',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'message-1',
+      text: Array.from({ length: 80 }, (_, i) => `reason-row-${i}`).join('\n'),
+    };
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 2,
       stopReason: 'end_turn',
     };
   }

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -85,8 +85,11 @@ export interface MakaPiTranscriptState {
    * live viewport and flips the default for entries created later. Entries
    * above the viewport keep their state — their rendered lines sit in terminal
    * scrollback, which cannot be rewritten, so resizing one would force pi-tui
-   * into a scrollback-clearing full redraw (#1097). In-memory only; never
-   * persisted to storage. Resume resets both to collapsed.
+   * into a scrollback-clearing full redraw (#1097). The deliberate exception:
+   * a second press within 2s of a collapse that stranded expanded entries
+   * above the viewport applies the default to them too and pays one such
+   * redraw knowingly (#4011, applyExpansionDefaultToAll). In-memory only;
+   * never persisted to storage. Resume resets both to collapsed.
    */
   expandAllTools: boolean;
   expandAllThinking: boolean;
@@ -516,52 +519,138 @@ function togglesInert(state: MakaPiTranscriptState): boolean {
  * future cards; false when the session has no tool card at all or the toggles
  * are inert pending a render.
  *
- * When every card sits above the viewport (e.g. a block whose own expansion
- * pushed its head into scrollback, #1134), nothing visible can change — those
- * lines are immutable short of a scrollback-clearing full redraw — so the
- * toggle still flips the default and appends a notice saying why.
+ * A collapse that strands expanded cards above the viewport (their heads sit
+ * in scrollback, #1134) appends a notice naming them and offering the #4011
+ * second-press escape: the runner arms a confirm window whenever
+ * hasExpandedEntriesAboveViewport still holds after the toggle. A partial
+ * collapse says so too — the keypress is never silent about what it skipped.
  */
 export function toggleAllToolExpansion(state: MakaPiTranscriptState): boolean {
-  if (togglesInert(state)) return false;
-  const candidates = state.entries.filter(
-    (entry): entry is MakaPiToolEntry => entry.kind === 'tool',
-  );
-  if (candidates.length === 0) return false;
-  state.expandAllTools = !state.expandAllTools;
-  const targets = candidates.filter((entry) => entryInLiveViewport(state, entry));
-  for (const entry of targets) entry.expanded = state.expandAllTools;
-  if (targets.length === 0) {
-    state.entries.push({
-      kind: 'notice',
-      level: 'info',
-      text: `No tool card in view to toggle — cards above stay as rendered in scrollback. New tool output starts ${state.expandAllTools ? 'expanded' : 'collapsed'}.`,
-    });
-  }
-  return true;
+  return toggleExpansion(state, 'tool');
 }
 
 /**
  * Toggle every thinking entry in the live viewport at once and flip the
  * default for future entries; false when there is no thinking at all or the
- * toggles are inert pending a render. Same head-scrolled contract as
- * toggleAllToolExpansion (#1134).
+ * toggles are inert pending a render. Same head-scrolled contract and #4011
+ * second-press escape as toggleAllToolExpansion.
  */
 export function toggleAllThinkingExpansion(state: MakaPiTranscriptState): boolean {
+  return toggleExpansion(state, 'thinking');
+}
+
+/**
+ * True when an entry of the kind above the live viewport remains expanded —
+ * the stranded blocks the #4011 confirmed collapse exists for. False while
+ * the toggles are inert (positions unknown after a wholesale replacement).
+ */
+export function hasExpandedEntriesAboveViewport(
+  state: MakaPiTranscriptState,
+  kind: ExpansionEntryKind,
+): boolean {
   if (togglesInert(state)) return false;
-  const candidates = state.entries.filter(
-    (entry): entry is MakaPiThinkingEntry =>
-      entry.kind === 'thinking' && Boolean(entry.text.trim()),
+  return expansionCandidates(state, kind).some(
+    (entry) => entry.expanded && !entryInLiveViewport(state, entry),
   );
+}
+
+/**
+ * Apply the current expansion default to every entry of the kind, including
+ * entries above the live viewport whose rendered lines sit in scrollback.
+ * This is #4011's confirmed second press: a true return means lines above
+ * the viewport change, so the caller MUST follow with pi-tui's
+ * `requestRender(true)` — a scrollback-clearing full redraw that re-anchors
+ * the viewport at the tail. (The differential path would reach the same
+ * redraw via `firstChanged < viewportTop`; forcing it keeps renderer and the
+ * layout's viewport shadow in agreement by construction.)
+ */
+export function applyExpansionDefaultToAll(
+  state: MakaPiTranscriptState,
+  kind: ExpansionEntryKind,
+): boolean {
+  const expanded = kind === 'tool' ? state.expandAllTools : state.expandAllThinking;
+  let changed = false;
+  for (const entry of expansionCandidates(state, kind)) {
+    if (entry.expanded === expanded) continue;
+    entry.expanded = expanded;
+    changed = true;
+  }
+  return changed;
+}
+
+export type ExpansionEntryKind = 'tool' | 'thinking';
+
+/**
+ * How close together two identical expansion-toggle presses read as the
+ * confirmed "collapse the stranded blocks above the viewport" gesture (#4011).
+ * Lives beside the notice copy so the offer text and the runner's confirm
+ * window share one authority and cannot drift.
+ */
+export const EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS = 2_000;
+
+const EXPANSION_KIND_COPY: Record<
+  ExpansionEntryKind,
+  {
+    key: string;
+    singular: string;
+    plural: string;
+    noTargetsNotice: (expand: boolean) => string;
+    newOutput: string;
+  }
+> = {
+  tool: {
+    key: 'Ctrl+O',
+    singular: 'tool card',
+    plural: 'tool cards',
+    newOutput: 'tool output',
+    noTargetsNotice: (expand) =>
+      `No tool card in view to toggle — cards above stay as rendered in scrollback. New tool output starts ${expand ? 'expanded' : 'collapsed'}.`,
+  },
+  thinking: {
+    key: 'Ctrl+T',
+    singular: 'thinking block',
+    plural: 'thinking blocks',
+    newOutput: 'thinking',
+    noTargetsNotice: (expand) =>
+      `No thinking in view to toggle — thinking above stays as rendered in scrollback. New thinking starts ${expand ? 'expanded' : 'collapsed'}.`,
+  },
+};
+
+function expansionCandidates(
+  state: MakaPiTranscriptState,
+  kind: ExpansionEntryKind,
+): Array<MakaPiToolEntry | MakaPiThinkingEntry> {
+  return kind === 'tool'
+    ? state.entries.filter((entry): entry is MakaPiToolEntry => entry.kind === 'tool')
+    : state.entries.filter(
+        (entry): entry is MakaPiThinkingEntry =>
+          entry.kind === 'thinking' && Boolean(entry.text.trim()),
+      );
+}
+
+function toggleExpansion(state: MakaPiTranscriptState, kind: ExpansionEntryKind): boolean {
+  if (togglesInert(state)) return false;
+  const candidates = expansionCandidates(state, kind);
   if (candidates.length === 0) return false;
-  state.expandAllThinking = !state.expandAllThinking;
+  const expand = kind === 'tool' ? !state.expandAllTools : !state.expandAllThinking;
+  if (kind === 'tool') state.expandAllTools = expand;
+  else state.expandAllThinking = expand;
   const targets = candidates.filter((entry) => entryInLiveViewport(state, entry));
-  for (const entry of targets) entry.expanded = state.expandAllThinking;
-  if (targets.length === 0) {
+  for (const entry of targets) entry.expanded = expand;
+  const stuck = candidates.filter((entry) => entry.expanded !== expand);
+  const copy = EXPANSION_KIND_COPY[kind];
+  // The confirm offer exists for collapses only: expanded-above blocks are the
+  // screen-reclaiming pain (#4011), while collapsed-above blocks are compact
+  // and harmless in scrollback — and arming on expand would make a quick
+  // expand-then-collapse pair read the second press as "expand everything".
+  if (!expand && stuck.length > 0) {
     state.entries.push({
       kind: 'notice',
       level: 'info',
-      text: `No thinking in view to toggle — thinking above stays as rendered in scrollback. New thinking starts ${state.expandAllThinking ? 'expanded' : 'collapsed'}.`,
+      text: `${stuck.length} ${stuck.length === 1 ? copy.singular : copy.plural} above the view stayed expanded in scrollback — press ${copy.key} again within ${EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS / 1000}s to collapse them too (this redraws the screen and clears pre-session scrollback). New ${copy.newOutput} starts collapsed.`,
     });
+  } else if (targets.length === 0) {
+    state.entries.push({ kind: 'notice', level: 'info', text: copy.noTargetsNotice(expand) });
   }
   return true;
 }

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -555,6 +555,28 @@ export function hasExpandedEntriesAboveViewport(
 }
 
 /**
+ * Appends the visible, explicit offer for the one deliberate full-redraw
+ * escape hatch. The runner owns the time window; this helper keeps both the
+ * first offer and an expired offer on the same copy authority.
+ */
+export function appendExpansionCollapseConfirmation(
+  state: MakaPiTranscriptState,
+  kind: ExpansionEntryKind,
+): boolean {
+  if (!hasExpandedEntriesAboveViewport(state, kind)) return false;
+  const copy = EXPANSION_KIND_COPY[kind];
+  const stuck = expansionCandidates(state, kind).filter(
+    (entry) => entry.expanded && !entryInLiveViewport(state, entry),
+  );
+  state.entries.push({
+    kind: 'notice',
+    level: 'info',
+    text: `${stuck.length} ${stuck.length === 1 ? copy.singular : copy.plural} above the view stayed expanded in scrollback — press ${copy.key} again within ${EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS / 1000}s to collapse them too (this redraws the screen and clears pre-session scrollback). New ${copy.newOutput} starts collapsed.`,
+  });
+  return true;
+}
+
+/**
  * Apply the current expansion default to every entry of the kind, including
  * entries above the live viewport whose rendered lines sit in scrollback.
  * This is #4011's confirmed second press: a true return means lines above
@@ -563,6 +585,9 @@ export function hasExpandedEntriesAboveViewport(
  * the viewport at the tail. (The differential path would reach the same
  * redraw via `firstChanged < viewportTop`; forcing it keeps renderer and the
  * layout's viewport shadow in agreement by construction.)
+ * This is intentionally the only expansion mutation that bypasses the
+ * unknown-geometry guard: its caller immediately forces that wholesale
+ * redraw, which resets the renderer's prior geometry before it re-renders.
  */
 export function applyExpansionDefaultToAll(
   state: MakaPiTranscriptState,
@@ -644,11 +669,7 @@ function toggleExpansion(state: MakaPiTranscriptState, kind: ExpansionEntryKind)
   // and harmless in scrollback — and arming on expand would make a quick
   // expand-then-collapse pair read the second press as "expand everything".
   if (!expand && stuck.length > 0) {
-    state.entries.push({
-      kind: 'notice',
-      level: 'info',
-      text: `${stuck.length} ${stuck.length === 1 ? copy.singular : copy.plural} above the view stayed expanded in scrollback — press ${copy.key} again within ${EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS / 1000}s to collapse them too (this redraws the screen and clears pre-session scrollback). New ${copy.newOutput} starts collapsed.`,
-    });
+    appendExpansionCollapseConfirmation(state, kind);
   } else if (targets.length === 0) {
     state.entries.push({ kind: 'notice', level: 'info', text: copy.noTargetsNotice(expand) });
   }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -88,6 +88,7 @@ import {
   type MakaSessionSwitchResult,
 } from './session-driver.js';
 import {
+  appendExpansionCollapseConfirmation,
   appendTurnFailureToTranscript,
   appendUserPrompt,
   applyMakaSessionEventToTranscript,
@@ -291,6 +292,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
   const tui = new TuiMainScreen(terminal);
   const state = createMakaPiTranscriptState();
+  // A pending confirmation is meaningful only for the exact transcript whose
+  // geometry produced it; reconnect/session replacement starts fresh.
+  let expansionCollapseConfirm: { kind: ExpansionEntryKind; at: number } | undefined;
   let transcriptLastUsedModel: string | undefined;
   const rememberTranscriptModel = (messages: readonly StoredMessage[]): void => {
     transcriptLastUsedModel = latestAssistantModelId(messages);
@@ -299,6 +303,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     messages: readonly StoredMessage[],
     options: { preserveClientLocalEntries?: boolean } = {},
   ): void => {
+    expansionCollapseConfirm = undefined;
     rememberTranscriptModel(messages);
     replaceTranscriptWithStoredMessages(state, messages, options);
   };
@@ -3412,16 +3417,25 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // one scrollback-clearing full redraw to collapse those blocks too. The
   // window (not a latch on other keys) is the only expiry, matching the
   // double-Escape interrupt pattern.
-  let expansionCollapseConfirm: { kind: ExpansionEntryKind; at: number } | undefined;
   const handleExpansionToggleKey = (kind: ExpansionEntryKind): boolean => {
     const armed = expansionCollapseConfirm;
     expansionCollapseConfirm = undefined;
-    if (armed?.kind === kind && Date.now() - armed.at <= EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS) {
-      // The confirmed second press: apply the (collapsed) default to every
-      // entry, including the ones above the viewport, and pay the deliberate
-      // full redraw the notice announced.
-      if (applyExpansionDefaultToAll(state, kind)) requestRender(true);
-      return true;
+    if (armed?.kind === kind) {
+      if (Date.now() - armed.at <= EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS) {
+        // The confirmed second press: apply the (collapsed) default to every
+        // entry, including the ones above the viewport, and pay the deliberate
+        // full redraw the notice announced.
+        if (applyExpansionDefaultToAll(state, kind)) requestRender(true);
+        return true;
+      }
+      // A reader can reasonably miss the short window. Keep the already
+      // collapsed default and make the explicit choice visible again instead
+      // of falling through to the opposite ordinary toggle.
+      if (appendExpansionCollapseConfirmation(state, kind)) {
+        expansionCollapseConfirm = { kind, at: Date.now() };
+        requestRender();
+        return true;
+      }
     }
     const toggled =
       kind === 'tool' ? toggleAllToolExpansion(state) : toggleAllThinkingExpansion(state);

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -94,8 +94,11 @@ import {
   createMakaPiTranscriptState,
   activeSandboxBoundaryRequest,
   activeUserQuestionRequest,
+  applyExpansionDefaultToAll,
   completePendingInteraction,
   applyShellRunViewUpdateToTranscript,
+  EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS,
+  hasExpandedEntriesAboveViewport,
   permissionModeLabel,
   retireCancelledTransientMessages,
   replaceTranscriptWithStoredMessages,
@@ -103,6 +106,7 @@ import {
   submitCompactToTranscript,
   toggleAllThinkingExpansion,
   toggleAllToolExpansion,
+  type ExpansionEntryKind,
   type MakaPiTranscriptMetadata,
 } from './pi-transcript.js';
 import { runMakaPiTuiTurn, type MakaPiTuiTurnRequest } from './pi-tui-turn.js';
@@ -522,9 +526,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     attention.setBaseTitle(`${title} (${input.title})`);
   };
 
-  const requestRender = () => {
+  const requestRender = (force = false) => {
     transcript.invalidate();
-    tui.requestRender();
+    tui.requestRender(force);
   };
   const unsubscribeSessionTitleChanges =
     input.subscribeSessionTitleChanges?.((sessionId) => {
@@ -3403,6 +3407,33 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
   refreshEditorCwd(cwd);
 
+  // #4011: a collapse toggle that strands expanded blocks above the viewport
+  // arms this window; pressing the same key again within it knowingly accepts
+  // one scrollback-clearing full redraw to collapse those blocks too. The
+  // window (not a latch on other keys) is the only expiry, matching the
+  // double-Escape interrupt pattern.
+  let expansionCollapseConfirm: { kind: ExpansionEntryKind; at: number } | undefined;
+  const handleExpansionToggleKey = (kind: ExpansionEntryKind): boolean => {
+    const armed = expansionCollapseConfirm;
+    expansionCollapseConfirm = undefined;
+    if (armed?.kind === kind && Date.now() - armed.at <= EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS) {
+      // The confirmed second press: apply the (collapsed) default to every
+      // entry, including the ones above the viewport, and pay the deliberate
+      // full redraw the notice announced.
+      if (applyExpansionDefaultToAll(state, kind)) requestRender(true);
+      return true;
+    }
+    const toggled =
+      kind === 'tool' ? toggleAllToolExpansion(state) : toggleAllThinkingExpansion(state);
+    if (!toggled) return false;
+    const collapsed = kind === 'tool' ? !state.expandAllTools : !state.expandAllThinking;
+    if (collapsed && hasExpandedEntriesAboveViewport(state, kind)) {
+      expansionCollapseConfirm = { kind, at: Date.now() };
+    }
+    requestRender();
+    return true;
+  };
+
   tui.addInputListener((data) => {
     // Track bracketed pastes before any consuming branch: this must observe
     // every chunk the editor could buffer, regardless of what the rest of the
@@ -3500,14 +3531,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // one (e.g. `Esc`, type, `Esc`).
     if (!matchesKey(data, Key.escape)) lastIdleEscapeAt = 0;
     if (matchesKey(data, Key.ctrl('o')) && !isKeyRepeat(data)) {
-      if (toggleAllToolExpansion(state)) {
-        requestRender();
+      if (handleExpansionToggleKey('tool')) {
         return { consume: true };
       }
     }
     if (matchesKey(data, Key.ctrl('t')) && !isKeyRepeat(data)) {
-      if (toggleAllThinkingExpansion(state)) {
-        requestRender();
+      if (handleExpansionToggleKey('thinking')) {
         return { consume: true };
       }
     }
@@ -3598,9 +3627,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // into a scrollback-clearing full redraw (its `firstChanged < viewportTop`
   // path). The toggles therefore retarget only entries inside the viewport;
   // see entryInLiveViewport in pi-transcript.ts (#1097). A block whose own
-  // expansion pushed its head above the viewport can consequently never be
-  // collapsed in place (#1134): the toggles still flip the default and append
-  // a notice, and the expanded content stays readable in scrollback.
+  // expansion pushed its head above the viewport can consequently not be
+  // collapsed by the next press (#1134): the toggle still flips the default
+  // and appends a notice, and the expanded content stays readable in
+  // scrollback. #4011 adds the deliberate exception: pressing the same key
+  // again within EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS applies the collapsed
+  // default to those blocks too and pays one scrollback-clearing full redraw
+  // (requestRender(true)), re-anchoring the viewport at the tail.
   tui.setClearOnShrink(false);
   tui.addChild(layout);
   tui.setFocus(editorSurface);


### PR DESCRIPTION
## Summary

Fixes #4011 — implements option 2 of #1134 (the explicit redraw command deferred by #1140 as an orthogonal follow-up).

Today a `Ctrl+O`/`Ctrl+T` collapse can strand expanded blocks above the live viewport: their heads sit in terminal scrollback, which the #1097 contract forbids rewriting, so they can never be collapsed again (#1134). #1140 made the fully-stranded case explained, but the common partial case — some cards collapse, the rest stay stuck — is silent, so the toggle reads as broken.

This PR turns the #1097 tradeoff into an informed per-press choice:

- A collapse that strands expanded blocks above the viewport now appends a notice naming them: *"N tool cards above the view stayed expanded in scrollback — press Ctrl+O again within 2s to collapse them too (this redraws the screen and clears pre-session scrollback)."* Partial collapses stop being silent; expand-direction toggles stay quiet about collapsed blocks above (they are compact and harmless, and arming there would make a quick expand–collapse pair read the second press as "expand everything").
- A second press of the same key within `EXPANSION_COLLAPSE_CONFIRM_WINDOW_MS` applies the collapsed default to every entry — without flipping the default the way a plain toggle would — and pays one deliberate scrollback-clearing full redraw through pi-tui's existing public `requestRender(true)`, which re-anchors the viewport at the tail. Transcript content is fully re-rendered into fresh scrollback, so nothing from the session is lost; only pre-session shell scrollback is cleared, and only after the explicit second press.
- The window constant lives beside the notice copy so the offer text and the runner's confirm window share one authority.

No pi-tui patch or upstream change is needed: `requestRender(force)` already exposes the full-render path (`resetRenderState` → width-change branch → `ESC[2J ESC[H ESC[3J` + full rewrite), and the layout's viewport shadow predicts the same re-anchor (`firstChanged < current → tailTop`).

## Verification

- `packages/cli`: `npm test` 546/546 — 4 new unit tests (mixed-position collapse notice, confirmed collapse does not flip the default and is idempotent, expand direction stays silent, inert-window predicate) and 1 new integration test.
- The integration test drives the real pi-tui renderer through `runMakaPiTui` on a 24-row terminal: an 80-line thinking block is expanded past the viewport, the first collapse press renders the offer with **no** `ESC[3J` in the output stream, and the confirmed second press emits the deliberate clear exactly once while the block returns to its compact `Thinking…` row. (Tool cards window their expanded rendering — `⋯ N lines hidden ⋯` — so a thinking block is what can actually push its head past the viewport; this matches how #1140 verified #1134.)
- Root `npm run lint`, `npm run format:check`, `packages/cli` typecheck, and `check:asf-headers` all clean.
- Not run: desktop/eval suites (cli-only change; nothing outside `packages/cli` is touched).

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenCode (kimi k3-256k) drafted the implementation and tests under human direction; the approach (second-press confirm, collapse-only arming) was reviewed and decided interactively. Commits carry `Generated-by: OpenCode` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
