### PR TITLE
docs(architecture): align managed resume status

### DIFF
--- a/docs/architecture/runtime-managed-workspace-execution-admission-v1.zh-CN.md
+++ b/docs/architecture/runtime-managed-workspace-execution-admission-v1.zh-CN.md
@@ -19,8 +19,8 @@
 
 # Managed Workspace Execution Admission v1：M1.1 可撤销 scope 门
 
-- 状态：M1.1 已实现；M1.2 owner-bound worker bridge 与 runtime-host composition 当前切片；尚未由 Desktop/CLI 默认启用
-- 更新日期：2026-08-04
+- 状态：M1.1 execution admission 与 M1.2 owner-bound worker / Runtime Host composition 已实现；尚未由 Desktop/CLI 默认启用
+- 更新日期：2026-08-27
 - 主要不变量：同一个 `ManagedWorkspaceOwner` 只能用其亲自签发的进程内 execution handle 创建 active
   execution scope；一次 admission 只签发一个 scope，但同一 handle 允许多个只读 admission 并发。每次创建
   scope 前重新证明 exact SQLite workspace head 与 exact Git artifact，公共 API 永不发布 raw cwd，callback
@@ -51,8 +51,8 @@ typed `ManagedWorkspaceExecutionAuthorityError`，其稳定 code 为
 `managed_workspace_execution_scope_expired`；伪造 scope 的 code 为
 `managed_workspace_execution_scope_invalid`。
 
-本切片没有接入 Desktop、CLI 或 ToolRuntime。它只建立 host 后续接线必须消费的唯一准入 API，不同时跨越
-runtime protocol、host lifecycle 与工具 I/O 三个边界。
+M1.1 没有接入 Desktop、CLI 或 ToolRuntime，只建立 host 后续接线必须消费的唯一准入 API。M1.2 已把该
+authority 接入 Runtime Host 的只读 worker 与 lifecycle composition，但仍未由 Desktop/CLI 默认启用。
 
 ## 2. Owner、原子性边界、失败状态与回滚
 
@@ -97,8 +97,9 @@ sequenceDiagram
 
 这不是跨 SQLite/Git/filesystem 的共同事务。它关闭 cooperating Maka writer 的 proof-to-scope seam；任意外部
 进程仍可能在最后一次 filesystem observation 后制造 drift，后续 admission 会 fail closed。普通生产路径只执行
-图中的一次 final Git verification；只有配置 production-shaped crash failpoint 的测试路径才先执行一次 preliminary
-verification，以便在真实 proof 完成后 `SIGKILL`，随后仍必须再次执行 final verification 才能签发 scope。M1.2 的 worker/
+图中的一次 exact Git verification，随后以 SQLite head 作为最后一次 durable reread；只有配置 production-shaped
+crash failpoint 的测试路径才先执行一次 preliminary verification，以便在真实 proof 完成后 `SIGKILL`，随后仍必须
+再次执行 exact Git verification 并完成 final head reread 才能签发 scope。M1.2 的 worker/
 sandbox 建立实际 I/O 隔离，M2 才负责 mutating tool 产生 successor candidate 并接受新 workspace version。
 
 ## 4. Provisioning 与实际可用性边界
@@ -159,9 +160,9 @@ JavaScript finally，因此本切片的安全保证来自“只读 operation all
 | runtime-host lifecycle composition | 支持 | 支持 | 支持生命周期与 typed profile，但 managed I/O 因 worker 不可用而拒绝 |
 | power-loss durability | 不承诺 | 不承诺 | 不承诺 |
 
-## 7. 后续切片
+## 7. 已交付边界与后续切片
 
-1. M1.2：owner-bound storage worker bridge 消费 active scope 并在内部解析 cwd；公共 caller 仍不获得 path。
+1. M1.2（已实现）：owner-bound storage worker bridge 消费 active scope 并在内部解析 cwd；公共 caller 仍不获得 path。
    managed profile 在 M2 前只允许 `workspaceEffect: none` 的 Read/Glob/Grep；Write/Edit/Format/Bash/未知工具在
    worker dispatch 前 fail closed。无 ownerToken 的 inspect API 仅保留在显式 test support 中；callback 内
    reentrant `owner.close()` 由 execution-context guard 拒绝。runtime-host 使用不可混淆的 attached/managed

--- a/docs/architecture/runtime-resume-architecture.md
+++ b/docs/architecture/runtime-resume-architecture.md
@@ -754,9 +754,9 @@ Layer responsibilities:
 
 The Runtime host uses strict recovery stores. It does not silently turn an unreadable ledger into best-effort fallback before admitting new writes.
 
-### Managed workspace execution admission (M1.1)
+### Managed workspace execution admission and read bridge (M1.1–M1.2)
 
-The workspace plane now has a storage-owned execution-admission foundation, but it is not yet wired into the Runtime host:
+The workspace plane now has storage-owned execution admission and an owner-bound, read-only Runtime Host bridge:
 
 - baseline open returns an opaque handle bound to its `ManagedWorkspaceOwner`, never a raw cwd;
 - every admission reproves storage-root identity, the exact Git receipt/binding/HEAD/tree/ownership, and the exact SQLite canonical head; the ordinary path performs its slow Git verification first, then makes the immutable SQLite head the final durable reread before the DB identity guard and pure in-memory comparisons;
@@ -764,7 +764,7 @@ The workspace plane now has a storage-owned execution-admission foundation, but 
 - `close()` rejects new admissions and drains every active scope; a scope expires when its callback exits, with typed `managed_workspace_execution_scope_invalid` and `managed_workspace_execution_scope_expired` codes for forged and retained scopes;
 - the crash harness may enable a preliminary-verification failpoint, but that test path must still pass the final verification before any scope is issued.
 
-M1.2 adds the owner-bound storage worker bridge and its runtime-host lifecycle composition in one delivery. It limits managed execution to Read/Glob/Grep, demotes unchecked scope inspection to explicit test support, rejects reentrant owner close, keeps attached and managed profiles structurally distinct, and orders shutdown as tool operations → managed owner → root owner. Desktop and CLI do not enable it by default in this slice; Write/Edit/Format/Bash/unknown tools fail closed, and managed mode never silently falls back to the attached checkout. See [Managed Workspace Execution Admission v1](./runtime-managed-workspace-execution-admission-v1.zh-CN.md) for the detailed contract.
+M1.2 wires that authority into the owner-bound storage worker bridge and Runtime Host lifecycle composition. It limits managed execution to Read/Glob/Grep, demotes unchecked scope inspection to explicit test support, rejects reentrant owner close, keeps attached and managed profiles structurally distinct, and orders shutdown as tool operations → managed owner → root owner. Desktop and CLI do not enable it by default; Write/Edit/Format/Bash/unknown tools fail closed, and managed mode never silently falls back to the attached checkout. See [Managed Workspace Execution Admission v1](./runtime-managed-workspace-execution-admission-v1.zh-CN.md) for the detailed contract.
 
 ### Eval
 

--- a/docs/architecture/runtime-resume-architecture.zh-CN.md
+++ b/docs/architecture/runtime-resume-architecture.zh-CN.md
@@ -785,17 +785,17 @@ flowchart LR
 
 Runtime host 使用 strict recovery stores 执行 startup repair。严格模式不会把 unreadable ledger 吞成 best-effort fallback，适合服务端 composition 在接收新写入前建立清楚的恢复边界。
 
-### Managed workspace execution admission（M1.1）
+### Managed workspace execution admission 与只读桥（M1.1–M1.2）
 
-Resume 的 workspace plane 已经有一层 storage-owned 的执行准入地基，但它还没有接入 Runtime host：
+Resume 的 workspace plane 已经有 storage-owned execution admission，并已接入 owner-bound、只读的 Runtime Host bridge：
 
 - baseline open 只返回绑定 `ManagedWorkspaceOwner` 的 opaque handle，不公开 raw cwd；
-- 每次 admission 都重新证明 storage-root identity、exact SQLite canonical head 和 exact Git receipt/binding/HEAD/tree/ownership；普通生产路径只在签发 scope 前做一次最终 Git verification；
+- 每次 admission 都重新证明 storage-root identity、exact SQLite canonical head 和 exact Git receipt/binding/HEAD/tree/ownership；普通路径先完成一次慢速 Git verification，再以 immutable SQLite head 作为最后一次 durable reread，随后只执行 DB identity guard 与纯内存比较；
 - 一次 admission 签发一个 callback-scoped、`workspaceEffect: none` 的 opaque scope；同一 handle 可以并发多个只读 scope；
 - `close()` 拒绝新 admission，并等待所有 active scope drain；callback 退出后 scope 立即失效，伪造与过期分别返回 typed `managed_workspace_execution_scope_invalid` / `managed_workspace_execution_scope_expired`；
 - crash harness 可配置 preliminary-verification failpoint，但该测试路径仍须再次通过 final verification 才能签发 scope。
 
-M1.2 在同一交付中完成 owner-bound storage worker bridge 与 runtime-host lifecycle composition：只允许 Read/Glob/Grep，把无 owner 校验的 inspect 降为显式 test support，拒绝 active callback 内 reentrant `owner.close()`，用不可混淆的 attached/managed typed profile 阻止 silent fallback，并固定 tool operations → managed owner → root owner 的关闭顺序。本切片不让 Desktop/CLI 默认开启 managed execution；Write/Edit/Format/Bash/未知工具必须 fail closed。详细合同见 [Managed Workspace Execution Admission v1](./runtime-managed-workspace-execution-admission-v1.zh-CN.md)。
+M1.2 已完成 owner-bound storage worker bridge 与 Runtime Host lifecycle composition：只允许 Read/Glob/Grep，把无 owner 校验的 inspect 降为显式 test support，拒绝 active callback 内 reentrant `owner.close()`，用不可混淆的 attached/managed typed profile 阻止 silent fallback，并固定 tool operations → managed owner → root owner 的关闭顺序。Desktop/CLI 仍不默认开启 managed execution；Write/Edit/Format/Bash/未知工具必须 fail closed。详细合同见 [Managed Workspace Execution Admission v1](./runtime-managed-workspace-execution-admission-v1.zh-CN.md)。
 
 ### Eval
 

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -581,14 +581,15 @@ baseline open 中。
 
 M1 拆成独立不变量，避免一次 PR 同时跨越 host lifecycle、runtime protocol 与 platform I/O：
 
-1. **M1.1 execution scope admission（当前切片）**：M0 只返回 owner-bound opaque handle；同一 owner 每次
+1. **M1.1 execution scope admission（已合并）**：M0 只返回 owner-bound opaque handle；同一 owner 每次
    execution 都在 drain residency 内重新证明 canonical head、Git receipt、HEAD/tree/ownership 与 root
    identity，最后只签发 callback 生命周期内有效的 opaque scope，不公开 raw cwd。provisioning 固定为
    `canonical_tree_only_v1`，`workspaceEffect` 固定为 `none`。同一 handle 可以并发多个只读 admission，
-   `close()` 必须等待全部 active scope drain；普通生产 admission 只做一次最终 Git verification，preliminary
-   verification 仅存在于配置 crash failpoint 的 production-shaped 测试路径；过期或伪造 scope 通过 typed
+   `close()` 必须等待全部 active scope drain；普通 production admission 先做一次 exact Git verification，再以
+   SQLite head 作为最后一次 durable reread；preliminary verification 仅存在于配置 crash failpoint 的
+   production-shaped 测试路径；过期或伪造 scope 通过 typed
    `ManagedWorkspaceExecutionAuthorityError` 的稳定 code fail closed；
-2. **M1.2 owner-bound worker 与 runtime-host composition**：storage-internal bridge 只能用同 owner 的 active
+2. **M1.2 owner-bound worker 与 runtime-host composition（已合并）**：storage-internal bridge 只能用同 owner 的 active
    scope 解析 cwd，M2 前只允许 Read/Glob/Grep；建立不可混淆的 managed/attached typed profile 与
    startup/drain/shutdown 顺序，关闭顺序固定为 tool operations → managed owner → root owner；
 3. **M1.3 environment provisioning**：单独设计 ignored dependency、secret 与 scratch overlay。M1.1 不复制
@@ -643,8 +644,8 @@ M0.1 Git artifact owner (merged)
   + M0.2 workspace version authority (merged)
   + M0.3 managed owner lifecycle (merged)
   └─> M0.4 baseline open bundle (merged)
-       └─> M1.1 execution scope admission (current)
-            └─> M1.2 runtime-host composition
+       └─> M1.1 execution scope admission (merged)
+            └─> M1.2 runtime-host composition (merged)
                  └─> M1.3 explicit environment provisioning
                       └─> M2 mutation version acceptance
                            └─> M3 workspace-bound continuation


### PR DESCRIPTION
## Summary
- mark M1.1 execution admission and M1.2 read-only Runtime Host composition as merged
- align the English and Chinese Resume chapters with the current Git-proof → SQLite-head durable reread order
- update the managed-workspace route and dedicated admission document without changing runtime behavior

## Primary invariant
The Resume architecture documents describe the managed-workspace execution stage that is actually present on `main`.

- Owner: architecture documentation for managed workspace Resume
- Atomicity boundary: four linked architecture documents updated together
- Failure state: readers infer that M1.2 is still pending or that Git verification is the final durable reread
- Rollback: revert this documentation-only commit; no schema, protocol, lifecycle, or I/O state changes

## Validation
- `git diff --check`
- all relative Markdown links in changed files resolve
- changed-file scope is limited to `docs/architecture/**`
- Biome intentionally ignores Markdown in this repository