### PR TITLE
feat(inspector): collapse loaded history

### DIFF
--- a/apps/desktop/src/main/__tests__/use-session-trace.test.ts
+++ b/apps/desktop/src/main/__tests__/use-session-trace.test.ts
@@ -458,6 +458,45 @@ describe('useSessionTrace', () => {
     );
   });
 
+  it('collapses all loaded earlier pages after reaching the oldest page', async () => {
+    const { root } = installReactRenderer();
+    const harness = createTraceHarness({
+      tracePages: [
+        tracePage('session-1', 'run-3', 'cursor-3'),
+        tracePage('session-1', 'run-2', null),
+      ],
+    });
+    let snapshot: ReturnType<typeof useSessionTrace> | undefined;
+    await act(async () => {
+      root.render(
+        createElement(Probe, {
+          services: harness.services,
+          sessionId: 'session-1',
+          active: true,
+          onHookSnapshot: (value) => {
+            snapshot = value;
+          },
+        }),
+      );
+    });
+
+    assert.equal(snapshot?.canHideEarlier, false);
+    await act(async () => snapshot?.loadEarlier());
+    assert.equal(snapshot?.canHideEarlier, true);
+    assert.deepEqual(
+      snapshot?.trace?.turns.map((turn) => turn.runId),
+      ['run-2', 'run-3'],
+    );
+
+    await act(async () => snapshot?.hideEarlier());
+    assert.equal(snapshot?.canHideEarlier, false);
+    assert.equal(snapshot?.nextCursor, 'cursor-3');
+    assert.deepEqual(
+      snapshot?.trace?.turns.map((turn) => turn.runId),
+      ['run-3'],
+    );
+  });
+
   it('rebuilds the loaded window when a run is inserted behind an unchanged head cursor', async () => {
     const { root } = installReactRenderer();
     const harness = createTraceHarness({

--- a/apps/desktop/src/renderer/features/workbar/tools/inspector/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/features/workbar/tools/inspector/session-inspector-panel.tsx
@@ -203,13 +203,19 @@ export function SessionInspectorPanel(props: { sessionId: string; active: boolea
                   />
                 ))}
               </ol>
-              {snapshot.nextCursor && (
+              {(snapshot.nextCursor || snapshot.canHideEarlier) && (
                 <Button
                   variant="ghost"
                   size="sm"
-                  label={snapshot.loadingEarlier ? copy.loadingEarlier : copy.loadEarlier}
+                  label={
+                    snapshot.canHideEarlier
+                      ? copy.hideEarlier
+                      : snapshot.loadingEarlier
+                        ? copy.loadingEarlier
+                        : copy.loadEarlier
+                  }
                   isDisabled={snapshot.loading || snapshot.loadingEarlier}
-                  onClick={snapshot.loadEarlier}
+                  onClick={snapshot.canHideEarlier ? snapshot.hideEarlier : snapshot.loadEarlier}
                 />
               )}
             </VStack>

--- a/apps/desktop/src/renderer/features/workbar/tools/inspector/use-session-trace.ts
+++ b/apps/desktop/src/renderer/features/workbar/tools/inspector/use-session-trace.ts
@@ -84,7 +84,12 @@ export function useSessionTrace(
   // whose comment once outran its code — is renderable in a test without the
   // UI package behind it.
   copy: { loadFailed: string; locale: UiLocale },
-): SessionTraceSnapshot & { retry: () => void; loadEarlier: () => void } {
+): SessionTraceSnapshot & {
+  canHideEarlier: boolean;
+  retry: () => void;
+  loadEarlier: () => void;
+  hideEarlier: () => void;
+} {
   const { inspector } = useWorkbarServices();
   const traceRevisionRef = useRef(0);
   const summaryRevisionRef = useRef(0);
@@ -337,6 +342,7 @@ export function useSessionTrace(
     [state.tracePages],
   );
   const nextCursor = state.tracePages?.at(-1)?.nextCursor;
+  const canHideEarlier = Boolean(state.tracePages && state.tracePages.length > 1 && !nextCursor);
 
   const loadEarlier = useCallback(() => {
     if (!sessionId || !nextCursor || state.loading || state.loadingEarlier) return;
@@ -348,11 +354,30 @@ export function useSessionTrace(
     readEarlierPage(sessionId, nextCursor);
   }, [nextCursor, readEarlierPage, sessionId, state.loading, state.loadingEarlier]);
 
+  const hideEarlier = useCallback(() => {
+    if (!sessionId || !canHideEarlier) return;
+    const loaded = traceWindowRef.current;
+    if (loaded?.sessionId !== sessionId || loaded.pages.length < 2) return;
+    const pages = loaded.pages.slice(0, 1);
+    traceWindowRef.current = { sessionId, pages };
+    desiredPageCountRef.current = { sessionId, count: 1 };
+    setState((current) =>
+      current.sessionId === sessionId ? { ...current, tracePages: pages } : current,
+    );
+  }, [canHideEarlier, sessionId]);
+
   if (state.sessionId !== sessionId) {
-    return { ...EMPTY_SNAPSHOT, loading: Boolean(sessionId) && active, retry, loadEarlier };
+    return {
+      ...EMPTY_SNAPSHOT,
+      loading: Boolean(sessionId) && active,
+      canHideEarlier: false,
+      retry,
+      loadEarlier,
+      hideEarlier,
+    };
   }
   const { tracePages: _tracePages, ...snapshot } = state;
-  return { ...snapshot, trace, nextCursor, retry, loadEarlier };
+  return { ...snapshot, trace, nextCursor, canHideEarlier, retry, loadEarlier, hideEarlier };
 }
 
 async function readTracePageWindow(

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -203,6 +203,7 @@ export interface DesktopConversationCopy {
     costUnavailable: string;
     costEstimateHelp: string;
     loadEarlier: string;
+    hideEarlier: string;
     loadingEarlier: string;
     loadingTrace: string;
     loadingSummary: string;
@@ -554,6 +555,7 @@ const COPY = {
       costUnavailable: '费用未知',
       costEstimateHelp: '基于已记录用量和定价估算；缺失或未定价的调用可能未计入。',
       loadEarlier: '加载更早记录',
+      hideEarlier: '隐藏所有更早记录',
       loadingEarlier: '正在加载…',
       loadingTrace: '正在读取时间线…',
       loadingSummary: '正在估算完整会话用量…',
@@ -783,6 +785,7 @@ const COPY = {
       costUnavailable: 'cost unknown',
       costEstimateHelp: 'Estimated from recorded usage and pricing; missing or unpriced calls may be excluded.',
       loadEarlier: 'Load earlier records',
+      hideEarlier: 'Hide all earlier records',
       loadingEarlier: 'Loading…',
       loadingTrace: 'Loading timeline…',
       loadingSummary: 'Estimating full-session usage…',


### PR DESCRIPTION
## Summary

- show Hide all earlier records after the oldest timeline page is loaded
- collapse all loaded earlier pages back to the initial recent page
- add localized copy and regression coverage for the interaction

<!-- The problem this solves and the outcome it produces. If the approach
is not the obvious one, say why. -->

Refs #3986

<!-- Delete the line above if this PR closes no issue. Use "Refs #N" instead
when an issue is context only. -->

## Verification

node --test apps/desktop/dist/main/__tests__/use-session-trace.test.js (12 tests passed)

### Before chang
<img width="465" height="658" alt="image" src="https://github.com/user-attachments/assets/ae402090-8ec8-4228-bcef-1a0245bc0a10" />


### After Change
<img width="463" height="711" alt="image" src="https://github.com/user-attachments/assets/487fcc92-18eb-4ea4-a704-18a27ca50a9a" />



<!-- The checks you actually ran and their results. Name relevant checks
you did not run. For user-visible changes, attach the lightest evidence
that demonstrates the behavior (screenshot, recording, or command output). -->

<!--
Add a section only when it changes how this PR should be reviewed,
released, or operated, and name it after the real risk: e.g.
Breaking change, Migration, Rollout, Root cause, Security, Review focus.
If work intentionally remains, open as a draft and track it with a
task list under its own section.
-->

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

<!-- If the second option applies, name the tool(s) and briefly describe their
scope. If AI authored material contribution content, add Generated-by trailers
to the affected commits and ensure the final squash commit retains the trailer. -->

Tool(s) and scope:

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
