### PR TITLE
fix(cli): share the TUI wait budget

### DIFF
--- a/packages/cli/src/__tests__/tui-mcp-control.test.ts
+++ b/packages/cli/src/__tests__/tui-mcp-control.test.ts
@@ -30,6 +30,7 @@ import type {
 } from '@maka/runtime-host/client';
 import { createMcpConfigStore } from '@maka/storage/mcp-config-store';
 import { createTuiMcpController } from '../tui-mcp-control.js';
+import { waitFor } from './tui-terminal-mock.js';
 
 test('TUI MCP startup stays backgrounded and publishes the discovered snapshot', async () => {
   const config = deferredValue<McpConfigFile>();
@@ -621,7 +622,10 @@ test('same-server credential retirement stays inside the shared config transacti
     expectedRevision: leftEdit.revision,
     config: { url: 'https://left.example/mcp' },
   });
-  await waitFor(() => leftOrder.includes('forget:docs'));
+  await waitFor(
+    () => leftOrder.includes('forget:docs'),
+    'same-server credential retirement inside the shared config transaction',
+  );
   const second = right.execute({
     kind: 'edit',
     serverId: 'docs',
@@ -893,13 +897,6 @@ function configStoreHarness(get: () => Promise<McpConfigFile>) {
     transform: async (apply: (current: McpConfigFile) => McpConfigFile | Promise<McpConfigFile>) =>
       apply(await get()),
   };
-}
-
-async function waitFor(condition: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 1_000 && !condition(); attempt += 1) {
-    await new Promise<void>((resolve) => setImmediate(resolve));
-  }
-  assert.ok(condition());
 }
 
 function deferred() {


### PR DESCRIPTION
## Summary

Replace `tui-mcp-control.test.ts`'s iteration-count polling loop with the shared TUI wait helper. All 28 call sites now inherit the established local/CI wall-clock budget and `MAKA_TEST_WAIT_BUDGET_MS` override; the observed credential-retirement race also gets a specific timeout description.

Fixes #4094

## Verification

- `node --test packages/cli/dist/__tests__/tui-mcp-control.test.js` — 19 passed
- `npx biome check packages/cli/src/__tests__/tui-mcp-control.test.ts` — passed
- Full `npm --workspace maka-agent test` built all prerequisites and ran the suite, but the Windows host reported unrelated pre-existing permission/durability failures (`EPERM` for symlink/fsync) plus unrelated timing assertions. The focused MCP controller file passed independently.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex traced the existing shared helper, prepared the focused import/removal change, and ran validation. The human contributor of record reviews and owns the submission.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
