### PR TITLE
docs: clarify DeepWiki disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@
 </p>
 
 <p align="center">
-  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a><br />
-  <sub>Unofficial AI-generated docs</sub>
+  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a> <sub>third-party AI docs</sub>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,8 +33,7 @@
 </p>
 
 <p align="center">
-  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a><br />
-  <sub>非官方 AI 生成文档</sub>
+  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a> <sub>第三方 AI 文档</sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Moves the third-party AI documentation label onto the same line as the DeepWiki badge in both READMEs, so it cannot be mistaken for a statement about Maka's project-maintained documentation.