### PR TITLE
perf(storage): bound Runtime Host cold-start artifact recovery cost (#4027)

### DIFF
--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -78,7 +78,9 @@ export const ARTIFACT_TEXT_PREVIEW_LIMIT_BYTES = 10 * 1024 * 1024;
 export const ARTIFACT_BINARY_PREVIEW_LIMIT_BYTES = 50 * 1024 * 1024;
 
 const PURGE_INTENT_SCHEMA_VERSION = 1 as const;
+
 const MAX_PURGE_INTENT_BYTES = 64 * 1024 * 1024;
+const ARTIFACT_PURGE_RESOLVE_CONCURRENCY = 8;
 const EMPTY_SESSION_SNAPSHOT: ArtifactSessionSnapshot = {
   records: [],
   revision: artifactListRevision([]),
@@ -883,28 +885,75 @@ class SqliteArtifactStore implements ArtifactAuthorityStore {
     const relativePaths = new Map(records.map((record) => [record.relativePath, record] as const));
     for (const record of records) {
       validateRelativeArtifactPath(record.relativePath);
-      const entry = await resolveArtifactRemovalEntry(this.artifactRoot, record.relativePath);
+    }
+    const purgeEntries = await this.resolveRemovalEntriesUnlocked(records);
+    for (const [index, record] of records.entries()) {
+      const entry = purgeEntries[index];
       if (!entry) continue;
       if (!isInsideOrSamePath(root, dirname(entry.unlinkPath))) {
         throw new Error(`Artifact ${record.id} resolves outside the artifact root`);
       }
       entries.set(entry.comparisonIdentity, { unlinkPath: entry.unlinkPath, record });
     }
-    for (const record of this.records) {
-      if (ids.has(record.id)) continue;
+    const guardRecords = this.records.filter((record) => !ids.has(record.id));
+    for (const record of guardRecords) {
       const exactTarget = relativePaths.get(record.relativePath);
       if (exactTarget) {
         throw new Error(
           `Artifact ${exactTarget.id} path is still referenced by artifact ${record.id}`,
         );
       }
-      const entry = await resolveArtifactRemovalEntry(this.artifactRoot, record.relativePath);
+    }
+    const guardEntries = await this.resolveRemovalEntriesUnlocked(guardRecords);
+    for (const [index, record] of guardRecords.entries()) {
+      const entry = guardEntries[index];
       const target = entry ? entries.get(entry.comparisonIdentity)?.record : undefined;
       if (target) {
         throw new Error(`Artifact ${target.id} path is still referenced by artifact ${record.id}`);
       }
     }
     return [...entries.values()].map((entry) => entry.unlinkPath);
+  }
+
+  // Resolves removal entries with bounded concurrency: each resolution issues
+  // realpath/lstat syscalls, so a serial loop over the full record set turned
+  // session-cleanup purges into a syscall storm on large artifact stores.
+  // Workers capture per-record results and always drain the queue, so all
+  // filesystem work settles before this mutation releases the writer lock,
+  // and resolver failures surface in record order rather than completion
+  // order.
+  private async resolveRemovalEntriesUnlocked(
+    records: readonly ArtifactRecord[],
+  ): Promise<readonly (ArtifactRemovalEntry | undefined)[]> {
+    type Resolution =
+      | { readonly ok: true; readonly entry: ArtifactRemovalEntry | undefined }
+      | { readonly ok: false; readonly error: unknown };
+    const results: (Resolution | undefined)[] = new Array(records.length);
+    let nextIndex = 0;
+    const worker = async () => {
+      while (nextIndex < records.length) {
+        const index = nextIndex++;
+        try {
+          const entry = await resolveArtifactRemovalEntry(
+            this.artifactRoot,
+            records[index]!.relativePath,
+          );
+          results[index] = { ok: true, entry };
+        } catch (error) {
+          results[index] = { ok: false, error };
+        }
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(ARTIFACT_PURGE_RESOLVE_CONCURRENCY, records.length) }, worker),
+    );
+    const resolved: (ArtifactRemovalEntry | undefined)[] = new Array(records.length);
+    for (const [index, result] of results.entries()) {
+      if (result === undefined) throw new Error('Artifact removal resolution did not settle');
+      if (!result.ok) throw result.error;
+      resolved[index] = result.entry;
+    }
+    return resolved;
   }
 
   private async completePurgeUnlocked(


### PR DESCRIPTION
## Summary

Contributes to #4027 (does not fully close it — see "Out of scope" below).

Cold-starting a Runtime Host against a workspace with a large accumulated artifact store blocked Host readiness for minutes while connected TUI clients rendered nothing. One profiled cost is addressed here, without touching any contract:

**`preparePurgePathsUnlocked` resolved removal entries serially over every live record** (realpath + lstat per record, per purge). Back-to-back purges (session sidecar cleanup when clients exit, purge-intent recovery) stacked into a syscall storm. Resolution now runs through an 8-wide worker pool (same pattern as `CANONICAL_PERMISSION_READ_CONCURRENCY` in `runtime-read-model.ts`):

- Workers capture per-record results and always drain the queue, so all filesystem work settles before the mutation releases the serialized writer lock.
- Resolver failures surface in record order, not completion order.
- Case-alias validation stays sequential and deterministic in record order; the inode/symlink aliasing integrity checks are unchanged.

An earlier revision of this PR also removed the eager recovery-time orphan content digest. That weakened the exact orphan snapshot proof (`rm` + rewrite can reuse the inode, defeating the fingerprint fallback) and the contract test `authority recovery adopts only its pre-existing exact stable-id orphan snapshot` correctly caught it on CI. That commit has been reverted; recovery semantics are untouched by this head.

## Verification

- `biome format` / `biome lint` clean on changed files
- `@maka/storage` suite (`npm --workspace @maka/storage run test:dist`): **988 tests, 970 pass, 0 fail, 18 skipped** (including `authority recovery adopts only its pre-existing exact stable-id orphan snapshot`)
- Local synthetic benchmark (10k records / 100 purge targets, 12 warm runs, Linux, Node 26.3): serial median 9,108 ms → pooled median 5,855 ms (~1.56x wall-clock speedup on this loop-mount workload)
- No new test: the observable behavior of the pooled resolver matches the serial implementation, so a behavioral test cannot discriminate between them. The benchmark above is retained as performance evidence instead.
- Not run: desktop e2e (no desktop surface touched)

## Out of scope (follow-ups tracked in #4027)

This is a constant-factor improvement, not the global fix. Each Session purge still resolves every non-target live record, and Runtime Host retirement drains a batch of M Sessions through M serialized purges (O(M×N)). Fully closing #4027 needs separate contract-level changes discussed in the issue thread:

- Batched multi-Session artifact purge reusing the existing multi-ID purge intent: one guard scan, one unlink plan, one metadata commit per retirement batch, with bounded resolution inside the batch.
- Durable-evidence-only orphan recovery (publication staging / purge intent), treating an untracked bare target as a conflict, instead of the authority-wide eager snapshot/adoption scan.
- Metadata change tracking to avoid re-decoding and rewriting the full record set on every mutation (`reloadForMutationUnlocked` → `readAll()`), which dominates the remaining purge time above.

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Kimi k3-256k — implementation, benchmarks, and this PR description. Commits carry `Generated-by` trailers.

## Checklist

- [x] Lint, format, typecheck and the affected suites pass locally
- [x] Performance claim is backed by a repeatable benchmark (see Verification)

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above

Behavior change is performance-only. One edge nuance: when a purge would trip both an exact-path reference and an inode-alias reference, the exact-path error now always wins (previously whichever record came first in scan order); both errors are the same `path is still referenced` failure.
