### PR TITLE
docs(desktop): record the workbar stories entry

### DIFF
--- a/apps/desktop/src/renderer/features/workbar/README.md
+++ b/apps/desktop/src/renderer/features/workbar/README.md
@@ -27,7 +27,12 @@ remounted when the active session changes.
 ## Dependency direction
 
 - Consumers import production APIs from `features/workbar`.
-- Tests and stories may additionally import `features/workbar/testing`.
+- Node test suites may additionally import `features/workbar/testing`.
+- Storybook may additionally import `features/workbar/stories`, which exposes
+  `WorkbarSurface`. It stays out of the production entry because `workbar-host`
+  reaches the surface through `lazy()`, and out of `testing` because that entry
+  is loaded by `node --test` against tsc output while the surface and its tool
+  panels use extensionless relative specifiers only a bundler resolves.
 - Workbar may use shared renderer primitives, core types and Maka UI.
 - Workbar must not import shell composition, Desktop bridge, or main-process implementation.
 - Desktop I/O enters through `WorkbarServices`; tool code does not read


### PR DESCRIPTION
Doc drift left by #4101.

That PR gave Storybook its own `features/workbar/stories` entry and moved `WorkbarSurface` out of `testing`, and taught `workbar-boundary.test.ts` to accept all three entries — but the feature README still told readers that stories share `testing`.

This names the three entries and records why the split exists: `stories` stays out of the production barrel because `workbar-host` reaches the surface through `lazy()`, and out of `testing` because that entry is loaded by `node --test` against tsc output, while the surface and its tool panels use extensionless relative specifiers only a bundler resolves. Putting it in `testing` is what broke CI on #4101's first attempt; the README is where the next person should find that out.

Docs only — no code change.