### PR TITLE
fix(desktop): offer safe resume after completed tool timeout

### DIFF
--- a/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
+++ b/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { latestInterruptedResumeTurnId } from '../../renderer/interrupted-resume.js';
+
+describe('latest interrupted resume candidate', () => {
+  it('recognizes a timeout after a completed tool result', () => {
+    assert.equal(
+      latestInterruptedResumeTurnId([
+        {
+          turnId: 'turn-1',
+          status: 'failed',
+          errorClass: 'timeout',
+          tools: [{ status: 'completed' }],
+        },
+      ]),
+      'turn-1',
+    );
+  });
+
+  it('does not offer continuation for an incomplete or errored tool', () => {
+    assert.equal(
+      latestInterruptedResumeTurnId([
+        {
+          turnId: 'turn-1',
+          status: 'failed',
+          errorClass: 'timeout',
+          tools: [{ status: 'running' }],
+        },
+      ]),
+      undefined,
+    );
+    assert.equal(
+      latestInterruptedResumeTurnId([
+        {
+          turnId: 'turn-1',
+          status: 'failed',
+          errorClass: 'timeout',
+          tools: [{ status: 'errored' }],
+        },
+      ]),
+      undefined,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
+++ b/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
@@ -19,6 +19,7 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { materializeTurns } from '@maka/ui';
 import { latestInterruptedResumeTurnId } from '../../renderer/interrupted-resume.js';
 
 describe('latest interrupted resume candidate', () => {
@@ -70,5 +71,34 @@ describe('latest interrupted resume candidate', () => {
       ]),
       undefined,
     );
+  });
+
+  it('rejects the mixed shape produced by materializeTurns', () => {
+    const [turn] = materializeTurns([
+      { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'inspect' },
+      {
+        type: 'turn_state',
+        id: 'state-1',
+        turnId: 'turn-1',
+        ts: 2,
+        status: 'failed',
+        errorClass: 'timeout',
+        partialOutputRetained: false,
+      },
+      { type: 'tool_call', id: 'call-1', turnId: 'turn-1', ts: 3, toolName: 'Read', args: {} },
+      {
+        type: 'tool_result',
+        id: 'result-1',
+        turnId: 'turn-1',
+        ts: 4,
+        toolUseId: 'call-1',
+        isError: false,
+        content: { kind: 'text', text: 'ok' },
+      },
+      { type: 'tool_call', id: 'call-2', turnId: 'turn-1', ts: 5, toolName: 'Read', args: {} },
+    ]);
+
+    assert.deepEqual(turn?.tools.map((tool) => tool.status), ['completed', 'interrupted']);
+    assert.equal(latestInterruptedResumeTurnId(turn ? [turn] : []), undefined);
   });
 });

--- a/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
+++ b/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
@@ -54,6 +54,17 @@ describe('latest interrupted resume candidate', () => {
           turnId: 'turn-1',
           status: 'failed',
           errorClass: 'timeout',
+          tools: [{ status: 'completed' }, { status: 'interrupted' }],
+        },
+      ]),
+      undefined,
+    );
+    assert.equal(
+      latestInterruptedResumeTurnId([
+        {
+          turnId: 'turn-1',
+          status: 'failed',
+          errorClass: 'timeout',
           tools: [{ status: 'errored' }],
         },
       ]),

--- a/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
+++ b/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { latestInterruptedResumeTurnId } from '../../renderer/interrupted-resume.js';

--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -94,4 +94,5 @@ describe('failed turn execution state', () => {
       /部分回答/,
     );
   });
+
 });

--- a/apps/desktop/src/renderer/interrupted-resume.ts
+++ b/apps/desktop/src/renderer/interrupted-resume.ts
@@ -21,14 +21,22 @@ export interface InterruptedResumeTurn {
   turnId: string;
   status: string;
   errorClass?: string;
+  /** Tool activity already has a durable result in the rendered Turn. */
+  tools?: readonly { status: string }[];
 }
 
 export function latestInterruptedResumeTurnId(
   turns: readonly InterruptedResumeTurn[],
 ): string | undefined {
   const latestTurn = turns.at(-1);
-  return latestTurn?.status === 'failed'
-    && latestTurn.errorClass?.toLowerCase() === 'app_restarted'
-    ? latestTurn.turnId
-    : undefined;
+  if (latestTurn?.status !== 'failed') return undefined;
+  const errorClass = latestTurn.errorClass?.toLowerCase();
+  if (errorClass === 'app_restarted') return latestTurn.turnId;
+  if (
+    errorClass?.includes('timeout') &&
+    latestTurn.tools?.some((tool) => tool.status === 'completed')
+  ) {
+    return latestTurn.turnId;
+  }
+  return undefined;
 }

--- a/apps/desktop/src/renderer/interrupted-resume.ts
+++ b/apps/desktop/src/renderer/interrupted-resume.ts
@@ -34,7 +34,9 @@ export function latestInterruptedResumeTurnId(
   if (errorClass === 'app_restarted') return latestTurn.turnId;
   if (
     errorClass?.includes('timeout') &&
-    latestTurn.tools?.some((tool) => tool.status === 'completed')
+    latestTurn.tools !== undefined &&
+    latestTurn.tools.length > 0 &&
+    latestTurn.tools.every((tool) => tool.status === 'completed')
   ) {
     return latestTurn.turnId;
   }


### PR DESCRIPTION
## Summary

- expose safe continuation guidance when a failed Turn timed out after a completed Tool Result
- make the Desktop resume candidate detector require a completed tool result for timeout recovery
- preserve fail-closed Runtime planner validation; incomplete or errored tools remain in inspection/parked flows
- add renderer presentation and candidate-selection regression tests

## Scope

This is the first Desktop recovery slice for #4074. It does not change Runtime tool execution, does not re-run tools, and does not change the `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME` rollout flag. The existing `turn.resume.query/start` planner remains the authority for whether continuation may actually start.

Related: #4074

## Validation

- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build:main`
- `node --test "dist/main/__tests__/session-status-presentation.test.js" "dist/main/__tests__/interrupted-resume.test.js"`
- `npx biome check` on changed files
