### PR TITLE
feat(runtime-host): bind capability providers to Client owners

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-operator-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-operator-command.test.ts
@@ -320,6 +320,40 @@ describe('Runtime Host operator commands', () => {
     assert.deepEqual(
       parseRuntimeHostCommand([
         'access',
+        'issue',
+        '--kind',
+        'capability-provider',
+        '--principal',
+        'terminal-mcp-provider',
+        '--capability-owner-credential',
+        'terminal-owner-credential',
+      ]),
+      {
+        kind: 'runtime-host-access-issue',
+        principalKind: 'capability_provider',
+        principalId: 'terminal-mcp-provider',
+        operationGrants: ['client.capability.replace', 'client.capability.unregister'],
+        canPublishClientCapabilities: true,
+        canUseHostPaths: false,
+        capabilityOwnerCredentialId: 'terminal-owner-credential',
+      },
+    );
+    assert.equal(
+      parseRuntimeHostCommand([
+        'access',
+        'issue',
+        '--principal',
+        'terminal-owner',
+        '--grant',
+        'session.catalog.query',
+        '--capability-owner-credential',
+        'terminal-owner-credential',
+      ]).kind,
+      'error',
+    );
+    assert.deepEqual(
+      parseRuntimeHostCommand([
+        'access',
         'prepare',
         '--current-fingerprint',
         'a'.repeat(32),

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -228,6 +228,7 @@ function helpText(cliCommand: string): string {
     '  --preset <name>               Grant the desktop-client or terminal-client operation set',
     '  --publish-client-capabilities Allow Client Capability publication',
     '  --allow-host-paths            Allow operations that submit Host paths',
+    '  --capability-owner-credential <id>  Bind a provider to one Client-bound owner credential',
     '',
     'Runtime Host capability provider options:',
     '  --url <ws-url>                Connect to an authenticated Runtime Host WebSocket',
@@ -631,6 +632,9 @@ export async function runMakaCli(
         operationGrants: command.operationGrants,
         canPublishClientCapabilities: command.canPublishClientCapabilities,
         canUseHostPaths: command.canUseHostPaths,
+        ...(command.capabilityOwnerCredentialId
+          ? { capabilityOwnerCredentialId: command.capabilityOwnerCredentialId }
+          : {}),
         ...(command.preset ? { preset: command.preset } : {}),
       });
     }

--- a/packages/cli/src/runtime-host-access-command.ts
+++ b/packages/cli/src/runtime-host-access-command.ts
@@ -63,6 +63,7 @@ export interface RuntimeHostAccessIssueOptions {
   readonly operationGrants: readonly string[];
   readonly canPublishClientCapabilities: boolean;
   readonly canUseHostPaths: boolean;
+  readonly capabilityOwnerCredentialId?: string;
   readonly preset?: RuntimeHostAccessPreset;
   readonly bindClientInstance?: boolean;
 }
@@ -228,6 +229,9 @@ async function mutateRuntimeHostAccessCredential(
       operationGrants: resolved.operationGrants,
       canPublishClientCapabilities: resolved.canPublishClientCapabilities,
       canUseHostPaths: resolved.canUseHostPaths,
+      ...(operation !== 'access.credential.prepare' && options.capabilityOwnerCredentialId
+        ? { capabilityOwnerCredentialId: options.capabilityOwnerCredentialId }
+        : {}),
       ...(operation === 'access.credential.prepare' && options.bindClientInstance
         ? { bindClientInstance: true }
         : {}),

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -254,6 +254,7 @@ export type RuntimeHostCliCommand =
       operationGrants: string[];
       canPublishClientCapabilities: boolean;
       canUseHostPaths: boolean;
+      capabilityOwnerCredentialId?: string;
       preset?: 'desktop-client' | 'terminal-client';
     }
   | {
@@ -1994,6 +1995,7 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
   let principalKind: 'remote_owner' | 'capability_provider' = 'remote_owner';
   let principalKindSpecified = false;
   let credentialId: string | undefined;
+  let capabilityOwnerCredentialId: string | undefined;
   let currentCredentialFingerprint: string | undefined;
   const operationGrants: string[] = [];
   let canPublishClientCapabilities = false;
@@ -2022,6 +2024,7 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
       argument === '--principal' ||
       argument === '--grant' ||
       argument === '--credential' ||
+      argument === '--capability-owner-credential' ||
       argument === '--current-fingerprint'
     ) {
       const parsed = optionValue(argv, index, argument);
@@ -2044,6 +2047,7 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
       if (argument === '--principal') principalId = parsed;
       if (argument === '--grant') operationGrants.push(parsed);
       if (argument === '--credential') credentialId = parsed;
+      if (argument === '--capability-owner-credential') capabilityOwnerCredentialId = parsed;
       if (argument === '--current-fingerprint') currentCredentialFingerprint = parsed;
       index += 1;
       continue;
@@ -2062,6 +2066,7 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
       canUseHostPaths ||
       preset ||
       credentialId ||
+      capabilityOwnerCredentialId ||
       currentCredentialFingerprint
     ) {
       return error('Credential mutation options are not valid for access list');
@@ -2086,7 +2091,8 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
       canPublishClientCapabilities ||
       canUseHostPaths ||
       preset ||
-      credentialId
+      credentialId ||
+      capabilityOwnerCredentialId
     ) {
       return error('Credential issue options are not valid for access prepare');
     }
@@ -2113,6 +2119,9 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
       return error('--preset cannot be combined with --kind, --grant, or authority flags');
     }
     if (preset) {
+      if (capabilityOwnerCredentialId) {
+        return error('--capability-owner-credential requires --kind capability-provider');
+      }
       return {
         kind: 'runtime-host-access-issue',
         ...(rootPath ? { rootPath } : {}),
@@ -2136,8 +2145,11 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
         return error('A capability provider may grant only Client Capability publication');
       }
       canPublishClientCapabilities = true;
-    } else if (operationGrants.length === 0) {
-      return error('At least one --grant is required');
+    } else {
+      if (capabilityOwnerCredentialId) {
+        return error('--capability-owner-credential requires --kind capability-provider');
+      }
+      if (operationGrants.length === 0) return error('At least one --grant is required');
     }
     return {
       kind: 'runtime-host-access-issue',
@@ -2148,7 +2160,11 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
       operationGrants,
       canPublishClientCapabilities,
       canUseHostPaths,
+      ...(capabilityOwnerCredentialId ? { capabilityOwnerCredentialId } : {}),
     };
+  }
+  if (capabilityOwnerCredentialId) {
+    return error('--capability-owner-credential is only valid for access issue');
   }
   if (!credentialId) return error('--credential is required');
   if (framed && !currentCredentialFingerprint) {

--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -656,6 +656,115 @@ test('access credentials persist only as hashes and stay revoked after reload', 
   }
 });
 
+test('capability-provider credentials retain a Host-verified Client owner identity', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-access-authority-provider-owner-'));
+  try {
+    const authority = await openRuntimeHostAccessAuthority(directory);
+    const owner = await authority.prepare({
+      principalKind: 'remote_owner',
+      principalId: 'terminal-owner',
+      operationGrants: ['access.credential.finalize', 'session.catalog.query'],
+      canPublishClientCapabilities: false,
+      canUseHostPaths: false,
+      bindClientInstance: true,
+    });
+    await authority.finalize(owner.credentialId, 'terminal-client');
+    const unboundOwner = await authority.issue({
+      principalKind: 'remote_owner',
+      principalId: 'unbound-owner',
+      operationGrants: ['session.catalog.query'],
+      canPublishClientCapabilities: false,
+      canUseHostPaths: false,
+    });
+    const providerInput = {
+      principalKind: 'capability_provider' as const,
+      principalId: 'terminal-mcp-provider',
+      operationGrants: ['client.capability.replace', 'client.capability.unregister'] as const,
+      canPublishClientCapabilities: true,
+      canUseHostPaths: false,
+    };
+    const expectedOwner = {
+      principalId: 'terminal-owner',
+      clientInstanceId: 'terminal-client',
+    } as const;
+    await assert.rejects(
+      authority.issue({
+        ...providerInput,
+        capabilityOwnerCredentialId: unboundOwner.credentialId,
+      }),
+      /must be bound to one Client identity/u,
+    );
+    await assert.rejects(
+      authority.issue({
+        principalKind: 'remote_owner',
+        principalId: 'invalid-owner-reference',
+        operationGrants: ['session.catalog.query'],
+        canPublishClientCapabilities: false,
+        canUseHostPaths: false,
+        capabilityOwnerCredentialId: owner.credentialId,
+      }),
+      /Only a capability provider/u,
+    );
+
+    const provider = await authority.issue({
+      ...providerInput,
+      capabilityOwnerCredentialId: owner.credentialId,
+    });
+    assert.deepEqual(provider.capabilityOwner, expectedOwner);
+    assert.equal(
+      JSON.parse(await readFile(join(directory, 'runtime-host-access.json'), 'utf8')).schemaVersion,
+      2,
+    );
+    const { consumeAccessCredentialDeliveryFromControlDirectory } = await import(
+      '../control/access-credential-delivery.js'
+    );
+    const credential = await consumeAccessCredentialDeliveryFromControlDirectory(
+      directory,
+      provider.deliveryId,
+      provider.credentialId,
+    );
+    assert.deepEqual(authority.authenticate(credential)?.capabilityOwner, expectedOwner);
+
+    const replacementOwner = await authority.prepareRotation({
+      replacementOfCredentialId: owner.credentialId,
+    });
+    await authority.finalize(replacementOwner.credentialId, 'terminal-client');
+    const replacementProvider = await authority.issue({
+      ...providerInput,
+      principalId: 'rotated-terminal-mcp-provider',
+      capabilityOwnerCredentialId: replacementOwner.credentialId,
+    });
+    assert.deepEqual(replacementProvider.capabilityOwner, provider.capabilityOwner);
+
+    const reopened = await openRuntimeHostAccessAuthority(directory);
+    assert.deepEqual(reopened.authenticate(credential)?.capabilityOwner, expectedOwner);
+    await assert.rejects(
+      reopened.issue({
+        ...providerInput,
+        principalId: 'missing-owner-provider',
+        capabilityOwnerCredentialId: 'missing-owner-credential',
+      }),
+      /active remote-owner credential/u,
+    );
+    await authority.close();
+    await reopened.close();
+    const downgraded = JSON.parse(
+      await readFile(join(directory, 'runtime-host-access.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    await writeFile(
+      join(directory, 'runtime-host-access.json'),
+      `${JSON.stringify({ ...downgraded, schemaVersion: 1 })}\n`,
+      { mode: 0o600 },
+    );
+    await assert.rejects(
+      openRuntimeHostAccessAuthority(directory),
+      /Legacy Runtime Host access files cannot declare Client Capability owners/u,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test('credential rotation preserves authority and cannot outlive its active source', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'maka-access-authority-rotation-'));
   const authority = await openRuntimeHostAccessAuthority(directory);

--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -713,7 +713,7 @@ test('capability-provider credentials retain a Host-verified Client owner identi
     assert.deepEqual(provider.capabilityOwner, expectedOwner);
     assert.equal(
       JSON.parse(await readFile(join(directory, 'runtime-host-access.json'), 'utf8')).schemaVersion,
-      2,
+      4,
     );
     const { consumeAccessCredentialDeliveryFromControlDirectory } = await import(
       '../control/access-credential-delivery.js'
@@ -753,14 +753,190 @@ test('capability-provider credentials retain a Host-verified Client owner identi
     ) as Record<string, unknown>;
     await writeFile(
       join(directory, 'runtime-host-access.json'),
-      `${JSON.stringify({ ...downgraded, schemaVersion: 1 })}\n`,
+      `${JSON.stringify({ ...downgraded, schemaVersion: 3 })}\n`,
       { mode: 0o600 },
     );
     await assert.rejects(
       openRuntimeHostAccessAuthority(directory),
-      /Legacy Runtime Host access files cannot declare Client Capability owners/u,
+      /Pre-association Runtime Host access files cannot declare capability owners/u,
     );
   } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('an unbound WebSocket credential cannot claim an existing bound Client identity', {
+  timeout: 120_000,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-bound-client-websocket-'));
+  const root = join(base, 'root');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const host = await startExecutionRuntimeHostService({
+    rootPath: root,
+    websocket: { host: '127.0.0.1', port: 0 },
+  });
+  let local: RuntimeHostConnection | undefined;
+  let owner: RuntimeHostConnection | undefined;
+  let provider: RuntimeHostConnection | undefined;
+  try {
+    local = requireConnection(await connectRuntimeHost({ rootPath: root, protocol: PROTOCOL }));
+    const ownerCandidate = await local.request('access.credential.prepare', {
+      principalKind: 'remote_owner',
+      principalId: 'shared-owner',
+      operationGrants: ['access.credential.finalize', 'session.catalog.query'],
+      canPublishClientCapabilities: false,
+      canUseHostPaths: false,
+      bindClientInstance: true,
+    });
+    const ownerCredential = await consumeAccessCredentialDelivery(
+      root,
+      ownerCandidate.deliveryId,
+      ownerCandidate.credentialId,
+    );
+    const url = host.websocketEndpoints[0]!;
+    const pairing = requireRemoteConnection(
+      await connectRemoteRuntimeHost({
+        url,
+        credential: ownerCredential,
+        expectedRootId: capability.rootId,
+        compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+        clientInstanceId: 'client-a',
+        protocol: PROTOCOL,
+      }),
+    );
+    assert.deepEqual(await pairing.request('access.credential.finalize', {}), {
+      reconnectRequired: true,
+    });
+    await pairing.close();
+    owner = requireRemoteConnection(
+      await connectRemoteRuntimeHost({
+        url,
+        credential: ownerCredential,
+        expectedRootId: capability.rootId,
+        compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+        clientInstanceId: 'client-a',
+        protocol: PROTOCOL,
+      }),
+    );
+    const unbound = await local.request('access.credential.issue', {
+      principalKind: 'remote_owner',
+      principalId: 'shared-owner',
+      operationGrants: ['session.catalog.query'],
+      canPublishClientCapabilities: false,
+      canUseHostPaths: false,
+    });
+    const unboundCredential = await consumeAccessCredentialDelivery(
+      root,
+      unbound.deliveryId,
+      unbound.credentialId,
+    );
+    const providerIssue = await local.request('access.credential.issue', {
+      principalKind: 'capability_provider',
+      principalId: 'shared-owner-provider',
+      operationGrants: ['client.capability.replace', 'client.capability.unregister'],
+      canPublishClientCapabilities: true,
+      canUseHostPaths: false,
+      capabilityOwnerCredentialId: ownerCandidate.credentialId,
+    });
+    const providerCredential = await consumeAccessCredentialDelivery(
+      root,
+      providerIssue.deliveryId,
+      providerIssue.credentialId,
+    );
+    provider = requireRemoteConnection(
+      await connectRemoteRuntimeHost({
+        url,
+        credential: providerCredential,
+        expectedRootId: capability.rootId,
+        compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+        clientInstanceId: 'provider-a',
+        protocol: PROTOCOL,
+      }),
+    );
+    await provider.replaceClientCapabilities({
+      offers: () => [
+        {
+          offerId: 'bound-provider',
+          version: '1',
+          affinity: 'session',
+          hostPathAccess: 'none',
+          label: 'Bound provider',
+          tools: [
+            {
+              serverId: 'bound-provider',
+              name: 'echo',
+              inputSchema: { type: 'object' },
+            },
+          ],
+        },
+      ],
+      call: async () => ({ content: [{ type: 'text', text: 'bound' }] }),
+    });
+
+    assert.deepEqual(
+      await connectRemoteRuntimeHost({
+        url,
+        credential: unboundCredential,
+        expectedRootId: capability.rootId,
+        compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+        clientInstanceId: 'client-a',
+        protocol: PROTOCOL,
+      }),
+      { kind: 'unavailable', reason: 'handshake_failed' },
+    );
+  } finally {
+    await Promise.allSettled([provider?.close(), owner?.close(), local?.close()]);
+    await host.close().catch(() => undefined);
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('writes the capability-owner schema only after the association commits', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-access-authority-owner-schema-'));
+  let rejectAssociation = false;
+  let authority: Awaited<ReturnType<typeof openRuntimeHostAccessAuthority>> | undefined;
+  try {
+    authority = await openRuntimeHostAccessAuthority(directory, {
+      writeFile: async (path, file) => {
+        if (rejectAssociation && file.schemaVersion === 4) {
+          throw new Error('association write rejected');
+        }
+        await writeAccessCredentialFile(path, file);
+      },
+    });
+    const owner = await authority.prepare({
+      principalKind: 'remote_owner',
+      principalId: 'schema-owner',
+      operationGrants: ['access.credential.finalize'],
+      canPublishClientCapabilities: false,
+      canUseHostPaths: false,
+      bindClientInstance: true,
+    });
+    await authority.finalize(owner.credentialId, 'schema-client');
+    const path = join(directory, 'runtime-host-access.json');
+    assert.equal(JSON.parse(await readFile(path, 'utf8')).schemaVersion, 3);
+
+    const providerInput = {
+      principalKind: 'capability_provider' as const,
+      principalId: 'schema-provider',
+      operationGrants: ['client.capability.replace', 'client.capability.unregister'] as const,
+      canPublishClientCapabilities: true,
+      canUseHostPaths: false,
+      capabilityOwnerCredentialId: owner.credentialId,
+    };
+    rejectAssociation = true;
+    await assert.rejects(authority.issue(providerInput), /association write rejected/u);
+    assert.equal(JSON.parse(await readFile(path, 'utf8')).schemaVersion, 3);
+
+    rejectAssociation = false;
+    await authority.issue(providerInput);
+    assert.equal(JSON.parse(await readFile(path, 'utf8')).schemaVersion, 4);
+  } finally {
+    await authority?.close();
     await rm(directory, { recursive: true, force: true });
   }
 });
@@ -1319,6 +1495,13 @@ function requireConnection(
   result: Awaited<ReturnType<typeof connectRuntimeHost>>,
 ): RuntimeHostConnection {
   if (result.kind !== 'connected') throw new Error(`Local Client did not connect: ${result.kind}`);
+  return result.connection;
+}
+
+function requireRemoteConnection(
+  result: Awaited<ReturnType<typeof connectRemoteRuntimeHost>>,
+): RuntimeHostConnection {
+  if (result.kind !== 'connected') throw new Error(`Remote Client did not connect: ${result.kind}`);
   return result.connection;
 }
 

--- a/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
@@ -414,6 +414,45 @@ describe('Host Client Capability coordinator', () => {
     await coordinator.close();
   });
 
+  test('does not match a companion from a hello-only Client identity', async () => {
+    const coordinator = createCoordinator();
+    const provider = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity(
+        'associated-provider',
+        'provider-client',
+        'provider-principal',
+        'capability_provider',
+        { principalId: 'owner-principal', clientInstanceId: 'owner-client' },
+      ),
+      { send: async () => {} },
+    );
+    await replaceTrustedProvider(
+      coordinator,
+      'associated-provider',
+      'associated-registration',
+      'inspect',
+    );
+    const unboundOwner = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity(
+        'unbound-owner',
+        'owner-client',
+        'owner-principal',
+        'remote_owner',
+        undefined,
+        false,
+      ),
+      { send: async () => {} },
+    );
+
+    assert.deepEqual(await coordinator.bindSession('unbound-owner', 'unbound-owner'), {
+      ok: true,
+    });
+    assert.equal(coordinator.snapshotForSession('unbound-owner'), undefined);
+
+    await Promise.all([provider.close(), unboundOwner.close()]);
+    await coordinator.close();
+  });
+
   test('previews the initiating provider without persisting a Session binding', async () => {
     const coordinator = createCoordinator();
     const connection = coordinator.attachConnection(

--- a/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
@@ -301,6 +301,119 @@ describe('Host Client Capability coordinator', () => {
     await coordinator.close();
   });
 
+  test('selects only the provider bound to the exact initiating Client identity', async () => {
+    const coordinator = createCoordinator();
+    const owner = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity(
+        'owner-connection',
+        'owner-client',
+        'owner-principal',
+        'remote_owner',
+      ),
+      { send: async () => {} },
+    );
+    const unrelated = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity(
+        'unrelated-provider',
+        'unrelated-provider-client',
+        'unrelated-provider-principal',
+        'capability_provider',
+        { principalId: 'other-principal', clientInstanceId: 'other-client' },
+      ),
+      { send: async () => {} },
+    );
+    await replaceTrustedProvider(
+      coordinator,
+      'unrelated-provider',
+      'unrelated-registration',
+      'inspect',
+    );
+
+    assert.deepEqual(await coordinator.bindSession('unrelated-only', 'owner-connection'), {
+      ok: true,
+    });
+    assert.equal(coordinator.snapshotForSession('unrelated-only'), undefined);
+
+    const associated = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity(
+        'associated-provider',
+        'associated-provider-client',
+        'associated-provider-principal',
+        'capability_provider',
+        { principalId: 'owner-principal', clientInstanceId: 'owner-client' },
+      ),
+      { send: async () => {} },
+    );
+    await replaceTrustedProvider(
+      coordinator,
+      'associated-provider',
+      'associated-registration',
+      'inspect',
+    );
+    assert.throws(
+      () =>
+        coordinator.attachConnection(
+          clientCapabilityConnectionIdentity(
+            'changed-owner-provider',
+            'associated-provider-client',
+            'associated-provider-principal',
+            'capability_provider',
+            { principalId: 'other-principal', clientInstanceId: 'other-client' },
+          ),
+          { send: async () => {} },
+        ),
+      /provider owner changed/u,
+    );
+
+    assert.deepEqual(await coordinator.bindSession('associated', 'owner-connection'), { ok: true });
+    const snapshot = coordinator.snapshotForSession('associated');
+    assert.deepEqual(snapshot?.registrationIds, ['associated-registration']);
+    snapshot?.release();
+
+    const otherClient = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity(
+        'other-client-connection',
+        'different-client',
+        'owner-principal',
+        'remote_owner',
+      ),
+      { send: async () => {} },
+    );
+    assert.deepEqual(await coordinator.bindSession('different-client', 'other-client-connection'), {
+      ok: true,
+    });
+    assert.equal(coordinator.snapshotForSession('different-client'), undefined);
+
+    const duplicate = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity(
+        'duplicate-provider',
+        'duplicate-provider-client',
+        'duplicate-provider-principal',
+        'capability_provider',
+        { principalId: 'owner-principal', clientInstanceId: 'owner-client' },
+      ),
+      { send: async () => {} },
+    );
+    await replaceTrustedProvider(
+      coordinator,
+      'duplicate-provider',
+      'duplicate-registration',
+      'inspect',
+    );
+    const ambiguous = await coordinator.bindSession('duplicate-owner', 'owner-connection');
+    assert.equal(ambiguous.ok, false);
+    if (!ambiguous.ok) assert.match(ambiguous.message, /bound to the initiating Client/u);
+
+    await Promise.all([
+      owner.close(),
+      unrelated.close(),
+      associated.close(),
+      otherClient.close(),
+      duplicate.close(),
+    ]);
+    await coordinator.close();
+  });
+
   test('previews the initiating provider without persisting a Session binding', async () => {
     const coordinator = createCoordinator();
     const connection = coordinator.attachConnection(
@@ -1186,6 +1299,23 @@ async function replace(
     {
       ...connectionContext(connectionId),
     },
+  );
+  assert.equal(outcome.ok, true);
+}
+
+async function replaceTrustedProvider(
+  coordinator: HostClientCapabilityCoordinator,
+  connectionId: string,
+  registrationId: string,
+  toolName: string,
+): Promise<void> {
+  const input = replacementInput(registrationId, toolName);
+  const outcome = await coordinator.handlers['client.capability.replace'](
+    {
+      ...input,
+      offers: input.offers.map((offer) => ({ ...offer, hostPathAccess: 'none' as const })),
+    },
+    connectionContext(connectionId),
   );
   assert.equal(outcome.ok, true);
 }

--- a/packages/runtime-host/src/__tests__/fixtures/client-capability.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/client-capability.ts
@@ -25,11 +25,13 @@ export function clientCapabilityConnectionIdentity(
   principalId = 'test-principal',
   principalKind: ClientCapabilityConnectionIdentity['principalKind'] = 'local_owner',
   capabilityOwner?: ClientCapabilityConnectionIdentity['capabilityOwner'],
+  credentialBound = principalKind === 'remote_owner',
 ): ClientCapabilityConnectionIdentity {
   return {
     connectionId,
     principalId,
     clientInstanceId,
+    ...(credentialBound ? { credentialBoundClientInstanceId: clientInstanceId } : {}),
     principalKind,
     ...(capabilityOwner ? { capabilityOwner } : {}),
   };

--- a/packages/runtime-host/src/__tests__/fixtures/client-capability.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/client-capability.ts
@@ -24,6 +24,13 @@ export function clientCapabilityConnectionIdentity(
   clientInstanceId = connectionId,
   principalId = 'test-principal',
   principalKind: ClientCapabilityConnectionIdentity['principalKind'] = 'local_owner',
+  capabilityOwner?: ClientCapabilityConnectionIdentity['capabilityOwner'],
 ): ClientCapabilityConnectionIdentity {
-  return { connectionId, principalId, clientInstanceId, principalKind };
+  return {
+    connectionId,
+    principalId,
+    clientInstanceId,
+    principalKind,
+    ...(capabilityOwner ? { capabilityOwner } : {}),
+  };
 }

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -302,6 +302,39 @@ describe('Runtime Host bootstrap protocol', () => {
     );
   });
 
+  test('decodes Host-bound capability-provider ownership at a new compatibility boundary', () => {
+    const input = {
+      principalKind: 'capability_provider',
+      principalId: 'terminal-mcp-provider',
+      operationGrants: ['client.capability.replace', 'client.capability.unregister'],
+      canPublishClientCapabilities: true,
+      canUseHostPaths: false,
+      capabilityOwnerCredentialId: 'terminal-owner-credential',
+    };
+    assert.deepEqual(HOST_OPERATION_SPECS['access.credential.issue'].decodeInput(input), input);
+    assert.throws(() =>
+      HOST_OPERATION_SPECS['access.credential.prepare'].decodeInput({
+        ...input,
+        bindClientInstance: true,
+      }),
+    );
+    const output = {
+      credentialId: 'provider-credential',
+      deliveryId: 'provider-delivery',
+      principalKind: 'capability_provider',
+      principalId: 'terminal-mcp-provider',
+      operationGrants: ['client.capability.replace', 'client.capability.unregister'],
+      canPublishClientCapabilities: true,
+      canUseHostPaths: false,
+      capabilityOwner: {
+        principalId: 'terminal-owner',
+        clientInstanceId: 'terminal-client',
+      },
+    };
+    assert.deepEqual(HOST_OPERATION_SPECS['access.credential.issue'].decodeOutput(output), output);
+    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 67);
+  });
+
   test('decodes atomic principal revocation and publishes its compatibility boundary', () => {
     assert.deepEqual(
       HOST_OPERATION_SPECS['access.principal.revoke'].decodeInput({

--- a/packages/runtime-host/src/protocol/access-authority.ts
+++ b/packages/runtime-host/src/protocol/access-authority.ts
@@ -39,6 +39,11 @@ export type ManagedAccessCredentialPrincipalKind = Exclude<
   'session_guest'
 >;
 
+export interface ClientCapabilityOwnerIdentity {
+  readonly principalId: string;
+  readonly clientInstanceId: string;
+}
+
 const ACCESS_ERRORS = [
   'host_not_ready',
   'host_draining',
@@ -55,6 +60,7 @@ export interface AccessCredentialIssueInput {
   readonly operationGrants: readonly OperationKey[];
   readonly canPublishClientCapabilities: boolean;
   readonly canUseHostPaths: boolean;
+  readonly capabilityOwnerCredentialId?: string;
 }
 
 export interface AccessCredentialIssueResult {
@@ -65,11 +71,13 @@ export interface AccessCredentialIssueResult {
   readonly operationGrants: readonly OperationKey[];
   readonly canPublishClientCapabilities: boolean;
   readonly canUseHostPaths: boolean;
+  readonly capabilityOwner?: ClientCapabilityOwnerIdentity;
 }
 
 export type AccessCredentialReplaceInput = AccessCredentialIssueInput;
 export type AccessCredentialReplaceResult = AccessCredentialIssueResult;
-export interface AccessCredentialPrepareInput extends AccessCredentialIssueInput {
+export interface AccessCredentialPrepareInput
+  extends Omit<AccessCredentialIssueInput, 'capabilityOwnerCredentialId'> {
   readonly bindClientInstance?: boolean;
 }
 export type AccessCredentialPrepareResult = AccessCredentialIssueResult;
@@ -202,15 +210,28 @@ export const ACCESS_AUTHORITY_OPERATION_SPECS = {
 } as const;
 
 export function decodeAccessCredentialIssueInput(value: unknown): AccessCredentialIssueInput {
-  const record = requireExactRecord(value, 'access credential issue input', [
-    'principalKind',
-    'principalId',
-    'operationGrants',
-    'canPublishClientCapabilities',
-    'canUseHostPaths',
-  ]);
+  const record = requireShapedRecord(
+    value,
+    'access credential issue input',
+    [
+      'principalKind',
+      'principalId',
+      'operationGrants',
+      'canPublishClientCapabilities',
+      'canUseHostPaths',
+    ],
+    ['capabilityOwnerCredentialId'],
+  );
+  const decodedPrincipalKind = principalKind(record.principalKind);
+  const capabilityOwnerCredentialId =
+    record.capabilityOwnerCredentialId === undefined
+      ? undefined
+      : requireId(record.capabilityOwnerCredentialId, 'capabilityOwnerCredentialId');
+  if (capabilityOwnerCredentialId && decodedPrincipalKind !== 'capability_provider') {
+    throw invalidProtocolFrame('Only a capability provider credential may declare a Client owner');
+  }
   return {
-    principalKind: principalKind(record.principalKind),
+    principalKind: decodedPrincipalKind,
     principalId: principalId(record.principalId),
     operationGrants: operationGrants(record.operationGrants),
     canPublishClientCapabilities: boolean(
@@ -218,6 +239,7 @@ export function decodeAccessCredentialIssueInput(value: unknown): AccessCredenti
       'canPublishClientCapabilities',
     ),
     canUseHostPaths: boolean(record.canUseHostPaths, 'canUseHostPaths'),
+    ...(capabilityOwnerCredentialId ? { capabilityOwnerCredentialId } : {}),
   };
 }
 
@@ -250,19 +272,32 @@ export function decodeAccessCredentialPrepareInput(value: unknown): AccessCreden
 }
 
 export function decodeAccessCredentialIssueResult(value: unknown): AccessCredentialIssueResult {
-  const record = requireExactRecord(value, 'access credential issue result', [
-    'credentialId',
-    'deliveryId',
-    'principalKind',
-    'principalId',
-    'operationGrants',
-    'canPublishClientCapabilities',
-    'canUseHostPaths',
-  ]);
+  const record = requireShapedRecord(
+    value,
+    'access credential issue result',
+    [
+      'credentialId',
+      'deliveryId',
+      'principalKind',
+      'principalId',
+      'operationGrants',
+      'canPublishClientCapabilities',
+      'canUseHostPaths',
+    ],
+    ['capabilityOwner'],
+  );
+  const decodedPrincipalKind = principalKind(record.principalKind);
+  const capabilityOwner =
+    record.capabilityOwner === undefined
+      ? undefined
+      : clientCapabilityOwnerIdentity(record.capabilityOwner);
+  if (capabilityOwner && decodedPrincipalKind !== 'capability_provider') {
+    throw invalidProtocolFrame('Only a capability provider credential may declare a Client owner');
+  }
   return {
     credentialId: requireId(record.credentialId, 'credentialId'),
     deliveryId: requireId(record.deliveryId, 'deliveryId'),
-    principalKind: principalKind(record.principalKind),
+    principalKind: decodedPrincipalKind,
     principalId: principalId(record.principalId),
     operationGrants: operationGrants(record.operationGrants),
     canPublishClientCapabilities: boolean(
@@ -270,6 +305,7 @@ export function decodeAccessCredentialIssueResult(value: unknown): AccessCredent
       'canPublishClientCapabilities',
     ),
     canUseHostPaths: boolean(record.canUseHostPaths, 'canUseHostPaths'),
+    ...(capabilityOwner ? { capabilityOwner } : {}),
   };
 }
 
@@ -382,6 +418,17 @@ function principalId(value: unknown): string {
     throw invalidProtocolFrame('Invalid access credential principalId');
   }
   return principal;
+}
+
+function clientCapabilityOwnerIdentity(value: unknown): ClientCapabilityOwnerIdentity {
+  const record = requireExactRecord(value, 'Client Capability owner identity', [
+    'principalId',
+    'clientInstanceId',
+  ]);
+  return {
+    principalId: principalId(record.principalId),
+    clientInstanceId: requireId(record.clientInstanceId, 'clientInstanceId'),
+  };
 }
 
 function boolean(value: unknown, label: string): boolean {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -95,7 +95,10 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 73 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 74 as const;
+// 74: Capability-provider credentials may carry one Host-authenticated owner
+// identity. Older peers cannot preserve the association and could select an
+// unrelated provider for an interactive Session.
 // 73: Transcript pages carry a Host-owned Turn range boundary. Older peers
 // cannot preserve both the complete edge Turn and the bounded projection.
 // 71: Session Guests can submit durable exact Turn access requests and Owners

--- a/packages/runtime-host/src/server/access-authority.ts
+++ b/packages/runtime-host/src/server/access-authority.ts
@@ -23,6 +23,7 @@ import { runtimeHostAccessCredentialHash } from '../access-credential-identity.j
 import {
   type AccessCredentialIssueInput,
   type AccessCredentialIssueResult,
+  type ClientCapabilityOwnerIdentity,
   type AccessCredentialFinalizeResult,
   type AccessCredentialPrepareInput,
   type AccessCredentialPrepareResult,
@@ -229,6 +230,7 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
             !match.bindClientInstanceOnFinalize && match.canPublishClientCapabilities,
           canUseHostPaths: !match.bindClientInstanceOnFinalize && match.canUseHostPaths,
           ...(match.clientInstanceId ? { clientInstanceId: match.clientInstanceId } : {}),
+          ...(match.capabilityOwner ? { capabilityOwner: match.capabilityOwner } : {}),
         })
       : undefined;
   }
@@ -601,7 +603,7 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
           operationGrants: current.operationGrants,
           canPublishClientCapabilities: current.canPublishClientCapabilities,
           canUseHostPaths: current.canUseHostPaths,
-          bindClientInstance: current.bindClientInstanceOnFinalize === true,
+          bindClientInstance: current.clientInstanceId !== undefined,
         },
         'prepare',
         current.operationGrants,
@@ -622,6 +624,9 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
     operationGrants = issuedAccessGrants(input.operationGrants),
   ): Promise<AccessCredentialIssueResult> {
     assertCredentialAuthority(input, operationGrants);
+    const capabilityOwner = this.#resolveCapabilityOwner(
+      'capabilityOwnerCredentialId' in input ? input.capabilityOwnerCredentialId : undefined,
+    );
     if (
       mode === 'prepare' &&
       (input.principalKind !== 'remote_owner' ||
@@ -639,6 +644,7 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
       operationGrants,
       canPublishClientCapabilities: input.canPublishClientCapabilities,
       canUseHostPaths: input.canUseHostPaths,
+      ...(capabilityOwner ? { capabilityOwner } : {}),
     });
     const credential = `${ACCESS_CREDENTIAL_PREFIX}${randomBytes(32).toString('base64url')}`;
     const createdAt = new Date();
@@ -651,6 +657,7 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
       operationGrants,
       canPublishClientCapabilities: input.canPublishClientCapabilities,
       canUseHostPaths: input.canUseHostPaths,
+      ...(capabilityOwner ? { capabilityOwner } : {}),
       createdAt: createdAt.toISOString(),
       ...(mode === 'prepare'
         ? {
@@ -700,7 +707,31 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
       operationGrants,
       canPublishClientCapabilities: stored.canPublishClientCapabilities,
       canUseHostPaths: stored.canUseHostPaths,
+      ...(stored.capabilityOwner ? { capabilityOwner: stored.capabilityOwner } : {}),
     };
+  }
+
+  #resolveCapabilityOwner(
+    credentialId: string | undefined,
+  ): ClientCapabilityOwnerIdentity | undefined {
+    if (!credentialId) return undefined;
+    const owner = this.#file.credentials.find(
+      (credential) => credential.credentialId === credentialId && credential.status === 'active',
+    );
+    if (!owner || owner.principalKind !== 'remote_owner') {
+      throw new RuntimeHostAccessInputError(
+        'A capability provider owner must be one active remote-owner credential',
+      );
+    }
+    if (!owner.clientInstanceId) {
+      throw new RuntimeHostAccessInputError(
+        'A capability provider owner credential must be bound to one Client identity',
+      );
+    }
+    return Object.freeze({
+      principalId: owner.principalId,
+      clientInstanceId: owner.clientInstanceId,
+    });
   }
 
   revoke(input: AccessCredentialRevokeInput): Promise<AccessCredentialRevokeResult> {
@@ -1056,7 +1087,14 @@ function assertCredentialAuthority(
   input: AccessCredentialIssueInput,
   operationGrants: readonly string[],
 ): void {
-  if (input.principalKind !== 'capability_provider') return;
+  if (input.principalKind !== 'capability_provider') {
+    if (input.capabilityOwnerCredentialId) {
+      throw new RuntimeHostAccessInputError(
+        'Only a capability provider credential may declare a Client owner',
+      );
+    }
+    return;
+  }
   if (!input.canPublishClientCapabilities || input.canUseHostPaths) {
     throw new RuntimeHostAccessInputError(
       'A capability provider must publish Client Capabilities without Host path authority',

--- a/packages/runtime-host/src/server/access-authority.ts
+++ b/packages/runtime-host/src/server/access-authority.ts
@@ -151,6 +151,7 @@ export interface RuntimeHostAccessAuthority {
     principalId: string,
     kind: SessionCollaborationGrantKind,
   ): SessionCollaborationGrant | undefined;
+  hasActiveBoundClientIdentity(principalId: string, clientInstanceId: string): boolean;
   subscribeRevocations(listener: (credentialId: string) => void): () => void;
   subscribeGrantRevocations(listener: (grant: SessionCollaborationGrant) => void): () => void;
   subscribeApprovedTurnAccessRequests(
@@ -578,6 +579,16 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
   ): SessionCollaborationGrant | undefined {
     return this.#file.sessionGrants.find(
       (grant) => grant.principalId === principalId && grant.kind === kind,
+    );
+  }
+
+  hasActiveBoundClientIdentity(principalId: string, clientInstanceId: string): boolean {
+    return this.#file.credentials.some(
+      (credential) =>
+        credential.status === 'active' &&
+        credential.principalKind === 'remote_owner' &&
+        credential.principalId === principalId &&
+        credential.clientInstanceId === clientInstanceId,
     );
   }
 

--- a/packages/runtime-host/src/server/access-credential-store.ts
+++ b/packages/runtime-host/src/server/access-credential-store.ts
@@ -31,9 +31,11 @@ import {
   type OperationKey,
 } from '../protocol/index.js';
 
-// Schema 4 makes provider ownership downgrade-safe: a pre-association Host
-// rejects the file instead of silently treating a bound provider as global.
+// Schema 4 makes provider ownership downgrade-safe once an association exists.
+// Ordinary access files remain schema 3 so this feature does not fence a
+// downgrade before there is an owner association to preserve.
 const ACCESS_FILE_SCHEMA_VERSION = 4;
+const PRE_CAPABILITY_OWNER_ACCESS_FILE_SCHEMA_VERSION = 3;
 const ACCESS_FILE_MAX_BYTES = 512 * 1024;
 const LEGACY_TRANSCRIPT_QUERY_GRANT = 'session.transcript.query';
 const TRANSCRIPT_QUERY_REPLACEMENT_GRANTS = [
@@ -92,7 +94,9 @@ export interface StoredAccessCredential {
 }
 
 export interface AccessCredentialFile {
-  readonly schemaVersion: typeof ACCESS_FILE_SCHEMA_VERSION;
+  readonly schemaVersion:
+    | typeof PRE_CAPABILITY_OWNER_ACCESS_FILE_SCHEMA_VERSION
+    | typeof ACCESS_FILE_SCHEMA_VERSION;
   readonly credentials: readonly StoredAccessCredential[];
   readonly sessionGrants: readonly SessionCollaborationGrant[];
   readonly turnAccessRequests: readonly SessionTurnAccessRequest[];
@@ -125,7 +129,9 @@ export function createAccessCredentialFile(
   turnAccessRequests: readonly SessionTurnAccessRequest[] = [],
 ): AccessCredentialFile {
   return {
-    schemaVersion: ACCESS_FILE_SCHEMA_VERSION,
+    schemaVersion: credentials.some((credential) => credential.capabilityOwner !== undefined)
+      ? ACCESS_FILE_SCHEMA_VERSION
+      : PRE_CAPABILITY_OWNER_ACCESS_FILE_SCHEMA_VERSION,
     credentials,
     sessionGrants,
     turnAccessRequests,
@@ -239,10 +245,10 @@ function decodeAccessFile(value: unknown): AccessCredentialFile {
   if (!Array.isArray(value.credentials)) throw new Error('Invalid Runtime Host access file');
   const credentials = value.credentials.map(decodeStoredCredential);
   if (
-    value.schemaVersion === LEGACY_ACCESS_FILE_SCHEMA_VERSION &&
+    value.schemaVersion < ACCESS_FILE_SCHEMA_VERSION &&
     credentials.some((credential) => credential.capabilityOwner !== undefined)
   ) {
-    throw new Error('Legacy Runtime Host access files cannot declare Client Capability owners');
+    throw new Error('Pre-association Runtime Host access files cannot declare capability owners');
   }
   if (
     new Set(credentials.map((credential) => credential.credentialId)).size !== credentials.length

--- a/packages/runtime-host/src/server/access-credential-store.ts
+++ b/packages/runtime-host/src/server/access-credential-store.ts
@@ -22,6 +22,7 @@ import { chmod, open, rename, rm, type FileHandle } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import {
   type AccessCredentialPrincipalKind,
+  type ClientCapabilityOwnerIdentity,
   HOST_OPERATION_SPECS,
   operationAllowsRemoteOwner,
   type SessionCollaborationGrant,
@@ -30,7 +31,9 @@ import {
   type OperationKey,
 } from '../protocol/index.js';
 
-const ACCESS_FILE_SCHEMA_VERSION = 3;
+// Schema 4 makes provider ownership downgrade-safe: a pre-association Host
+// rejects the file instead of silently treating a bound provider as global.
+const ACCESS_FILE_SCHEMA_VERSION = 4;
 const ACCESS_FILE_MAX_BYTES = 512 * 1024;
 const LEGACY_TRANSCRIPT_QUERY_GRANT = 'session.transcript.query';
 const TRANSCRIPT_QUERY_REPLACEMENT_GRANTS = [
@@ -80,6 +83,7 @@ export interface StoredAccessCredential {
   readonly operationGrants: readonly OperationKey[];
   readonly canPublishClientCapabilities: boolean;
   readonly canUseHostPaths: boolean;
+  readonly capabilityOwner?: ClientCapabilityOwnerIdentity;
   readonly createdAt: string;
   readonly bindClientInstanceOnFinalize?: true;
   readonly clientInstanceId?: string;
@@ -225,12 +229,21 @@ function serializeAccessCredentialFile(file: AccessCredentialFile): string {
 function decodeAccessFile(value: unknown): AccessCredentialFile {
   if (
     !isRecord(value) ||
-    (value.schemaVersion !== 1 && value.schemaVersion !== 2 && value.schemaVersion !== 3)
+    (value.schemaVersion !== 1 &&
+      value.schemaVersion !== 2 &&
+      value.schemaVersion !== 3 &&
+      value.schemaVersion !== 4)
   ) {
     throw new Error('Unsupported Runtime Host access file');
   }
   if (!Array.isArray(value.credentials)) throw new Error('Invalid Runtime Host access file');
   const credentials = value.credentials.map(decodeStoredCredential);
+  if (
+    value.schemaVersion === LEGACY_ACCESS_FILE_SCHEMA_VERSION &&
+    credentials.some((credential) => credential.capabilityOwner !== undefined)
+  ) {
+    throw new Error('Legacy Runtime Host access files cannot declare Client Capability owners');
+  }
   if (
     new Set(credentials.map((credential) => credential.credentialId)).size !== credentials.length
   ) {
@@ -349,6 +362,10 @@ function decodeStoredCredential(value: unknown): StoredAccessCredential {
   ) {
     throw new Error('Invalid access credential Client binding state');
   }
+  const capabilityOwner = decodeCapabilityOwner(value.capabilityOwner);
+  if (capabilityOwner && principalKind !== 'capability_provider') {
+    throw new Error('Only a capability provider may declare a Client Capability owner');
+  }
   const expiresAt = value.expiresAt;
   if (value.status === 'pending') {
     if (typeof expiresAt !== 'string' || !Number.isFinite(Date.parse(expiresAt))) {
@@ -370,6 +387,7 @@ function decodeStoredCredential(value: unknown): StoredAccessCredential {
     operationGrants,
     canPublishClientCapabilities: value.canPublishClientCapabilities,
     canUseHostPaths: value.canUseHostPaths,
+    ...(capabilityOwner ? { capabilityOwner } : {}),
     createdAt,
     ...(bindClientInstanceOnFinalize === true ? { bindClientInstanceOnFinalize } : {}),
     ...(typeof clientInstanceId === 'string' ? { clientInstanceId } : {}),
@@ -397,6 +415,23 @@ function decodeStoredSessionGrant(value: unknown): SessionCollaborationGrant {
     sessionId,
     createdAt,
   });
+}
+
+function decodeCapabilityOwner(value: unknown): ClientCapabilityOwnerIdentity | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error('Invalid Client Capability owner identity');
+  const principalId = requireStoredString(value.principalId, 'capabilityOwner.principalId');
+  if (!/^[A-Za-z0-9_.:-]{1,128}$/u.test(principalId)) {
+    throw new Error('Invalid capabilityOwner.principalId');
+  }
+  const clientInstanceId = requireStoredString(
+    value.clientInstanceId,
+    'capabilityOwner.clientInstanceId',
+  );
+  if (clientInstanceId.length > 128) {
+    throw new Error('Invalid capabilityOwner.clientInstanceId');
+  }
+  return Object.freeze({ principalId, clientInstanceId });
 }
 
 function migrateStoredOperationGrants(grants: readonly string[]): readonly string[] {

--- a/packages/runtime-host/src/server/client-capability-coordinator.ts
+++ b/packages/runtime-host/src/server/client-capability-coordinator.ts
@@ -66,6 +66,7 @@ interface ClientProviderState {
   readonly providerId: string;
   readonly principalId: string;
   readonly clientInstanceId: string;
+  readonly credentialBoundClientInstanceId?: string;
   readonly principalKind: ClientCapabilityConnectionIdentity['principalKind'];
   readonly trustedProvider: boolean;
   readonly capabilityOwner?: ClientCapabilityOwnerIdentity;
@@ -341,16 +342,18 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       initiatingProvider?.current && this.#activeConnection(initiatingProvider)
         ? initiatingProvider
         : undefined;
-    const associatedProviders = initiatingProvider
-      ? [...this.#providers.values()].filter(
-          (provider) =>
-            provider.trustedProvider &&
-            provider.current !== undefined &&
-            this.#activeConnection(provider) !== undefined &&
-            provider.capabilityOwner?.principalId === initiatingProvider.principalId &&
-            provider.capabilityOwner.clientInstanceId === initiatingProvider.clientInstanceId,
-        )
-      : [];
+    const associatedProviders =
+      initiatingProvider &&
+      initiatingProvider.credentialBoundClientInstanceId === initiatingProvider.clientInstanceId
+        ? [...this.#providers.values()].filter(
+            (provider) =>
+              provider.trustedProvider &&
+              provider.current !== undefined &&
+              this.#activeConnection(provider) !== undefined &&
+              provider.capabilityOwner?.principalId === initiatingProvider.principalId &&
+              provider.capabilityOwner.clientInstanceId === initiatingProvider.clientInstanceId,
+          )
+        : [];
     if (!directProvider && associatedProviders.length > 1) {
       return {
         ok: false,
@@ -1028,6 +1031,9 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
         providerId,
         principalId: identity.principalId,
         clientInstanceId: identity.clientInstanceId,
+        ...(identity.credentialBoundClientInstanceId
+          ? { credentialBoundClientInstanceId: identity.credentialBoundClientInstanceId }
+          : {}),
         principalKind: identity.principalKind,
         trustedProvider,
         ...(identity.capabilityOwner
@@ -1038,7 +1044,8 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       this.#providers.set(providerId, provider);
     } else if (
       provider.principalKind !== identity.principalKind ||
-      provider.trustedProvider !== trustedProvider
+      provider.trustedProvider !== trustedProvider ||
+      provider.credentialBoundClientInstanceId !== identity.credentialBoundClientInstanceId
     ) {
       throw new Error('Client Capability provider authority changed across connections');
     } else if (

--- a/packages/runtime-host/src/server/client-capability-coordinator.ts
+++ b/packages/runtime-host/src/server/client-capability-coordinator.ts
@@ -25,6 +25,7 @@ import type { RootExecutionDescriptor } from '@maka/core/agent-run';
 import { type ToolGroup } from '@maka/runtime/tool-availability';
 import {
   type ClientCapabilityOffer,
+  type ClientCapabilityOwnerIdentity,
   type ClientCapabilityReplaceInput,
   type ClientCapabilityServiceOffer,
   type ClientCapabilityToolDescriptor,
@@ -65,7 +66,9 @@ interface ClientProviderState {
   readonly providerId: string;
   readonly principalId: string;
   readonly clientInstanceId: string;
+  readonly principalKind: ClientCapabilityConnectionIdentity['principalKind'];
   readonly trustedProvider: boolean;
+  readonly capabilityOwner?: ClientCapabilityOwnerIdentity;
   activeConnectionId?: string;
   current?: CapabilityRegistration;
   readonly registrations: Map<string, CapabilityRegistration>;
@@ -333,14 +336,41 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     initiatingConnectionId: string,
     mode: SessionBindingMode,
   ): SessionBindingSelection {
-    const initiatingProviderId = this.#connections.get(initiatingConnectionId)?.provider.providerId;
-    const initiatingProvider = initiatingProviderId
-      ? this.#providers.get(initiatingProviderId)
-      : undefined;
+    const initiatingProvider = this.#connections.get(initiatingConnectionId)?.provider;
+    const directProvider =
+      initiatingProvider?.current && this.#activeConnection(initiatingProvider)
+        ? initiatingProvider
+        : undefined;
+    const associatedProviders = initiatingProvider
+      ? [...this.#providers.values()].filter(
+          (provider) =>
+            provider.trustedProvider &&
+            provider.current !== undefined &&
+            this.#activeConnection(provider) !== undefined &&
+            provider.capabilityOwner?.principalId === initiatingProvider.principalId &&
+            provider.capabilityOwner.clientInstanceId === initiatingProvider.clientInstanceId,
+        )
+      : [];
+    if (!directProvider && associatedProviders.length > 1) {
+      return {
+        ok: false,
+        message: 'Multiple Client Capability providers are bound to the initiating Client',
+      };
+    }
+    const selectedInitiatingProvider = directProvider ?? associatedProviders[0];
+    // A remote Client must never inherit an unrelated provider merely because
+    // it is the only candidate. Local-owner and recovery flows retain their
+    // existing provider-independent fallback when no provider was selected.
+    const initiatingProviderId =
+      selectedInitiatingProvider?.providerId ??
+      (initiatingProvider?.principalKind === 'remote_owner'
+        ? initiatingProvider.providerId
+        : undefined);
     const previousState = this.#sessions.get(sessionId);
     const serviceProviderId =
       previousState?.serviceProviderId ??
-      (initiatingProvider?.current && initiatingProvider.current.servicesByContract.size > 0
+      (selectedInitiatingProvider?.current &&
+      selectedInitiatingProvider.current.servicesByContract.size > 0
         ? initiatingProviderId
         : undefined);
     const previous = previousState?.sessionBindings ?? new Map();
@@ -388,10 +418,8 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
           };
         }
       } else {
-        candidate =
-          candidates.find((entry) => entry.registration.providerId === initiatingProviderId) ??
-          (candidates.length === 1 ? candidates[0] : undefined);
-        if (!candidate && candidates.length > 1) {
+        candidate = selectProviderCandidate(candidates, initiatingProviderId);
+        if (!candidate && initiatingProviderId === undefined && candidates.length > 1) {
           if (mode === 'degrade') continue;
           return {
             ok: false,
@@ -436,9 +464,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       left.localeCompare(right),
     )) {
       if (candidates[0]?.offer.offer.affinity !== 'turn') continue;
-      const candidate =
-        candidates.find((entry) => entry.registration.providerId === initiatingProviderId) ??
-        (candidates.length === 1 ? candidates[0] : undefined);
+      const candidate = selectProviderCandidate(candidates, initiatingProviderId);
       if (!candidate || offerConflictsWithProxyNames(candidate.offer, proxyNames)) continue;
       nextTurn.set(contractId, {
         kind: 'bound',
@@ -510,7 +536,13 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     for (const [contractId, candidates] of [...eligible].sort(([left], [right]) =>
       left.localeCompare(right),
     )) {
-      const offer = candidates[0]?.offer;
+      // A provider-independent snapshot keeps one representative descriptor so
+      // a dynamic call can report ambiguity. A remote Client's explicit
+      // selector must instead hide every unrelated provider.
+      const offer =
+        state?.initiatingProviderId === undefined
+          ? candidates[0]?.offer
+          : selectProviderCandidate(candidates, state.initiatingProviderId)?.offer;
       if (
         !offer ||
         offer.offer.affinity !== 'call' ||
@@ -987,18 +1019,32 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
   #provider(identity: ClientCapabilityConnectionIdentity): ClientProviderState {
     const providerId = clientProviderId(identity.principalId, identity.clientInstanceId);
     const trustedProvider = identity.principalKind === 'capability_provider';
+    if (identity.capabilityOwner && !trustedProvider) {
+      throw new Error('Only a capability provider may declare a Client Capability owner');
+    }
     let provider = this.#providers.get(providerId);
     if (!provider) {
       provider = {
         providerId,
         principalId: identity.principalId,
         clientInstanceId: identity.clientInstanceId,
+        principalKind: identity.principalKind,
         trustedProvider,
+        ...(identity.capabilityOwner
+          ? { capabilityOwner: Object.freeze({ ...identity.capabilityOwner }) }
+          : {}),
         registrations: new Map(),
       };
       this.#providers.set(providerId, provider);
-    } else if (provider.trustedProvider !== trustedProvider) {
+    } else if (
+      provider.principalKind !== identity.principalKind ||
+      provider.trustedProvider !== trustedProvider
+    ) {
       throw new Error('Client Capability provider authority changed across connections');
+    } else if (
+      !clientCapabilityOwnerIdentitiesEqual(provider.capabilityOwner, identity.capabilityOwner)
+    ) {
+      throw new Error('Client Capability provider owner changed across connections');
     }
     return provider;
   }
@@ -1033,13 +1079,13 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     readonly tool: FrozenToolBinding;
   } {
     const candidates = this.#eligibleOffersByContract().get(contractId) ?? [];
-    const candidate =
-      candidates.find((entry) => entry.registration.providerId === initiatingProviderId) ??
-      (candidates.length === 1 ? candidates[0] : undefined);
+    const candidate = selectProviderCandidate(candidates, initiatingProviderId);
     if (!candidate) {
       throw new ClientCapabilityInvocationError(
-        candidates.length > 1 ? 'capability_ambiguous' : 'capability_lost',
-        candidates.length > 1
+        initiatingProviderId === undefined && candidates.length > 1
+          ? 'capability_ambiguous'
+          : 'capability_lost',
+        initiatingProviderId === undefined && candidates.length > 1
           ? 'Multiple Client Capability providers offer this call-affine contract'
           : 'Client Capability provider is unavailable',
       );
@@ -1368,6 +1414,30 @@ function rememberOfferProxyNames(offer: FrozenOfferBinding, proxyNames: Map<stri
   for (const descriptor of offer.offer.tools) {
     proxyNames.set(mcpProxyToolName(descriptor.serverId, descriptor.name), offer.contractId);
   }
+}
+
+function selectProviderCandidate(
+  candidates: readonly SelectedOfferBinding[],
+  initiatingProviderId: string | undefined,
+): SelectedOfferBinding | undefined {
+  return initiatingProviderId === undefined
+    ? candidates.length === 1
+      ? candidates[0]
+      : undefined
+    : candidates.find((candidate) => candidate.registration.providerId === initiatingProviderId);
+}
+
+function clientCapabilityOwnerIdentitiesEqual(
+  left: ClientProviderState['capabilityOwner'],
+  right: ClientCapabilityConnectionIdentity['capabilityOwner'],
+): boolean {
+  return (
+    left === right ||
+    (left !== undefined &&
+      right !== undefined &&
+      left.principalId === right.principalId &&
+      left.clientInstanceId === right.clientInstanceId)
+  );
 }
 
 function canonicalJson(value: unknown): string {

--- a/packages/runtime-host/src/server/client-capability-service.ts
+++ b/packages/runtime-host/src/server/client-capability-service.ts
@@ -21,6 +21,7 @@ import type {
   AccessCredentialPrincipalKind,
   ClientCapabilityClientFrame,
   ClientCapabilityHostFrame,
+  ClientCapabilityOwnerIdentity,
 } from '../protocol/index.js';
 
 export interface ClientCapabilityConnectionSender {
@@ -32,6 +33,7 @@ export interface ClientCapabilityConnectionIdentity {
   readonly principalId: string;
   readonly clientInstanceId: string;
   readonly principalKind: 'local_owner' | AccessCredentialPrincipalKind;
+  readonly capabilityOwner?: ClientCapabilityOwnerIdentity;
 }
 
 export interface ClientCapabilityConnection {

--- a/packages/runtime-host/src/server/client-capability-service.ts
+++ b/packages/runtime-host/src/server/client-capability-service.ts
@@ -32,6 +32,8 @@ export interface ClientCapabilityConnectionIdentity {
   readonly connectionId: string;
   readonly principalId: string;
   readonly clientInstanceId: string;
+  /** Present only when the access credential, rather than hello, authenticated this Client ID. */
+  readonly credentialBoundClientInstanceId?: string;
   readonly principalKind: 'local_owner' | AccessCredentialPrincipalKind;
   readonly capabilityOwner?: ClientCapabilityOwnerIdentity;
 }

--- a/packages/runtime-host/src/server/connection-authority.ts
+++ b/packages/runtime-host/src/server/connection-authority.ts
@@ -22,6 +22,7 @@ import {
   operationAllowsRemoteOwner,
   operationUsesHostPaths,
   type AccessCredentialPrincipalKind,
+  type ClientCapabilityOwnerIdentity,
   type ClientCapabilityClientFrame,
   type OperationKey,
   type RequestFrame,
@@ -32,6 +33,7 @@ export interface RuntimeHostConnectionAuthority {
   readonly principalId: string;
   readonly credentialId?: string;
   readonly clientInstanceId?: string;
+  readonly capabilityOwner?: ClientCapabilityOwnerIdentity;
   readonly operationGrants: 'all' | readonly OperationKey[];
   readonly canPublishClientCapabilities: boolean;
   readonly canUseHostPaths: boolean;
@@ -63,6 +65,20 @@ export function createRuntimeHostConnectionAuthority(
   ) {
     throw new Error('Runtime Host bound Client identity is invalid');
   }
+  if (input.capabilityOwner) {
+    if (input.principalKind !== 'capability_provider') {
+      throw new Error('Only a capability provider may declare a Client Capability owner');
+    }
+    if (!/^[A-Za-z0-9_.:-]{1,128}$/u.test(input.capabilityOwner.principalId)) {
+      throw new Error('Runtime Host Client Capability owner principal is invalid');
+    }
+    if (
+      input.capabilityOwner.clientInstanceId.length === 0 ||
+      input.capabilityOwner.clientInstanceId.length > 128
+    ) {
+      throw new Error('Runtime Host Client Capability owner identity is invalid');
+    }
+  }
   const operationGrants =
     input.operationGrants === 'all'
       ? 'all'
@@ -74,7 +90,14 @@ export function createRuntimeHostConnectionAuthority(
             return operation;
           }),
         );
-  return Object.freeze({ ...input, operationGrants });
+  const capabilityOwner = input.capabilityOwner
+    ? Object.freeze({ ...input.capabilityOwner })
+    : undefined;
+  return Object.freeze({
+    ...input,
+    operationGrants,
+    ...(capabilityOwner ? { capabilityOwner } : {}),
+  });
 }
 
 export function authorizeRuntimeHostOperation(

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -296,6 +296,12 @@ export class RuntimeHostConnectionSession {
           connectionId: this.#options.connection.connectionId,
           principalId: this.#options.connection.authority.principalId,
           clientInstanceId: this.#options.connection.clientInstanceId,
+          ...(this.#options.connection.authority.clientInstanceId
+            ? {
+                credentialBoundClientInstanceId:
+                  this.#options.connection.authority.clientInstanceId,
+              }
+            : {}),
           principalKind: this.#options.connection.authority.principalKind,
           ...(this.#options.connection.authority.capabilityOwner
             ? { capabilityOwner: this.#options.connection.authority.capabilityOwner }

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -297,6 +297,9 @@ export class RuntimeHostConnectionSession {
           principalId: this.#options.connection.authority.principalId,
           clientInstanceId: this.#options.connection.clientInstanceId,
           principalKind: this.#options.connection.authority.principalKind,
+          ...(this.#options.connection.authority.capabilityOwner
+            ? { capabilityOwner: this.#options.connection.authority.capabilityOwner }
+            : {}),
         },
         {
           send: (frame) => {

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -480,6 +480,16 @@ export class RuntimeHostKernel {
     if (authority.clientInstanceId && authority.clientInstanceId !== hello.clientInstanceId) {
       throw new Error('Runtime Host access credential belongs to another Client');
     }
+    if (
+      authority.principalKind === 'remote_owner' &&
+      authority.clientInstanceId === undefined &&
+      this.#options.accessAuthority?.hasActiveBoundClientIdentity(
+        authority.principalId,
+        hello.clientInstanceId,
+      )
+    ) {
+      throw new Error('Runtime Host Client identity is bound to another access credential');
+    }
     const selectedProtocol = negotiateProtocol(
       { min: hello.protocolMin, max: hello.protocolMax },
       HOST_PROTOCOL,


### PR DESCRIPTION
## Summary

Add the Runtime Host association contract needed for a remote TUI to use a separate Client Capability provider without exposing that provider to unrelated Clients.

- Let a local owner issue a capability-provider credential against one active, Client-bound remote-owner credential. The caller supplies only the owner credential id; the Host resolves and persists the authenticated `{ principalId, clientInstanceId }`.
- Carry authenticated identity provenance through Client Capability attachment, then select the initiating Client's direct provider or exactly one matching companion. Hello-only Client IDs cannot participate, and an unbound credential cannot claim an active bound Client identity.
- Preserve existing Session-frozen bindings, provider reconnect behavior, and provider-independent local/recovery flows. Multiple companions for one owner fail closed.
- Publish compatibility epoch 74 and access-file schema 4. Ordinary access files remain on schema 3 until an owner association commits; older Hosts reject associated files instead of silently dropping the security boundary.

Refs #3838

## Review focus

This keeps one authority for the association. The access authority derives the Client identity from an existing bound credential; the capability coordinator only consumes that derived fact. There is no caller-supplied identity tuple, name-based matching, association registry, or second lifecycle manager.

Client-bound credential rotation preserves the binding requirement so a rotated owner can remain the trusted source for companion credentials.

This slice intentionally does not launch or supervise a TUI companion process and does not add TUI credential storage or UI. Those lifecycle and end-to-end changes remain in the follow-up PR stacked on this contract.

## Verification

- Authenticated WebSocket regression: an unbound same-principal credential cannot claim an active bound Client ID
- Client Capability regression: a hello-only Client identity cannot select an associated provider
- Access-store regressions: ordinary and failed association mutations remain schema 3; a committed association writes schema 4; downgrade rejects owner data
- Exact final stack: affected Runtime Host and CLI suites — 144 passed, 0 failed
- Full Runtime Host suite before the final non-overlapping main rebase — 1,411 passed, 9 skipped, 0 failed
- `git diff --check origin/main...HEAD`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex traced the existing access, Client identity, Session binding, and provider lifecycle boundaries; implemented the credential association and exact provider selection; repaired the authenticated identity and conditional schema fences from review; added regression coverage; and performed architecture and simplification reviews. The commits carry a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
