### PR TITLE
fix: align Runtime Host compatible-change epoch

### DIFF
--- a/packages/runtime-host/protocol-compatible-changes/session-catalog-deep-research-import.json
+++ b/packages/runtime-host/protocol-compatible-changes/session-catalog-deep-research-import.json
@@ -1,5 +1,5 @@
 {
-  "epoch": 65,
+  "epoch": 68,
   "files": [
     "packages/runtime-host/src/protocol/session-catalog.ts",
     "packages/runtime-host/src/protocol/session-continuity.ts"


### PR DESCRIPTION
## Summary

Align the Runtime Host compatible-change declaration introduced by #4176 with the current protocol compatibility epoch, 68. This restores the merge-result protocol guard without changing the wire protocol or advancing the epoch.

## Root cause

The branch for #4176 created the declaration while its base was at epoch 65. Independent protocol changes advanced `main` to epoch 68 before #4176 merged.

Git reported no conflict because #4176 did not edit `packages/runtime-host/src/protocol/index.ts`: the merge result kept `main`'s epoch 68 and added the declaration containing epoch 65. The merge-result guard compares the result with its first parent and requires a newly added compatible-change declaration to match the result's epoch, so it deterministically rejected the mismatched declaration.

This PR changes only the declaration's epoch. It does not modify a wire codec, bump the protocol epoch, change historical result decoding, or add another compatibility path.

## Verification

- Before the fix, `node scripts/protocol-epoch-check.mjs --base d7efbb478518525c24d8b6dddcde396683ba36a2 --head 8aed381eab3aa429d786a1aafc137fa7163d4e34` exited 2 with `Invalid compatible protocol change declaration`.
- After the fix, `node scripts/protocol-epoch-check.mjs --base d7efbb478518525c24d8b6dddcde396683ba36a2 --head HEAD` passed with `Protocol added a declared compatible extension at epoch 68.`
- `node scripts/protocol-epoch-check.mjs --base origin/main --head HEAD` passed.
- `node --test scripts/protocol-epoch-check.test.mjs` passed: 12 tests.
- `npx biome format --write packages/runtime-host/protocol-compatible-changes/session-catalog-deep-research-import.json` passed with no fixes needed.
- `npx biome check packages/runtime-host/protocol-compatible-changes/session-catalog-deep-research-import.json` passed.
- `git diff --check origin/main...HEAD` passed.
- Full-repository tests and typechecks were not run because the change is limited to one guard declaration value.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex traced the merge-result guard and historical persistence boundary, authored the one-line declaration fix, ran focused validation, and drafted this pull request. The commit includes a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

The protocol guard tests and scoped Biome checks pass; typecheck was not run because no typed source changed.

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
