### PR TITLE
fix(desktop): keep session workspace action identities fixed

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -165,6 +165,28 @@ async function seedE2eLocale(userDataDir: string, locale: 'zh' | 'en'): Promise<
   });
 }
 
+/** Rows for the rail-render contract: enough that a stray render is loud. */
+export const RAIL_RENDER_SESSION_COUNT = 12;
+
+async function seedRailRenderSessions(userDataDir: string): Promise<void> {
+  const workspaceRoot = path.join(userDataDir, 'workspaces', 'default');
+  const store = createSessionStore(workspaceRoot);
+  try {
+    for (let index = 0; index < RAIL_RENDER_SESSION_COUNT; index += 1) {
+      await store.create({
+        cwd: path.join(userDataDir, 'project'),
+        llmConnectionSlug: 'e2e',
+        model: 'claude-sonnet-4-5-20250929',
+        permissionMode: 'ask',
+        name: `Rail row ${index}`,
+        labels: [],
+      });
+    }
+  } finally {
+    await store.close?.();
+  }
+}
+
 async function seedParentRemovalSessions(userDataDir: string): Promise<void> {
   const workspaceRoot = path.join(userDataDir, 'workspaces', 'default');
   const store = createSessionStore(workspaceRoot);
@@ -354,6 +376,7 @@ async function withE2eWindow(
     invocableSkills,
     gitReviewExtraFiles,
     parentRemovalSessions,
+    railRenderSessions,
     newTaskProject,
   }: {
     seed: boolean;
@@ -369,6 +392,7 @@ async function withE2eWindow(
     invocableSkills?: boolean;
     gitReviewExtraFiles?: number;
     parentRemovalSessions?: boolean;
+    railRenderSessions?: boolean;
     newTaskProject?: boolean;
   },
   use: (page: Page, context: { userDataDir: string }) => Promise<void>,
@@ -384,6 +408,7 @@ async function withE2eWindow(
   try {
     if (seed) await seedE2eConnection(userDataDir);
     if (parentRemovalSessions) await seedParentRemovalSessions(userDataDir);
+    if (railRenderSessions) await seedRailRenderSessions(userDataDir);
     if (invocableSkills) await seedE2eInvocableSkills(userDataDir);
     if (gitReviewExtraFiles !== undefined) {
       await seedE2eGitReviewProject(userDataDir, gitReviewExtraFiles);
@@ -455,6 +480,7 @@ export const test = base.extend<{
   linkColorWindow: Page;
   projectSidebarWindow: Page;
   parentRemovalWindow: Page;
+  railRenderWindow: Page;
   promptRailWindow: Page;
   promptRailMotionWindow: Page;
   requestHeaderRowWindow: Page;
@@ -533,6 +559,17 @@ export const test = base.extend<{
         readinessSelector: COMPOSER_INPUT,
         locale: 'zh',
         parentRemovalSessions: true,
+      },
+      use,
+    );
+  },
+  railRenderWindow: async ({}, use) => {
+    await withE2eWindow(
+      {
+        seed: true,
+        readinessSelector: COMPOSER_INPUT,
+        locale: 'zh',
+        railRenderSessions: true,
       },
       use,
     );

--- a/apps/desktop/e2e/session-rail-render-contract.spec.ts
+++ b/apps/desktop/e2e/session-rail-render-contract.spec.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import {
   ensureSidebarExpanded,
   RAIL_RENDER_SESSION_COUNT,
@@ -36,17 +36,67 @@ import {
  * ones not yet found, including anything that raises the number of commits a
  * switch produces (#4109).
  *
- * The budget counts inline `style` writes on rail buttons because that is the
+ * The counter reads inline `style` writes on rail buttons because that is the
  * dominant term: every Astryx button removes and re-adds its `anchor-name` per
  * render, so one wasted rail render is two style writes per button plus the
  * style recalculation they force.
  *
- * Measured on this fixture: 4 writes when the rail behaves — the leaving row
- * and the arriving row, two each — against 336 with `setActiveId` restored to a
- * per-render identity. The budget sits an order of magnitude clear of both, so
- * it fails on a regression rather than on scheduling noise.
+ * The assertion that carries the contract is `rowsTouched`, not the total.
+ * Attributing each write to its row makes the budget independent of how many
+ * rows the fixture seeds, and closes the hole a total-only budget leaves: a
+ * regression that re-renders the whole rail exactly ONCE stays under any total
+ * generous enough not to flake, but it cannot touch two rows. That is also the
+ * missing middle of the fix's own claim — identity is fixed so `memo` holds, and
+ * `memo` holding means untouched rows produce no DOM work at all.
+ *
+ * `styleWrites > 0` is the counter's own liveness check. Every write counted
+ * here comes from an Astryx ref callback that is not wrapped in `useCallback`;
+ * if that upstream detail is ever memoised, both the healthy and the regressed
+ * reading collapse to zero and a one-sided budget would pass forever without
+ * ever failing again.
  */
-const RAIL_STYLE_WRITE_BUDGET = 3 * RAIL_RENDER_SESSION_COUNT;
+const RAIL_ROWS_TOUCHED_BUDGET = 2;
+/** The leaving row and the arriving row, two writes each, doubled for slack. */
+const RAIL_STYLE_WRITE_BUDGET = 8;
+
+interface RailCounters {
+  /** Cumulative since the last `resetRailCounters`; what the budgets read. */
+  styleWrites: number;
+  rowIds: string[];
+  rowRemounts: number;
+  /** Drained by every quiet poll, so it reports only the latest interval. */
+  delta: number;
+}
+
+type RailWindow = Window & { __railCounters: RailCounters };
+
+/**
+ * Waits until the rail has been silent for ~300ms.
+ *
+ * A fixed `waitForTimeout` would be the only thing standing between a slow
+ * machine and a red run: `toHaveCount` proves the rows mounted, not that the
+ * commits behind them are done, and one late catalog refresh writes more than
+ * the whole budget. `retries` is 0 in `playwright.config.ts`, so that failure
+ * would land on an unrelated pull request.
+ */
+async function waitForRailQuiet(page: Page): Promise<void> {
+  let quietPolls = 0;
+  await expect
+    .poll(
+      async () => {
+        const delta = await page.evaluate(() => {
+          const counters = (window as unknown as RailWindow).__railCounters;
+          const seen = counters.delta;
+          counters.delta = 0;
+          return seen;
+        });
+        quietPolls = delta === 0 ? quietPolls + 1 : 0;
+        return quietPolls;
+      },
+      { timeout: 15_000, intervals: [100] },
+    )
+    .toBeGreaterThanOrEqual(3);
+}
 
 test('switching sessions does not rewrite the whole Session rail', async ({
   railRenderWindow: page,
@@ -62,43 +112,69 @@ test('switching sessions does not rewrite the whole Session rail', async ({
   const selected = page.locator('.maka-session-row button.astryx-side-nav-item.selected');
   await expect(target).toBeVisible();
 
-  // Settle first: the budget is about a switch, not about arriving.
-  await page.waitForTimeout(500);
-
   await page.evaluate(() => {
-    const counter = { styleWrites: 0 };
-    (window as unknown as { __railWrites: typeof counter }).__railWrites = counter;
+    const counters = { styleWrites: 0, rowIds: [] as string[], rowRemounts: 0, delta: 0 };
+    (window as unknown as { __railCounters: typeof counters }).__railCounters = counters;
     const observer = new MutationObserver((records) => {
       for (const record of records) {
-        const target = record.target as Element;
-        if (!target.closest?.('.maka-session-row')) continue;
-        counter.styleWrites += 1;
+        if (record.type === 'childList') {
+          for (const node of record.addedNodes) {
+            const element = node as Element;
+            if (element.nodeType !== 1) continue;
+            // A row that unmounts and remounts writes its `anchor-name` once
+            // on the way in, from a ref callback that runs AFTER insertion —
+            // so an attribute-only counter reads a whole rail remount as
+            // cheaper than a rail re-render. Count the remounts directly.
+            if (element.classList?.contains('maka-session-row')) counters.rowRemounts += 1;
+          }
+          continue;
+        }
+        const row = (record.target as Element).closest?.('.maka-session-row');
+        if (!row) continue;
+        counters.styleWrites += 1;
+        counters.delta += 1;
+        const rowId = row.getAttribute('data-session-id');
+        if (rowId && !counters.rowIds.includes(rowId)) counters.rowIds.push(rowId);
       }
     });
     observer.observe(document.body, {
       subtree: true,
+      childList: true,
       attributes: true,
       attributeFilter: ['style'],
     });
     (window as unknown as { __railObserver: MutationObserver }).__railObserver = observer;
   });
 
+  // Settle first: the budget is about a switch, not about arriving.
+  await waitForRailQuiet(page);
+  await page.evaluate(() => {
+    const counters = (window as unknown as RailWindow).__railCounters;
+    counters.styleWrites = 0;
+    counters.rowIds = [];
+    counters.rowRemounts = 0;
+    counters.delta = 0;
+  });
+
   await target.click();
   await expect(selected).toHaveText(/Rail row 3/);
-  // Let the post-switch commit cascade finish before reading the counter.
-  await page.waitForTimeout(1500);
+  // Let the post-switch commit cascade finish before reading the counters.
+  await waitForRailQuiet(page);
 
-  const styleWrites = await page.evaluate(() => {
-    const scope = window as unknown as {
-      __railWrites: { styleWrites: number };
-      __railObserver: MutationObserver;
-    };
+  const counted = await page.evaluate(() => {
+    const scope = window as unknown as RailWindow & { __railObserver: MutationObserver };
     scope.__railObserver.disconnect();
-    return scope.__railWrites.styleWrites;
+    const { styleWrites, rowIds, rowRemounts } = scope.__railCounters;
+    return { styleWrites, rowIds, rowRemounts };
   });
 
   expect(
-    styleWrites,
-    `rail inline-style writes for one session switch (${RAIL_RENDER_SESSION_COUNT} rows)`,
-  ).toBeLessThanOrEqual(RAIL_STYLE_WRITE_BUDGET);
+    counted.rowIds.length,
+    `rail rows touched by one session switch, of ${RAIL_RENDER_SESSION_COUNT} (${counted.rowIds.join(', ')})`,
+  ).toBeLessThanOrEqual(RAIL_ROWS_TOUCHED_BUDGET);
+  expect(counted.rowRemounts, 'rail rows remounted by one session switch').toBe(0);
+  expect(counted.styleWrites, 'the style-write counter never fired').toBeGreaterThan(0);
+  expect(counted.styleWrites, 'rail inline-style writes for one session switch').toBeLessThanOrEqual(
+    RAIL_STYLE_WRITE_BUDGET,
+  );
 });

--- a/apps/desktop/e2e/session-rail-render-contract.spec.ts
+++ b/apps/desktop/e2e/session-rail-render-contract.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  ensureSidebarExpanded,
+  RAIL_RENDER_SESSION_COUNT,
+  test,
+} from './fixtures.js';
+
+/**
+ * Switching a session moves one row's selection. What it must not do is rewrite
+ * the rest of the rail.
+ *
+ * Deliberately a budget on the OUTCOME rather than an assertion about
+ * identities or `memo`. The rail's cost has had several independent causes —
+ * `setActiveId` changing identity every AppShell render, `Intl` formatters
+ * rebuilt per row, catalog refreshes replacing unchanged row objects — and each
+ * was invisible to the others. A DOM-write budget catches all of them and the
+ * ones not yet found, including anything that raises the number of commits a
+ * switch produces (#4109).
+ *
+ * The budget counts inline `style` writes on rail buttons because that is the
+ * dominant term: every Astryx button removes and re-adds its `anchor-name` per
+ * render, so one wasted rail render is two style writes per button plus the
+ * style recalculation they force.
+ *
+ * Measured on this fixture: 4 writes when the rail behaves — the leaving row
+ * and the arriving row, two each — against 336 with `setActiveId` restored to a
+ * per-render identity. The budget sits an order of magnitude clear of both, so
+ * it fails on a regression rather than on scheduling noise.
+ */
+const RAIL_STYLE_WRITE_BUDGET = 3 * RAIL_RENDER_SESSION_COUNT;
+
+test('switching sessions does not rewrite the whole Session rail', async ({
+  railRenderWindow: page,
+}) => {
+  await ensureSidebarExpanded(page);
+
+  const rows = page.locator('.maka-session-row');
+  await expect(rows).toHaveCount(RAIL_RENDER_SESSION_COUNT);
+
+  const target = page.locator('.maka-session-row button.astryx-side-nav-item', {
+    hasText: 'Rail row 3',
+  });
+  const selected = page.locator('.maka-session-row button.astryx-side-nav-item.selected');
+  await expect(target).toBeVisible();
+
+  // Settle first: the budget is about a switch, not about arriving.
+  await page.waitForTimeout(500);
+
+  await page.evaluate(() => {
+    const counter = { styleWrites: 0 };
+    (window as unknown as { __railWrites: typeof counter }).__railWrites = counter;
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        const target = record.target as Element;
+        if (!target.closest?.('.maka-session-row')) continue;
+        counter.styleWrites += 1;
+      }
+    });
+    observer.observe(document.body, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['style'],
+    });
+    (window as unknown as { __railObserver: MutationObserver }).__railObserver = observer;
+  });
+
+  await target.click();
+  await expect(selected).toHaveText(/Rail row 3/);
+  // Let the post-switch commit cascade finish before reading the counter.
+  await page.waitForTimeout(1500);
+
+  const styleWrites = await page.evaluate(() => {
+    const scope = window as unknown as {
+      __railWrites: { styleWrites: number };
+      __railObserver: MutationObserver;
+    };
+    scope.__railObserver.disconnect();
+    return scope.__railWrites.styleWrites;
+  });
+
+  expect(
+    styleWrites,
+    `rail inline-style writes for one session switch (${RAIL_RENDER_SESSION_COUNT} rows)`,
+  ).toBeLessThanOrEqual(RAIL_STYLE_WRITE_BUDGET);
+});

--- a/apps/desktop/src/main/__tests__/session-workspace-action-identity.test.ts
+++ b/apps/desktop/src/main/__tests__/session-workspace-action-identity.test.ts
@@ -33,21 +33,19 @@ import { useAppShellSessionWorkspace } from '../../renderer/use-app-shell-sessio
  * for a single session switch. Identity is a contract, not an implementation
  * detail, so it is asserted here rather than left to review.
  */
-const ACTION_KEYS = [
-  'setActiveId',
-  'startNewSession',
-  'clearOwnedSessionState',
-  'setMessages',
-  'addTransientMessage',
-  'updateTransientMessage',
-  'projectQueuedTransientMessages',
-  'retireCancelledTransientMessages',
-  'removeTransientMessage',
-  'refreshSessions',
-  'seedSessions',
-] as const;
-
 type Workspace = ReturnType<typeof useAppShellSessionWorkspace>;
+
+/**
+ * Every function the hook returns, read off the first render rather than
+ * listed here. A hand-kept list covers what someone remembered on the day it
+ * was written and silently stops covering whatever is added later, which is
+ * the opposite of what a contract test is for.
+ */
+function actionKeys(workspace: Workspace): string[] {
+  return Object.keys(workspace).filter(
+    (key) => typeof (workspace as Record<string, unknown>)[key] === 'function',
+  );
+}
 
 describe('session workspace action identity', () => {
   afterEach(cleanupFakeDom);
@@ -75,11 +73,15 @@ describe('session workspace action identity', () => {
     assert.ok(reads.length > 1, 'the probe should have re-rendered');
 
     const first = reads[0]!;
-    for (const key of ACTION_KEYS) {
+    const keys = actionKeys(first);
+    // A guard on the guard: if the hook's shape ever collapses, the loop below
+    // would pass by having nothing to check.
+    assert.ok(keys.length > 10, `expected the workspace to expose actions, saw ${keys.length}`);
+    for (const key of keys) {
       for (const later of reads.slice(1)) {
         assert.equal(
-          later[key],
-          first[key],
+          (later as Record<string, unknown>)[key],
+          (first as Record<string, unknown>)[key],
           `${key} changed identity between renders`,
         );
       }

--- a/apps/desktop/src/main/__tests__/session-workspace-action-identity.test.ts
+++ b/apps/desktop/src/main/__tests__/session-workspace-action-identity.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { act, createElement } from 'react';
+import { LocaleProvider } from '@maka/ui';
+import { cleanupFakeDom, installReactRenderer } from './fake-dom.js';
+import { useAppShellSessionWorkspace } from '../../renderer/use-app-shell-session-workspace.js';
+
+/**
+ * The session workspace hands its actions to consumers that put them in
+ * dependency arrays and pass them down as props. When `setActiveId` was a
+ * function declaration in the hook body it changed identity every render, which
+ * rebuilt the whole Session rail command chain and defeated `SessionNavRow`'s
+ * `memo` on every commit — measured at 20 full re-renders of a 32-row sidebar
+ * for a single session switch. Identity is a contract, not an implementation
+ * detail, so it is asserted here rather than left to review.
+ */
+const ACTION_KEYS = [
+  'setActiveId',
+  'startNewSession',
+  'clearOwnedSessionState',
+  'setMessages',
+  'addTransientMessage',
+  'updateTransientMessage',
+  'projectQueuedTransientMessages',
+  'retireCancelledTransientMessages',
+  'removeTransientMessage',
+  'refreshSessions',
+  'seedSessions',
+] as const;
+
+type Workspace = ReturnType<typeof useAppShellSessionWorkspace>;
+
+describe('session workspace action identity', () => {
+  afterEach(cleanupFakeDom);
+
+  it('keeps every action identity fixed across re-renders', () => {
+    const { root } = installReactRenderer();
+    const reads: Workspace[] = [];
+
+    function Probe(): null {
+      reads.push(useAppShellSessionWorkspace({ error: () => {} }));
+      return null;
+    }
+
+    act(() => {
+      root.render(
+        createElement(LocaleProvider, { locale: 'en', children: createElement(Probe) }),
+      );
+    });
+    assert.equal(reads.length, 1);
+
+    // Three unrelated state changes, each of which re-renders the hook.
+    act(() => reads[0]!.setActiveId('session-a'));
+    act(() => reads[0]!.setMessages([]));
+    act(() => reads[0]!.setMessageLoadPending(true));
+    assert.ok(reads.length > 1, 'the probe should have re-rendered');
+
+    const first = reads[0]!;
+    for (const key of ACTION_KEYS) {
+      for (const later of reads.slice(1)) {
+        assert.equal(
+          later[key],
+          first[key],
+          `${key} changed identity between renders`,
+        );
+      }
+    }
+  });
+});

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -67,6 +67,7 @@ import {
   noRealConnectionSetupDescription,
 } from './model-connection-errors.js';
 import type { RefreshMessagesOptions } from './session-message-settlement.js';
+import type { MessageListUpdater } from './session-workspace-actions.js';
 
 export type { RefreshMessagesOptions };
 
@@ -81,7 +82,6 @@ type BooleanRecordUpdater = (updater: (current: Record<string, boolean>) => Reco
 type LiveTurnRecordUpdater = (
   updater: (current: Record<string, LiveTurnProjection>) => Record<string, LiveTurnProjection>,
 ) => void;
-type MessageListUpdater = (next: StoredMessage[] | ((current: StoredMessage[]) => StoredMessage[])) => void;
 type MessageLoadErrorUpdater = (updater: (current: Record<string, string>) => Record<string, string>) => void;
 type InteractionQueueUpdater = (updater: (current: InteractionQueues) => InteractionQueues) => void;
 

--- a/apps/desktop/src/renderer/app-shell-revision-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-revision-actions.ts
@@ -37,11 +37,9 @@ import {
   type SessionCopyAttemptKey,
 } from './session-copy-attempt.js';
 import { readSettledMessages } from './session-message-settlement.js';
+import type { MessageListUpdater } from './session-workspace-actions.js';
 
 type RefBox<T> = { current: T };
-type MessageListUpdater = (
-  next: StoredMessage[] | ((current: StoredMessage[]) => StoredMessage[]),
-) => void;
 
 type ToastApi = {
   info(title: string, description?: string): void;

--- a/apps/desktop/src/renderer/app-shell-turn-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-turn-actions.ts
@@ -28,9 +28,9 @@ import {
   showSessionWorkspaceUnavailableToast,
 } from './session-workspace-errors.js';
 import { acquireSessionCopyAttempt } from './session-copy-attempt.js';
+import type { MessageListUpdater } from './session-workspace-actions.js';
 
 type RefBox<T> = { current: T };
-type MessageListUpdater = (next: StoredMessage[] | ((current: StoredMessage[]) => StoredMessage[])) => void;
 
 type ToastApi = {
   info(title: string, description?: string): void;

--- a/apps/desktop/src/renderer/session-workspace-actions.ts
+++ b/apps/desktop/src/renderer/session-workspace-actions.ts
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Session-workspace actions: active-session selection, the durable message
+ * list, and the transient (optimistic) message projection.
+ *
+ * Every dependency here is a ref box, a React state setter, or a method of the
+ * once-created session-UI controller — all fixed for the renderer's lifetime.
+ * The factory therefore runs ONCE (issue #1043's `useStableActions` exists for
+ * factories whose closures capture changing deps; these capture none, so the
+ * cheaper structural guarantee applies). Declaring these in the hook body
+ * instead handed every consumer a fresh identity per render, and
+ * `activateSession` alone rebuilt the Session rail's whole command chain, which
+ * defeated `SessionNavRow`'s `memo` on every commit.
+ */
+
+import type { StoredMessage } from '@maka/core/session';
+import type { TransientUserMessageProjection } from '@maka/ui';
+import { MESSAGE_QUEUE_MAX_ENTRIES } from '@maka/runtime-host/protocol';
+import { clearNewTaskReloadIntent, markNewTaskReloadIntent } from './new-task-reload-intent.js';
+import type { DesktopTranscriptRangeController } from './desktop-transcript-range-store.js';
+import {
+  mergeTransientMessageProjection,
+  projectQueuedTransientMessages as applyQueuedTransientProjection,
+  reconcileTransientMessages,
+} from './transient-message-projection.js';
+
+type RefBox<T> = { current: T };
+
+type TransientUserMessage = TransientUserMessageProjection;
+
+export type MessageListUpdater = (
+  next: StoredMessage[] | ((current: StoredMessage[]) => StoredMessage[]),
+) => void;
+
+export interface SessionWorkspaceActions {
+  setActiveId(next: string | undefined): void;
+  startNewSession(): void;
+  clearOwnedSessionState(sessionId: string): void;
+  setMessages: MessageListUpdater;
+  addTransientMessage(sessionId: string, message: TransientUserMessage): void;
+  updateTransientMessage(sessionId: string, message: TransientUserMessage): void;
+  projectQueuedTransientMessages(
+    sessionId: string,
+    messages: readonly TransientUserMessage[],
+  ): void;
+  retireCancelledTransientMessages(sessionId: string): Promise<void>;
+  removeTransientMessage(sessionId: string, messageId: string): void;
+}
+
+export function createSessionWorkspaceActions(deps: {
+  activeIdRef: RefBox<string | undefined>;
+  messagesRef: RefBox<StoredMessage[]>;
+  transientMessagesBySessionRef: RefBox<Map<string, Map<string, TransientUserMessage>>>;
+  transcriptRangeRef: RefBox<DesktopTranscriptRangeController | undefined>;
+  selectionRevisionRef: RefBox<number>;
+  messageRetryPendingRef: RefBox<Set<string>>;
+  stopPendingRef: RefBox<Set<string>>;
+  setActiveIdState: (next: string | undefined) => void;
+  setMessagesState: (next: StoredMessage[]) => void;
+  setTransientMessagesState: (next: TransientUserMessage[]) => void;
+  setMessageLoadPending: (pending: boolean) => void;
+  clearSessionUiState: (sessionId: string) => void;
+}): SessionWorkspaceActions {
+  const {
+    activeIdRef,
+    messagesRef,
+    transientMessagesBySessionRef,
+    transcriptRangeRef,
+    selectionRevisionRef,
+    messageRetryPendingRef,
+    stopPendingRef,
+    setActiveIdState,
+    setMessagesState,
+    setTransientMessagesState,
+    setMessageLoadPending,
+    clearSessionUiState,
+  } = deps;
+
+  function projectTransientMessages(
+    sessionId: string,
+    durable: readonly StoredMessage[],
+  ): TransientUserMessage[] {
+    const pending = transientMessagesBySessionRef.current.get(sessionId);
+    if (!pending || pending.size === 0) return [];
+    let includeTransient = true;
+    try {
+      const range = transcriptRangeRef.current?.store.range();
+      includeTransient = range?.sessionId !== sessionId || !range.hasNewer;
+    } catch {
+      // An unopened transcript has no historical range to hide the live tail from.
+    }
+    const projected = reconcileTransientMessages(pending, durable, { includeTransient });
+    if (pending.size === 0) {
+      transientMessagesBySessionRef.current.delete(sessionId);
+    }
+    return projected;
+  }
+
+  function reprojectActiveTransients(sessionId: string): void {
+    if (activeIdRef.current !== sessionId) return;
+    setTransientMessagesState(projectTransientMessages(sessionId, messagesRef.current));
+  }
+
+  const setMessages: MessageListUpdater = (next) => {
+    const projected = typeof next === 'function' ? next([...messagesRef.current]) : next;
+    messagesRef.current = projected;
+    setMessagesState(projected);
+    const sessionId = activeIdRef.current;
+    setTransientMessagesState(
+      sessionId ? projectTransientMessages(sessionId, projected) : [],
+    );
+  };
+
+  function addTransientMessage(sessionId: string, message: TransientUserMessage): void {
+    let pending = transientMessagesBySessionRef.current.get(sessionId);
+    if (!pending) {
+      pending = new Map();
+      transientMessagesBySessionRef.current.set(sessionId, pending);
+    }
+    pending.set(message.id, message);
+    reprojectActiveTransients(sessionId);
+  }
+
+  function updateTransientMessage(sessionId: string, message: TransientUserMessage): void {
+    const pending = transientMessagesBySessionRef.current.get(sessionId);
+    const current = pending?.get(message.id);
+    if (!pending || !current) return;
+    pending.set(message.id, mergeTransientMessageProjection(current, message));
+    reprojectActiveTransients(sessionId);
+  }
+
+  function projectQueuedTransientMessages(
+    sessionId: string,
+    messages: readonly TransientUserMessage[],
+  ): void {
+    let pending = transientMessagesBySessionRef.current.get(sessionId);
+    if (!pending && messages.length === 0) return;
+    if (!pending) {
+      pending = new Map();
+      transientMessagesBySessionRef.current.set(sessionId, pending);
+    }
+    applyQueuedTransientProjection(pending, messages);
+    reprojectActiveTransients(sessionId);
+  }
+
+  async function retireCancelledTransientMessages(sessionId: string): Promise<void> {
+    const pending = transientMessagesBySessionRef.current.get(sessionId);
+    if (!pending || pending.size === 0) return;
+    try {
+      // A legal Host queue already fills the protocol's per-query cap, and an
+      // unreconciled root Message sits beside it, so asking about every row at
+      // once fails the whole proof and retires nothing.
+      const messageIds = [...pending.keys()];
+      const cancelled: string[] = [];
+      for (let from = 0; from < messageIds.length; from += MESSAGE_QUEUE_MAX_ENTRIES) {
+        const result = await window.maka.sessions.queryCancelledMessages(
+          sessionId,
+          messageIds.slice(from, from + MESSAGE_QUEUE_MAX_ENTRIES),
+        );
+        cancelled.push(...result.cancelledMessageIds);
+      }
+      const current = transientMessagesBySessionRef.current.get(sessionId);
+      if (!current) return;
+      for (const messageId of cancelled) current.delete(messageId);
+      if (current.size === 0) transientMessagesBySessionRef.current.delete(sessionId);
+      reprojectActiveTransients(sessionId);
+    } catch {
+      // A failed proof query leaves presentation intact until canonical proof arrives.
+    }
+  }
+
+  function removeTransientMessage(sessionId: string, messageId: string): void {
+    const pending = transientMessagesBySessionRef.current.get(sessionId);
+    if (!pending?.delete(messageId)) return;
+    if (pending.size === 0) transientMessagesBySessionRef.current.delete(sessionId);
+    reprojectActiveTransients(sessionId);
+  }
+
+  function setActiveId(next: string | undefined): void {
+    selectionRevisionRef.current += 1;
+    // Clear here, not in the read effect: a layout-effect clear would wipe an
+    // optimistic first message before the first paint.
+    if (!next) {
+      setMessageLoadPending(false);
+    } else if (next !== activeIdRef.current) {
+      messagesRef.current = [];
+      setMessagesState([]);
+      setTransientMessagesState(projectTransientMessages(next, []));
+      setMessageLoadPending(true);
+    }
+    activeIdRef.current = next;
+    if (next) clearNewTaskReloadIntent();
+    setActiveIdState(next);
+  }
+
+  function startNewSession(): void {
+    markNewTaskReloadIntent();
+    setActiveId(undefined);
+    messagesRef.current = [];
+    setMessagesState([]);
+    setTransientMessagesState([]);
+  }
+
+  function clearOwnedSessionState(sessionId: string): void {
+    messageRetryPendingRef.current.delete(sessionId);
+    stopPendingRef.current.delete(sessionId);
+    transientMessagesBySessionRef.current.delete(sessionId);
+    if (activeIdRef.current === sessionId) setTransientMessagesState([]);
+    clearSessionUiState(sessionId);
+  }
+
+  return {
+    setActiveId,
+    startNewSession,
+    clearOwnedSessionState,
+    setMessages,
+    addTransientMessage,
+    updateTransientMessage,
+    projectQueuedTransientMessages,
+    retireCancelledTransientMessages,
+    removeTransientMessage,
+  };
+}

--- a/apps/desktop/src/renderer/use-app-shell-session-list.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-list.ts
@@ -23,11 +23,11 @@ import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 import { localizedShellErrorMessage } from './locales/shell-copy.js';
 import {
   normalizeSessionSummaryForDisplay,
-} from './session-status-presentation';
+} from './session-status-presentation.js';
 import {
   createSessionListRefresher,
   type SessionListRefresher,
-} from './session-read-state';
+} from './session-read-state.js';
 import { reconcileSettledSessionTransients } from './settled-session-transients.js';
 import type { DesktopSessionSummary } from '../preload/bridge-contract.js';
 
@@ -97,19 +97,26 @@ export function useAppShellSessionList(
     });
   }
 
-  async function refreshSessions(): Promise<DesktopSessionSummary[]> {
-    return refresherRef.current!.refresh();
-  }
-
-  function seedSessions(
-    snapshotSessions: readonly DesktopSessionSummary[],
-  ): DesktopSessionSummary[] {
-    const next = snapshotSessions.map(normalizeSessionSummaryForDisplay);
-    commitSessions(next);
-    return next;
-  }
-
-
+  // Fixed identities for the renderer's lifetime: both close over ref boxes and
+  // a state setter only, and consumers list them in dep arrays and hand them
+  // down as props (see `session-workspace-actions.ts`).
+  const actionsRef = useRef<{
+    refreshSessions(): Promise<DesktopSessionSummary[]>;
+    seedSessions(
+      snapshotSessions: readonly DesktopSessionSummary[],
+    ): DesktopSessionSummary[];
+  } | null>(null);
+  actionsRef.current ??= {
+    async refreshSessions() {
+      return refresherRef.current!.refresh();
+    },
+    seedSessions(snapshotSessions) {
+      const next = snapshotSessions.map(normalizeSessionSummaryForDisplay);
+      commitSessions(next);
+      return next;
+    },
+  };
+  const { refreshSessions, seedSessions } = actionsRef.current;
 
   return {
     sessions,

--- a/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
@@ -20,29 +20,19 @@
 import { useRef, useState } from 'react';
 import type { StoredMessage } from '@maka/core/session';
 import type { TransientUserMessageProjection } from '@maka/ui';
-import { MESSAGE_QUEUE_MAX_ENTRIES } from '@maka/runtime-host/protocol';
-import { useAppShellSessionUiState } from './app-shell-session-ui-state';
-import { useAppShellSessionList } from './use-app-shell-session-list';
-import { createBootstrapSelectionLease } from './bootstrap-selection-lease';
-import {
-  clearNewTaskReloadIntent,
-  hasNewTaskReloadIntent,
-  markNewTaskReloadIntent,
-} from './new-task-reload-intent';
+import { useAppShellSessionUiState } from './app-shell-session-ui-state.js';
+import { useAppShellSessionList } from './use-app-shell-session-list.js';
+import { createBootstrapSelectionLease } from './bootstrap-selection-lease.js';
+import { hasNewTaskReloadIntent } from './new-task-reload-intent.js';
 import type { DesktopTranscriptRangeController } from './desktop-transcript-range-store.js';
 import {
-  mergeTransientMessageProjection,
-  projectQueuedTransientMessages as applyQueuedTransientProjection,
-  reconcileTransientMessages,
-} from './transient-message-projection.js';
+  createSessionWorkspaceActions,
+  type SessionWorkspaceActions,
+} from './session-workspace-actions.js';
 
 type ToastApi = {
   error(title: string, description?: string): void;
 };
-
-type MessageListUpdater = (
-  next: StoredMessage[] | ((current: StoredMessage[]) => StoredMessage[]),
-) => void;
 
 type TransientUserMessage = TransientUserMessageProjection;
 
@@ -68,149 +58,34 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
   const messageRetryPendingRef = useRef<Set<string>>(new Set());
   const stopPendingRef = useRef<Set<string>>(new Set());
 
-  function projectTransientMessages(
-    sessionId: string,
-    durable: readonly StoredMessage[],
-  ): TransientUserMessage[] {
-    const pending = transientMessagesBySessionRef.current.get(sessionId);
-    if (!pending || pending.size === 0) return [];
-    let includeTransient = true;
-    try {
-      const range = transcriptRangeRef.current?.store.range();
-      includeTransient = range?.sessionId !== sessionId || !range.hasNewer;
-    } catch {
-      // An unopened transcript has no historical range to hide the live tail from.
-    }
-    const projected = reconcileTransientMessages(pending, durable, { includeTransient });
-    if (pending.size === 0) {
-      transientMessagesBySessionRef.current.delete(sessionId);
-    }
-    return projected;
-  }
-
-  const setMessagesForActiveSession: MessageListUpdater = (next) => {
-    const projected = typeof next === 'function' ? next([...messagesRef.current]) : next;
-    messagesRef.current = projected;
-    setMessages(projected);
-    const sessionId = activeIdRef.current;
-    setTransientMessages(sessionId ? projectTransientMessages(sessionId, projected) : []);
-  };
-
-  function addTransientMessage(sessionId: string, message: TransientUserMessage): void {
-    let pending = transientMessagesBySessionRef.current.get(sessionId);
-    if (!pending) {
-      pending = new Map();
-      transientMessagesBySessionRef.current.set(sessionId, pending);
-    }
-    pending.set(message.id, message);
-    if (activeIdRef.current === sessionId) {
-      setTransientMessages(projectTransientMessages(sessionId, messagesRef.current));
-    }
-  }
-
-  function updateTransientMessage(sessionId: string, message: TransientUserMessage): void {
-    const pending = transientMessagesBySessionRef.current.get(sessionId);
-    const current = pending?.get(message.id);
-    if (!pending || !current) return;
-    pending.set(message.id, mergeTransientMessageProjection(current, message));
-    if (activeIdRef.current === sessionId) {
-      setTransientMessages(projectTransientMessages(sessionId, messagesRef.current));
-    }
-  }
-
-  function projectQueuedTransientMessages(
-    sessionId: string,
-    messages: readonly TransientUserMessage[],
-  ): void {
-    let pending = transientMessagesBySessionRef.current.get(sessionId);
-    if (!pending && messages.length === 0) return;
-    if (!pending) {
-      pending = new Map();
-      transientMessagesBySessionRef.current.set(sessionId, pending);
-    }
-    applyQueuedTransientProjection(pending, messages);
-    if (activeIdRef.current === sessionId) {
-      setTransientMessages(projectTransientMessages(sessionId, messagesRef.current));
-    }
-  }
-
-  async function retireCancelledTransientMessages(sessionId: string): Promise<void> {
-    const pending = transientMessagesBySessionRef.current.get(sessionId);
-    if (!pending || pending.size === 0) return;
-    try {
-      // A legal Host queue already fills the protocol's per-query cap, and an
-      // unreconciled root Message sits beside it, so asking about every row at
-      // once fails the whole proof and retires nothing.
-      const messageIds = [...pending.keys()];
-      const cancelled: string[] = [];
-      for (let from = 0; from < messageIds.length; from += MESSAGE_QUEUE_MAX_ENTRIES) {
-        const result = await window.maka.sessions.queryCancelledMessages(
-          sessionId,
-          messageIds.slice(from, from + MESSAGE_QUEUE_MAX_ENTRIES),
-        );
-        cancelled.push(...result.cancelledMessageIds);
-      }
-      const current = transientMessagesBySessionRef.current.get(sessionId);
-      if (!current) return;
-      for (const messageId of cancelled) current.delete(messageId);
-      if (current.size === 0) transientMessagesBySessionRef.current.delete(sessionId);
-      if (activeIdRef.current === sessionId) {
-        setTransientMessages(projectTransientMessages(sessionId, messagesRef.current));
-      }
-    } catch {
-      // A failed proof query leaves presentation intact until canonical proof arrives.
-    }
-  }
-
-  function removeTransientMessage(sessionId: string, messageId: string): void {
-    const pending = transientMessagesBySessionRef.current.get(sessionId);
-    if (!pending?.delete(messageId)) return;
-    if (pending.size === 0) transientMessagesBySessionRef.current.delete(sessionId);
-    if (activeIdRef.current === sessionId) {
-      setTransientMessages(projectTransientMessages(sessionId, messagesRef.current));
-    }
-  }
-
-  function setActiveId(next: string | undefined): void {
-    selectionRevisionRef.current += 1;
-    // Clear here, not in the read effect: a layout-effect clear would wipe an
-    // optimistic first message before the first paint.
-    if (!next) {
-      setMessageLoadPending(false);
-    } else if (next !== activeIdRef.current) {
-      messagesRef.current = [];
-      setMessages([]);
-      setTransientMessages(projectTransientMessages(next, []));
-      setMessageLoadPending(true);
-    }
-    activeIdRef.current = next;
-    if (next) clearNewTaskReloadIntent();
-    setActiveIdState(next);
-  }
+  const actionsRef = useRef<SessionWorkspaceActions | null>(null);
+  // Every dep below is a ref box, a state setter, or a method of the
+  // once-created session-UI controller, so one instance serves the renderer's
+  // lifetime. Consumers list these in dep arrays and pass them as props; a
+  // per-render identity there is what defeated the Session rail's memo.
+  actionsRef.current ??= createSessionWorkspaceActions({
+    activeIdRef,
+    messagesRef,
+    transientMessagesBySessionRef,
+    transcriptRangeRef,
+    selectionRevisionRef,
+    messageRetryPendingRef,
+    stopPendingRef,
+    setActiveIdState,
+    setMessagesState: setMessages,
+    setTransientMessagesState: setTransientMessages,
+    setMessageLoadPending,
+    clearSessionUiState: sessionUi.clearSessionUiState,
+  });
+  const actions = actionsRef.current;
 
   if (!bootstrapSelectionLeaseRef.current) {
     bootstrapSelectionLeaseRef.current = createBootstrapSelectionLease({
       readActiveId: () => activeIdRef.current,
       readSelectionRevision: () => selectionRevisionRef.current,
-      select: setActiveId,
+      select: actions.setActiveId,
     });
     if (hasNewTaskReloadIntent()) bootstrapSelectionLeaseRef.current.release();
-  }
-
-  function startNewSession(): void {
-    markNewTaskReloadIntent();
-    setActiveId(undefined);
-    messagesRef.current = [];
-    setMessages([]);
-    setTransientMessages([]);
-  }
-
-  function clearOwnedSessionState(sessionId: string): void {
-    messageRetryPendingRef.current.delete(sessionId);
-    stopPendingRef.current.delete(sessionId);
-    transientMessagesBySessionRef.current.delete(sessionId);
-    if (activeIdRef.current === sessionId) setTransientMessages([]);
-    sessionUi.clearSessionUiState(sessionId);
   }
 
   return {
@@ -218,17 +93,9 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
     activeId,
     activeIdRef,
     bootstrapSelectionLease: bootstrapSelectionLeaseRef.current,
-    setActiveId,
-    startNewSession,
-    clearOwnedSessionState,
+    ...actions,
     messages,
     transientMessages,
-    setMessages: setMessagesForActiveSession,
-    addTransientMessage,
-    updateTransientMessage,
-    projectQueuedTransientMessages,
-    retireCancelledTransientMessages,
-    removeTransientMessage,
     transcriptRangeRef,
     messageLoadPending,
     setMessageLoadPending,

--- a/packages/core/src/__tests__/relative-time.test.ts
+++ b/packages/core/src/__tests__/relative-time.test.ts
@@ -20,6 +20,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  formatAbsoluteTimestamp,
   formatCompactTimestamp,
   formatRelativeTimestamp,
   formatSidebarTimestamp,
@@ -112,6 +113,44 @@ describe('relative timestamp labels', () => {
     ]) {
       const delay = nextRelativeRefreshDelay(ts, NOW);
       assert.ok(delay === null || (Number.isFinite(delay) && delay > 0 && delay <= 10 * 60_000));
+    }
+  });
+
+  it('reuses both formatters when relative and absolute readings alternate', () => {
+    resetRelativeTimeFormatters();
+    const OriginalDateTimeFormat = Intl.DateTimeFormat;
+    const OriginalRelativeTimeFormat = Intl.RelativeTimeFormat;
+    let constructions = 0;
+    function countConstructions(name: 'DateTimeFormat' | 'RelativeTimeFormat'): void {
+      const Original = Intl[name] as unknown as new (...args: unknown[]) => unknown;
+      function Counting(...args: unknown[]): unknown {
+        constructions += 1;
+        return new Original(...args);
+      }
+      Object.defineProperty(Intl, name, { value: Counting, configurable: true, writable: true });
+    }
+    countConstructions('DateTimeFormat');
+    countConstructions('RelativeTimeFormat');
+    try {
+      for (let round = 0; round < 5; round += 1) {
+        // The sidebar reads both per row: the relative label and, for the
+        // accessible name and the tooltip, the absolute one.
+        formatRelativeTimestamp(NOW - 60_000, NOW, 'en');
+        formatAbsoluteTimestamp(NOW - 60_000, 'en');
+      }
+      assert.equal(constructions, 2, 'one formatter of each kind for one locale');
+    } finally {
+      Object.defineProperty(Intl, 'DateTimeFormat', {
+        value: OriginalDateTimeFormat,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(Intl, 'RelativeTimeFormat', {
+        value: OriginalRelativeTimeFormat,
+        configurable: true,
+        writable: true,
+      });
+      resetRelativeTimeFormatters();
     }
   });
 });

--- a/packages/core/src/relative-time.ts
+++ b/packages/core/src/relative-time.ts
@@ -57,31 +57,44 @@ function relativeAgeMs(ts: number, now: number): number {
   return Math.max(0, now - ts);
 }
 
-let cachedRelativeFormat: Intl.RelativeTimeFormat | null = null;
-let cachedAbsoluteFormat: Intl.DateTimeFormat | null = null;
-let cachedLocale: string | null = null;
+// One cache per formatter. They used to share `cachedLocale` and clear each
+// other on a miss, so alternating relative and absolute reads — which is what
+// the sidebar does, once per row — rebuilt an `Intl` formatter every call.
+let cachedRelativeFormat: { locale: string; format: Intl.RelativeTimeFormat } | null = null;
+let cachedAbsoluteFormat: { locale: string; format: Intl.DateTimeFormat } | null = null;
 
 function getRelativeFormat(uiLocale: UiLocale): Intl.RelativeTimeFormat {
   const locale = uiLocaleToIntlLocale(uiLocale);
-  if (!cachedRelativeFormat || cachedLocale !== locale) {
-    cachedRelativeFormat = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
-    cachedAbsoluteFormat = null;
-    cachedLocale = locale;
+  if (cachedRelativeFormat?.locale !== locale) {
+    cachedRelativeFormat = {
+      locale,
+      format: new Intl.RelativeTimeFormat(locale, { numeric: 'auto' }),
+    };
   }
-  return cachedRelativeFormat;
+  return cachedRelativeFormat.format;
 }
 
 function getAbsoluteFormat(uiLocale: UiLocale): Intl.DateTimeFormat {
   const locale = uiLocaleToIntlLocale(uiLocale);
-  if (!cachedAbsoluteFormat || cachedLocale !== locale) {
-    cachedAbsoluteFormat = new Intl.DateTimeFormat(locale, {
-      dateStyle: 'medium',
-      timeStyle: 'short',
-    });
-    cachedRelativeFormat = null;
-    cachedLocale = locale;
+  if (cachedAbsoluteFormat?.locale !== locale) {
+    cachedAbsoluteFormat = {
+      locale,
+      format: new Intl.DateTimeFormat(locale, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }),
+    };
   }
-  return cachedAbsoluteFormat;
+  return cachedAbsoluteFormat.format;
+}
+
+/**
+ * Date and time for `ts`, spelled out. The single authority for the absolute
+ * reading a relative label falls back to and a tooltip shows; `@maka/ui` had
+ * its own uncached copy of the same `Intl` options until this became public.
+ */
+export function formatAbsoluteTimestamp(ts: number, locale: UiLocale = 'zh'): string {
+  return getAbsoluteFormat(locale).format(new Date(ts));
 }
 
 /**
@@ -180,7 +193,6 @@ export function formatSidebarTimestamp(
 export function resetRelativeTimeFormatters(): void {
   cachedRelativeFormat = null;
   cachedAbsoluteFormat = null;
-  cachedLocale = null;
   cachedCompactSameYearFormat = null;
   cachedCompactOtherYearFormat = null;
   cachedCompactLocale = null;

--- a/packages/ui/src/chat-display-helpers.ts
+++ b/packages/ui/src/chat-display-helpers.ts
@@ -43,12 +43,11 @@
 import type { UiLocale } from '@maka/core/ui-locale';
 import { getConversationCopy } from './conversation-copy.js';
 
-/* `formatAbsoluteTimestamp` used to be a second copy of the same `Intl` options
-   `@maka/core/relative-time` already owned, and it built a formatter per call —
-   the sidebar renders one per row for the row tooltip and one for the row's
-   accessible name. Re-exported rather than reimplemented so the two readings of
-   a timestamp cannot drift apart. */
-export { formatAbsoluteTimestamp } from '@maka/core/relative-time';
+/* `formatAbsoluteTimestamp` used to live here as a second copy of the same
+   `Intl` options `@maka/core/relative-time` already owned, and it built a
+   formatter per call — the sidebar renders one per row for the row tooltip and
+   one for the row's accessible name. Its callers now read the core module
+   directly, so there is no second reading of a timestamp to keep in step. */
 
 /* `formatClockTime` (a 24-hour `HH:mm` for the user-message time) lived here
    until the meta row moved to Astryx's `Timestamp`. Locking the hour cycle was

--- a/packages/ui/src/chat-display-helpers.ts
+++ b/packages/ui/src/chat-display-helpers.ts
@@ -40,22 +40,15 @@
  * sites.
  */
 
-import { uiLocaleToIntlLocale, type UiLocale } from '@maka/core/ui-locale';
+import type { UiLocale } from '@maka/core/ui-locale';
 import { getConversationCopy } from './conversation-copy.js';
 
-function createAbsoluteTimeFormat(locale: UiLocale): Intl.DateTimeFormat {
-  if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
-    return { format: (d: Date) => d.toISOString() } as unknown as Intl.DateTimeFormat;
-  }
-  return new Intl.DateTimeFormat(
-    uiLocaleToIntlLocale(locale),
-    { dateStyle: 'medium', timeStyle: 'short' },
-  );
-}
-
-export function formatAbsoluteTimestamp(ts: number, locale: UiLocale): string {
-  return createAbsoluteTimeFormat(locale).format(new Date(ts));
-}
+/* `formatAbsoluteTimestamp` used to be a second copy of the same `Intl` options
+   `@maka/core/relative-time` already owned, and it built a formatter per call —
+   the sidebar renders one per row for the row tooltip and one for the row's
+   accessible name. Re-exported rather than reimplemented so the two readings of
+   a timestamp cannot drift apart. */
+export { formatAbsoluteTimestamp } from '@maka/core/relative-time';
 
 /* `formatClockTime` (a 24-hour `HH:mm` for the user-message time) lived here
    until the meta row moved to Astryx's `Timestamp`. Locking the hour cycle was

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -22,11 +22,8 @@ import { useMountedRef } from './use-mounted-ref.js';
 import { ICON_SIZE, Ban, Check, Copy, GitBranch, Info, Pencil, RefreshCcw, Timer } from './icons.js';
 import { type ClipboardCopyPhase, useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { Markdown } from './markdown.js';
-import {
-  formatAbsoluteTimestamp,
-  formatTurnDuration,
-  turnAbortStatusLabel,
-} from './chat-display-helpers.js';
+import { formatTurnDuration, turnAbortStatusLabel } from './chat-display-helpers.js';
+import { formatAbsoluteTimestamp } from '@maka/core/relative-time';
 import { isTimeDrivenMotionEnabled } from './streaming-presentation.js';
 import { computerRunningLabel } from './tool-activity/computer-action-label.js';
 import {

--- a/packages/ui/src/relative-time.tsx
+++ b/packages/ui/src/relative-time.tsx
@@ -18,8 +18,8 @@
  */
 
 import { useEffect, useState } from 'react';
-import { formatAbsoluteTimestamp } from './chat-display-helpers.js';
 import {
+  formatAbsoluteTimestamp,
   formatRelativeTimestamp,
   nextRelativeRefreshDelay,
   formatSidebarTimestamp,

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -44,7 +44,7 @@ import {
   Trash2,
 } from './icons.js';
 import { RelativeTime } from './relative-time.js';
-import { formatAbsoluteTimestamp } from './chat-display-helpers.js';
+import { formatAbsoluteTimestamp } from '@maka/core/relative-time';
 import { Badge } from '@astryxdesign/core/Badge';
 import { MoreMenu } from '@astryxdesign/core/MoreMenu';
 import {


### PR DESCRIPTION
## Summary

Switching a session held the renderer at 34% CPU with peaks near 77%, and roughly 58% of that was React render and commit work. The cause is one function identity.

`setActiveId` was a function declaration in the `useAppShellSessionWorkspace` body, so it changed identity on every AppShell render. As `activateSession` it invalidated `openSession`'s `useCallback`, then the Session navigation controller's `commands`, then the host's `rowActions` and `onSelectSession`, then `renderSessionRow` — which defeated `SessionNavRow`'s `memo` on every commit. A single switch re-rendered all 32 sidebar rows about twenty times, and because every Astryx button removes and re-adds its inline `anchor-name` per render, that switch also produced roughly 2,500 style writes and the style recalculation they force.

Every dependency these actions close over is a ref box, a React state setter, or a method of the once-created session-UI controller, so they are constant by construction rather than by discipline. `createSessionWorkspaceActions` moves them out of the render body and the hook instantiates it once; `refreshSessions` and `seedSessions` get the same treatment. They are deliberately not routed through `useStableActions`, whose facade exists for factories whose closures do capture changing deps — paying for that indirection here would buy nothing.

Smaller pieces ride along, each its own commit:

- `@maka/ui`'s `formatAbsoluteTimestamp` was a second copy of the `Intl` options `@maka/core/relative-time` already owned, and built a formatter per call — about 1,300 per switch, since the sidebar reads one per row for the tooltip and one for the accessible name. Core's cache could not have absorbed them either: `getRelativeFormat` and `getAbsoluteFormat` shared one `cachedLocale` and cleared each other on a miss, so alternating readings rebuilt a formatter every call. Core now caches each with its own locale and exports the function, and the three UI call sites import it from there. Profiling attributed ~33 ms per switch to this, and an A/B swapping in a memoising `Intl.DateTimeFormat` moved renderer JS by less than the run-to-run spread — a duplicate-authority removal, not a measurable win.
- Two declarations the move left without an owner: the local `MessageListUpdater` copies in `app-shell-{chat,turn,revision}-actions`, and the alias re-export of `formatAbsoluteTimestamp` in `chat-display-helpers`.
- A contract spec that budgets the rail's DOM writes for one switch, described under Review focus.

Refs #4109

## Behaviour differences worth naming

Neither is reachable from a current call site; both are recorded because they widen what a future one could do.

- The moved `formatAbsoluteTimestamp` drops a `typeof Intl === 'undefined'` fallback to `toISOString()`. Core's module has never had that guard and `formatRelativeTimestamp`'s absolute branch already called `Intl` unconditionally, so it only protected a runtime that would fail a line later.
- Core's signature defaults `locale` to `'zh'`, where the UI copy required it. All four call sites pass it explicitly; the default matches the module's three sibling formatters.

## Verification

All measurements are same-instance A/B: the two identities were made runtime-switchable and alternated inside one running dev app, six switches each. Cross-instance comparison is not usable here — restarting the app moves these numbers by more than the effect.

| per session switch | unstable | stable |
|---|---|---|
| Row renders | 459 | 85 |
| `memo` hits | 0 | 432 |
| DOM mutations | 3,438 | 1,992 |
| Renderer JS | 521 ms | 380 ms |
| Renderer CPU under a repeated-switch loop | 34% (peak 77%) | 24% (peak 55%) |

Renderer JS fell in 6 of 6 paired runs. Idle CPU was 0.1% before and after; this workload is entirely interaction-driven.

Ran locally:

- `session-workspace-action-identity`, `session-navigation-controller`, `relative-time` — pass
- `session-rail-render-contract` (Playwright) — pass, three consecutive runs
- `tsc -p apps/desktop/tsconfig.renderer.json --noEmit`, `@maka/core` and `@maka/ui` builds, `npm run format` — clean

Not run: the full repository suite, and the end-to-end check on a dev app built from this branch — a dev app from another checkout holds the shared profile lock. The Playwright spec covers the same observable on a clean fixture, so the gap is the manual pass, not the assertion.

Falsifiability was checked for both new tests by reverting the fix in the built renderer bundle. The identity test fails with `setActiveId changed identity between renders`; the contract spec fails on rows-touched, 12 of 12 rows written where 2 is the budget. Restoring the mutual cache invalidation in core fails the formatter test.

## Review focus

The contract spec is the piece worth arguing about. It asserts an outcome rather than an identity, because this rail has had several independent regressions of the same shape and each was invisible to the others. An identity assertion pins one mechanism in one hook; the next plain function declaration upstream passes every existing check, since the dependency arrays stay correct and `useExhaustiveDependencies` has nothing to flag.

What carries the contract is which rows were written, not how many writes there were. A switch touches the leaving row and the arriving row and nothing else, at any rail length. A total budget cannot say that: `3 * rows` is 1.5 whole-rail renders, so a regression that re-renders the rail exactly once — the likeliest one, since `renderSessionRow` depends on `rowActions`, `sessionMeta` and three Sets — would have passed. The spec also counts row remounts, because React sets attributes before insertion and an attribute-only observer reads a whole rail remounting as cheaper than a re-render, and asserts the counter fired at all, because its sensitivity comes from an Astryx ref callback that upstream could reasonably memoise.

It also covers ground this PR does not fix. A switch still produces about twenty commits, and why is not yet attributed; it is not animation-driven, since emulating `prefers-reduced-motion` cuts `requestAnimationFrame` callbacks from 188 to 13 while the render count is unchanged. That cascade multiplies whatever the rail costs per render, and anything that raises it shows up in this budget. Tracked in #4109 along with the structural direction — letting the rail subscribe through the store seam `app-shell-session-ui-state.ts` already establishes, instead of receiving props through five layers.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code. It drove the CDP profiling and DOM probes that isolated the cause and produced every number above, then wrote the change, the tests, and this description. Three Claude Code agents then reviewed the branch adversarially — runtime correctness, formatter equivalence, and test validity — each tasked with refuting the PR's claims rather than confirming them; they found no correctness defect, and every finding they did raise about the tests is addressed in the last three commits. That review is AI output and does not substitute for human review. The human contributor reviewed the diff, the commit messages, and the measurement method. `Generated-by` trailers are on all six commits.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
