### PR TITLE
test(desktop): settle transcript scroll extremes

### DIFF
--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -85,7 +85,8 @@ function probeRail(page: Page): Promise<RailProbe | null> {
   return page.evaluate(RAIL_PROBE) as Promise<RailProbe | null>;
 }
 
-async function scrollTranscriptTo(page: Page, position: 'top' | 'bottom'): Promise<void> {
+/** One jump, so a caller can still observe whatever the app does after it. */
+async function scrollTranscriptOnce(page: Page, position: 'top' | 'bottom'): Promise<void> {
   await page.evaluate((where) => {
     const scroller = document.querySelector('[data-chat-scroll-container="true"]');
     if (!scroller) throw new Error('the chat scroll container is missing');
@@ -93,6 +94,24 @@ async function scrollTranscriptTo(page: Page, position: 'top' | 'bottom'): Promi
   }, position);
   await notifyTranscriptScrolled(page);
   await waitForPaintedFrames(page);
+}
+
+/** A single jump can stop thousands of px short of a virtualized extreme. */
+async function settleTranscriptAtExtreme(page: Page, position: 'top' | 'bottom'): Promise<void> {
+  // Polls the remaining distance rather than a boolean, so giving up says how
+  // far off it was.
+  await expect.poll(async () => {
+    await scrollTranscriptOnce(page, position);
+    return page.evaluate((where) => {
+      const scroller = document.querySelector('[data-chat-scroll-container="true"]');
+      if (!scroller) throw new Error('the chat scroll container is missing');
+      return Math.round(
+        where === 'top'
+          ? scroller.scrollTop
+          : scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop,
+      );
+    }, position);
+  }).toBeLessThanOrEqual(1);
 }
 
 async function waitForPaintedFrames(page: Page, count = 2): Promise<void> {
@@ -118,7 +137,7 @@ function notifyTranscriptScrolled(page: Page): Promise<void> {
 
 async function loadPromptRailBeyondVirtualWindow(page: Page): Promise<void> {
   const transcript = page.locator('.maka-chat-message-list');
-  await scrollTranscriptTo(page, 'top');
+  await scrollTranscriptOnce(page, 'top');
   await transcript.hover();
   await page.mouse.wheel(0, -100);
   await expect.poll(async () => Number(await transcript.getAttribute('data-turn-source-count')))
@@ -154,7 +173,7 @@ test('the rail stays inside the scrollport at both scroll extremes', async ({
   expect(scroll.height).toBeGreaterThan(scroll.client);
 
   for (const position of ['top', 'bottom'] as const) {
-    await scrollTranscriptTo(page, position);
+    await settleTranscriptAtExtreme(page, position);
     // The bottom is where it bites: a sticky offset is clamped by its
     // containing block, and the chat shell ends a dock-height above the
     // scrollport's bottom edge (CI caught -62px insetTop that way).
@@ -291,8 +310,26 @@ test('evicting a turn-owned sibling interaction hands focus back to the transcri
   const scroller = page.locator('[data-chat-scroll-container="true"][data-turn-window="ready"]');
   await scroller.waitFor();
   await loadPromptRailBeyondVirtualWindow(page);
-  await scrollTranscriptTo(page, 'bottom');
-  await expect(page.locator('[data-virtual-turn-id="turn-prompt-rail-120"]')).toHaveCount(1);
+  await settleTranscriptAtExtreme(page, 'bottom');
+  // A bare count says only that a turn is missing. Report the scroll and window
+  // state as one string; a subset matcher would print just the key it matched.
+  await expect.poll(async () => page.evaluate(() => {
+    const scroller = document.querySelector('[data-chat-scroll-container="true"]');
+    if (!scroller) throw new Error('the chat scroll container is missing');
+    const mounted = [...document.querySelectorAll<HTMLElement>('[data-virtual-turn-id]')]
+      .map((turn) => turn.dataset.virtualTurnId ?? '');
+    const gap = Math.round(scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop);
+    const source = document.querySelector('.maka-chat-message-list')
+      ?.getAttribute('data-turn-source-count');
+    return [
+      `tail=${mounted.includes('turn-prompt-rail-120')}`,
+      `gap=${gap}`,
+      `client=${scroller.clientHeight}`,
+      `mounted=${mounted.length}`,
+      `last=${mounted.at(-1) ?? 'none'}`,
+      `source=${source ?? 'none'}`,
+    ].join(' ');
+  })).toMatch(/^tail=true /u);
   const retainedTurnId = await page.evaluate(() => {
     const turns = document.querySelectorAll<HTMLElement>('[data-virtual-turn-id]');
     const turn = turns.item(turns.length - 1);
@@ -314,7 +351,7 @@ test('evicting a turn-owned sibling interaction hands focus back to the transcri
   // the one-shot jump so the assertion still catches any later restore that
   // would pin the viewport back on the retained Turn (#3121).
   await waitForPaintedFrames(page);
-  await scrollTranscriptTo(page, 'top');
+  await scrollTranscriptOnce(page, 'top');
   await notifyTranscriptScrolled(page);
   await expect.poll(async () => page.evaluate((turnId) => {
     const root = document.querySelector<HTMLElement>('[data-chat-scroll-container="true"]');


### PR DESCRIPTION
## Summary

`prompt-rail.spec.ts` intermittently fails on CI at `evicting a turn-owned sibling interaction hands focus back to the transcript`: `turn-prompt-rail-120` is expected to be mounted after scrolling to the bottom, and the locator resolves to zero for the full ten-second poll. It has failed on `main` — most recently at `01369b082`, the commit this branch is based on.

`scrollTranscriptTo` assigned `scrollTop` once. Measured on the runner, that single assignment can leave the scroller **2982px above the bottom** while every turn is already loaded, so the virtual window ends seven turns short of the tail and the awaited turn never mounts. The failing state is identical on every occurrence:

```text
tail=false gap=2982 client=780 mounted=14 last=turn-prompt-rail-113 source=120
```

`#3863` added a one-shot `scroll` dispatch plus two painted frames here, which cannot help when the layout keeps growing past them.

The helper now re-scrolls until a painted frame agrees the scroller is at the requested extreme. It is split rather than changed in place, because its callers want opposite things: `settleTranscriptAtExtreme` is used where a test needs to actually be at an extreme, while `scrollTranscriptOnce` keeps the single jump for the focus-handback test, which deliberately jumps once so a late scroll-anchor restore stays observable — a retrying helper would fight that restore and turn the `#3121` regression into a false pass.

The assertion also reports the scroll offset, mounted window and loaded turn count on failure, so a future CI-only failure names its own cause instead of saying only that a turn is missing.

Test-only. No renderer or virtualizer behavior changes.

## Verification

Thirty full-suite runs per side on GitHub-hosted `ubuntu-latest`, the same runner class that produces the failure. Both sides carry the same probe workflow; apart from it the two trees differ only by this commit.

```text
before — 01369b082
  26 rounds  79 passed
   3 rounds  78 passed, 1 failed
   1 round   77 passed, 2 failed
  prompt-rail.spec.ts:288          3 / 30
  partial-history-notice.spec.ts:59 2 / 30

after — this branch
  30 rounds  79 passed
  prompt-rail.spec.ts:288          0 / 30
  partial-history-notice.spec.ts:59 0 / 30
```

All three `before` failures reported the same state, quoted under Summary.

Two limits worth stating. Three-of-thirty against zero-of-thirty is not statistically significant on its own (Fisher exact, p ≈ 0.23); the argument rests on the measured mechanism, with the rates as corroboration. And `partial-history-notice.spec.ts:59` is an unrelated flake that this change does not address — its zero on the `after` side is sampling, not a fix.

```text
$ npm exec -w @maka/desktop -- playwright test --config e2e/playwright.config.ts prompt-rail.spec.ts
7 passed (19.7s)

$ ./node_modules/.bin/biome check apps/desktop/e2e/prompt-rail.spec.ts
Checked 1 file. No fixes applied.
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code reproduced the failure, took the measurements above, wrote the change, and prepared this PR description.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

The first box is deliberately unchecked. The change is itself a test, and the failure it removes is a race that appears in roughly one CI run in ten rather than on demand; the before/after measurement above stands in for a deterministic red run.

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
