### PR TITLE
feat(runtime-host): expose peer Mesh transit controls

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-ssh-terminal.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-ssh-terminal.test.ts
@@ -712,6 +712,7 @@ test('sends a Mesh invitation only after the authenticated remote operator reque
         localPeerId: 'peer-b',
         available: true,
         transit: {
+          meshId: null,
           allowedMemberCount: 0,
           activeReservationCount: 0,
           activeCircuitCount: 0,
@@ -733,7 +734,6 @@ test('sends a Mesh invitation only after the authenticated remote operator reque
               { peerId: 'peer-b', state: 'local' },
             ],
             pendingInvitationCount: 0,
-            transitEnabled: false,
           },
         ],
       },

--- a/apps/desktop/src/main/__tests__/runtime-host-ssh-terminal.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-ssh-terminal.test.ts
@@ -711,6 +711,16 @@ test('sends a Mesh invitation only after the authenticated remote operator reque
       result: {
         localPeerId: 'peer-b',
         available: true,
+        transit: {
+          allowedMemberCount: 0,
+          activeReservationCount: 0,
+          activeCircuitCount: 0,
+          maxReservationCount: 32,
+          maxCircuitCount: 8,
+          maxCircuitsPerPeer: 2,
+          maxCircuitDurationSeconds: 7_200,
+          maxCircuitBytes: 256 * 1024 * 1024,
+        },
         meshes: [
           {
             meshId: 'mesh-id',
@@ -723,6 +733,7 @@ test('sends a Mesh invitation only after the authenticated remote operator reque
               { peerId: 'peer-b', state: 'local' },
             ],
             pendingInvitationCount: 0,
+            transitEnabled: false,
           },
         ],
       },

--- a/apps/desktop/src/main/runtime-host-peer-mesh-management.ts
+++ b/apps/desktop/src/main/runtime-host-peer-mesh-management.ts
@@ -85,8 +85,7 @@ export function createDesktopRuntimeHostPeerMeshManagement(input: {
         rootId: managed.profile.rootId,
         deploymentId: managed.deployment.deploymentId,
       },
-      ...(meshId ? { meshId } : {}),
-      ...(action === 'transit' && meshId === null ? { transitOff: true as const } : {}),
+      ...(meshId !== undefined ? { meshId } : {}),
       ...(peerId ? { peerId } : {}),
       ...(invitation ? { invitation: JSON.stringify(invitation) } : {}),
     });

--- a/apps/desktop/src/main/runtime-host-peer-mesh-management.ts
+++ b/apps/desktop/src/main/runtime-host-peer-mesh-management.ts
@@ -24,7 +24,7 @@ import {
   type PeerMeshInvitationResult,
   type PeerMeshQueryResult,
 } from '@maka/runtime-host/protocol';
-import { projectPeerMeshStatus } from '@maka/runtime-host/server';
+import { projectPeerMeshQuery } from '@maka/runtime-host/server';
 import type {
   DesktopRuntimeHostPeerMeshTarget,
 } from '../preload/bridge-contract.js';
@@ -52,7 +52,12 @@ export function createDesktopRuntimeHostPeerMeshManagement(input: {
   ): Promise<PeerMeshQueryResult | PeerMeshInvitationResult> => {
     const target = requireTarget(targetValue);
     const action = requireAction(actionValue);
-    const meshId = actionNeedsMesh(action) ? requireIdentifier(meshIdValue, 'Mesh ID') : undefined;
+    const meshId =
+      action === 'transit' && meshIdValue === null
+        ? null
+        : actionNeedsMesh(action)
+          ? requireIdentifier(meshIdValue, 'Mesh ID')
+          : undefined;
     const peerId = action === 'remove' ? requireIdentifier(peerIdValue, 'Peer ID') : undefined;
     const invitation = action === 'join' ? requireInvitation(invitationValue) : undefined;
     if (target.kind === 'desktop') {
@@ -81,6 +86,7 @@ export function createDesktopRuntimeHostPeerMeshManagement(input: {
         deploymentId: managed.deployment.deploymentId,
       },
       ...(meshId ? { meshId } : {}),
+      ...(action === 'transit' && meshId === null ? { transitOff: true as const } : {}),
       ...(peerId ? { peerId } : {}),
       ...(invitation ? { invitation: JSON.stringify(invitation) } : {}),
     });
@@ -101,7 +107,7 @@ export function createDesktopRuntimeHostPeerMeshManagement(input: {
 async function executeLocal(
   mesh: PeerMeshNode | undefined,
   action: PeerMeshAction,
-  meshId: string | undefined,
+  meshId: string | null | undefined,
   peerId: string | undefined,
   invitation: ReturnType<typeof decodePeerMeshInvitation> | undefined,
 ): Promise<PeerMeshQueryResult | PeerMeshInvitationResult> {
@@ -109,11 +115,7 @@ async function executeLocal(
     if (action === 'status') return { available: false, meshes: [] };
     throw new Error('This Desktop build does not include Direct peer support');
   }
-  const snapshot = (): PeerMeshQueryResult => ({
-    available: true,
-    localPeerId: mesh.localPeerId(),
-    meshes: mesh.status().map(projectPeerMeshStatus),
-  });
+  const snapshot = (): PeerMeshQueryResult => projectPeerMeshQuery(mesh);
   switch (action) {
     case 'status':
       return snapshot();
@@ -139,11 +141,14 @@ async function executeLocal(
     case 'reconcile':
       await mesh.reconcile();
       return snapshot();
+    case 'transit':
+      await mesh.setTransitMesh(meshId ?? null);
+      return snapshot();
   }
 }
 
-function requiredValue<T>(value: T | undefined, label: string): T {
-  if (value === undefined) throw new Error(`${label} is required`);
+function requiredValue<T>(value: T | null | undefined, label: string): NonNullable<T> {
+  if (value === undefined || value === null) throw new Error(`${label} is required`);
   return value;
 }
 
@@ -168,13 +173,23 @@ function requireTarget(value: unknown): DesktopRuntimeHostPeerMeshTarget {
 function requireAction(value: unknown): PeerMeshAction {
   if (
     value === 'status' || value === 'create' || value === 'invite' || value === 'join' ||
-    value === 'remove' || value === 'leave' || value === 'close' || value === 'reconcile'
+    value === 'remove' ||
+    value === 'leave' ||
+    value === 'close' ||
+    value === 'reconcile' ||
+    value === 'transit'
   ) return value;
   throw new Error('Peer Mesh action is invalid');
 }
 
 function actionNeedsMesh(action: PeerMeshAction): boolean {
-  return action === 'invite' || action === 'remove' || action === 'leave' || action === 'close';
+  return (
+    action === 'invite' ||
+    action === 'remove' ||
+    action === 'leave' ||
+    action === 'close' ||
+    action === 'transit'
+  );
 }
 
 function requireIdentifier(value: unknown, label: string): string {

--- a/apps/desktop/src/main/runtime-host-ssh-terminal.ts
+++ b/apps/desktop/src/main/runtime-host-ssh-terminal.ts
@@ -190,6 +190,7 @@ export interface DesktopRuntimeHostSshPeerMeshManagementInput {
   readonly expectedTarget: DesktopRuntimeHostSshManagementInput['expectedTarget'];
   readonly meshId?: string;
   readonly peerId?: string;
+  readonly transitOff?: true;
   readonly invitation?: string;
   readonly signal?: AbortSignal;
 }
@@ -1367,6 +1368,7 @@ function runtimeHostPeerMeshManagementRemoteCommand(
     '--framed',
     ...(input.meshId ? ['--mesh', input.meshId] : []),
     ...(input.peerId ? ['--peer', input.peerId] : []),
+    ...(input.transitOff ? ['--off'] : []),
     ...managedServiceTargetArgs(input.expectedTarget),
   ].map(quotePosix).join(' ');
   return `exec "\${SHELL:-/bin/sh}" -lic ${quotePosix(`exec ${command}`)}`;

--- a/apps/desktop/src/main/runtime-host-ssh-terminal.ts
+++ b/apps/desktop/src/main/runtime-host-ssh-terminal.ts
@@ -188,9 +188,8 @@ export interface DesktopRuntimeHostSshPeerMeshManagementInput {
   readonly operatorPath: string;
   readonly action: RuntimeHostPeerMeshManagementAction;
   readonly expectedTarget: DesktopRuntimeHostSshManagementInput['expectedTarget'];
-  readonly meshId?: string;
+  readonly meshId?: string | null;
   readonly peerId?: string;
-  readonly transitOff?: true;
   readonly invitation?: string;
   readonly signal?: AbortSignal;
 }
@@ -1366,9 +1365,12 @@ function runtimeHostPeerMeshManagementRemoteCommand(
     'mesh',
     input.action,
     '--framed',
-    ...(input.meshId ? ['--mesh', input.meshId] : []),
+    ...(typeof input.meshId === 'string'
+      ? ['--mesh', input.meshId]
+      : input.meshId === null
+        ? ['--off']
+        : []),
     ...(input.peerId ? ['--peer', input.peerId] : []),
-    ...(input.transitOff ? ['--off'] : []),
     ...managedServiceTargetArgs(input.expectedTarget),
   ].map(quotePosix).join(' ');
   return `exec "\${SHELL:-/bin/sh}" -lic ${quotePosix(`exec ${command}`)}`;

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -746,7 +746,11 @@ export interface MakaBridge {
     execute(
       target: DesktopRuntimeHostPeerMeshTarget,
       action: DesktopRuntimeHostPeerMeshAction,
-      input?: { readonly meshId?: string; readonly peerId?: string; readonly invitation?: string },
+      input?: {
+        readonly meshId?: string | null;
+        readonly peerId?: string;
+        readonly invitation?: string;
+      },
     ): Promise<DesktopRuntimeHostPeerMeshResult>;
   };
 

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1380,7 +1380,11 @@ const makaBridge = {
     execute(
       target: import('./bridge-contract.js').DesktopRuntimeHostPeerMeshTarget,
       action: import('./bridge-contract.js').DesktopRuntimeHostPeerMeshAction,
-      input: { readonly meshId?: string; readonly peerId?: string; readonly invitation?: string } = {},
+      input: {
+        readonly meshId?: string | null;
+        readonly peerId?: string;
+        readonly invitation?: string;
+      } = {},
     ) {
       return ipcRenderer.invoke(
         'runtime-host-peer-mesh:execute',

--- a/apps/desktop/src/renderer/settings/runtime-host-peer-mesh-dialog.tsx
+++ b/apps/desktop/src/renderer/settings/runtime-host-peer-mesh-dialog.tsx
@@ -28,12 +28,23 @@ import {
   Button,
   MoreMenu,
   redactSecrets,
+  Switch,
   Text,
   TextArea,
   useToast,
   useUiLocale,
 } from '@maka/ui';
-import { ArrowLeft, Copy, ICON_SIZE, KeyRound, Network, Plus, RefreshCcw } from '@maka/ui/icons';
+import {
+  ArrowLeft,
+  Copy,
+  HelpCircle,
+  ICON_SIZE,
+  KeyRound,
+  Network,
+  Plus,
+  RefreshCcw,
+  Workflow,
+} from '@maka/ui/icons';
 import type { DesktopRuntimeHostPeerMeshTarget } from '../../preload/bridge-contract.js';
 
 type PeerMeshDialogView =
@@ -158,6 +169,22 @@ export function RuntimeHostPeerMeshDialog(props: {
     }
   }
 
+  async function setTransit(meshId: string, enabled: boolean): Promise<void> {
+    setWorking(true);
+    setError(undefined);
+    try {
+      const result = await window.maka.runtimeHostPeerMesh.execute(props.target, 'transit', {
+        meshId: enabled ? meshId : null,
+      });
+      if (!isSnapshot(result)) throw new Error(copy.invalidResult);
+      setSnapshot(result);
+    } catch (failure) {
+      setError(peerMeshErrorMessage(failure, copy.unknownError));
+    } finally {
+      setWorking(false);
+    }
+  }
+
   async function copyInvitation(): Promise<void> {
     if (view.kind !== 'invitation') return;
     try {
@@ -209,6 +236,7 @@ export function RuntimeHostPeerMeshDialog(props: {
                   onJoin={() => setView({ kind: 'join' })}
                   onCreate={() => void run('create')}
                   onRefresh={() => void run('reconcile')}
+                  onSetTransit={(meshId, enabled) => void setTransit(meshId, enabled)}
                 />
               )}
             </div>
@@ -260,6 +288,7 @@ function Overview(props: {
   readonly onJoin: () => void;
   readonly onCreate: () => void;
   readonly onRefresh: () => void;
+  readonly onSetTransit: (meshId: string, enabled: boolean) => void;
 }) {
   const { snapshot, copy } = props;
   if (!snapshot) {
@@ -357,12 +386,14 @@ function Overview(props: {
               <MeshCard
                 key={mesh.meshId}
                 mesh={mesh}
+                transit={snapshot.transit}
                 copy={copy}
                 working={props.working}
                 onInvite={() => props.onInvite(mesh.meshId)}
                 onRemove={(peerId) => props.onRemove(mesh.meshId, peerId)}
                 onLeave={() => props.onLeave(mesh.meshId)}
                 onClose={() => props.onClose(mesh.meshId)}
+                onSetTransit={(enabled) => props.onSetTransit(mesh.meshId, enabled)}
               />
             ))}
           </div>
@@ -449,12 +480,14 @@ function InvitationView(props: {
 
 function MeshCard(props: {
   readonly mesh: PeerMeshProjection;
+  readonly transit: PeerMeshQueryResult['transit'];
   readonly copy: ReturnType<typeof peerMeshCopy>;
   readonly working: boolean;
   readonly onInvite: () => void;
   readonly onRemove: (peerId: string) => void;
   readonly onLeave: () => void;
   readonly onClose: () => void;
+  readonly onSetTransit: (enabled: boolean) => void;
 }) {
   const { mesh, copy } = props;
   return (
@@ -509,6 +542,56 @@ function MeshCard(props: {
         {copy.revision(mesh.revision)} · {copy.memberCount(mesh.members.length)}
         {mesh.pendingInvitationCount > 0 ? ` · ${copy.pending(mesh.pendingInvitationCount)}` : ''}
       </Text>
+      {!mesh.closed ? (
+        <div className="settingsPeerMeshTransit">
+          <div className="settingsPeerMeshTransitIdentity">
+            <span className="settingsPeerMeshTransitIcon" aria-hidden="true">
+              <Workflow size={ICON_SIZE.chrome} />
+            </span>
+            <div>
+              <div className="settingsPeerMeshTransitTitle">
+                <Text type="supporting" weight="semibold">
+                  {copy.transit}
+                </Text>
+                <span
+                  className="settingsPeerMeshTransitHelp"
+                  role="img"
+                  aria-label={copy.transitLimitsLabel}
+                  title={copy.transitLimits(props.transit)}
+                >
+                  <HelpCircle size={ICON_SIZE.meta} aria-hidden="true" />
+                </span>
+              </div>
+              <Text type="supporting" color="secondary">
+                {copy.transitHelp}
+              </Text>
+            </div>
+          </div>
+          <Switch
+            label={copy.transitToggle}
+            isLabelHidden
+            value={mesh.transitEnabled}
+            isDisabled={props.working}
+            onChange={props.onSetTransit}
+          />
+        </div>
+      ) : null}
+      {mesh.transitEnabled && props.transit ? (
+        <div className="settingsPeerMeshTransitMetrics" aria-label={copy.transitStatus}>
+          <TransitMetric
+            label={copy.allowedMembers}
+            value={String(props.transit.allowedMemberCount)}
+          />
+          <TransitMetric
+            label={copy.reservations}
+            value={`${props.transit.activeReservationCount}/${props.transit.maxReservationCount}`}
+          />
+          <TransitMetric
+            label={copy.circuits}
+            value={`${props.transit.activeCircuitCount}/${props.transit.maxCircuitCount}`}
+          />
+        </div>
+      ) : null}
       <div className="settingsPeerMeshMembersHeading">
         <Text type="supporting" color="secondary">
           {copy.members}
@@ -558,6 +641,19 @@ function MeshCard(props: {
         ))}
       </div>
     </section>
+  );
+}
+
+function TransitMetric(props: { readonly label: string; readonly value: string }) {
+  return (
+    <div>
+      <Text type="supporting" color="secondary">
+        {props.label}
+      </Text>
+      <Text type="body" weight="semibold">
+        {props.value}
+      </Text>
+    </div>
   );
 }
 
@@ -615,6 +711,18 @@ function peerMeshCopy(locale: string) {
         revision: (value: number) => `版本 ${value}`,
         memberCount: (value: number) => `${value} 个成员`,
         pending: (value: number) => `${value} 个待使用邀请`,
+        transit: '成员转发',
+        transitHelp: '允许此 Mesh 的成员通过本机建立连接；会使用本机带宽。',
+        transitToggle: '为此 Mesh 提供转发',
+        transitStatus: '成员转发状态',
+        transitLimitsLabel: '成员转发限制',
+        transitLimits: (value: PeerMeshQueryResult['transit']) =>
+          value
+            ? `固定上限：每个成员 ${value.maxCircuitsPerPeer} 条连接，每条最长 ${formatHours(value.maxCircuitDurationSeconds)}，最多 ${formatMebibytes(value.maxCircuitBytes)}。一次只能为一个 Mesh 开启。`
+            : '成员转发使用固定资源上限，一次只能为一个 Mesh 开启。',
+        allowedMembers: '允许成员',
+        reservations: 'Reservation',
+        circuits: '连接',
         routeState: {
           local: '本机',
           route_available: '路径可用',
@@ -669,6 +777,18 @@ function peerMeshCopy(locale: string) {
         revision: (value: number) => `Revision ${value}`,
         memberCount: (value: number) => `${value} members`,
         pending: (value: number) => `${value} pending invites`,
+        transit: 'Member transit',
+        transitHelp: 'Let members of this Mesh connect through this device using its bandwidth.',
+        transitToggle: 'Provide transit for this Mesh',
+        transitStatus: 'Member transit status',
+        transitLimitsLabel: 'Member transit limits',
+        transitLimits: (value: PeerMeshQueryResult['transit']) =>
+          value
+            ? `Fixed limits: ${value.maxCircuitsPerPeer} circuits per member, ${formatHours(value.maxCircuitDurationSeconds)} per circuit, and ${formatMebibytes(value.maxCircuitBytes)}. Only one Mesh can be served at a time.`
+            : 'Member transit uses fixed resource limits. Only one Mesh can be served at a time.',
+        allowedMembers: 'Allowed members',
+        reservations: 'Reservations',
+        circuits: 'Circuits',
         routeState: {
           local: 'Local',
           route_available: 'Route known',
@@ -702,4 +822,12 @@ function peerMeshCopy(locale: string) {
         meshActions: 'Mesh actions',
         memberActions: (peerId: string) => `Actions for ${peerId}`,
       };
+}
+
+function formatHours(seconds: number): string {
+  return `${seconds / 3_600}h`;
+}
+
+function formatMebibytes(bytes: number): string {
+  return `${bytes / (1024 * 1024)} MiB`;
 }

--- a/apps/desktop/src/renderer/settings/runtime-host-peer-mesh-dialog.tsx
+++ b/apps/desktop/src/renderer/settings/runtime-host-peer-mesh-dialog.tsx
@@ -490,6 +490,7 @@ function MeshCard(props: {
   readonly onSetTransit: (enabled: boolean) => void;
 }) {
   const { mesh, copy } = props;
+  const transitEnabled = props.transit?.meshId === mesh.meshId;
   return (
     <section className="settingsPeerMeshCard">
       <div className="settingsPeerMeshCardHeading">
@@ -570,13 +571,13 @@ function MeshCard(props: {
           <Switch
             label={copy.transitToggle}
             isLabelHidden
-            value={mesh.transitEnabled}
+            value={transitEnabled}
             isDisabled={props.working}
             onChange={props.onSetTransit}
           />
         </div>
       ) : null}
-      {mesh.transitEnabled && props.transit ? (
+      {transitEnabled && props.transit ? (
         <div className="settingsPeerMeshTransitMetrics" aria-label={copy.transitStatus}>
           <TransitMetric
             label={copy.allowedMembers}

--- a/apps/desktop/src/renderer/styles/settings/runtime-host.css
+++ b/apps/desktop/src/renderer/styles/settings/runtime-host.css
@@ -402,6 +402,67 @@
   flex: 0 0 auto;
 }
 
+.settingsPeerMeshTransit {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-control);
+  background: var(--foreground-2);
+}
+
+.settingsPeerMeshTransitIdentity,
+.settingsPeerMeshTransitTitle {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settingsPeerMeshTransitIdentity > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settingsPeerMeshTransitIcon {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: var(--radius-control);
+  color: var(--accent);
+  background: oklch(from var(--accent) l c h / 0.1);
+}
+
+.settingsPeerMeshTransitHelp {
+  display: inline-flex;
+  cursor: help;
+}
+
+.settingsPeerMeshTransitHelp svg {
+  color: var(--foreground-secondary);
+}
+
+.settingsPeerMeshTransitMetrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-2);
+}
+
+.settingsPeerMeshTransitMetrics > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-2) var(--space-3);
+  border: var(--border-width-hairline) solid var(--border-soft);
+  border-radius: var(--radius-control);
+}
+
 .settingsPeerMeshCardIdentity {
   min-width: 0;
 }
@@ -513,6 +574,10 @@
 
   .settingsPeerMeshToolbar > div:last-child {
     align-self: stretch;
+  }
+
+  .settingsPeerMeshTransitMetrics {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/native/runtime-host-peer/src/bindings.rs
+++ b/native/runtime-host-peer/src/bindings.rs
@@ -72,6 +72,11 @@ pub struct PeerTransitSnapshot {
     pub allowed_peer_count: u32,
     pub active_reservation_count: u32,
     pub active_circuit_count: u32,
+    pub max_reservation_count: u32,
+    pub max_circuit_count: u32,
+    pub max_circuits_per_peer: u32,
+    pub max_circuit_duration_seconds: u32,
+    pub max_circuit_bytes: u32,
 }
 
 #[napi(object)]
@@ -124,6 +129,11 @@ impl PeerEndpoint {
             allowed_peer_count: snapshot.allowed_peer_count as u32,
             active_reservation_count: snapshot.active_reservation_count as u32,
             active_circuit_count: snapshot.active_circuit_count as u32,
+            max_reservation_count: snapshot.max_reservation_count as u32,
+            max_circuit_count: snapshot.max_circuit_count as u32,
+            max_circuits_per_peer: snapshot.max_circuits_per_peer as u32,
+            max_circuit_duration_seconds: snapshot.max_circuit_duration_seconds as u32,
+            max_circuit_bytes: snapshot.max_circuit_bytes as u32,
         }
     }
 

--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -138,11 +138,32 @@ pub struct TransitPolicy {
     pub relays: Vec<Multiaddr>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct TransitSnapshot {
     pub allowed_peer_count: usize,
     pub active_reservation_count: usize,
     pub active_circuit_count: usize,
+    pub max_reservation_count: usize,
+    pub max_circuit_count: usize,
+    pub max_circuits_per_peer: usize,
+    pub max_circuit_duration_seconds: u64,
+    pub max_circuit_bytes: u64,
+}
+
+impl Default for TransitSnapshot {
+    fn default() -> Self {
+        Self {
+            allowed_peer_count: 0,
+            trusted_relay_count: 0,
+            active_reservation_count: 0,
+            active_circuit_count: 0,
+            max_reservation_count: MAX_TRANSIT_RESERVATIONS,
+            max_circuit_count: MAX_TRANSIT_CIRCUITS,
+            max_circuits_per_peer: MAX_TRANSIT_CIRCUITS_PER_PEER,
+            max_circuit_duration_seconds: MAX_TRANSIT_CIRCUIT_DURATION.as_secs(),
+            max_circuit_bytes: MAX_TRANSIT_CIRCUIT_BYTES,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1711,6 +1732,7 @@ fn publish_transit_snapshot(transit: &TransitRuntime) {
             allowed_peer_count,
             active_reservation_count: transit.reservations.len(),
             active_circuit_count: transit.circuits.values().sum(),
+            ..TransitSnapshot::default()
         };
     }
 }

--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -154,7 +154,6 @@ impl Default for TransitSnapshot {
     fn default() -> Self {
         Self {
             allowed_peer_count: 0,
-            trusted_relay_count: 0,
             active_reservation_count: 0,
             active_circuit_count: 0,
             max_reservation_count: MAX_TRANSIT_RESERVATIONS,

--- a/packages/cli/src/__tests__/runtime-host-operator-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-operator-command.test.ts
@@ -75,6 +75,15 @@ describe('Runtime Host operator commands', () => {
       parseRuntimeHostCommand(['service', 'mesh', 'join', '--invitation', 'secret', ...base]).kind,
       'error',
     );
+    assert.deepEqual(parseRuntimeHostCommand(['service', 'mesh', 'transit', '--off', ...base]), {
+      kind: 'runtime-host-service-peer-mesh',
+      action: 'transit',
+      json: false,
+      managedRootId: target.rootId,
+      operatorDeploymentId: target.deploymentId,
+      expectedTarget: target,
+      transitOff: true,
+    });
   });
 
   test('parses and emits the stable framed managed activation contract', async () => {
@@ -380,6 +389,7 @@ describe('Runtime Host operator commands', () => {
         'peer.mesh.query',
         'peer.mesh.reconcile',
         'peer.mesh.remove',
+        'peer.mesh.transit.set',
       ],
     );
   });

--- a/packages/cli/src/__tests__/runtime-host-operator-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-operator-command.test.ts
@@ -82,7 +82,7 @@ describe('Runtime Host operator commands', () => {
       managedRootId: target.rootId,
       operatorDeploymentId: target.deploymentId,
       expectedTarget: target,
-      transitOff: true,
+      meshId: null,
     });
   });
 

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -505,6 +505,7 @@ export async function runMakaCli(
         expectedTarget: command.expectedTarget,
         ...(command.meshId ? { meshId: command.meshId } : {}),
         ...(command.peerId ? { peerId: command.peerId } : {}),
+        ...(command.transitOff ? { transitOff: true } : {}),
       });
     }
     case 'runtime-host-service-update': {

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -503,9 +503,8 @@ export async function runMakaCli(
         operatorDeploymentId: command.operatorDeploymentId,
         cliPath: process.argv[1] ?? '',
         expectedTarget: command.expectedTarget,
-        ...(command.meshId ? { meshId: command.meshId } : {}),
+        ...(command.meshId !== undefined ? { meshId: command.meshId } : {}),
         ...(command.peerId ? { peerId: command.peerId } : {}),
-        ...(command.transitOff ? { transitOff: true } : {}),
       });
     }
     case 'runtime-host-service-update': {

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -1059,14 +1059,9 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
     );
   }
   const needsMesh =
-    action === 'invite' ||
-    action === 'remove' ||
-    action === 'leave' ||
-    action === 'close';
+    action === 'invite' || action === 'remove' || action === 'leave' || action === 'close';
   if (needsMesh && typeof meshId !== 'string') {
-    return error(
-      `runtime-host service mesh ${action} requires --mesh`,
-    );
+    return error(`runtime-host service mesh ${action} requires --mesh`);
   }
   if (!needsMesh && action !== 'transit' && typeof meshId === 'string') {
     return error('--mesh is only valid with mesh invite, remove, leave, close, or transit');

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -187,9 +187,8 @@ export type RuntimeHostCliCommand =
       managedRootId: string;
       operatorDeploymentId: string;
       expectedTarget: RuntimeHostManagedServiceTarget;
-      meshId?: string;
+      meshId?: string | null;
       peerId?: string;
-      transitOff?: true;
     }
   | {
       kind: 'runtime-host-service-check-update';
@@ -1029,9 +1028,8 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
         : 'runtime-host service mesh requires status, create, invite, join, remove, leave, close, reconcile, or transit',
     );
   }
-  let meshId: string | undefined;
+  let meshId: string | null | undefined;
   let peerId: string | undefined;
-  let transitOff = false;
   const options = parseManagedServiceOptions(argv.slice(1), {
     allowConfiguration: false,
     allowFramed: true,
@@ -1049,8 +1047,8 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
     },
     flagOptions: {
       '--off': () => {
-        if (transitOff) return error('Duplicate --off');
-        transitOff = true;
+        if (meshId !== undefined) return error('mesh transit accepts either --mesh or --off');
+        meshId = null;
       },
     },
   });
@@ -1064,14 +1062,14 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
     action === 'invite' ||
     action === 'remove' ||
     action === 'leave' ||
-    action === 'close' ||
-    (action === 'transit' && !transitOff);
-  if (needsMesh !== (meshId !== undefined)) {
+    action === 'close';
+  if (needsMesh && typeof meshId !== 'string') {
     return error(
-      needsMesh
-        ? `runtime-host service mesh ${action} requires --mesh`
-        : '--mesh is only valid with mesh invite, remove, leave, close, or transit',
+      `runtime-host service mesh ${action} requires --mesh`,
     );
+  }
+  if (!needsMesh && action !== 'transit' && typeof meshId === 'string') {
+    return error('--mesh is only valid with mesh invite, remove, leave, close, or transit');
   }
   if ((action === 'remove') !== (peerId !== undefined)) {
     return error(
@@ -1080,11 +1078,11 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
         : '--peer is only valid with mesh remove',
     );
   }
-  if (transitOff && action !== 'transit') {
+  if (meshId === null && action !== 'transit') {
     return error('--off is only valid with mesh transit');
   }
-  if (transitOff && meshId !== undefined) {
-    return error('mesh transit accepts either --mesh or --off, not both');
+  if (action === 'transit' && meshId === undefined) {
+    return error('runtime-host service mesh transit requires --mesh or --off');
   }
   return {
     kind: 'runtime-host-service-peer-mesh',
@@ -1094,9 +1092,8 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
     managedRootId: options.managedRootId,
     operatorDeploymentId: options.operatorDeploymentId,
     expectedTarget: options.expectedTarget,
-    ...(meshId ? { meshId } : {}),
+    ...(meshId !== undefined ? { meshId } : {}),
     ...(peerId ? { peerId } : {}),
-    ...(transitOff ? { transitOff: true as const } : {}),
   };
 }
 

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -172,7 +172,16 @@ export type RuntimeHostCliCommand =
     }
   | {
       kind: 'runtime-host-service-peer-mesh';
-      action: 'status' | 'create' | 'invite' | 'join' | 'remove' | 'leave' | 'close' | 'reconcile';
+      action:
+        | 'status'
+        | 'create'
+        | 'invite'
+        | 'join'
+        | 'remove'
+        | 'leave'
+        | 'close'
+        | 'reconcile'
+        | 'transit';
       json: boolean;
       framed?: true;
       managedRootId: string;
@@ -180,6 +189,7 @@ export type RuntimeHostCliCommand =
       expectedTarget: RuntimeHostManagedServiceTarget;
       meshId?: string;
       peerId?: string;
+      transitOff?: true;
     }
   | {
       kind: 'runtime-host-service-check-update';
@@ -1010,16 +1020,18 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
     action !== 'remove' &&
     action !== 'leave' &&
     action !== 'close' &&
-    action !== 'reconcile'
+    action !== 'reconcile' &&
+    action !== 'transit'
   ) {
     return error(
       action
         ? `Unexpected runtime-host service mesh command: ${action}`
-        : 'runtime-host service mesh requires status, create, invite, join, remove, leave, close, or reconcile',
+        : 'runtime-host service mesh requires status, create, invite, join, remove, leave, close, reconcile, or transit',
     );
   }
   let meshId: string | undefined;
   let peerId: string | undefined;
+  let transitOff = false;
   const options = parseManagedServiceOptions(argv.slice(1), {
     allowConfiguration: false,
     allowFramed: true,
@@ -1035,6 +1047,12 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
         peerId = value;
       },
     },
+    flagOptions: {
+      '--off': () => {
+        if (transitOff) return error('Duplicate --off');
+        transitOff = true;
+      },
+    },
   });
   if ('kind' in options) return options;
   if (!options.managedRootId || !options.operatorDeploymentId || !options.expectedTarget) {
@@ -1043,12 +1061,16 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
     );
   }
   const needsMesh =
-    action === 'invite' || action === 'remove' || action === 'leave' || action === 'close';
+    action === 'invite' ||
+    action === 'remove' ||
+    action === 'leave' ||
+    action === 'close' ||
+    (action === 'transit' && !transitOff);
   if (needsMesh !== (meshId !== undefined)) {
     return error(
       needsMesh
         ? `runtime-host service mesh ${action} requires --mesh`
-        : '--mesh is only valid with mesh invite, remove, leave, or close',
+        : '--mesh is only valid with mesh invite, remove, leave, close, or transit',
     );
   }
   if ((action === 'remove') !== (peerId !== undefined)) {
@@ -1057,6 +1079,12 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
         ? 'runtime-host service mesh remove requires --peer'
         : '--peer is only valid with mesh remove',
     );
+  }
+  if (transitOff && action !== 'transit') {
+    return error('--off is only valid with mesh transit');
+  }
+  if (transitOff && meshId !== undefined) {
+    return error('mesh transit accepts either --mesh or --off, not both');
   }
   return {
     kind: 'runtime-host-service-peer-mesh',
@@ -1068,6 +1096,7 @@ function parseServicePeerMeshCommand(argv: string[]): RuntimeHostCliCommand {
     expectedTarget: options.expectedTarget,
     ...(meshId ? { meshId } : {}),
     ...(peerId ? { peerId } : {}),
+    ...(transitOff ? { transitOff: true as const } : {}),
   };
 }
 

--- a/packages/cli/src/runtime-host-peer-mesh-management-command.ts
+++ b/packages/cli/src/runtime-host-peer-mesh-management-command.ts
@@ -59,9 +59,8 @@ export interface RuntimeHostPeerMeshManagementCliOptions {
   readonly operatorDeploymentId: string;
   readonly cliPath: string;
   readonly expectedTarget: RuntimeHostManagedServiceTarget;
-  readonly meshId?: string;
+  readonly meshId?: string | null;
   readonly peerId?: string;
-  readonly transitOff?: true;
 }
 
 interface RuntimeHostPeerMeshManagementCliDeps {
@@ -161,7 +160,7 @@ async function executePeerMeshAction(
         kind: 'result',
         action: 'invite',
         result: await request('peer.mesh.invite', {
-          meshId: requiredOption(options.meshId, 'Mesh ID'),
+          meshId: requiredMeshId(options.meshId),
         }),
       };
     case 'join':
@@ -177,7 +176,7 @@ async function executePeerMeshAction(
         kind: 'result',
         action: 'remove',
         result: await request('peer.mesh.remove', {
-          meshId: requiredOption(options.meshId, 'Mesh ID'),
+          meshId: requiredMeshId(options.meshId),
           peerId: requiredOption(options.peerId, 'Peer ID'),
         }),
       };
@@ -186,7 +185,7 @@ async function executePeerMeshAction(
         kind: 'result',
         action: 'leave',
         result: await request('peer.mesh.leave', {
-          meshId: requiredOption(options.meshId, 'Mesh ID'),
+          meshId: requiredMeshId(options.meshId),
         }),
       };
     case 'close':
@@ -194,7 +193,7 @@ async function executePeerMeshAction(
         kind: 'result',
         action: 'close',
         result: await request('peer.mesh.close', {
-          meshId: requiredOption(options.meshId, 'Mesh ID'),
+          meshId: requiredMeshId(options.meshId),
         }),
       };
     case 'reconcile':
@@ -208,7 +207,7 @@ async function executePeerMeshAction(
         kind: 'result',
         action: 'transit',
         result: await request('peer.mesh.transit.set', {
-          meshId: options.transitOff ? null : requiredOption(options.meshId, 'Mesh ID'),
+          meshId: requiredOption(options.meshId, 'Mesh ID'),
         }),
       };
   }
@@ -216,6 +215,11 @@ async function executePeerMeshAction(
 
 function requiredOption<T>(value: T | undefined, label: string): T {
   if (value === undefined) throw new Error(`${label} is required`);
+  return value;
+}
+
+function requiredMeshId(value: string | null | undefined): string {
+  if (typeof value !== 'string') throw new Error('Mesh ID is required');
   return value;
 }
 

--- a/packages/cli/src/runtime-host-peer-mesh-management-command.ts
+++ b/packages/cli/src/runtime-host-peer-mesh-management-command.ts
@@ -61,6 +61,7 @@ export interface RuntimeHostPeerMeshManagementCliOptions {
   readonly expectedTarget: RuntimeHostManagedServiceTarget;
   readonly meshId?: string;
   readonly peerId?: string;
+  readonly transitOff?: true;
 }
 
 interface RuntimeHostPeerMeshManagementCliDeps {
@@ -201,6 +202,14 @@ async function executePeerMeshAction(
         kind: 'result',
         action: 'reconcile',
         result: await request('peer.mesh.reconcile', {}),
+      };
+    case 'transit':
+      return {
+        kind: 'result',
+        action: 'transit',
+        result: await request('peer.mesh.transit.set', {
+          meshId: options.transitOff ? null : requiredOption(options.meshId, 'Mesh ID'),
+        }),
       };
   }
 }

--- a/packages/runtime-host/src/__tests__/peer-listener.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-listener.test.ts
@@ -131,7 +131,6 @@ function peerWith(streams: RuntimeHostPeerNativeStream[]): RuntimeHostPeerClient
     verifyIdentity: () => false,
     transitSnapshot: () => ({
       allowedPeerCount: 0,
-      trustedRelayCount: 0,
       activeReservationCount: 0,
       activeCircuitCount: 0,
       maxReservationCount: 32,

--- a/packages/runtime-host/src/__tests__/peer-listener.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-listener.test.ts
@@ -134,6 +134,11 @@ function peerWith(streams: RuntimeHostPeerNativeStream[]): RuntimeHostPeerClient
       trustedRelayCount: 0,
       activeReservationCount: 0,
       activeCircuitCount: 0,
+      maxReservationCount: 32,
+      maxCircuitCount: 8,
+      maxCircuitsPerPeer: 2,
+      maxCircuitDurationSeconds: 7_200,
+      maxCircuitBytes: 256 * 1024 * 1024,
     }),
     configureTransit: async () => undefined,
     connect: async () => {

--- a/packages/runtime-host/src/__tests__/peer-mesh.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-mesh.test.ts
@@ -255,7 +255,7 @@ test('reconciles one selected Mesh into signed transit routes and native policy'
     await authority.setTransitMesh(meshId);
     await authority.reconcile();
     await memberB.reconcile();
-    assert.equal(authority.status()[0]?.transitEnabled, true);
+    assert.equal(authority.transitMeshId(), meshId);
     assert.deepEqual(authorityPeer.transitPolicy.allowedPeerIds, ['peer-b', 'peer-c', 'peer-d']);
     assert.deepEqual(memberBPeer.transitPolicy.relayCandidates, [
       { peerId: 'peer-a', addresses: ['/memory/peer-a/p2p/peer-a'] },
@@ -287,6 +287,7 @@ test('reconciles one selected Mesh into signed transit routes and native policy'
 
     await authority.closeMesh(meshId);
     assert.deepEqual(authority.status(), []);
+    assert.equal(authority.transitMeshId(), null);
     assert.deepEqual(authorityPeer.transitPolicy.allowedPeerIds, []);
   } finally {
     await Promise.allSettled([

--- a/packages/runtime-host/src/__tests__/peer-mesh.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-mesh.test.ts
@@ -511,6 +511,11 @@ class MemoryPeerClient implements PeerMeshTransport {
       allowedPeerCount: this.transitPolicy.allowedPeerIds.length,
       activeReservationCount: 0,
       activeCircuitCount: 0,
+      maxReservationCount: 32,
+      maxCircuitCount: 8,
+      maxCircuitsPerPeer: 2,
+      maxCircuitDurationSeconds: 7_200,
+      maxCircuitBytes: 256 * 1024 * 1024,
     };
   }
 

--- a/packages/runtime-host/src/__tests__/peer-native.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-native.test.ts
@@ -68,7 +68,7 @@ module.exports = {
       peerId: 'client',
       listenAddresses: [],
       activeCoordinationRelays: [],
-      transitSnapshot: { allowedPeerCount: 0, activeReservationCount: 0, activeCircuitCount: 0 },
+      transitSnapshot: { allowedPeerCount: 0, activeReservationCount: 0, activeCircuitCount: 0, maxReservationCount: 32, maxCircuitCount: 8, maxCircuitsPerPeer: 2, maxCircuitDurationSeconds: 7_200, maxCircuitBytes: 256 * 1024 * 1024 },
       connect: ({ requestId, peerId, routeHints, coordinationRelays, transitRelayPeerIds }) => {
         stats.requests.push({ requestId, peerId, routeHints, coordinationRelays, transitRelayPeerIds });
         if (peerId === 'ready') return Promise.resolve(stream);
@@ -214,7 +214,7 @@ module.exports = {
     peerId: 'peer',
     listenAddresses: [],
     activeCoordinationRelays: [],
-    transitSnapshot: { allowedPeerCount: 0, activeReservationCount: 0, activeCircuitCount: 0 },
+    transitSnapshot: { allowedPeerCount: 0, activeReservationCount: 0, activeCircuitCount: 0, maxReservationCount: 32, maxCircuitCount: 8, maxCircuitsPerPeer: 2, maxCircuitDurationSeconds: 7_200, maxCircuitBytes: 256 * 1024 * 1024 },
     connect: async () => stream,
     connectMeshControl: async () => stream,
     configureTransit: async () => {},

--- a/packages/runtime-host/src/operator/peer-mesh-management-frame.ts
+++ b/packages/runtime-host/src/operator/peer-mesh-management-frame.ts
@@ -38,6 +38,7 @@ const ACTION_SCHEMA = z.enum([
   'leave',
   'close',
   'reconcile',
+  'transit',
 ]);
 const FRAME_SCHEMA = z.union([
   z.object({ kind: z.literal('input'), action: z.literal('join') }).strict(),
@@ -64,12 +65,21 @@ export type RuntimeHostPeerMeshManagementAction =
   | 'remove'
   | 'leave'
   | 'close'
-  | 'reconcile';
+  | 'reconcile'
+  | 'transit';
 export type RuntimeHostPeerMeshManagementFrame =
   | { readonly kind: 'input'; readonly action: 'join' }
   | {
       readonly kind: 'result';
-      readonly action: 'status' | 'create' | 'join' | 'remove' | 'leave' | 'close' | 'reconcile';
+      readonly action:
+        | 'status'
+        | 'create'
+        | 'join'
+        | 'remove'
+        | 'leave'
+        | 'close'
+        | 'reconcile'
+        | 'transit';
       readonly result: PeerMeshQueryResult;
     }
   | {
@@ -127,6 +137,12 @@ function decodeFrame(value: unknown): RuntimeHostPeerMeshManagementFrame {
       return {
         kind: 'result',
         action: 'reconcile',
+        result: decodePeerMeshQueryResult(frame.result),
+      };
+    case 'transit':
+      return {
+        kind: 'result',
+        action: 'transit',
         result: decodePeerMeshQueryResult(frame.result),
       };
     case 'invite':

--- a/packages/runtime-host/src/peer-mesh/node.ts
+++ b/packages/runtime-host/src/peer-mesh/node.ts
@@ -135,6 +135,7 @@ export interface PeerMeshNode {
   leave(meshId: string, signal?: AbortSignal): Promise<void>;
   closeMesh(meshId: string): Promise<PeerMeshStatus>;
   setTransitMesh(meshId: string | null): Promise<void>;
+  transitMeshId(): string | null;
   transitSnapshot(): RuntimeHostPeerTransitSnapshot;
   resolveRoutes(peerId: string):
     | {
@@ -154,7 +155,6 @@ export interface PeerMeshStatus {
   readonly roster: SignedPeerMeshRosterV1;
   readonly pendingInvitationCount: number;
   readonly memberRoutes: readonly PeerMeshMemberRouteStatus[];
-  readonly transitEnabled: boolean;
 }
 
 export interface PeerMeshMemberRouteStatus {
@@ -299,7 +299,6 @@ class PeerMeshNodeImpl implements PeerMeshNode {
         findMesh(stored.meshes, state.roster.roster.meshId)!,
         identity,
         stored.routes,
-        stored.transitMeshId,
         now,
       );
     });
@@ -449,7 +448,6 @@ class PeerMeshNodeImpl implements PeerMeshNode {
           findMesh(stored.meshes, invitation.meshId)!,
           identity,
           stored.routes,
-          stored.transitMeshId,
         );
       } finally {
         await stream.close().catch(() => undefined);
@@ -546,6 +544,11 @@ class PeerMeshNodeImpl implements PeerMeshNode {
   transitSnapshot(): RuntimeHostPeerTransitSnapshot {
     this.#assertOpen();
     return this.#peer.transitSnapshot();
+  }
+
+  transitMeshId(): string | null {
+    this.#assertOpen();
+    return this.#store.read().transitMeshId;
   }
 
   resolveRoutes(peerId: string) {
@@ -960,7 +963,6 @@ class PeerMeshNodeImpl implements PeerMeshNode {
       findMesh(stored.meshes, meshId)!,
       this.#peer.identity(),
       stored.routes,
-      stored.transitMeshId,
     );
   }
 
@@ -1336,7 +1338,6 @@ function peerMeshStatus(
   state: PeerMeshStateV1,
   identity: ReturnType<PeerMeshTransport['identity']>,
   routes: readonly SignedPeerMeshRouteRecordV1[] = [],
-  transitMeshId: string | null = null,
   now = Date.now(),
 ): PeerMeshStatus {
   return Object.freeze({
@@ -1349,7 +1350,6 @@ function peerMeshStatus(
             (invitation) => invitation.status === 'pending' && invitation.expiresAt > now,
           ).length
         : 0,
-    transitEnabled: state.roster.roster.meshId === transitMeshId,
     memberRoutes: Object.freeze(
       state.roster.roster.members.map((peerId) => {
         if (peerId === identity.peerId) return Object.freeze({ peerId, state: 'local' as const });

--- a/packages/runtime-host/src/peer-mesh/node.ts
+++ b/packages/runtime-host/src/peer-mesh/node.ts
@@ -444,11 +444,7 @@ class PeerMeshNodeImpl implements PeerMeshNode {
         await this.#refreshLocalRoute();
         await this.#reconcileTransit();
         const stored = this.#store.read();
-        return peerMeshStatus(
-          findMesh(stored.meshes, invitation.meshId)!,
-          identity,
-          stored.routes,
-        );
+        return peerMeshStatus(findMesh(stored.meshes, invitation.meshId)!, identity, stored.routes);
       } finally {
         await stream.close().catch(() => undefined);
       }
@@ -959,11 +955,7 @@ class PeerMeshNodeImpl implements PeerMeshNode {
     await this.#refreshLocalRoute();
     await this.#reconcileTransit();
     const stored = this.#store.read();
-    return peerMeshStatus(
-      findMesh(stored.meshes, meshId)!,
-      this.#peer.identity(),
-      stored.routes,
-    );
+    return peerMeshStatus(findMesh(stored.meshes, meshId)!, this.#peer.identity(), stored.routes);
   }
 
   #acceptIncoming(stream: RuntimeHostPeerNativeStream): void {

--- a/packages/runtime-host/src/peer-mesh/node.ts
+++ b/packages/runtime-host/src/peer-mesh/node.ts
@@ -248,9 +248,7 @@ class PeerMeshNodeImpl implements PeerMeshNode {
     return Object.freeze(
       stored.meshes
         .filter((state) => isActiveMembership(state, identity.peerId))
-        .map((state) =>
-          peerMeshStatus(state, identity, stored.routes, stored.transitMeshId, this.#now()),
-        ),
+        .map((state) => peerMeshStatus(state, identity, stored.routes, this.#now())),
     );
   }
 

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -94,7 +94,8 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 65 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 66 as const;
+// 66: Peer Mesh management exposes transit selection and runtime metrics.
 // 65: live `tool_start` frames may carry optional `intent` / `argsPreview`
 // keys. Older Clients decode the event with a strict allowed-key list and tear
 // the connection down on unknown keys, so the pair must be refused up front.

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -95,7 +95,7 @@ export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
 export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 66 as const;
-// 66: Peer Mesh management exposes transit selection and runtime metrics.
+// 66: Peer Mesh queries expose one canonical transit selection and runtime metrics.
 // 65: live `tool_start` frames may carry optional `intent` / `argsPreview`
 // keys. Older Clients decode the event with a strict allowed-key list and tear
 // the connection down on unknown keys, so the pair must be refused up front.

--- a/packages/runtime-host/src/protocol/peer-mesh.ts
+++ b/packages/runtime-host/src/protocol/peer-mesh.ts
@@ -54,6 +54,7 @@ export interface PeerMeshProjection {
   readonly closed: boolean;
   readonly members: readonly PeerMeshMemberProjection[];
   readonly pendingInvitationCount: number;
+  readonly transitEnabled: boolean;
 }
 
 export interface PeerMeshMemberProjection {
@@ -66,6 +67,18 @@ export interface PeerMeshQueryResult {
   readonly available: boolean;
   readonly localPeerId?: string;
   readonly meshes: readonly PeerMeshProjection[];
+  readonly transit?: PeerMeshTransitProjection;
+}
+
+export interface PeerMeshTransitProjection {
+  readonly allowedMemberCount: number;
+  readonly activeReservationCount: number;
+  readonly activeCircuitCount: number;
+  readonly maxReservationCount: number;
+  readonly maxCircuitCount: number;
+  readonly maxCircuitsPerPeer: number;
+  readonly maxCircuitDurationSeconds: number;
+  readonly maxCircuitBytes: number;
 }
 
 export interface PeerMeshTargetInput {
@@ -80,6 +93,10 @@ export interface PeerMeshJoinInput {
 
 export interface PeerMeshRemoveInput extends PeerMeshTargetInput {
   readonly peerId: string;
+}
+
+export interface PeerMeshTransitSetInput {
+  readonly meshId: string | null;
 }
 
 export interface PeerMeshInvitationResult {
@@ -150,6 +167,13 @@ export const PEER_MESH_OPERATION_SPECS = {
     availability: 'ready',
     errors: MUTATION_ERRORS,
     decodeInput: decodeEmptyInput,
+    decodeOutput: decodePeerMeshQueryResult,
+  }),
+  'peer.mesh.transit.set': defineOperation({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodePeerMeshTransitSetInput,
     decodeOutput: decodePeerMeshQueryResult,
   }),
 } as const;
@@ -236,6 +260,16 @@ function decodePeerMeshRemoveInput(value: unknown): PeerMeshRemoveInput {
   };
 }
 
+function decodePeerMeshTransitSetInput(value: unknown): PeerMeshTransitSetInput {
+  const record = requireExactRecord(value, 'Peer Mesh transit input', ['meshId']);
+  return {
+    meshId:
+      record.meshId === null
+        ? null
+        : requireString(record.meshId, 'Peer Mesh meshId', MESH_ID_MAX_BYTES),
+  };
+}
+
 export function decodePeerMeshQueryResult(value: unknown): PeerMeshQueryResult {
   const record = requireRecord(value, 'Peer Mesh query result');
   assertExactKeys(
@@ -243,7 +277,7 @@ export function decodePeerMeshQueryResult(value: unknown): PeerMeshQueryResult {
     'Peer Mesh query result',
     record.localPeerId === undefined
       ? ['available', 'meshes']
-      : ['available', 'localPeerId', 'meshes'],
+      : ['available', 'localPeerId', 'meshes', 'transit'],
   );
   if (
     typeof record.available !== 'boolean' ||
@@ -262,6 +296,7 @@ export function decodePeerMeshQueryResult(value: unknown): PeerMeshQueryResult {
       ? {}
       : {
           localPeerId: requireString(localPeerId, 'Peer Mesh localPeerId', PEER_ID_MAX_BYTES),
+          transit: decodePeerMeshTransitProjection(record.transit),
         }),
     meshes: Object.freeze(record.meshes.map(decodePeerMeshProjection)),
   };
@@ -276,10 +311,12 @@ export function decodePeerMeshProjection(value: unknown): PeerMeshProjection {
     'closed',
     'members',
     'pendingInvitationCount',
+    'transitEnabled',
   ]);
   if (
     (record.role !== 'authority' && record.role !== 'member') ||
     typeof record.closed !== 'boolean' ||
+    typeof record.transitEnabled !== 'boolean' ||
     !Array.isArray(record.members) ||
     record.members.length > PEER_MESH_MAX_MEMBERS
   ) {
@@ -304,6 +341,33 @@ export function decodePeerMeshProjection(value: unknown): PeerMeshProjection {
       record.pendingInvitationCount,
       'Peer Mesh pendingInvitationCount',
     ),
+    transitEnabled: record.transitEnabled,
+  };
+}
+
+function decodePeerMeshTransitProjection(value: unknown): PeerMeshTransitProjection {
+  const record = requireExactRecord(value, 'Peer Mesh transit projection', [
+    'allowedMemberCount',
+    'activeReservationCount',
+    'activeCircuitCount',
+    'maxReservationCount',
+    'maxCircuitCount',
+    'maxCircuitsPerPeer',
+    'maxCircuitDurationSeconds',
+    'maxCircuitBytes',
+  ]);
+  return {
+    allowedMemberCount: requireCount(record.allowedMemberCount, 'allowedMemberCount'),
+    activeReservationCount: requireCount(record.activeReservationCount, 'activeReservationCount'),
+    activeCircuitCount: requireCount(record.activeCircuitCount, 'activeCircuitCount'),
+    maxReservationCount: requireCount(record.maxReservationCount, 'maxReservationCount'),
+    maxCircuitCount: requireCount(record.maxCircuitCount, 'maxCircuitCount'),
+    maxCircuitsPerPeer: requireCount(record.maxCircuitsPerPeer, 'maxCircuitsPerPeer'),
+    maxCircuitDurationSeconds: requireCount(
+      record.maxCircuitDurationSeconds,
+      'maxCircuitDurationSeconds',
+    ),
+    maxCircuitBytes: requireCount(record.maxCircuitBytes, 'maxCircuitBytes'),
   };
 }
 

--- a/packages/runtime-host/src/protocol/peer-mesh.ts
+++ b/packages/runtime-host/src/protocol/peer-mesh.ts
@@ -54,7 +54,6 @@ export interface PeerMeshProjection {
   readonly closed: boolean;
   readonly members: readonly PeerMeshMemberProjection[];
   readonly pendingInvitationCount: number;
-  readonly transitEnabled: boolean;
 }
 
 export interface PeerMeshMemberProjection {
@@ -71,6 +70,7 @@ export interface PeerMeshQueryResult {
 }
 
 export interface PeerMeshTransitProjection {
+  readonly meshId: string | null;
   readonly allowedMemberCount: number;
   readonly activeReservationCount: number;
   readonly activeCircuitCount: number;
@@ -311,12 +311,10 @@ export function decodePeerMeshProjection(value: unknown): PeerMeshProjection {
     'closed',
     'members',
     'pendingInvitationCount',
-    'transitEnabled',
   ]);
   if (
     (record.role !== 'authority' && record.role !== 'member') ||
     typeof record.closed !== 'boolean' ||
-    typeof record.transitEnabled !== 'boolean' ||
     !Array.isArray(record.members) ||
     record.members.length > PEER_MESH_MAX_MEMBERS
   ) {
@@ -341,12 +339,12 @@ export function decodePeerMeshProjection(value: unknown): PeerMeshProjection {
       record.pendingInvitationCount,
       'Peer Mesh pendingInvitationCount',
     ),
-    transitEnabled: record.transitEnabled,
   };
 }
 
 function decodePeerMeshTransitProjection(value: unknown): PeerMeshTransitProjection {
   const record = requireExactRecord(value, 'Peer Mesh transit projection', [
+    'meshId',
     'allowedMemberCount',
     'activeReservationCount',
     'activeCircuitCount',
@@ -357,6 +355,10 @@ function decodePeerMeshTransitProjection(value: unknown): PeerMeshTransitProject
     'maxCircuitBytes',
   ]);
   return {
+    meshId:
+      record.meshId === null
+        ? null
+        : requireString(record.meshId, 'Peer Mesh transit meshId', MESH_ID_MAX_BYTES),
     allowedMemberCount: requireCount(record.allowedMemberCount, 'allowedMemberCount'),
     activeReservationCount: requireCount(record.activeReservationCount, 'activeReservationCount'),
     activeCircuitCount: requireCount(record.activeCircuitCount, 'activeCircuitCount'),

--- a/packages/runtime-host/src/server/index.ts
+++ b/packages/runtime-host/src/server/index.ts
@@ -27,6 +27,7 @@ export { startExecutionRuntimeHostService } from './execution-service.js';
 export { runRuntimeHostProcessLifecycle } from './process-lifecycle.js';
 export {
   createPeerMeshOperationHandlers,
+  projectPeerMeshQuery,
   projectPeerMeshStatus,
 } from './peer-mesh-authority.js';
 export { installRuntimeHostLogCapture } from '../process-diagnostics.js';

--- a/packages/runtime-host/src/server/peer-mesh-authority.ts
+++ b/packages/runtime-host/src/server/peer-mesh-authority.ts
@@ -157,7 +157,6 @@ export function projectPeerMeshStatus(status: PeerMeshStatus): PeerMeshProjectio
     closed: status.roster.roster.closed,
     members: Object.freeze(status.memberRoutes.map((member) => Object.freeze({ ...member }))),
     pendingInvitationCount: status.pendingInvitationCount,
-    transitEnabled: status.transitEnabled,
   });
 }
 
@@ -167,12 +166,16 @@ export function projectPeerMeshQuery(mesh: PeerMeshNode | undefined): PeerMeshQu
     available: true,
     localPeerId: mesh.localPeerId(),
     meshes: Object.freeze(mesh.status().map(projectPeerMeshStatus)),
-    transit: projectTransitSnapshot(mesh.transitSnapshot()),
+    transit: projectTransitSnapshot(mesh.transitMeshId(), mesh.transitSnapshot()),
   });
 }
 
-function projectTransitSnapshot(snapshot: ReturnType<PeerMeshNode['transitSnapshot']>) {
+function projectTransitSnapshot(
+  meshId: string | null,
+  snapshot: ReturnType<PeerMeshNode['transitSnapshot']>,
+) {
   return Object.freeze({
+    meshId,
     allowedMemberCount: snapshot.allowedPeerCount,
     activeReservationCount: snapshot.activeReservationCount,
     activeCircuitCount: snapshot.activeCircuitCount,

--- a/packages/runtime-host/src/server/peer-mesh-authority.ts
+++ b/packages/runtime-host/src/server/peer-mesh-authority.ts
@@ -33,20 +33,14 @@ export type PeerMeshOperationHandlers = Pick<
   | 'peer.mesh.leave'
   | 'peer.mesh.close'
   | 'peer.mesh.reconcile'
+  | 'peer.mesh.transit.set'
 >;
 
 export function createPeerMeshOperationHandlers(
   mesh: PeerMeshNode | undefined,
   options: { readonly requestDrain?: () => void } = {},
 ): PeerMeshOperationHandlers {
-  const query = (): PeerMeshQueryResult =>
-    mesh
-      ? {
-          available: true,
-          localPeerId: mesh.localPeerId(),
-          meshes: mesh.status().map(projectPeerMeshStatus),
-        }
-      : { available: false, meshes: [] };
+  const query = (): PeerMeshQueryResult => projectPeerMeshQuery(mesh);
   const unavailable = <K extends keyof PeerMeshOperationHandlers>(): OperationOutcome<K> =>
     ({
       ok: false,
@@ -144,6 +138,13 @@ export function createPeerMeshOperationHandlers(
         return { ok: true, result: query() };
       });
     },
+    'peer.mesh.transit.set': async (input) => {
+      if (!mesh) return unavailable();
+      return mutate(async () => {
+        await mesh.setTransitMesh(input.meshId);
+        return { ok: true, result: query() };
+      });
+    },
   };
 }
 
@@ -156,5 +157,29 @@ export function projectPeerMeshStatus(status: PeerMeshStatus): PeerMeshProjectio
     closed: status.roster.roster.closed,
     members: Object.freeze(status.memberRoutes.map((member) => Object.freeze({ ...member }))),
     pendingInvitationCount: status.pendingInvitationCount,
+    transitEnabled: status.transitEnabled,
+  });
+}
+
+export function projectPeerMeshQuery(mesh: PeerMeshNode | undefined): PeerMeshQueryResult {
+  if (!mesh) return { available: false, meshes: [] };
+  return Object.freeze({
+    available: true,
+    localPeerId: mesh.localPeerId(),
+    meshes: Object.freeze(mesh.status().map(projectPeerMeshStatus)),
+    transit: projectTransitSnapshot(mesh.transitSnapshot()),
+  });
+}
+
+function projectTransitSnapshot(snapshot: ReturnType<PeerMeshNode['transitSnapshot']>) {
+  return Object.freeze({
+    allowedMemberCount: snapshot.allowedPeerCount,
+    activeReservationCount: snapshot.activeReservationCount,
+    activeCircuitCount: snapshot.activeCircuitCount,
+    maxReservationCount: snapshot.maxReservationCount,
+    maxCircuitCount: snapshot.maxCircuitCount,
+    maxCircuitsPerPeer: snapshot.maxCircuitsPerPeer,
+    maxCircuitDurationSeconds: snapshot.maxCircuitDurationSeconds,
+    maxCircuitBytes: snapshot.maxCircuitBytes,
   });
 }

--- a/packages/runtime-host/src/transport/peer-native.ts
+++ b/packages/runtime-host/src/transport/peer-native.ts
@@ -95,6 +95,11 @@ export interface RuntimeHostPeerTransitSnapshot {
   readonly allowedPeerCount: number;
   readonly activeReservationCount: number;
   readonly activeCircuitCount: number;
+  readonly maxReservationCount: number;
+  readonly maxCircuitCount: number;
+  readonly maxCircuitsPerPeer: number;
+  readonly maxCircuitDurationSeconds: number;
+  readonly maxCircuitBytes: number;
 }
 
 export interface RuntimeHostPeerTransitRelayCandidate {
@@ -498,7 +503,17 @@ function isPeerTransitSnapshot(value: unknown): value is RuntimeHostPeerTransitS
     'activeReservationCount' in value &&
     isCount(value.activeReservationCount) &&
     'activeCircuitCount' in value &&
-    isCount(value.activeCircuitCount)
+    isCount(value.activeCircuitCount) &&
+    'maxReservationCount' in value &&
+    isCount(value.maxReservationCount) &&
+    'maxCircuitCount' in value &&
+    isCount(value.maxCircuitCount) &&
+    'maxCircuitsPerPeer' in value &&
+    isCount(value.maxCircuitsPerPeer) &&
+    'maxCircuitDurationSeconds' in value &&
+    isCount(value.maxCircuitDurationSeconds) &&
+    'maxCircuitBytes' in value &&
+    isCount(value.maxCircuitBytes)
   );
 }
 


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Expose the Host-owned Peer Mesh transit switch through the CLI and Desktop, with bounded live reservation/circuit status and fixed resource limits sourced from the native endpoint.

Refs #3842

## Verification

- Runtime Host, CLI, and Desktop typechecks passed
- 17 focused Runtime Host tests, 6 CLI operator tests, and 23 Desktop management tests passed
- Rust tests (10) and Clippy passed
- Astryx inventory and ASF header checks passed
- Real Desktop flow verified: create Mesh, enable transit, reload, and observe the persisted state

Before:

![](https://github.com/apache/maka/blob/806308c6bf37467c02085ee38070e44e72998c48/pr4147-before.png?raw=true)

After:

![](https://github.com/apache/maka/blob/806308c6bf37467c02085ee38070e44e72998c48/pr4147-after.png?raw=true)

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented and verified the change under the contributor's direction

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 摘要

将 Runtime Host 所有的 Peer Mesh 成员转发开关接入 CLI 和 Desktop，并显示由 native endpoint 提供的有界 reservation/circuit 状态及固定资源上限

关联 #3842

## 验证

- Runtime Host、CLI、Desktop typecheck 通过
- 17 个 Runtime Host 聚焦测试、6 个 CLI operator 测试、23 个 Desktop 管理测试通过
- Rust 10 个测试及 Clippy 通过
- Astryx inventory 与 ASF header 检查通过
- 已在真实 Desktop 中验证创建 Mesh、开启转发、刷新并恢复持久状态的完整流程

变更前：

![](https://github.com/apache/maka/blob/806308c6bf37467c02085ee38070e44e72998c48/pr4147-before.png?raw=true)

变更后：

![](https://github.com/apache/maka/blob/806308c6bf37467c02085ee38070e44e72998c48/pr4147-after.png?raw=true)

## AI 使用

- [ ] 没有生成式工具做出实质贡献
- [x] 生成式工具做出实质贡献

工具与范围：OpenAI Codex 在贡献者指导下实现并验证了本次变更

## 检查清单

- [x] 测试覆盖本次变更，且缺少变更时会失败
- [x] lint、格式化、typecheck 与受影响测试均在本地通过

本 PR 是否改变行为？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
