### PR TITLE
fix(desktop): align MCP editor choice icons with radio and label

### DIFF
--- a/apps/desktop/src/renderer/styles/module-pages/mcp.css
+++ b/apps/desktop/src/renderer/styles/module-pages/mcp.css
@@ -122,6 +122,11 @@
 
 .maka-mcp-choice-icon {
   margin-inline-start: var(--space-1);
+  /* The icon shares Item's startContent flex slot with the 24px radio circle.
+     That slot defaults to align-items: stretch, which top-aligns a definite-height
+     child, leaving the 14px icon riding above the radio dot and the centered label.
+     Center it so all three sit on the same axis. */
+  align-self: center;
 }
 
 .maka-mcp-manual-form,


### PR DESCRIPTION
## Summary

In the MCP settings editor, the leading icons of the two horizontal radio groups sat slightly above the radio dot and the vertically centered label, so each icon/label pair looked misaligned (`Manual` / `Paste JSON` and `Local stdio` / `Remote URL`).

Each icon is `ICON_SIZE.control` (14px) and shares `Item`'s `startContent` flex slot with the 24px (`md`) radio circle. That slot defaults to `align-items: stretch`, which top-aligns a definite-height child, so the smaller icon rode ~5px above the centerline while the radio dot and label are centered by the row. The fix sets `align-self: center` on `.maka-mcp-choice-icon` so all three sit on the same axis. All four affected icons share that class, so one rule covers every case.

Fixes #4148

## Verification

- Root-caused against the design-system source: `Item` wraps `startContent` in a `display:flex` slot with no explicit `align-items` (`node_modules/@astryxdesign/core/src/Item/Item.tsx`), and `RadioListItem` places the icon as a sibling of the 24px radio circle in that slot (`RadioListItem.tsx`). A definite-height child under `align-items: stretch` resolves to cross-start (top) alignment — hence the offset.
- CSS is not covered by this repo's Biome config (it ignores CSS), and there is no automated harness that asserts this visual alignment, so no unit test accompanies the change. `biome format` on the file confirms it is not reformatted.
- I have **not** launched the Desktop (Electron) app to capture an after-screenshot. The "before" state is the reported screenshot in #4148. Happy to attach an after-shot via the Desktop Storybook if a reviewer wants live evidence.

before & after:

<img width="1137" height="412" alt="image" src="https://github.com/user-attachments/assets/5144d4ff-701b-411a-843d-62084e9a3714" />


## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Claude Opus 4.8) — diagnosed the flex-alignment root cause, wrote the one-line CSS fix, and drafted the issue/PR text. The commit carries a `Generated-by` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

<!-- No test added: this is a cosmetic CSS alignment fix with no existing visual-assertion harness. CSS is excluded from Biome; full typecheck/suites not run for a single-property style change. -->

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No