### PR TITLE
refactor(runtime): remove unused preview APIs

### DIFF
--- a/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
@@ -190,7 +190,7 @@ describe('ToolRuntime session sandbox boundary', () => {
     });
     assert.match(JSON.stringify(overlapping.result), /already pending/u);
     assert.equal(events.filter((event) => event.type === 'sandbox_boundary_request').length, 1);
-    await runtime.respondToSandboxBoundaryRequest('turn-1', {
+    await runtime.respondToSandboxBoundaryResponse({
       requestId: requestEvent.requestId,
       decision: 'allow',
     });
@@ -266,7 +266,7 @@ describe('ToolRuntime session sandbox boundary', () => {
       false,
     );
     await assert.rejects(
-      runtime.respondToSandboxBoundaryRequest('turn-1', {
+      runtime.respondToSandboxBoundaryResponse({
         requestId: admittedRequest!.requestId,
         decision: 'allow',
       }),
@@ -432,7 +432,7 @@ describe('ToolRuntime session sandbox boundary', () => {
       const request = await waitForBoundaryRequest(events);
       assert.equal(request.expansion.filesystem?.entries[0]?.path, canonicalFile);
       assert.equal(created?.expansion.filesystem?.entries[0]?.path, canonicalFile);
-      await runtime.respondToSandboxBoundaryRequest('turn-1', {
+      await runtime.respondToSandboxBoundaryResponse({
         requestId: request.requestId,
         decision: 'deny',
       });

--- a/packages/runtime/src/bots/bot-registry.ts
+++ b/packages/runtime/src/bots/bot-registry.ts
@@ -49,14 +49,12 @@ export interface BotRegistryDeps {
   onStatusChange: (status: BotStatus) => void;
 }
 
-export class BotRegistry extends EventEmitter {
+export class BotRegistry {
   private bridges = new Map<BotPlatform, BotBridge>();
   private statuses = new Map<BotPlatform, BotStatus>();
   private applyQueue: Promise<void> = Promise.resolve();
 
-  constructor(private readonly deps: BotRegistryDeps) {
-    super();
-  }
+  constructor(private readonly deps: BotRegistryDeps) {}
 
   async applySettings(settings: BotChatSettings): Promise<void> {
     const next = this.applyQueue.then(

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -180,8 +180,6 @@ export interface BuildBuiltinToolsOptions {
   sandboxManager?: SandboxManager;
   /** Sandboxed worker used for all local filesystem tools. */
   filesystemWorker?: Pick<FilesystemWorkerClient, 'execute'>;
-  /** Host-surface gate for Edit. Defaults to enabled. */
-  includeEdit?: boolean;
   /** Test/embedding override. Production callers use the current process platform. */
   sandboxPlatform?: SandboxPlatform;
   snapshotImage?: (input: {
@@ -600,7 +598,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
       },
     },
   ];
-  return tools.filter((tool) => options.includeEdit !== false || tool.name !== 'Edit');
+  return tools;
 }
 
 /** The per-call context every file tool hands to the filesystem authority. */

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -653,10 +653,11 @@ export class ToolRuntime {
     return this.settleUserQuestionAnswer(turnId, response, pending);
   }
 
-  async respondToSandboxBoundaryRequest(
-    turnId: string,
-    response: { requestId: string; decision: SandboxBoundaryDecision },
-  ): Promise<boolean> {
+  async respondToSandboxBoundaryResponse(response: {
+    requestId: string;
+    decision: SandboxBoundaryDecision;
+  }): Promise<boolean> {
+    if (!this.sandboxBoundaryRequests.has(response.requestId)) return false;
     if (
       !response ||
       typeof response.requestId !== 'string' ||
@@ -682,14 +683,6 @@ export class ToolRuntime {
       decision: response.decision,
     });
     return this.sandboxBoundaryRequests.resolve(response.requestId, settlement) !== null;
-  }
-
-  async respondToSandboxBoundaryResponse(response: {
-    requestId: string;
-    decision: SandboxBoundaryDecision;
-  }): Promise<boolean> {
-    if (!this.sandboxBoundaryRequests.has(response.requestId)) return false;
-    return this.respondToSandboxBoundaryRequest(this.turnId, response);
   }
 
   private settleUserQuestionAnswer(


### PR DESCRIPTION
## Summary

Remove three unconsumed `@maka/runtime` preview API surfaces while keeping the canonical seams they obscured:

- remove the unused `includeEdit` option and filtering branch; Edit remains part of the built-in tool set
- remove `ToolRuntime.respondToSandboxBoundaryRequest(turnId, response)` and migrate direct tests to `respondToSandboxBoundaryResponse(response)`
- remove the unused `EventEmitter` inheritance from `BotRegistry`; concrete bot bridges remain EventEmitters and keep their existing wiring

This intentionally narrows pre-1.0 private-workspace API shapes before third-party imports are supported. It does not close future embedding seams or change package export entries.

## Verification

- `node --test --test-concurrency=3 packages/runtime/dist/__tests__/builtin-tools.test.js packages/runtime/dist/__tests__/tool-runtime-sandbox-boundary.test.js packages/runtime/dist/bots/__tests__/bot-registry.test.js` — 80 passed
- `npm --workspace @maka/runtime run typecheck` — passed
- `npm --workspace @maka/runtime-host run typecheck` — passed
- `npm run lint` — passed
- `npm run format:check` — passed
- exact static and dynamic-string searches found no consumers of the removed surfaces

The retained Edit, sandbox settlement, and BotRegistry lifecycle behavior is covered by existing tests. The removed API absence is verified by exact-symbol search and typecheck rather than a brittle negative runtime test.

## Breaking change

This removes unconsumed APIs from the private `@maka/runtime` 0.1.0 workspace package. Current product producers and consumers already use the retained seams, so no migration is required inside the repository.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex audited consumers and exports, migrated the sandbox tests, made the scoped removals, and ran local verification. Each material commit includes a `Generated-by: Codex` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

The first item remains unchecked because this is an API-surface deletion with no consumers; retained behavior is covered, while absence is established by source search and typecheck.

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No