### PR TITLE
fix(runtime-host): align enabled model limit

### DIFF
--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -22,6 +22,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENT_COUNT } from '@maka/core/attachments';
 import { CONTEXT_BUDGET_EXHAUSTED_DETAILS, TOOL_OUTPUT_DELTA_MAX_CHARS } from '@maka/core/events';
+import { CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS } from '@maka/core/runtime-policy';
 import {
   decodeClientCapabilityReplaceInput,
   decodeClientFrame,
@@ -799,6 +800,35 @@ describe('Runtime Host bootstrap protocol', () => {
       () =>
         exportCredentials.decodeOutput({
           credential: { locator: apiKeyLocator, secretBase64 },
+        }),
+      isInvalidFrame,
+    );
+  });
+
+  test('keeps the connection update model limit aligned with the catalog', () => {
+    const updateConnection = RUNTIME_POLICY_OPERATION_SPECS['connection.catalog.update'];
+    const enabledModelIds = Array.from(
+      { length: CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS },
+      (_, index) => `model-${index}`,
+    );
+    const input = {
+      expected: { connectionId: '00000000-0000-4000-8000-000000000001', revision: 1 },
+      changes: {
+        name: 'OpenRouter',
+        enabled: true,
+        enabledModelIds,
+      },
+    };
+
+    assert.doesNotThrow(() => updateConnection.decodeInput(input));
+    assert.throws(
+      () =>
+        updateConnection.decodeInput({
+          ...input,
+          changes: {
+            ...input.changes,
+            enabledModelIds: [...enabledModelIds, 'model-too-many'],
+          },
         }),
       isInvalidFrame,
     );

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -94,7 +94,9 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 62 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 63 as const;
+// 63: Connection updates accept the full canonical enabled-model limit.
+// Older peers reject valid catalogs containing more than 64 enabled models.
 // 62: A Direct peer listener can expose owner-only Peer Mesh management
 // operations. Older peers do not have this closed operation vocabulary.
 // 61: Session explicit model targets carry immutable Connection identity,

--- a/packages/runtime-host/src/protocol/runtime-policy.ts
+++ b/packages/runtime-host/src/protocol/runtime-policy.ts
@@ -78,7 +78,6 @@ export const CONNECTION_CATALOG_PAGE_MAX_BYTES = 48 * 1024;
 export const RUNTIME_POLICY_SNAPSHOT_MAX_BYTES = 48 * 1024;
 export const CREDENTIAL_SECRET_MAX_BYTES = 10 * 1024;
 
-const CONNECTION_MUTATION_MAX_ENABLED_MODEL_IDS = 64;
 const QUERY_ERRORS = [
   'host_not_ready',
   'host_draining',
@@ -1073,7 +1072,7 @@ function modelSource(value: unknown): 'fetched' | 'fallback' {
 }
 
 function assertMutationEnabledModelIds(values: readonly string[]): void {
-  if (values.length > CONNECTION_MUTATION_MAX_ENABLED_MODEL_IDS) {
+  if (values.length > CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS) {
     throw invalidProtocolFrame('Invalid enabled model ids');
   }
 }


### PR DESCRIPTION
## Summary

Use the shared connection catalog limit when validating enabled model IDs.
This allows Enable all to save provider catalogs larger than 64 entries while
keeping the existing 512-entry protocol bound.

Fixes #3993

## Verification

- `npm exec -- biome lint packages/runtime-host/src/protocol/runtime-policy.ts packages/runtime-host/src/__tests__/protocol.test.ts` — passed
- `npm exec -- biome format packages/runtime-host/src/protocol/runtime-policy.ts packages/runtime-host/src/__tests__/protocol.test.ts` — passed
- `npm --workspace @maka/runtime-host run typecheck` — passed
- `npm --workspace @maka/runtime-host test` — 1,356 tests, 0 failures

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the limit mismatch, implemented
the fix, added the regression test, and ran verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
