### PR TITLE
fix(ui): drop the reasoning body's left rail, restore upstream geometry

### DIFF
--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -245,16 +245,12 @@
 .maka-turn-truncation-badge { display: flex; width: fit-content; margin-top: 6px; cursor: help; }
 .maka-deep-thinking { min-width: 0; }
 /* Reasoning uses the same safe Markdown pipeline as answers, then lowers its
-   visual weight inside the disclosure. The inset rule makes a long derivation
-   scannable without turning it into a second answer bubble. */
-.maka-chat-reasoning-content {
-  margin-block-start: 4px;
-  margin-inline-start: 22px;
-  padding: 2px 0 4px 12px;
-  border-inline-start: 2px solid color-mix(in oklch, var(--link) 32%, var(--border));
-  white-space: pre-wrap;
-  word-break: break-word;
-}
+   visual weight inside the disclosure. Body layout stays with the upstream
+   Astryx atoms (secondary color, 22px inline-start indent, no rail): the
+   #2645 inset added a 2px link-tinted border that visually outweighed the
+   muted text it framed, and its padding-top/inline-start were dead code —
+   the ejected component's higher-specificity atoms already own both. */
+.maka-chat-reasoning-content { white-space: pre-wrap; word-break: break-word; }
 .maka-deep-thinking [data-maka-contract="markdown"] .astryx-markdown {
   color: var(--muted-foreground);
   font: var(--maka-text-body);


### PR DESCRIPTION
## Why

The expanded 深度思考 body gained a 2px link-tinted left rail in #2645. Two problems:

1. **It is not the upstream Astryx design.** The ejected `ChatReasoning` atoms own the body's reading geometry already — secondary text color (`xv1l7n4`), 8px top padding (`x1xye8es`), 22px inline-start indent (`x1f43n9v`, `calc(16px + spacing-1-5)`) — and none of the ejected atoms draws a border. Upstream differentiates reasoning by color + indent alone.
2. **Half of the added rule was dead code.** The atoms' stacked `:not(#\#)` specificity beats the product class, so `padding-top: 2px` and `padding-inline-start: 12px` in `padding: 2px 0 4px 12px` never applied; the visible line-to-text gap was the atom's 22px, not the authored 12px.

The saturated 32%-link rail also visually outweighed the muted text it framed — the loudest element in the block was the decoration.

## What

Restore the pre-#2645 rule on `.maka-chat-reasoning-content` (`white-space: pre-wrap; word-break: break-word;` only) and let the upstream atoms own layout. Net diff vs. before #2645 is zero; the comment now records why no rail.

## Validation

- `node --test dist/__tests__/chat-turn-answer-identity.test.js` — 8/8 pass, including the test that pins `white-space: pre-wrap` on this rule.
- No test, story, or e2e fixture references the inset declarations (grep: `border-inline-start`, `margin-inline-start: 22px` only matched this rule).

AI-assisted (Maka): investigation, diff, and this description; geometry claims verified against the compiled atoms in `@astryxdesign/core` dist.