### PR TITLE
perf(runtime-host): list recovery Session headers without the duplicate message decode (#4032)

### DIFF
--- a/packages/runtime-host/src/server/hosted-execution-recovery.ts
+++ b/packages/runtime-host/src/server/hosted-execution-recovery.ts
@@ -49,7 +49,10 @@ export interface PrepareHostedExecutionRecoveryInput {
 export async function prepareHostedExecutionRecovery(
   input: PrepareHostedExecutionRecoveryInput,
 ): Promise<readonly HostedExecutionRecoveryPlan[]> {
-  const sessions = await input.stores.sessionStore.listForRecovery();
+  // listHeaders() avoids listForRecovery()'s discarded per-Session message
+  // pre-read; the per-Session readMessagesForRecovery below remains the single
+  // decode that validates durable messages before replay.
+  const sessions = await input.stores.sessionStore.listHeaders();
   const prepared: PreparedRecoverySession[] = [];
   for (const session of sessions) {
     const admissions = await input.rootAdmissions.recoverSession(session.id);


### PR DESCRIPTION
## Summary

Refs #4032

`prepareHostedExecutionRecovery` decoded every recoverable Session's durable messages twice at Host startup: `listForRecovery()` performs a discarded per-Session `readMessagesForRecovery` pre-read, and the recovery loop then calls `readMessagesForRecovery` again per Session (that second read is the one actually used to index and validate admission/message relationships).

This PR lists recovery Session headers via `listHeaders()` instead, keeping the per-Session `readMessagesForRecovery` as the single decode. Fail-closed coverage is unchanged: corrupt durable messages still fail startup for the same Sessions, detected at the per-Session read instead of in an upfront sweep.

This is intentionally the conservative first step from #4032. The dominant startup cost — the discarded per-run `readEventsForRecovery`/`readRuntimeEvents` validation reads over every run of every Session — is left for maintainer discussion, since skipping it for terminal runs changes the startup-validation contract.

## Verification

- `biome format` / `biome lint` clean
- `@maka/runtime-host` suite (`npm --workspace @maka/runtime-host run test:dist`): **1288 tests, 1279 pass, 0 fail, 9 skipped** — includes the `execution-host-recovery` composition tests that exercise `prepareHostedExecutionRecovery` end to end
- No new test added: behavior is unchanged by construction (`listForRecovery()` returns `listHeaders()` after its discarded pre-read), and the existing recovery suite covers the path. The removed work was a duplicated read whose result no caller consumed.

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Kimi k3-256k — change, verification, and this PR description. The commit carries a `Generated-by` trailer.

## Checklist

- [x] Tests cover the change and fail without it (see note above — behavioral no-op covered by the existing recovery suite)
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above

Performance-only: identical recovery outcomes and identical startup failure coverage, one less full message decode pass per Host start.
