### PR TITLE
fix(scripts): encode direct entrypoint paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Test AX tree audit contract
         run: node --test scripts/ax-tree-audit.test.mjs
 
+      - name: Test script entrypoint contracts
+        run: node --test scripts/script-entrypoints.test.mjs
+
       - name: Verify ASF npm preflight policy
         run: npm run check:asf-npm
 

--- a/scripts/build-cursor-overlay.mjs
+++ b/scripts/build-cursor-overlay.mjs
@@ -24,7 +24,7 @@
 // - cursor-overlay.html: copied verbatim.
 import * as esbuild from 'esbuild';
 import { resolve, dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { mkdir, copyFile } from 'node:fs/promises';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -140,7 +140,7 @@ export async function buildPermissionOverlay({ logLevel = 'info' } = {}) {
 }
 
 // Run directly (npm run build:overlay) or import buildCursorOverlay (dev.mjs).
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const dir = await buildCursorOverlay();
   console.log('overlays built →', dir);
 }

--- a/scripts/prepare-deepseek-harness-toolchain.mjs
+++ b/scripts/prepare-deepseek-harness-toolchain.mjs
@@ -45,7 +45,7 @@ import { createReadStream } from 'node:fs';
 import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
@@ -218,7 +218,7 @@ async function recordFingerprint(fingerprint) {
   await writeFile(identityPath, next, 'utf8');
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const argv = process.argv.slice(2);
   const outIndex = argv.indexOf('--out');
   const result = await prepareDeepSeekHarnessToolchain({

--- a/scripts/script-entrypoints.test.mjs
+++ b/scripts/script-entrypoints.test.mjs
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+test('direct script guards encode entrypoint paths with spaces', async () => {
+  const entrypointPath = join(tmpdir(), 'Maka Project', 'script.mjs');
+  assert.match(pathToFileURL(entrypointPath).href, /Maka%20Project/);
+  assert.notEqual(pathToFileURL(entrypointPath).href, `file://${entrypointPath}`);
+
+  for (const script of ['build-cursor-overlay.mjs', 'prepare-deepseek-harness-toolchain.mjs']) {
+    const source = await readFile(new URL(script, import.meta.url), 'utf8');
+    assert.match(
+      source,
+      /process\.argv\[1\] && import\.meta\.url === pathToFileURL\(process\.argv\[1\]\)\.href/,
+      `${script} must compare encoded file URLs`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Directly running the cursor-overlay builder or DeepSeek harness toolchain preparer from a workspace path containing spaces exits successfully without executing the script body.

Each entrypoint compared its encoded `import.meta.url` with an unencoded `file://${process.argv[1]}` string, so any character requiring URL encoding made the direct-execution guard false.

Build the comparison URL with `pathToFileURL()`, matching the repository's other direct script guards. Add a pure Node contract that demonstrates the encoded-path difference and keeps both entrypoints on the safe comparison, then run it in CI.

## Evidence

```text
Before:
file:///tmp/Maka%20Project/script.mjs
file:///tmp/Maka Project/script.mjs
false

After:
file:///tmp/Maka%20Project/script.mjs
file:///tmp/Maka%20Project/script.mjs
true
```

## Verification

- `node --test scripts/script-entrypoints.test.mjs` — 1/1 passed
- `node --test --test-concurrency=1 scripts/ci-test-plan.test.mjs scripts/verify-windows-harness.test.mjs` — 88/88 passed
- `npm run lint`
- `npm run format:check`
- `node scripts/asf-license-headers.mjs check`
- `git diff --check`

Full build and typecheck were not run for this entrypoint-only draft.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the URL-safe entrypoint guards, regression contract, CI wiring, and PR description.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
