### PR TITLE
test(runtime-host): synchronize recovery phase assertion

### DIFF
--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -1182,7 +1182,11 @@ describe('non-serving Runtime Host kernel', () => {
 
   test('does not take over a generation-mismatched Host before it is ready', async () => {
     await withHostPaths(async (paths) => {
+      let markRecoveryEntered!: () => void;
       let releaseRecovery!: () => void;
+      const recoveryEntered = new Promise<void>((resolve) => {
+        markRecoveryEntered = resolve;
+      });
       const recovery = new Promise<void>((resolve) => {
         releaseRecovery = resolve;
       });
@@ -1197,33 +1201,30 @@ describe('non-serving Runtime Host kernel', () => {
         composition: defineInteractiveRuntimeHostComposition(async () => ({
           ...testComposition(),
           async recover() {
+            markRecoveryEntered();
             await recovery;
           },
         })),
       });
 
-      let takeover = await connectRuntimeHost({
-        rootPath: paths.root,
-        protocol: CURRENT_PROTOCOL,
-        generation: 'desktop-new',
-      });
-      while (takeover.kind === 'unavailable' && takeover.reason === 'not_registered') {
-        await sleep(10);
-        takeover = await connectRuntimeHost({
+      try {
+        await withTimeout(recoveryEntered, 5_000, 'Runtime Host did not enter recovery');
+        const takeover = await connectRuntimeHost({
           rootPath: paths.root,
           protocol: CURRENT_PROTOCOL,
           generation: 'desktop-new',
         });
+        assert.equal(takeover.kind, 'upgrade_required');
+        if (takeover.kind === 'upgrade_required') {
+          assert.equal(takeover.restartable, false);
+          assert.equal(takeover.handshake?.state, 'recovering');
+        }
+      } finally {
+        releaseRecovery();
+        const host = await hostPromise;
+        await host.close();
+        await sleep(100);
       }
-      assert.equal(takeover.kind, 'upgrade_required');
-      if (takeover.kind === 'upgrade_required') {
-        assert.equal(takeover.restartable, false);
-        assert.equal(takeover.handshake?.state, 'recovering');
-      }
-      releaseRecovery();
-      const host = await hostPromise;
-      await host.close();
-      await sleep(100);
     });
   });
 


### PR DESCRIPTION
## Summary

- synchronize the generation-mismatch test with the Runtime Host entering recovery
- preserve the exact `recovering` lifecycle assertion without depending on registration timing
- always release the recovery gate and close the Host when an assertion fails

## Root cause

The Host intentionally publishes one registration while it is still `starting`, then publishes `recovering` before the test composition begins recovery. The old test stopped polling as soon as any registration appeared, so a loaded runner could observe the legal `starting` registration and fail before recovery began.

This changes only the test synchronization. The production result in the failing run was already correct: the generation-mismatched client received `upgrade_required` with `restartable: false`.

## Verification

- mutation: removing the recovery-entry wait makes the focused test fail; restoring it passes
- focused regression: 100/100 concurrent repetitions passed
- complete Host kernel tests: 66/66 passed
- complete Runtime Host suite: 1,279 passed, 0 failed, 9 platform skips
- Core, Storage, Runtime, and Runtime Host TypeScript build passed
- Biome and `git diff --check` passed

Fixes #4028

Generative AI contribution: OpenAI Codex independently reproduced the race, implemented the test-only synchronization, and ran the verification above.

---
_Posted by an automated review agent operated by @M4n5ter. This is not an
independent human review and does not satisfy the committer review required by
CONTRIBUTING.md. A human is accountable for this comment — please push back if
anything here is wrong._

<details><summary>简体中文</summary>

_本条评论由 @M4n5ter 运行的自动化审查程序发出。它不构成 CONTRIBUTING.md
所要求的独立人类审查，也不能替代人类审查。有人类对本条评论负责，如有错误请直接指出。_

</details>
