### PR TITLE
refactor(desktop): remove expired local compatibility migrations

### DIFF
--- a/apps/desktop/src/main/__tests__/nav-selection.test.ts
+++ b/apps/desktop/src/main/__tests__/nav-selection.test.ts
@@ -43,6 +43,27 @@ describe('Navigation selection persistence', () => {
     );
   });
 
+  it('migrates plan reminders written by the oldest supported version', () => {
+    assert.deepEqual(
+      parseNavigationState(
+        JSON.stringify({
+          selection: { section: 'automations', module: 'plan-reminders' },
+          moduleMemory: {
+            extensions: 'skills',
+            automations: 'plan-reminders',
+          },
+        }),
+      ),
+      {
+        selection: { section: 'automations', module: 'scheduled-tasks' },
+        moduleMemory: {
+          extensions: 'skills',
+          automations: 'scheduled-tasks',
+        },
+      },
+    );
+  });
+
   it('ignores pre-hub selections from versions outside the support window', () => {
     const legacySelections = [
       { section: 'skills' },

--- a/apps/desktop/src/main/__tests__/nav-selection.test.ts
+++ b/apps/desktop/src/main/__tests__/nav-selection.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseNavigationState } from '../../renderer/nav-selection.js';
+
+describe('Navigation selection persistence', () => {
+  it('hydrates the hub-shaped navigation state written by supported versions', () => {
+    assert.deepEqual(
+      parseNavigationState(
+        JSON.stringify({
+          selection: { section: 'extensions', module: 'mcp' },
+          moduleMemory: {
+            extensions: 'mcp',
+            automations: 'daily-review',
+          },
+        }),
+      ),
+      {
+        selection: { section: 'extensions', module: 'mcp' },
+        moduleMemory: {
+          extensions: 'mcp',
+          automations: 'daily-review',
+        },
+      },
+    );
+  });
+
+  it('ignores pre-hub selections from versions outside the support window', () => {
+    const legacySelections = [
+      { section: 'skills' },
+      { section: 'mcp' },
+      { section: 'daily-review' },
+      { section: 'automations' },
+    ];
+
+    for (const selection of legacySelections) {
+      assert.deepEqual(parseNavigationState(JSON.stringify(selection)), {
+        selection: { section: 'sessions' },
+        moduleMemory: {
+          extensions: 'skills',
+          automations: 'scheduled-tasks',
+        },
+      });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/workbar-model.test.ts
+++ b/apps/desktop/src/main/__tests__/workbar-model.test.ts
@@ -166,7 +166,7 @@ describe('Workbar topology', () => {
     );
   });
 
-  it('hydrates v2 right-panel storage without changing its migration', () => {
+  it('ignores workbar storage from versions outside the support window', () => {
     cleanups.push(
       installMemoryLocalStorage({
         'maka-session-workbar-tabs-v2': JSON.stringify({
@@ -177,27 +177,10 @@ describe('Workbar topology', () => {
           ],
           activeTabId: 'workbar:review',
         }),
-      }),
-    );
-    const state = readSessionWorkbarPanels();
-    assert.deepEqual(state.right.tabs, [
-      { id: 'workbar:review', kind: 'review' },
-    ]);
-    assert.equal(state.right.activeTabId, 'workbar:review');
-    assert.deepEqual(state.bottom.tabs, []);
-  });
-
-  it('hydrates the v1 active-tab storage without changing its migration', () => {
-    cleanups.push(
-      installMemoryLocalStorage({
         'maka-session-workbar-tab-v1': 'browser',
       }),
     );
-    const state = loadWorkbarLayout();
-    assert.deepEqual(state.panels.right.tabs, [
-      { id: 'workbar:browser', kind: 'browser' },
-    ]);
-    assert.equal(state.panels.right.activeTabId, 'workbar:browser');
+    assert.deepEqual(readSessionWorkbarPanels(), createSessionWorkbarPanelsState());
   });
 
   it('round-trips v3 layout while filtering transient tab data', () => {

--- a/apps/desktop/src/renderer/features/workbar/model/workbar-tabs.ts
+++ b/apps/desktop/src/renderer/features/workbar/model/workbar-tabs.ts
@@ -584,51 +584,10 @@ export function readSessionWorkbarPanels(): SessionWorkbarPanelsState {
         );
       }
     } catch {
-      // Fall through to the v2 right-panel migration.
+      // Fall through to an empty topology.
     }
   }
-  return createSessionWorkbarPanelsState(readLegacySessionWorkbarTabs());
-}
-
-function readLegacySessionWorkbarTabs(): SessionWorkbarTabsState {
-  const raw = safeLocalStorageGet('maka-session-workbar-tabs-v2');
-  if (raw) {
-    try {
-      const parsed = JSON.parse(raw) as Partial<PersistedSessionWorkbarTabs>;
-      if (parsed.version === 2 && Array.isArray(parsed.tabs)) {
-        const tabs = parsed.tabs.flatMap((candidate) => {
-          if (
-            !candidate ||
-            typeof candidate.id !== 'string' ||
-            !isSessionWorkbarTabKind(candidate.kind) ||
-            !isPersistedWorkbarTool(candidate.kind)
-          ) {
-            return [];
-          }
-          return [{ id: candidate.id, kind: candidate.kind }];
-        });
-        return createSessionWorkbarTabsState(
-          tabs,
-          typeof parsed.activeTabId === 'string' ? parsed.activeTabId : null,
-        );
-      }
-    } catch {
-      // Fall through to the v1 active-tab migration.
-    }
-  }
-
-  const legacy = safeLocalStorageGet('maka-session-workbar-tab-v1');
-  if (
-    legacy === 'review' ||
-    legacy === 'terminal' ||
-    legacy === 'tasks' ||
-    legacy === 'browser' ||
-    legacy === 'files' ||
-    legacy === 'inspector'
-  ) {
-    return openStaticSessionWorkbarTab(createSessionWorkbarTabsState(), legacy);
-  }
-  return createSessionWorkbarTabsState();
+  return createSessionWorkbarPanelsState();
 }
 
 function readPersistedPanel(

--- a/apps/desktop/src/renderer/nav-selection.ts
+++ b/apps/desktop/src/renderer/nav-selection.ts
@@ -63,17 +63,6 @@ function parseSelection(value: unknown): NavSelection | null {
   if (candidate.section === 'automations' && isAutomationModule(candidate.module)) {
     return { section: 'automations', module: candidate.module };
   }
-
-  // Migrate the pre-hub destinations written by maka-nav-selection-v1.
-  if (candidate.section === 'skills' || candidate.section === 'mcp') {
-    return { section: 'extensions', module: candidate.section };
-  }
-  if (candidate.section === 'daily-review') {
-    return { section: 'automations', module: 'daily-review' };
-  }
-  if (candidate.section === 'automations') {
-    return { section: 'automations', module: 'scheduled-tasks' };
-  }
   return null;
 }
 

--- a/apps/desktop/src/renderer/nav-selection.ts
+++ b/apps/desktop/src/renderer/nav-selection.ts
@@ -63,6 +63,9 @@ function parseSelection(value: unknown): NavSelection | null {
   if (candidate.section === 'automations' && isAutomationModule(candidate.module)) {
     return { section: 'automations', module: candidate.module };
   }
+  if (candidate.section === 'automations' && candidate.module === 'plan-reminders') {
+    return { section: 'automations', module: 'scheduled-tasks' };
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary

- Stop reading `maka-session-workbar-tabs-v2` and `maka-session-workbar-tab-v1` now that every supported Desktop version already writes `maka-session-workbar-panels-v3`.
- Stop translating pre-hub `skills`, `mcp`, `daily-review`, and module-less `automations` navigation selections now that every supported version writes hub-shaped `maka-nav-selection-v1` state.
- Preserve the supported v0.1.10 `plan-reminders` selection by migrating it explicitly to `scheduled-tasks`.
- Preserve the current v3 workbar payload and its embedded `version: 2` panel schema.

Local state from versions older than the v0.1.10 support floor now falls back to the current default state instead of being migrated.

## Verification

- `node --test apps/desktop/dist/main/__tests__/nav-selection.test.js apps/desktop/dist/main/__tests__/workbar-model.test.js` — 10 tests passed
- `npm --workspace @maka/desktop run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run check:asf-headers`
- `git diff --check origin/main...HEAD`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the migration removals, preserved the supported `plan-reminders` vocabulary migration after adversarial review, added support-window regression coverage, and ran local verification. All material commits include `Generated-by: Codex` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No