### PR TITLE
fix(inspector): align cost summary style

### DIFF
--- a/apps/desktop/src/renderer/features/workbar/tools/inspector/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/features/workbar/tools/inspector/session-inspector-panel.tsx
@@ -266,25 +266,22 @@ function InspectorOverview(props: {
 
   return (
     <VStack gap={6} data-maka-contract="session-inspector-overview">
-      {/* The figures open the panel with nothing above them. Every heading
-          tried here ranked below the numbers it introduced, because a label
-          over a 20px figure is exactly what a StatCell already is — the three
-          cells label themselves. */}
       {props.showTotals && (
-        <>
-          <dl className="maka-inspector-stats" data-maka-contract="session-inspector-stats">
-            <StatCell
-              label={copy.totals.cost}
-              value={formatCost(estimatedSessionCost(props.summary), copy.costUnavailable)}
+        <VStack gap={2} data-maka-contract="session-inspector-stats">
+          <InspectorOverviewStat
+            label={copy.totals.cost}
+            value={formatCost(estimatedSessionCost(props.summary), copy.costUnavailable)}
+          />
+          {overview.cacheHitRate !== undefined && (
+            <InspectorOverviewStat
+              label={copy.overview.cacheHit}
+              value={formatPercent(overview.cacheHitRate)}
             />
-            {overview.cacheHitRate !== undefined && (
-              <StatCell label={copy.overview.cacheHit} value={formatPercent(overview.cacheHitRate)} />
-            )}
-          </dl>
+          )}
           <Text type="supporting" color="secondary">
             {copy.costEstimateHelp}
           </Text>
-        </>
+        </VStack>
       )}
 
       {context && (
@@ -308,15 +305,17 @@ function InspectorOverview(props: {
 }
 
 /**
- * One headline figure. A label small enough to stay out of the way over a
- * number big enough to be the thing the eye lands on — the inverse of a table
- * row, and the reason these three do not need a section heading to rank them.
+ * One overview total on the same title/readout rhythm as the sections below.
+ * These figures answer parallel questions, so changing typography between the
+ * first and second block would imply a hierarchy the data does not have.
  */
-function StatCell(props: { label: string; value: ReactNode }) {
+function InspectorOverviewStat(props: { label: string; value: ReactNode }) {
   return (
-    <div className="maka-inspector-stat">
-      <dt>{props.label}</dt>
-      <dd>{props.value}</dd>
+    <div className="maka-inspector-section-head">
+      <Heading level={3} className="maka-inspector-section-title">
+        {props.label}
+      </Heading>
+      <span className="maka-inspector-section-readout">{props.value}</span>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/styles/workbar/inspector.css
+++ b/apps/desktop/src/renderer/styles/workbar/inspector.css
@@ -424,32 +424,6 @@
   box-shadow: inset 0 0 0 var(--border-width-hairline) var(--border-strong);
 }
 
-/* The three headline figures, across the column rather than down it.
-   A 480px panel of label-then-value rows leaves its whole right half empty and
-   still reads as cramped, because every row is the same weight; giving the
-   three figures a reader actually came for their own band fills the width with
-   the thing that deserves it and lets everything below stay quiet. */
-.maka-inspector-stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
-  gap: var(--space-3);
-  margin: 0;
-}
-
-.maka-inspector-stat dt {
-  font: var(--maka-text-body);
-  color: var(--muted-foreground);
-  margin-bottom: 2px;
-}
-
-.maka-inspector-stat dd {
-  margin: 0;
-  font: var(--maka-text-heading-1);
-  color: var(--foreground);
-  font-variant-numeric: tabular-nums;
-  overflow-wrap: anywhere;
-}
-
 /* The overview's data grid, on the IDE template's `metadataCompact` rhythm
    (row space-1, column space-3) at body type: these facts are the content of
    the panel, not its chrome. Only a qualifier steps down to supporting. */


### PR DESCRIPTION
## Summary

<!-- The problem this solves and the outcome it produces. If the approach
is not the obvious one, say why. -->

Align Estimated cost with the Context window title/readout layout in the Inspector overview.

Fixes #4121

<!-- Delete the line above if this PR closes no issue. Use "Refs #N" instead
when an issue is context only. -->

## Verification

<!-- The checks you actually ran and their results. Name relevant checks
you did not run. For user-visible changes, attach the lightest evidence
that demonstrates the behavior (screenshot, recording, or command output). -->

<!--
Add a section only when it changes how this PR should be reviewed,
released, or operated, and name it after the real risk: e.g.
Breaking change, Migration, Rollout, Root cause, Security, Review focus.
If work intentionally remains, open as a draft and track it with a
task list under its own section.
-->

- Targeted Biome lint passed for both changed files.
- TypeScript syntax check and git diff check passed.
- Manually verified the updated layout in the running desktop app.
- Full renderer typecheck remains blocked by pre-existing Peer Mesh type errors in runtime-host-peer-mesh-dialog.tsx.

### Before Change
<img width="968" height="1506" alt="image" src="https://github.com/user-attachments/assets/99f72e90-6433-44f6-b560-39720480fd22" />


### After Change
<img width="476" height="660" alt="image" src="https://github.com/user-attachments/assets/b4a6bf4f-22ef-42bb-af03-2a5f202340ce" />


## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

<!-- If the second option applies, name the tool(s) and briefly describe their
scope. If AI authored material contribution content, add Generated-by trailers
to the affected commits and ensure the final squash commit retains the trailer. -->

Tool(s) and scope:

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
