### PR TITLE
fix(storage): widen the Windows ADS query timeout for cold Add-Type compiles

### DIFF
--- a/packages/storage/src/managed-dependency-environment.ts
+++ b/packages/storage/src/managed-dependency-environment.ts
@@ -66,7 +66,15 @@ const MANAGED_DEPENDENCY_PRODUCER_POLICY_V1 = Object.freeze({
   lifecycleScripts: 'disabled' as const,
 });
 const activeAuthorityOwners = new Map<string, object>();
-const WINDOWS_STREAM_QUERY_TIMEOUT_MS = 30_000;
+// Each query spawns a fresh powershell.exe that JIT-compiles the C# helper
+// below via `Add-Type`. On a cold GitHub-hosted Windows runner that first
+// compile (cold csc.exe launch + .NET Framework warmup) has been observed at
+// ~31s, tripping a 30s budget while the following warm queries finish in 2-4s.
+// The bounded, non-recursive walk cannot hang, so the timeout only exists to
+// bound a wedged interpreter; give the cold compile generous headroom rather
+// than misreport it as a wedge. The 45-minute job budget still bounds a true
+// hang.
+const WINDOWS_STREAM_QUERY_TIMEOUT_MS = 120_000;
 const WINDOWS_STREAM_QUERY_MAX_OUTPUT_BYTES = 1024 * 1024;
 const WINDOWS_STREAM_QUERY_SCRIPT = String.raw`
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Summary

The managed-dependency alternate-stream guard (`assertNoWindowsAlternateStreams` in `packages/storage/src/managed-dependency-environment.ts`) spawns a fresh `powershell.exe` per query that JIT-compiles the `FindFirstStreamW` P/Invoke helper via `Add-Type`. On a **cold** GitHub-hosted Windows runner that first compile — a cold `csc.exe` launch plus .NET Framework warmup — was observed at ~31s, tripping the 30s `WINDOWS_STREAM_QUERY_TIMEOUT_MS`. It then rejected with `Timed out querying Windows alternate data streams`, which is the wrong error for the test's `assert.rejects`, so the *"rejects an NTFS alternate stream created inside a dependency artifact"* subtest failed. The next two subtests reused the now-warm compiler and passed in 2–4s.

This flaked the unfiltered main-push **Windows recovery** lane ([run 33096120938](https://github.com/apache/maka/actions/runs/33096120938)) even though the triggering commit only touched desktop tests. The lane had been green for the prior ~4 hours; the ADS code itself was unchanged since #3789.

The tree walk feeding the query is bounded and non-recursive, so the query cannot hang — the timeout exists only to bound a wedged interpreter. This raises it to 120s so the one-time cold compile has generous headroom rather than being misreported as a wedge. The 45-minute job budget still bounds a true hang. I kept the P/Invoke design (which deliberately replaced the recursive `Get-Item -Stream` walk) rather than rewrite a security boundary; the cold compile is the sole ~30s cost.

Refs #3789

## Verification

- Change is a single constant widening (`30_000` → `120_000`) plus an explanatory comment; no behavioral change to the query or its callers.
- No deterministic regression test accompanies it: the failure is a runner-cold-start timing artifact, not a logic bug, so there is no input that fails at 30s but passes at 120s on a warm machine. The existing three Windows ADS subtests continue to assert correctness; this only removes their cold-start flake.
- Note on local checks: `tsc`/suite runs could not be executed in my environment because dependencies are not installed (`@types/node` absent). CI (`test` + `Windows recovery`) will exercise the build and the affected Windows suite.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code diagnosed the failing run and authored the one-line timeout change and its comment. Commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No