### PR TITLE
docs: align the DeepWiki badge with the badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,7 @@
   <img src="https://img.shields.io/badge/macOS-arm64-4C8DFF?style=flat&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   <img src="https://img.shields.io/badge/Windows-preview-9BB8F0?style=flat&logo=windows&logoColor=white" alt="Windows unsigned preview" />
   <img src="https://img.shields.io/badge/Linux-soon-D0D4DA?style=flat&logo=linux&logoColor=6B7280" alt="Linux not yet supported" />
-</p>
-
-<p align="center">
-  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a> <sub>third-party AI docs</sub>
+  <a href="https://deepwiki.com/apache/maka"><img src="https://img.shields.io/badge/DeepWiki-third--party%20AI%20docs-9BB8F0?style=flat" alt="DeepWiki: third-party AI-generated docs" /></a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,10 +30,7 @@
   <img src="https://img.shields.io/badge/macOS-arm64-4C8DFF?style=flat&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   <img src="https://img.shields.io/badge/Windows-preview-9BB8F0?style=flat&logo=windows&logoColor=white" alt="Windows 未签名预览" />
   <img src="https://img.shields.io/badge/Linux-soon-D0D4DA?style=flat&logo=linux&logoColor=6B7280" alt="Linux 尚未支持" />
-</p>
-
-<p align="center">
-  <a href="https://deepwiki.com/apache/maka"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a> <sub>第三方 AI 文档</sub>
+  <a href="https://deepwiki.com/apache/maka"><img src="https://img.shields.io/badge/DeepWiki-%E7%AC%AC%E4%B8%89%E6%96%B9%20AI%20%E6%96%87%E6%A1%A3-9BB8F0?style=flat" alt="DeepWiki：第三方 AI 生成文档" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

The third-party AI documentation label sits below the DeepWiki badge's bottom edge instead of on its centre line. An `<img>` aligns to the text baseline, so the badge's bottom edge rests on it, and `<sub>` then drops the following text a further 0.25em. GitHub strips inline styles from READMEs, so this cannot be corrected with CSS.

Fold the disclosure into the badge text itself and move the badge into the existing badge row. With no separate text node there is nothing left to misalign, the badge shares the row's 20px height and the `#9BB8F0` tone already used for the Windows preview badge, and the extra centred `<p>` disappears — six lines removed, two added, across both READMEs.

The trade is DeepWiki's own badge artwork. The disclosure has to stay visible, and keeping their badge means keeping a second element beside it; carrying the label inside one badge is what removes the failure mode rather than re-styling it.

Refs #4035, refs #4052

## Verification

Rendered both READMEs through GitHub's own Markdown API (`gh api /markdown --mode gfm`) and compared before/after in light and dark themes at 2.3x. Badge SVGs confirmed at 20px, matching the rest of the row.

`README.md`:

![image](https://github.com/user-attachments/assets/646e9549-1a95-4fd8-b632-4dff91f4bf43)

`README.zh-CN.md`:

<!-- SCREENSHOT: drop deepwiki-badge-zh-before-after.png here -->

No test suites run: the change is Markdown only and Biome does not cover it.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code diagnosed the baseline cause, authored the README edits and the commit message, and produced the rendered comparison. The human contributor reviewed the diff and the rendered result.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

