### PR TITLE
fix(runtime): classify post-tool model timeouts

### DIFF
--- a/apps/desktop/src/renderer/session-error-presentation.ts
+++ b/apps/desktop/src/renderer/session-error-presentation.ts
@@ -34,6 +34,8 @@ export function describeSessionErrorReason(reason: string | undefined, locale: U
       return copy.contextBudgetExhausted;
     case 'timeout':
       return copy.timeout;
+    case 'model_after_tool_timeout':
+      return copy.timeout;
     case 'auth':
       return copy.auth;
     case 'provider_billing':

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10102,6 +10102,96 @@ describe('AiSdkBackend RunTrace', () => {
     assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
   });
 
+  test('retries post-tool continuation once without re-running the durable tool result', async () => {
+    const timers = manualWatchdogTimer();
+    const durable = durableTurnHarness('turn-1', 'read notes');
+    let providerCalls = 0;
+    let toolCalls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        providerCalls += 1;
+        if (providerCalls === 1) {
+          return {
+            stream: simulateReadableStream({
+              chunks: [
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'read-1',
+                  toolName: 'Read',
+                  input: JSON.stringify({ path: 'notes.md' }),
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: emptyUsage(),
+                },
+              ],
+              initialDelayInMs: null,
+              chunkDelayInMs: null,
+            }),
+          };
+        }
+        return {
+          stream: hangingProviderStream(
+            [{ type: 'stream-start', warnings: [] }],
+            options.abortSignal,
+          ),
+        };
+      },
+    });
+    const readTool: MakaTool = {
+      name: 'Read',
+      description: 'Read notes',
+      parameters: z.object({ path: z.string() }),
+      impl: async () => {
+        toolCalls += 1;
+        return 'notes contents';
+      },
+    };
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [readTool],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    const eventsPromise = collectEvents(backend.send(durable.input()), events, durable.record);
+    await waitFor(() => providerCalls === 2);
+    timers.fire();
+    await waitFor(() => providerCalls === 3);
+    timers.fire();
+    await eventsPromise;
+
+    assert.equal(providerCalls, 3);
+    assert.equal(toolCalls, 1);
+    assert.equal(events.filter((event) => event.type === 'tool_result').length, 1);
+    assert.equal(
+      durable.ledger.filter((event) => event.content?.kind === 'function_response').length,
+      1,
+    );
+    assert.equal(
+      events.filter((event) => event.type === 'provider_retry' && event.phase === 'scheduled')
+        .length,
+      1,
+    );
+    assert.equal(
+      events.find((event) => event.type === 'error')?.reason,
+      'model_after_tool_timeout',
+    );
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
   test('does not retry an idle watchdog timeout after partial answer text', async () => {
     const timers = manualWatchdogTimer();
     const traces: RunTraceEvent[] = [];

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10192,6 +10192,74 @@ describe('AiSdkBackend RunTrace', () => {
     assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
   });
 
+  test('keeps a projection timeout as a generic timeout before continuation dispatch', async () => {
+    const durable = durableTurnHarness('turn-1', 'read notes');
+    let providerCalls = 0;
+    let toolCalls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        providerCalls += 1;
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'tool-call',
+                toolCallId: 'read-1',
+                toolName: 'Read',
+                input: JSON.stringify({ path: 'notes.md' }),
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                usage: emptyUsage(),
+              },
+            ],
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [
+        {
+          name: 'Read',
+          description: 'Read notes',
+          parameters: z.object({ path: z.string() }),
+          impl: async () => {
+            toolCalls += 1;
+            return 'notes contents';
+          },
+        },
+      ],
+      loadTurnRuntimeEvents: async (turnId) => {
+        if (durable.ledger.some((event) => event.content?.kind === 'function_response')) {
+          throw Object.assign(new Error('durable projection timeout'), { name: 'TimeoutError' });
+        }
+        return durable.loadTurnRuntimeEvents(turnId);
+      },
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events: SessionEvent[] = [];
+    await collectEvents(backend.send(durable.input()), events, durable.record);
+
+    assert.equal(providerCalls, 1);
+    assert.equal(toolCalls, 1);
+    assert.equal(events.filter((event) => event.type === 'tool_result').length, 1);
+    assert.equal(events.find((event) => event.type === 'error')?.reason, 'timeout');
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
   test('does not retry an idle watchdog timeout after partial answer text', async () => {
     const timers = manualWatchdogTimer();
     const traces: RunTraceEvent[] = [];

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -598,6 +598,14 @@ describe('ModelAdapter stream and error normalization', () => {
         .reason,
       'timeout',
     );
+    assert.equal(
+      adapter.makeErrorEvent(
+        'turn-1',
+        new Error('Model stream idle timeout after 120000ms'),
+        'model_after_tool_timeout',
+      ).reason,
+      'model_after_tool_timeout',
+    );
     assert.equal(adapter.mapFinishReason('stop'), 'end_turn');
     assert.equal(adapter.mapFinishReason('length'), 'max_tokens');
     assert.equal(adapter.mapFinishReason('tool-calls'), 'end_turn');

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1905,6 +1905,7 @@ export class AiSdkBackend implements AgentBackend {
         watchdogTimeoutState.current = null;
         return timeout;
       };
+      let lastCompletedStepHadToolResult = false;
       try {
         const startWatchdog = (): void => {
           watchdogState.current?.stop();
@@ -2788,6 +2789,7 @@ export class AiSdkBackend implements AgentBackend {
             toolCalls: returnedToolCalls,
             ...(providerStepUsage ? { usage: providerStepUsage } : {}),
           });
+          lastCompletedStepHadToolResult = returnedToolCalls.length > 0;
           const stepLimitReached = maxSteps !== undefined && runtimeSteps >= maxSteps;
           if (
             sandboxBoundaryFinalizationStep ||
@@ -3030,7 +3032,11 @@ export class AiSdkBackend implements AgentBackend {
           } satisfies CompleteEvent);
         } else {
           const terminalError = currentWatchdogTimeout()?.error ?? err;
-          queue.push(this.makeErrorEvent(turnId, terminalError));
+          const errorReason =
+            streamErrorClass === 'Timeout' && lastCompletedStepHadToolResult
+              ? 'model_after_tool_timeout'
+              : undefined;
+          queue.push(this.makeErrorEvent(turnId, terminalError, errorReason));
           trace.modelStreamFailed(
             streamErrorClass,
             terminalError,
@@ -3344,8 +3350,8 @@ export class AiSdkBackend implements AgentBackend {
     return this.modelAdapter.mapFinishReason(reason);
   }
 
-  private makeErrorEvent(turnId: string, err: unknown): ErrorEvent {
-    return this.modelAdapter.makeErrorEvent(turnId, err);
+  private makeErrorEvent(turnId: string, err: unknown, reasonOverride?: string): ErrorEvent {
+    return this.modelAdapter.makeErrorEvent(turnId, err, reasonOverride);
   }
 
   private computeTokenUsageCostUsd(usage: NormalizedAiSdkUsage): number | undefined {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1906,6 +1906,7 @@ export class AiSdkBackend implements AgentBackend {
         return timeout;
       };
       let lastCompletedStepHadToolResult = false;
+      let terminalProviderErrorReason: string | undefined;
       try {
         const startWatchdog = (): void => {
           watchdogState.current?.stop();
@@ -2520,6 +2521,10 @@ export class AiSdkBackend implements AgentBackend {
                   : providerOutcome.failure;
               if (scope.loopStopRequested) {
                 terminalProviderError = settledWatchdogTimeout?.error ?? failure;
+                terminalProviderErrorReason =
+                  lastCompletedStepHadToolResult && failure.kind === 'timeout'
+                    ? 'model_after_tool_timeout'
+                    : undefined;
                 break agentLoop;
               }
               // A retry is a fresh provider request that would run at least one
@@ -2635,6 +2640,10 @@ export class AiSdkBackend implements AgentBackend {
               // handler after settling any authoritative usage — never a
               // fabricated success.
               terminalProviderError = settledWatchdogTimeout?.error ?? failure;
+              terminalProviderErrorReason =
+                lastCompletedStepHadToolResult && failure.kind === 'timeout'
+                  ? 'model_after_tool_timeout'
+                  : undefined;
               break agentLoop;
             }
             break;
@@ -3032,11 +3041,7 @@ export class AiSdkBackend implements AgentBackend {
           } satisfies CompleteEvent);
         } else {
           const terminalError = currentWatchdogTimeout()?.error ?? err;
-          const errorReason =
-            streamErrorClass === 'Timeout' && lastCompletedStepHadToolResult
-              ? 'model_after_tool_timeout'
-              : undefined;
-          queue.push(this.makeErrorEvent(turnId, terminalError, errorReason));
+          queue.push(this.makeErrorEvent(turnId, terminalError, terminalProviderErrorReason));
           trace.modelStreamFailed(
             streamErrorClass,
             terminalError,

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -466,7 +466,7 @@ export class ModelAdapter {
     );
   }
 
-  makeErrorEvent(turnId: string, err: unknown): ErrorEvent {
+  makeErrorEvent(turnId: string, err: unknown, reasonOverride?: string): ErrorEvent {
     const failure = normalizeModelFailure(err);
     return {
       type: 'error',
@@ -475,7 +475,11 @@ export class ModelAdapter {
       ts: this.input.now(),
       recoverable: false,
       ...(failure.code !== undefined ? { code: failure.code } : {}),
-      ...(failure.kind !== 'abort' && failure.kind !== 'unknown' ? { reason: failure.kind } : {}),
+      ...(reasonOverride !== undefined
+        ? { reason: reasonOverride }
+        : failure.kind !== 'abort' && failure.kind !== 'unknown'
+          ? { reason: failure.kind }
+          : {}),
       message: failure.message,
     };
   }


### PR DESCRIPTION
## Summary

- classify a provider timeout after a completed tool step as `model_after_tool_timeout`
- preserve the underlying timeout diagnostics while exposing a stable recovery phase
- reuse the existing bounded idle-watchdog retry for post-tool continuation
- prove that the retry reuses the durable Tool Result and never executes the tool again
- retain the fail-closed safe-resume planner for incomplete, errored, or indeterminate tools

Together with #4075, this completes the stage-aware post-tool timeout recovery
path described in #4074. Transcript delivery remains independently covered by
#4066.

Closes #4074

## Runtime behavior covered

```text
provider tool call
  -> tool executes once
  -> Tool Result becomes durable
  -> post-tool provider continuation times out
  -> one bounded provider-only retry
  -> retry times out
  -> Turn fails as model_after_tool_timeout
  -> Desktop can offer planner-gated Safe Resume
```

The automatic retry never re-dispatches the completed tool. Unsafe or unsettled
tool boundaries remain parked by the existing continuation planner.

## Validation

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/runtime run build`
- targeted Runtime tests:
  - post-tool continuation retries once
  - tool executes once
  - exactly one durable `function_response`
  - terminal reason is `model_after_tool_timeout`
- `npx biome check` on changed files
- `git diff --check`
