### PR TITLE
Remove Titlebar top blank

### DIFF
--- a/apps/desktop/src/renderer/styles/module-pages/module-shell.css
+++ b/apps/desktop/src/renderer/styles/module-pages/module-shell.css
@@ -29,11 +29,14 @@
    vendor's `incident-console` page template. Layout owns the zones, the
    padding collapse and the scroll containment, so the module main is
    reduced to giving it a box to fill — plus the top
-   inset the frameless titlebar still needs. */
+   inset the frameless titlebar still needs.
+   Titlebar clearance lives on `.mainColumn` (`--maka-plate-titlebar-clearance`).
+   Do NOT re-add a large padding-top here — that double-counts the inset and
+   leaves a tall empty band above "Extensions" / "Scheduled tasks" / etc. */
 .maka-module-main[data-page-shell="layout"] {
   display: flex;
   gap: 0;
-  padding: var(--space-16) 0 0;
+  padding: 0;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## remove Titlebar top blank

## Summary

Module pages (Extensions, Scheduled tasks, etc.) showed a large empty band under the frameless titlebar. `.mainColumn` already reserves `--maka-plate-titlebar-clearance`, and `.maka-module-main[data-page-shell="layout"]` also applied `padding-top: var(--space-16)` (64px), so the inset was applied twice.

Remove the extra module-page top padding (`padding: 0`). Titlebar clearance stays solely on `.mainColumn`, and page content aligns to the top of the content plate again.

## Verification

- Visual check: open Extensions / Scheduled tasks — the tall blank above the page header is gone; content still clears the titlebar chrome.
- Did not run full lint / typecheck / test suites (CSS-only change).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Cursor Agent — diagnosed the double titlebar inset and updated `module-shell.css`.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No