### PR TITLE
fix(models): support Node 26 type stripping

### DIFF
--- a/scripts/sync-model-metadata.mjs
+++ b/scripts/sync-model-metadata.mjs
@@ -496,8 +496,8 @@ async function assertGeneratedOutputs(metadataPath, pricingPath, source) {
   );
 }
 
-async function loadTypeScriptModule(source) {
-  const javascript = stripTypeScriptTypes(source, { mode: 'transform' });
+export async function loadTypeScriptModule(source) {
+  const javascript = stripTypeScriptTypes(source, { mode: 'strip' });
   return import(`data:text/javascript;base64,${Buffer.from(javascript).toString('base64')}`);
 }
 

--- a/scripts/sync-model-metadata.test.mjs
+++ b/scripts/sync-model-metadata.test.mjs
@@ -22,7 +22,7 @@ import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { main, PROVIDERS } from './sync-model-metadata.mjs';
+import { loadTypeScriptModule, main, PROVIDERS } from './sync-model-metadata.mjs';
 
 function fixtureCatalog() {
   const catalog = {};
@@ -45,6 +45,24 @@ function fixtureCatalog() {
   catalog.unused = { id: 'unused', name: 'Unused', doc: 'https://example.test/unused', models: {} };
   return catalog;
 }
+
+test('loads the committed generated TypeScript modules', async () => {
+  const [metadataSource, pricingSource] = await Promise.all([
+    readFile(new URL('../packages/core/src/model-metadata.generated.ts', import.meta.url), 'utf8'),
+    readFile(
+      new URL('../packages/runtime/src/telemetry/model-pricing.generated.ts', import.meta.url),
+      'utf8',
+    ),
+  ]);
+  const [metadataModule, pricingModule] = await Promise.all([
+    loadTypeScriptModule(metadataSource),
+    loadTypeScriptModule(pricingSource),
+  ]);
+
+  assert.ok(Object.keys(metadataModule.GENERATED_MODELS_DEV_METADATA).length > 0);
+  assert.ok(Array.isArray(pricingModule.GENERATED_MODEL_PRICING));
+  assert.ok(pricingModule.GENERATED_MODEL_PRICING.length > 0);
+});
 
 test('a refresh persists the exact selected input and check fails on stale output', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-model-snapshot-'));


### PR DESCRIPTION
## Summary

`npm run check:model-metadata` fails on supported Node 26 releases before it can validate either committed generated module.

Node 26 removed the `transform` mode from `module.stripTypeScriptTypes()`, while the metadata checker still requested it. The generated metadata and pricing modules use erasable TypeScript syntax, so the supported `strip` mode is sufficient on both Node 22.19 and Node 26.

Use `strip` and add a regression test that converts and imports both committed generated modules before asserting their runtime exports.

## Evidence

```text
Before (Node v26.5.0):
TypeError [ERR_INVALID_ARG_VALUE]: The property 'options.mode' must be one of: 'strip'. Received 'transform'
    at loadTypeScriptModule (scripts/sync-model-metadata.mjs:500:22)

After (Node v26.5.0):
✔ loads the committed generated TypeScript modules
ℹ pass 1
ℹ fail 0

After (Node v22.19.0):
ok 1 - loads the committed generated TypeScript modules
# pass 1
# fail 0
```

## Verification

- `npm run check:model-metadata` on Node 26.5.0
- `npx --yes node@22.19.0 scripts/sync-model-metadata.mjs --check`
- `node --test scripts/sync-model-metadata.test.mjs` — 9/9 passed
- `npm run lint`
- `npm run format:check`
- `node scripts/asf-license-headers.mjs check`
- `git diff --check`

Full build and typecheck were not run for this script-only draft.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the Node compatibility change, regression test, and PR description.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
