### PR TITLE
fix(runtime-host): recover settled scheduled task runs

### DIFF
--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -478,6 +478,81 @@ test('startup recovery replays one admitted safe-boundary continuation without a
   }
 });
 
+test('startup recovery closes a ScheduledTask Run after its pending fire was settled', async () => {
+  const validations: Array<'pending_fire_required' | 'run_recorded'> = [];
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) =>
+      backends.register('ai-sdk', (context) => new FakeBackend(context)),
+    assertScheduledTaskRecoveryAdmission: async (_admission, state) => {
+      validations.push(state);
+    },
+  });
+  const turnId = 'turn-scheduled-task-settled-fire';
+  const runId = 'run-scheduled-task-settled-fire';
+  const userMessageId = 'message-scheduled-task-settled-fire';
+  let recovery: RootTurnCoordinator | undefined;
+  try {
+    await fixture.coordinator.close();
+    const session = await fixture.stores.sessionStore.readHeaderSnapshot(fixture.sessionId);
+    const admittedAt = Date.now();
+    const admission = await fixture.stores.agentRunStore.admitRootTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+      proposedRunId: runId,
+      proposedUserMessageId: userMessageId,
+      execution: { kind: 'scheduled_task', scheduledTaskId: 'task-settled-fire' },
+      previousRootTurnId: null,
+      normalizedInput: { text: 'Continue the scheduled work.' },
+      sourceMessages: [],
+      admittedAt,
+    });
+    assert.equal(admission.kind, 'admitted');
+    await fixture.stores.sessionStore.appendMessage(fixture.sessionId, {
+      type: 'user',
+      id: userMessageId,
+      turnId,
+      ts: admittedAt,
+      text: 'Continue the scheduled work.',
+      origin: { kind: 'scheduled_task', scheduledTaskId: 'task-settled-fire' },
+    });
+    await fixture.stores.agentRunStore.createRun(
+      {
+        runId,
+        invocationId: runId,
+        sessionId: fixture.sessionId,
+        turnId,
+        status: 'created',
+        backendKind: 'fake',
+        llmConnectionId: session.llmConnectionId,
+        llmConnectionSlug: session.llmConnectionSlug,
+        modelId: session.model,
+        cwd: session.cwd,
+        scheduledTaskId: 'task-settled-fire',
+        permissionMode: session.permissionMode,
+        collaborationMode: session.collaborationMode,
+        createdAt: admittedAt,
+        updatedAt: admittedAt,
+      },
+      { durable: true },
+    );
+
+    recovery = fixture.createRecoveryCoordinator();
+    await recovery.prepareRecovery();
+    assert.deepEqual(validations, ['run_recorded']);
+    await fixture.manager.recoverInterruptedSessionsStrict(fixture.stores);
+    await recovery.recover();
+
+    const run = await fixture.stores.agentRunStore.readRun(fixture.sessionId, runId);
+    assert.equal(run.status, 'failed');
+    assert.equal(run.failureClass, 'app_restarted');
+    assert.deepEqual(recovery.readRootState(fixture.sessionId), { kind: 'idle' });
+  } finally {
+    await recovery?.close();
+    await fixture.messages.close();
+    await fixture.dispose();
+  }
+});
+
 test('a failed exact Capability retry does not poison the parked continuation binding', async () => {
   const capabilities = new HostClientCapabilityCoordinator({
     activation: new RuntimePolicyActivationGate(),
@@ -4961,6 +5036,10 @@ async function createFailureFixture(options: {
     text: string;
     skillIds: readonly string[];
   }): Promise<PreparedSkillInvocationMessage>;
+  assertScheduledTaskRecoveryAdmission?(
+    admission: RootTurnAdmission,
+    state: 'pending_fire_required' | 'run_recorded',
+  ): Promise<void>;
 }) {
   const base = await mkdtemp(join(tmpdir(), 'maka-root-turn-message-failure-'));
   const capability = await resolveStorageRoot({
@@ -5141,7 +5220,7 @@ async function createFailureFixture(options: {
       requestDrain,
       options.clientCapabilities,
       () => NO_EXECUTION_OBSERVER,
-      undefined,
+      options.assertScheduledTaskRecoveryAdmission,
       artifactAuthority,
       options.prepareSkillInvocation,
       options.agentGraphEpochs,

--- a/packages/runtime-host/src/__tests__/scheduled-task-coordinator-recovery.test.ts
+++ b/packages/runtime-host/src/__tests__/scheduled-task-coordinator-recovery.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { RootTurnAdmission } from '@maka/storage/execution-stores';
+import { openInteractiveScheduledTaskStoreForWrite } from '@maka/storage/scheduled-task-store';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import { HostScheduledTaskCoordinator } from '../server/scheduled-task-coordinator.js';
+
+test('ScheduledTask recovery distinguishes a settled fire from a newer pending fire', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-scheduled-task-recovery-'));
+  const capability = await resolveStorageRoot({ path: join(base, 'root'), kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) throw new Error('Unable to acquire the ScheduledTask recovery test root');
+  const store = await openInteractiveScheduledTaskStoreForWrite(owner.lease);
+  const coordinator = new HostScheduledTaskCoordinator({
+    store,
+    sessions: null as never,
+    runtime: null as never,
+    root: null as never,
+    runtimePolicy: null as never,
+    nativeEffects: null as never,
+    createSession: async () => undefined,
+    changes: { publish: () => undefined },
+    acquireResidency: () => ({ release: () => undefined }),
+    requestDrain: () => undefined,
+  });
+  try {
+    const task = await store.create(
+      {
+        title: 'Recurring recovery task',
+        intentBody: 'Continue the scheduled work.',
+        schedule: { kind: 'interval', everySeconds: 60 },
+        effect: {
+          kind: 'agent_run',
+          execution: {
+            cwd: '/workspace',
+            backend: 'ai-sdk',
+            llmConnectionSlug: 'default',
+            model: 'test-model',
+            permissionMode: 'ask',
+            collaborationMode: 'agent',
+            orchestrationMode: 'default',
+          },
+        },
+        createdBy: { kind: 'user' },
+      },
+      1_000,
+    );
+    const oldExecution = execution('old');
+    const oldClaim = await store.claimNow(task.id, 2_000);
+    await store.bindFireExecution(oldClaim.id, oldExecution);
+    await store.settleFire(oldClaim.id, {
+      at: 2_001,
+      outcome: 'ok',
+      message: 'settled before the AgentRun terminal fact',
+      sessionId: oldExecution.sessionId,
+      runId: oldExecution.runId,
+    });
+    const newExecution = execution('new');
+    const newClaim = await store.claimNow(task.id, 3_000);
+    await store.bindFireExecution(newClaim.id, newExecution);
+
+    await coordinator.prepareRecovery();
+    await coordinator.assertRecoveryAdmission(admission(task.id, oldExecution), 'run_recorded');
+    await coordinator.assertRecoveryAdmission(
+      admission(task.id, newExecution),
+      'pending_fire_required',
+    );
+    await assert.rejects(
+      () =>
+        coordinator.assertRecoveryAdmission(
+          admission(task.id, execution('missing')),
+          'pending_fire_required',
+        ),
+      /has no matching pending fire/,
+    );
+
+    await store.settleFire(newClaim.id, {
+      at: 3_001,
+      outcome: 'ok',
+      message: 'settled newer fire',
+      sessionId: newExecution.sessionId,
+      runId: newExecution.runId,
+    });
+    const conflictingExecution = { ...oldExecution, runId: 'run-conflicting' };
+    const conflictingClaim = await store.claimNow(task.id, 4_000);
+    await store.bindFireExecution(conflictingClaim.id, conflictingExecution);
+    await assert.rejects(
+      () => coordinator.assertRecoveryAdmission(admission(task.id, oldExecution), 'run_recorded'),
+      /has no matching pending fire/,
+    );
+  } finally {
+    await coordinator.close();
+    store.close();
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+function execution(suffix: string) {
+  return {
+    sessionId: `session-${suffix}`,
+    turnId: `turn-${suffix}`,
+    runId: `run-${suffix}`,
+    userMessageId: `message-${suffix}`,
+  };
+}
+
+function admission(
+  scheduledTaskId: string,
+  identity: ReturnType<typeof execution>,
+): RootTurnAdmission {
+  return {
+    schemaVersion: 1,
+    ...identity,
+    execution: { kind: 'scheduled_task', scheduledTaskId },
+    previousRootTurnId: null,
+    normalizedInput: { text: 'Continue the scheduled work.' },
+    sourceMessages: [],
+    admittedAt: 1_000,
+  };
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1092,7 +1092,8 @@ export async function createExecutionRuntimeHostComposition(
       context.requestDrain,
       clientCapabilities,
       () => requireGoal(goal),
-      (admission) => requireScheduledTasks(scheduledTasks).assertRecoveryAdmission(admission),
+      (admission, state) =>
+        requireScheduledTasks(scheduledTasks).assertRecoveryAdmission(admission, state),
       artifacts,
       async ({ sessionId, text, skillIds }) => {
         const header = await stores.sessionStore.readHeaderSnapshot(sessionId);

--- a/packages/runtime-host/src/server/hosted-execution-recovery.ts
+++ b/packages/runtime-host/src/server/hosted-execution-recovery.ts
@@ -42,7 +42,10 @@ export interface PrepareHostedExecutionRecoveryInput {
   readonly rootAdmissions: RootAdmissionOwner;
   readonly projection: HostedExecutionProjectionReader;
   readonly runtime: Pick<SessionManager, 'closePendingHostedAdmission'>;
-  readonly assertScheduledTaskAdmission?: (admission: RootTurnAdmission) => Promise<void>;
+  readonly assertScheduledTaskAdmission?: (
+    admission: RootTurnAdmission,
+    state: 'pending_fire_required' | 'run_recorded',
+  ) => Promise<void>;
 }
 
 /** Validates and repairs durable admission/message relationships before execution replay. */
@@ -83,7 +86,10 @@ export async function prepareHostedExecutionRecovery(
             'ScheduledTask recovery admission has no canonical authority validator',
           );
         }
-        await input.assertScheduledTaskAdmission(admission);
+        await input.assertScheduledTaskAdmission(
+          admission,
+          run === undefined ? 'pending_fire_required' : 'run_recorded',
+        );
       }
       if (!executionContract.allowsQueueSources && admission.sourceMessages.length !== 0) {
         throw new Error(

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -327,6 +327,7 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
     private readonly resolveExecutionObserver: () => HostedExecutionObserver,
     private readonly assertScheduledTaskRecoveryAdmission?: (
       admission: RootTurnAdmission,
+      state: 'pending_fire_required' | 'run_recorded',
     ) => Promise<void>,
     attachmentValidator?: HostTurnAttachmentValidator,
     prepareSkillInvocation?: HostSkillInvocationPreparer,

--- a/packages/runtime-host/src/server/scheduled-task-coordinator.ts
+++ b/packages/runtime-host/src/server/scheduled-task-coordinator.ts
@@ -165,15 +165,24 @@ export class HostScheduledTaskCoordinator implements ScheduledTaskToolAuthority 
     await this.#refreshResidency();
   }
 
-  async assertRecoveryAdmission(admission: RootTurnAdmission): Promise<void> {
+  async assertRecoveryAdmission(
+    admission: RootTurnAdmission,
+    state: 'pending_fire_required' | 'run_recorded',
+  ): Promise<void> {
     if (!this.#prepared) {
       throw new Error('ScheduledTask recovery admission was inspected before Store recovery');
     }
     if (admission.execution.kind !== 'scheduled_task') return;
     const scheduledTaskId = admission.execution.scheduledTaskId;
     const claims = await this.#store.listPendingFires();
-    const claim = claims.find((candidate) => candidate.task.id === scheduledTaskId);
+    const claim = claims.find(
+      (candidate) =>
+        candidate.task.id === scheduledTaskId &&
+        candidate.execution?.sessionId === admission.sessionId &&
+        candidate.execution.turnId === admission.turnId,
+    );
     const execution = claim?.execution;
+    if (!claim && state === 'run_recorded') return;
     if (
       !claim ||
       !execution ||


### PR DESCRIPTION
## Summary

- recover a non-terminal ScheduledTask Run when its pending fire was already settled
- ignore a newer fire for a different turn while rejecting conflicting identity for the same turn
- let existing Runtime recovery durably terminate the interrupted Run as `app_restarted`

Fixes #4133

## Verification

- `npm run build --workspace @maka/runtime-host`
- `npx biome check` on all changed files
- ScheduledTask coordinator recovery regression test
- Root-turn `app_restarted` recovery regression test
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the recovery fix, tests, and validation.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No