### PR TITLE
docs: align DeepWiki disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@
 </p>
 
 <p align="center">
-  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a> <sub>third-party AI docs</sub>
+  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a><br />
+  <sub>DeepWiki · third-party AI docs</sub>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,7 +33,8 @@
 </p>
 
 <p align="center">
-  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a> <sub>第三方 AI 文档</sub>
+  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a><br />
+  <sub>DeepWiki · 第三方 AI 文档</sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Places the disclosure below the badge again for clean alignment, while explicitly naming DeepWiki so it cannot be read as a statement about Maka's project-maintained documentation.