### PR TITLE
perf(ui): incrementally prepare streamed Markdown math

### DIFF
--- a/packages/ui/src/__tests__/markdown-body.test.ts
+++ b/packages/ui/src/__tests__/markdown-body.test.ts
@@ -59,6 +59,50 @@ it('renders Markdown emphasis and LaTeX without exposing their source delimiters
   assert.doesNotMatch(markup, /\\\\\\\(/);
 });
 
+it('keeps URL, email, and Markdown markers atomic inside math', () => {
+  const markup = renderToStaticMarkup(createElement(LocaleProvider, {
+    locale: 'en',
+    children: createElement(MarkdownBody, {
+      text: [
+        'URL \\( \\texttt{https://example.com} \\)',
+        'Email \\( \\text{person@example.com} \\)',
+        'Markers \\( x \\left[y\\right] * z \\)',
+      ].join('\n\n'),
+      streaming: true,
+      settledText: [
+        'URL \\( \\texttt{https://example.com} \\)',
+        'Email \\( \\text{person@example.com} \\)',
+        'Markers \\( x \\left[y\\right] * z \\)',
+      ].join('\n\n'),
+    }),
+  }));
+
+  assert.equal((markup.match(/class="maka-math maka-math-inline"/g) ?? []).length, 3);
+  assert.equal((markup.match(/class="katex"/g) ?? []).length, 3);
+  assert.doesNotMatch(markup, /<a\b|mailto:/);
+  assert.doesNotMatch(markup, /\\\(|\\\)/);
+});
+
+it('falls back to ordinary Markdown for an empty formula', () => {
+  const markup = renderToStaticMarkup(createElement(MarkdownBody, {
+    text: 'Empty \\( \\) end',
+  }));
+
+  assert.doesNotMatch(markup, /class="maka-math/);
+  assert.doesNotMatch(markup, /\\\(|\\\)/);
+  assert.match(markup, /Empty \( \) end/);
+});
+
+it('keeps literal math transport syntax as prose', () => {
+  const literalToken = '\uE000MAKA_MATH:0:78\uE001';
+  const markup = renderToStaticMarkup(createElement(MarkdownBody, {
+    text: `Literal ${literalToken} end`,
+  }));
+
+  assert.doesNotMatch(markup, /class="maka-math/);
+  assert.match(markup, new RegExp(literalToken));
+});
+
 it('leaves LaTeX delimiters untouched inside inline and fenced code', () => {
   const markup = renderToStaticMarkup(createElement(MarkdownBody, {
     text: ['Use `\\( x + 1 \\)` literally.', '', '```tex', '\\( y + 2 \\)', '```'].join('\n'),
@@ -67,6 +111,44 @@ it('leaves LaTeX delimiters untouched inside inline and fenced code', () => {
   assert.doesNotMatch(markup, /class="maka-math/);
   assert.match(markup, /\\\( x \+ 1 \\\)/);
   assert.match(markup, /\\\( y \+ 2 \\\)/);
+});
+
+it('does not let an unmatched inline backtick hide later math', () => {
+  const markup = renderToStaticMarkup(createElement(MarkdownBody, {
+    text: 'Unmatched ` prose.\n\nMath \\(x + 1\\)',
+  }));
+
+  assert.match(markup, /class="maka-math maka-math-inline"/);
+  assert.match(markup, /class="katex"/);
+});
+
+it('does not let an unmatched math delimiter hide a later formula', () => {
+  for (const text of [
+    'bad \\( then \\[x\\]',
+    'bad $$ then \\(x\\)',
+    'bad \\[ then \\(x\\)',
+  ]) {
+    const markup = renderToStaticMarkup(createElement(MarkdownBody, { text }));
+    assert.match(markup, /class="maka-math/);
+    assert.match(markup, /class="katex/);
+  }
+});
+
+it('lets a formula own backticks that occur inside its delimiters', () => {
+  for (const formula of ['\\(x ` y\\)', '\\(x \\text{`foo`}\\)']) {
+    const markup = renderToStaticMarkup(createElement(MarkdownBody, { text: formula }));
+    assert.match(markup, /class="maka-math maka-math-inline"/);
+    assert.match(markup, /class="katex"/);
+  }
+});
+
+it('keeps scanning after a malformed math transport prefix', () => {
+  const markup = renderToStaticMarkup(createElement(MarkdownBody, {
+    text: `bad \uE000MAKA_MATH:bad then \\(x\\)`,
+  }));
+
+  assert.match(markup, /MAKA_MATH:bad/);
+  assert.match(markup, /class="maka-math maka-math-inline"/);
 });
 
 it('renders display math while leaving ordinary currency alone', () => {
@@ -99,21 +181,6 @@ it('does not treat shell variables, currency, or inline code as dollar-delimited
   assert.match(markup, /class="katex"/);
 });
 
-it('keeps raw and malformed internal-token lookalikes literal', () => {
-  for (const token of [
-    '\uE000MAKAMATHIFFFFFFEND\uE001',
-    '\uE000MAKAMATH:0:0:\uE001',
-    '\uE000MAKAMATH:999:not-a-token:\uE001',
-  ]) {
-    const markup = renderToStaticMarkup(createElement(MarkdownBody, {
-      text: `Before ${token} after with \\( x + 1 \\).`,
-    }));
-
-    assert.match(markup, new RegExp(token));
-    assert.equal((markup.match(/class="maka-math maka-math-inline"/g) ?? []).length, 1);
-  }
-});
-
 it('renders multiline display math outside code for both supported delimiters', () => {
   for (const [text, mathNode] of [
     [['Before', '', '$$', 'E = mc^2', '$$', '', 'After'].join('\n'), '<msup>'],
@@ -129,6 +196,26 @@ it('renders multiline display math outside code for both supported delimiters', 
     assert.doesNotMatch(markup, /\\\[/);
     assert.match(markup, new RegExp(mathNode));
     assert.doesNotMatch(markup, /<em[^>]*>1<\/em>/);
+  }
+});
+
+it('keeps display math intact across Markdown-looking block boundaries', () => {
+  const bodies = [
+    ['x + 1', '', 'y + 2'],
+    ['x + 1', '# heading-shaped'],
+    ['x + 1', '- list-shaped'],
+    ['x + 1', '| table | shaped |', '| --- | --- |'],
+  ];
+
+  for (const [open, close] of [['$$', '$$'], ['\\[', '\\]']]) {
+    for (const body of bodies) {
+      const markup = renderToStaticMarkup(createElement(MarkdownBody, {
+        text: ['Before', '', open, ...body, close, '', 'After'].join('\n'),
+      }));
+
+      assert.match(markup, /class="maka-math maka-math-display"/);
+      assert.doesNotMatch(markup, /<h1\b|<ul\b|<table\b/);
+    }
   }
 });
 
@@ -409,15 +496,13 @@ it('shows only the restored prefix on its first streaming render', () => {
   assert.doesNotMatch(markup, /new delta/);
 });
 
-it('uses the same protected math registry for live and settled streaming text', () => {
-  const rawToken = '\uE000MAKAMATH:0:0:\uE001';
+it('renders settled math while keeping the live tail behind the display cursor', () => {
   const markup = renderToStaticMarkup(createElement(MarkdownBody, {
-    text: `Stable ${rawToken} \\( x + 1 \\) with a new delta`,
+    text: 'Stable \\( x + 1 \\) with a new delta',
     streaming: true,
-    settledText: `Stable ${rawToken} \\( x + 1 \\)`,
+    settledText: 'Stable \\( x + 1 \\)',
   }));
 
-  assert.match(markup, new RegExp(rawToken));
   assert.match(markup, /class="maka-math maka-math-inline"/);
   assert.match(markup, /class="katex"/);
   assert.doesNotMatch(markup, /new delta/);

--- a/packages/ui/src/__tests__/streaming-text.test.tsx
+++ b/packages/ui/src/__tests__/streaming-text.test.tsx
@@ -23,6 +23,8 @@ import { useStreamingText } from '@astryxdesign/core';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { parseHTML } from 'linkedom';
+import { LocaleProvider } from '../locale-context.js';
+import { MarkdownBody } from '../markdown-body.js';
 
 const originalGlobals = {
   document: globalThis.document,
@@ -106,6 +108,120 @@ test('never reveals half of a Unicode code point', async () => {
   assert.ok(frame);
   await act(() => frame?.(100));
   assert.equal(container.textContent, 'a123456789😀');
+
+  await act(() => root.unmount());
+});
+
+test('keeps settled math stable while the live Markdown tail grows and flushes', async () => {
+  const frames: FrameRequestCallback[] = [];
+  const { container, root } = streamingRoot((callback) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  const settled = [
+    'Before',
+    '',
+    '\\( \\texttt{https://example.com} + \\text{person@example.com} \\)',
+    '',
+    '',
+  ].join('\n');
+
+  function render(text: string, streaming: boolean) {
+    return root.render(
+      <LocaleProvider locale="en">
+        <MarkdownBody
+          text={text}
+          settledText={streaming ? settled : undefined}
+          streaming={streaming}
+        />
+      </LocaleProvider>,
+    );
+  }
+
+  await act(() => render(`${settled}growing`, true));
+  const math = container.querySelector('.maka-math');
+  assert.ok(math);
+  assert.ok(math.querySelector('.katex'));
+  assert.equal(container.querySelector('a'), null);
+
+  const firstFrame = frames.shift();
+  assert.ok(firstFrame);
+  await act(() => firstFrame(100));
+  assert.equal(container.querySelector('.maka-math'), math);
+
+  await act(() => render(`${settled}growing live tail`, true));
+  const secondFrame = frames.shift();
+  assert.ok(secondFrame);
+  await act(() => secondFrame(200));
+  assert.equal(container.querySelector('.maka-math'), math);
+  assert.equal(container.querySelector('a'), null);
+
+  await act(() => render(`${settled}final tail`, false));
+  assert.ok(container.querySelector('.maka-math .katex'));
+  assert.equal(container.querySelector('a'), null);
+  assert.match(container.textContent ?? '', /final tail/);
+
+  await act(() => root.unmount());
+});
+
+test('never exposes math transport syntax as a formula crosses the display cursor', async () => {
+  const frames: FrameRequestCallback[] = [];
+  const { container, root } = streamingRoot((callback) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  const target = 'Before \\(x + 1\\) after';
+
+  await act(() => root.render(
+    <LocaleProvider locale="en">
+      <MarkdownBody text={target} settledText="Before " streaming />
+    </LocaleProvider>,
+  ));
+
+  for (let tick = 1; tick <= 8 && container.querySelector('.maka-math') === null; tick++) {
+    const frame = frames.shift();
+    assert.ok(frame);
+    await act(() => frame(tick * 100));
+    assert.doesNotMatch(container.textContent ?? '', /MAKA_MATH|\uE000|\uE001/);
+  }
+
+  assert.ok(container.querySelector('.maka-math .katex'));
+  assert.match(container.textContent ?? '', /Before/);
+  await act(() => root.unmount());
+});
+
+test('keeps a restored prefix inside math visible and handles a formula rewrite', async () => {
+  const frames: FrameRequestCallback[] = [];
+  const { container, root } = streamingRoot((callback) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  const first = 'Before \\(x + 1\\) after';
+  const second = 'Before \\(x + 2\\) after';
+
+  await act(() => root.render(
+    <LocaleProvider locale="en">
+      <MarkdownBody text={first} settledText={'Before \\(x'} streaming />
+    </LocaleProvider>,
+  ));
+  assert.match(container.textContent ?? '', /Before \(x/);
+  assert.doesNotMatch(container.textContent ?? '', /MAKA_MATH|\uE000|\uE001/);
+
+  await act(() => root.render(
+    <LocaleProvider locale="en">
+      <MarkdownBody text={second} settledText={first} streaming />
+    </LocaleProvider>,
+  ));
+  assert.doesNotMatch(container.textContent ?? '', /MAKA_MATH|\uE000|\uE001/);
+
+  for (let tick = 1; tick <= 8 && container.querySelector('.maka-math') === null; tick++) {
+    const frame = frames.shift();
+    assert.ok(frame);
+    await act(() => frame(tick * 100));
+    assert.doesNotMatch(container.textContent ?? '', /MAKA_MATH|\uE000|\uE001/);
+  }
+  assert.ok(container.querySelector('.maka-math .katex'));
+  assert.match(container.textContent ?? '', /2/);
 
   await act(() => root.unmount());
 });

--- a/packages/ui/src/__tests__/streaming-text.test.tsx
+++ b/packages/ui/src/__tests__/streaming-text.test.tsx
@@ -48,6 +48,9 @@ function streamingRoot(
   requestAnimationFrame: (callback: FrameRequestCallback) => number = () => 1,
 ) {
   const { document, window } = parseHTML('<div id="root"></div>');
+  Object.assign(window, {
+    getComputedStyle: () => ({ direction: 'ltr', writingMode: 'horizontal-tb' }),
+  });
   Object.assign(globalThis, {
     document,
     window,
@@ -224,4 +227,40 @@ test('keeps a restored prefix inside math visible and handles a formula rewrite'
   assert.match(container.textContent ?? '', /2/);
 
   await act(() => root.unmount());
+});
+
+test('keeps split fenced-code openers literal through final flush', async () => {
+  for (const { prefix, target } of [
+    { prefix: '~~', target: '~~~ts\n\\(not math\\)\n~~~' },
+    { prefix: '``', target: '```ts\n\\(not math\\)\n```' },
+  ]) {
+    const frames: FrameRequestCallback[] = [];
+    const { container, root } = streamingRoot((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const render = (text: string, streaming: boolean) => root.render(
+      <LocaleProvider locale="en">
+        <MarkdownBody
+          text={text}
+          settledText={streaming ? prefix : undefined}
+          streaming={streaming}
+        />
+      </LocaleProvider>,
+    );
+
+    await act(() => render(prefix, true));
+    await act(() => render(target, true));
+    for (let tick = 1; tick <= 30 && frames.length > 0; tick++) {
+      const frame = frames.shift();
+      assert.ok(frame);
+      await act(() => frame(tick * 100));
+    }
+    await act(() => render(target, false));
+
+    assert.equal(container.querySelector('code')?.textContent, '\\(not math\\)');
+    assert.equal(container.querySelector('.maka-math'), null);
+    assert.doesNotMatch(container.textContent ?? '', /MAKA_MATH|\uE000|\uE001/);
+    await act(() => root.unmount());
+  }
 });

--- a/packages/ui/src/markdown-body.tsx
+++ b/packages/ui/src/markdown-body.tsx
@@ -29,7 +29,7 @@
  * product-specific trust boundaries around that renderer.
  */
 
-import { useContext, type ReactNode } from 'react';
+import { useCallback, useContext, useRef, type ReactNode } from 'react';
 import {
   Markdown as AstryxMarkdown,
   type MarkdownComponents,
@@ -46,7 +46,11 @@ import { MakaUriContext } from './markdown.js';
 import { useUiLocale } from './locale-context.js';
 import { getSharedUiCopy } from './shared-ui-copy.js';
 import { MermaidDiagram } from './mermaid-diagram.js';
-import { prepareMarkdownMath } from './markdown-math.js';
+import {
+  createMarkdownMathCache,
+  MARKDOWN_MATH_PLUGINS,
+  prepareMarkdownMath,
+} from './markdown-math.js';
 import { parseAttachmentResourceRef } from '@maka/core/attachments';
 import { useAttachmentImageSource } from './attachment-image.js';
 
@@ -132,9 +136,12 @@ export function MarkdownBody(props: {
   settledText?: string;
   density?: 'default' | 'compact';
 }) {
-  const prepared = prepareMarkdownMath(props.text, props.settledText);
-  const safeText = prepared.text;
-  const budgetedText = props.streaming ? safeText : applyMermaidRenderBudget(safeText);
+  const mathCache = useRef(createMarkdownMathCache());
+  const transformMathSource = useCallback(
+    (source: string) => prepareMarkdownMath(source, mathCache.current),
+    [],
+  );
+  const budgetedText = props.streaming ? props.text : applyMermaidRenderBudget(props.text);
   const density = props.density ?? 'default';
   const components = props.streaming
     ? density === 'compact'
@@ -175,9 +182,10 @@ export function MarkdownBody(props: {
         // the one combination neither half of the argument asks for.
         density={density}
         components={components}
-        inlinePlugins={[prepared.plugin]}
+        inlinePlugins={MARKDOWN_MATH_PLUGINS}
         isStreaming={props.streaming}
-        settledText={prepared.settledText}
+        settledText={props.settledText}
+        transformSource={transformMathSource}
       >
         {budgetedText}
       </AstryxMarkdown>

--- a/packages/ui/src/markdown-math.tsx
+++ b/packages/ui/src/markdown-math.tsx
@@ -20,177 +20,280 @@
 import katex from 'katex';
 import type { MarkdownInlinePlugin } from '@astryxdesign/core/Markdown';
 
-export interface PreparedMarkdownMath {
+const TOKEN_START = '\uE000MAKA_MATH:';
+const TOKEN_END = '\uE001';
+const TOKEN_PATTERN = /\uE000MAKA_MATH:([012]):([0-9a-f]+)\uE001/g;
+const LITERAL_TOKEN_PATTERN = /^\uE000MAKA_MATH:[012]:[0-9a-f]+\uE001/;
+
+/**
+ * Discardable derived state owned by one MarkdownBody mount. Capacity is two
+ * strings no larger than that component's currently displayed source and its
+ * transport form; a rewrite resets both and unmounting drops the cache.
+ */
+export interface MarkdownMathCache {
+  source: string;
   text: string;
-  settledText?: string;
-  plugin: MarkdownInlinePlugin;
+  safeSourceEnd: number;
+  safeTextEnd: number;
 }
 
-interface MathTokenValue {
-  formula: string;
-  displayMode: boolean;
+export function createMarkdownMathCache(): MarkdownMathCache {
+  return { source: '', text: '', safeSourceEnd: 0, safeTextEnd: 0 };
 }
 
 export function prepareMarkdownMath(
   source: string,
-  settledSource?: string,
-): PreparedMarkdownMath {
-  const registry = createMathTokenRegistry([source, settledSource]);
-  return {
-    text: protectMathOutsideCode(source, registry.register),
-    ...(settledSource === undefined
-      ? {}
-      : { settledText: protectMathOutsideCode(settledSource, registry.register) }),
-    plugin: {
-      pattern: registry.pattern,
-      render: (match, key) => {
-        const value = registry.values.get(match[0]);
-        if (!value) return match[0];
-        const html = katex.renderToString(value.formula, {
-          displayMode: value.displayMode,
-          output: 'htmlAndMathml',
-          strict: 'warn',
-          throwOnError: false,
-          trust: false,
-        });
-        return (
-          <span
-            key={key}
-            className={
-              value.displayMode ? 'maka-math maka-math-display' : 'maka-math maka-math-inline'
-            }
-            dangerouslySetInnerHTML={{ __html: html }}
-          />
-        );
-      },
-    },
-  };
+  cache: MarkdownMathCache,
+): string {
+  // The caller currently supplies a full string rather than an append token,
+  // so proving that a rewrite did not occur requires this prefix check. It
+  // keeps the JavaScript lexer on the changing tail; it does not make the
+  // full-string identity check itself incremental.
+  const extendsPrevious = source.startsWith(cache.source);
+  const sourceStart = extendsPrevious ? cache.safeSourceEnd : 0;
+  const textStart = extendsPrevious ? cache.safeTextEnd : 0;
+  const protectedTail = protectMarkdownMath(
+    source.slice(sourceStart),
+    sourceStart === 0 || source[sourceStart - 1] === '\n',
+  );
+  const text = `${extendsPrevious ? cache.text.slice(0, textStart) : ''}${protectedTail.text}`;
+
+  cache.source = source;
+  cache.text = text;
+  cache.safeSourceEnd = sourceStart + protectedTail.safeSourceEnd;
+  cache.safeTextEnd = textStart + protectedTail.safeTextEnd;
+  return text;
 }
 
-function createMathTokenRegistry(sources: Array<string | undefined>): {
-  pattern: RegExp;
-  register: (formula: string, displayMode: boolean) => string;
-  values: Map<string, MathTokenValue>;
+export const MARKDOWN_MATH_PLUGINS = [{
+  pattern: TOKEN_PATTERN,
+  render: (match, key) => {
+    const formula = decodeFormula(match[2] ?? '');
+    if (match[1] === '2') return formula;
+    const displayMode = match[1] === '1';
+    const html = katex.renderToString(formula, {
+      displayMode,
+      output: 'htmlAndMathml',
+      strict: 'warn',
+      throwOnError: false,
+      trust: false,
+    });
+    return (
+      <span
+        key={key}
+        className={
+          displayMode ? 'maka-math maka-math-display' : 'maka-math maka-math-inline'
+        }
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  },
+}] satisfies MarkdownInlinePlugin[];
+
+function protectMarkdownMath(source: string, startsAtLineStart = true): {
+  text: string;
+  safeSourceEnd: number;
+  safeTextEnd: number;
 } {
-  let namespaceIndex = 0;
-  let namespace = '';
-  do {
-    namespace = `\uE000MAKAMATH:${namespaceIndex}:`;
-    namespaceIndex += 1;
-  } while (sources.some((source) => source?.includes(namespace)));
-
-  const tokenEnd = ':\uE001';
-  const values = new Map<string, MathTokenValue>();
-  const tokensByValue = new Map<string, string>();
-  let nextTokenId = 0;
-  return {
-    pattern: new RegExp(`${escapeRegExp(namespace)}\\d+${escapeRegExp(tokenEnd)}`, 'g'),
-    register: (formula, displayMode) => {
-      const valueKey = JSON.stringify([displayMode, formula]);
-      const existingToken = tokensByValue.get(valueKey);
-      if (existingToken) return existingToken;
-
-      const token = `${namespace}${nextTokenId}${tokenEnd}`;
-      nextTokenId += 1;
-      values.set(token, { formula, displayMode });
-      tokensByValue.set(valueKey, token);
-      return token;
-    },
-    values,
-  };
-}
-
-function protectMathOutsideCode(
-  source: string,
-  register: (formula: string, displayMode: boolean) => string,
-): string {
-  const lines = source.split('\n');
-  let fence: { character: string; length: number } | undefined;
-  let proseLines: string[] = [];
-  const protectedParts: string[] = [];
-
-  const flushProse = () => {
-    if (proseLines.length === 0) return;
-    protectedParts.push(protectMathInProse(proseLines.join('\n'), register));
-    proseLines = [];
-  };
-
-  for (const line of lines) {
-    const opening = /^( {0,3})(`{3,}|~{3,})/.exec(line);
-    if (opening) {
-      flushProse();
-      const marker = opening[2] ?? '';
-      const character = marker[0] ?? '';
-      if (!fence) {
-        fence = { character, length: marker.length };
-      } else if (character === fence.character && marker.length >= fence.length) {
-        fence = undefined;
-      }
-      protectedParts.push(line);
-    } else if (fence) {
-      protectedParts.push(line);
-    } else {
-      proseLines.push(line);
-    }
-  }
-  flushProse();
-
-  return protectedParts.join('\n');
-}
-
-function protectMathInProse(
-  source: string,
-  register: (formula: string, displayMode: boolean) => string,
-): string {
-  let output = '';
+  let text = '';
   let index = 0;
+  let safeSourceEnd = 0;
+  let safeTextEnd = 0;
+  let atLineStart = startsAtLineStart;
+  let canMarkSafe = true;
+  const markSafe = () => {
+    if (!canMarkSafe) return;
+    safeSourceEnd = index;
+    safeTextEnd = text.length;
+  };
 
   while (index < source.length) {
+    const fence = atLineStart ? readFence(source, index) : undefined;
+    if (fence) {
+      text += source.slice(index, fence.end);
+      index = fence.end;
+      atLineStart = source[index - 1] === '\n';
+      if (fence.closed) markSafe();
+      else break;
+      continue;
+    }
+
+    const literalToken = readLiteralToken(source, index);
+    if (literalToken?.kind === 'pending') {
+      text += source.slice(index);
+      break;
+    }
+    if (literalToken?.kind === 'match') {
+      text += transportToken(literalToken.source, '2');
+      index = literalToken.end;
+      atLineStart = false;
+      markSafe();
+      continue;
+    }
+
     if (source[index] === '`') {
-      const run = /^`+/.exec(source.slice(index))?.[0] ?? '`';
-      const close = source.indexOf(run, index + run.length);
-      if (close >= 0) {
-        output += source.slice(index, close + run.length);
-        index = close + run.length;
+      let runEnd = index + 1;
+      while (source[runEnd] === '`') runEnd++;
+      const run = source.slice(index, runEnd);
+      const close = source.indexOf(run, runEnd);
+      if (close < 0) {
+        text += run;
+        index = runEnd;
+        atLineStart = false;
+        canMarkSafe = false;
         continue;
       }
+      const end = close + run.length;
+      text += source.slice(index, end);
+      index = end;
+      atLineStart = source[index - 1] === '\n';
+      markSafe();
+      continue;
     }
 
     const delimited =
       readDelimitedMath(source, index, '\\(', '\\)', false, false)
       ?? readDelimitedMath(source, index, '\\[', '\\]', true, true)
       ?? readDelimitedMath(source, index, '$$', '$$', true, true);
-    if (delimited) {
-      output += register(delimited.formula, delimited.displayMode);
+    if (delimited?.kind === 'pending') {
+      text += source.slice(index, delimited.end);
       index = delimited.end;
+      atLineStart = false;
+      canMarkSafe = false;
+      continue;
+    }
+    if (delimited?.kind === 'match') {
+      text += mathToken(delimited.formula, delimited.displayMode);
+      index = delimited.end;
+      atLineStart = false;
+      markSafe();
       continue;
     }
 
-    output += source[index];
-    index += 1;
+    const character = source[index] ?? '';
+    text += character;
+    index++;
+    atLineStart = character === '\n';
+    if (
+      index < source.length ||
+      (character !== '\\' && character !== '$' && character !== '`')
+    ) {
+      markSafe();
+    }
   }
 
-  return output;
+  return { text, safeSourceEnd, safeTextEnd };
+}
+
+function readFence(
+  source: string,
+  index: number,
+): { end: number; closed: boolean } | undefined {
+  const opening = /^( {0,3})(`{3,}|~{3,})/.exec(source.slice(index));
+  if (!opening) return undefined;
+  const marker = opening[2] ?? '';
+  let lineStart = source.indexOf('\n', index);
+  while (lineStart >= 0) {
+    lineStart++;
+    const candidate = /^( {0,3})(`{3,}|~{3,})/.exec(source.slice(lineStart));
+    const candidateMarker = candidate?.[2] ?? '';
+    if (
+      candidateMarker[0] === marker[0] &&
+      candidateMarker.length >= marker.length
+    ) {
+      const lineEnd = source.indexOf('\n', lineStart);
+      return { end: lineEnd < 0 ? source.length : lineEnd + 1, closed: true };
+    }
+    lineStart = source.indexOf('\n', lineStart);
+  }
+  return { end: source.length, closed: false };
+}
+
+function readLiteralToken(
+  source: string,
+  index: number,
+):
+  | { kind: 'match'; source: string; end: number }
+  | { kind: 'pending' }
+  | undefined {
+  if (source[index] !== TOKEN_START[0]) return undefined;
+  if (!source.startsWith(TOKEN_START, index)) {
+    const tail = source.slice(index);
+    return tail.length < TOKEN_START.length && TOKEN_START.startsWith(tail)
+      ? { kind: 'pending' }
+      : undefined;
+  }
+  const tokenEnd = source.indexOf(TOKEN_END, index + TOKEN_START.length);
+  if (tokenEnd < 0) {
+    const payload = source.slice(index + TOKEN_START.length);
+    return /^(?:[012](?::[0-9a-f]*)?)?$/.test(payload)
+      ? { kind: 'pending' }
+      : undefined;
+  }
+  const candidate = source.slice(index, tokenEnd + TOKEN_END.length);
+  const match = LITERAL_TOKEN_PATTERN.exec(candidate);
+  if (!match) return undefined;
+  const token = match[0];
+  return { kind: 'match', source: token, end: index + token.length };
 }
 
 function readDelimitedMath(
-  line: string,
+  source: string,
   index: number,
   opening: string,
   closing: string,
   displayMode: boolean,
   allowNewlines: boolean,
-): { formula: string; displayMode: boolean; end: number } | undefined {
-  if (!line.startsWith(opening, index)) return undefined;
+):
+  | { kind: 'match'; formula: string; displayMode: boolean; end: number }
+  | { kind: 'pending'; end: number }
+  | undefined {
+  if (!source.startsWith(opening, index)) return undefined;
   const contentStart = index + opening.length;
-  const close = line.indexOf(closing, contentStart);
-  if (close < 0) return undefined;
-  if (!allowNewlines && line.slice(contentStart, close).includes('\n')) return undefined;
-  const formula = line.slice(contentStart, close).trim();
-  if (!formula) return undefined;
-  return { formula, displayMode, end: close + closing.length };
+  const close = source.indexOf(closing, contentStart);
+
+  if (close < 0) {
+    if (!allowNewlines && source.indexOf('\n', contentStart) >= 0) return undefined;
+    if (findPendingFenceBoundary(source, contentStart) >= 0) return undefined;
+    return { kind: 'pending', end: contentStart };
+  }
+  const rawFormula = source.slice(contentStart, close);
+  if (!allowNewlines && rawFormula.includes('\n')) return undefined;
+  if (/(?:^|\n) {0,3}(?:`{3,}|~{3,})/.test(rawFormula)) {
+    return undefined;
+  }
+  const formula = rawFormula.trim();
+  if (formula === '') return undefined;
+  return { kind: 'match', formula, displayMode, end: close + closing.length };
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function findPendingFenceBoundary(source: string, from: number): number {
+  const fenceMatch = /(?:^|\n) {0,3}(?:`{3,}|~{3,})/g;
+  fenceMatch.lastIndex = from;
+  const fence = fenceMatch.exec(source);
+  return fence ? fence.index + (source[fence.index] === '\n' ? 1 : 0) : -1;
+}
+
+function mathToken(formula: string, displayMode: boolean): string {
+  return transportToken(formula, displayMode ? '1' : '0');
+}
+
+function transportToken(value: string, kind: '0' | '1' | '2'): string {
+  return `${TOKEN_START}${kind}:${encodeFormula(value)}${TOKEN_END}`;
+}
+
+function encodeFormula(formula: string): string {
+  let encoded = '';
+  for (const byte of new TextEncoder().encode(formula)) {
+    encoded += byte.toString(16).padStart(2, '0');
+  }
+  return encoded;
+}
+
+function decodeFormula(encoded: string): string {
+  const bytes = new Uint8Array(encoded.length / 2);
+  for (let index = 0; index < bytes.length; index++) {
+    bytes[index] = Number.parseInt(encoded.slice(index * 2, index * 2 + 2), 16);
+  }
+  return new TextDecoder().decode(bytes);
 }

--- a/packages/ui/src/markdown-math.tsx
+++ b/packages/ui/src/markdown-math.tsx
@@ -109,7 +109,11 @@ function protectMarkdownMath(source: string, startsAtLineStart = true): {
 
   while (index < source.length) {
     const fence = atLineStart ? readFence(source, index) : undefined;
-    if (fence) {
+    if (fence?.kind === 'pending') {
+      text += source.slice(index);
+      break;
+    }
+    if (fence?.kind === 'match') {
       text += source.slice(index, fence.end);
       index = fence.end;
       atLineStart = source[index - 1] === '\n';
@@ -188,9 +192,17 @@ function protectMarkdownMath(source: string, startsAtLineStart = true): {
 function readFence(
   source: string,
   index: number,
-): { end: number; closed: boolean } | undefined {
-  const opening = /^( {0,3})(`{3,}|~{3,})/.exec(source.slice(index));
-  if (!opening) return undefined;
+):
+  | { kind: 'match'; end: number; closed: boolean }
+  | { kind: 'pending' }
+  | undefined {
+  const tail = source.slice(index);
+  const opening = /^( {0,3})(`{3,}|~{3,})/.exec(tail);
+  if (!opening) {
+    return /^ {0,3}(?:`{1,2}|~{1,2})?$/.test(tail)
+      ? { kind: 'pending' }
+      : undefined;
+  }
   const marker = opening[2] ?? '';
   let lineStart = source.indexOf('\n', index);
   while (lineStart >= 0) {
@@ -202,11 +214,15 @@ function readFence(
       candidateMarker.length >= marker.length
     ) {
       const lineEnd = source.indexOf('\n', lineStart);
-      return { end: lineEnd < 0 ? source.length : lineEnd + 1, closed: true };
+      return {
+        kind: 'match',
+        end: lineEnd < 0 ? source.length : lineEnd + 1,
+        closed: true,
+      };
     }
     lineStart = source.indexOf('\n', lineStart);
   }
-  return { end: source.length, closed: false };
+  return { kind: 'match', end: source.length, closed: false };
 }
 
 function readLiteralToken(

--- a/patches/@astryxdesign+core+0.5.0.patch
+++ b/patches/@astryxdesign+core+0.5.0.patch
@@ -154,29 +154,34 @@ index 08b5f7d..94c623b 100644
      ...(isOrdered && start != null && start !== 1 ? {
        start
 diff --git a/node_modules/@astryxdesign/core/dist/Markdown/Markdown.d.ts b/node_modules/@astryxdesign/core/dist/Markdown/Markdown.d.ts
-index d9ad714..2b9c461 100644
+index d9ad714..91cde1e 100644
 --- a/node_modules/@astryxdesign/core/dist/Markdown/Markdown.d.ts
 +++ b/node_modules/@astryxdesign/core/dist/Markdown/Markdown.d.ts
-@@ -90,6 +90,8 @@ export interface MarkdownProps extends BaseProps<HTMLElement> {
+@@ -90,6 +90,10 @@ export interface MarkdownProps extends BaseProps<HTMLElement> {
       */
      headingLevelStart?: 1 | 2 | 3 | 4 | 5 | 6;
      isStreaming?: boolean;
 +    /** Source text the host has authoritatively marked as already presented. */
 +    settledText?: string;
++    /** Transform displayed source immediately before Markdown parsing. */
++    transformSource?: (source: string) => string;
      onLinkClick?: (href: string, event: React.MouseEvent<HTMLAnchorElement>) => void | false;
      /**
       * Citation sources keyed by ID. When provided, `[id]` and `【id】` markers
-@@ -155,7 +157,7 @@ export interface MarkdownProps extends BaseProps<HTMLElement> {
+@@ -155,8 +159,8 @@ export interface MarkdownProps extends BaseProps<HTMLElement> {
   * </Markdown>
   * ```
   */
 -export declare function Markdown({ ref, children, display, density, headingLevelStart, isStreaming, onLinkClick, sources, citationStyle, contentWidth, contentAlign, components, inlinePlugins, autolink, xstyle, className, style, 'data-testid': testId, }: MarkdownProps): React.ReactElement;
-+export declare function Markdown({ ref, children, display, density, headingLevelStart, isStreaming, settledText, onLinkClick, sources, citationStyle, contentWidth, contentAlign, components, inlinePlugins, autolink, xstyle, className, style, 'data-testid': testId, }: MarkdownProps): React.ReactElement;
++export declare function Markdown({ ref, children, display, density, headingLevelStart, isStreaming, settledText, transformSource, onLinkClick, sources, citationStyle, contentWidth, contentAlign, components, inlinePlugins, autolink, xstyle, className, style, 'data-testid': testId, }: MarkdownProps): React.ReactElement;
  export declare namespace Markdown {
      var displayName: string;
  }
+-//# sourceMappingURL=Markdown.d.ts.map
+\ No newline at end of file
++//# sourceMappingURL=Markdown.d.ts.map
 diff --git a/node_modules/@astryxdesign/core/dist/Markdown/Markdown.js b/node_modules/@astryxdesign/core/dist/Markdown/Markdown.js
-index 0fd8329..7e4ec57 100644
+index 0fd8329..a4a158a 100644
 --- a/node_modules/@astryxdesign/core/dist/Markdown/Markdown.js
 +++ b/node_modules/@astryxdesign/core/dist/Markdown/Markdown.js
 @@ -8,7 +8,7 @@
@@ -188,15 +193,16 @@ index 0fd8329..7e4ec57 100644
  import { Fragment } from 'react';
  import * as stylex from '@stylexjs/stylex';
  import "../theme/tokens.stylex.js";
-@@ -1048,6 +1048,7 @@ export function Markdown({
+@@ -1048,6 +1048,8 @@ export function Markdown({
    density = 'default',
    headingLevelStart = 1,
    isStreaming = false,
 +  settledText,
++  transformSource,
    onLinkClick,
    sources,
    citationStyle = 'label',
-@@ -1072,7 +1073,9 @@ export function Markdown({
+@@ -1072,26 +1074,22 @@ export function Markdown({
  
    // Smooth bursty streamed chunks into a steady character-by-character reveal.
    // When not streaming, the hook returns children unchanged (no-op).
@@ -204,10 +210,42 @@ index 0fd8329..7e4ec57 100644
 +  const smoothedText = useStreamingText(children, isStreaming, {
 +    settledText
 +  });
++  const parsedText = transformSource ? transformSource(smoothedText) : smoothedText;
    const incrementalStateRef = useRef(createIncrementalState());
-   // Reset incremental cache when the autolink option toggles — cached
-   // settled blocks were parsed with the previous setting.
-@@ -1139,17 +1142,25 @@ export function Markdown({
+-  // Reset incremental cache when the autolink option toggles — cached
+-  // settled blocks were parsed with the previous setting.
+-  const prevAutolinkRef = useRef(autolink);
+-  if (prevAutolinkRef.current !== autolink) {
+-    incrementalStateRef.current = createIncrementalState();
+-    prevAutolinkRef.current = autolink;
+-  }
+   const blocks = useMemo(() => {
+     if (display === 'inline') {
+       return [];
+     }
+     if (isStreaming) {
+       if (smoothedText === '') {
+         incrementalStateRef.current = createIncrementalState();
+         return [];
+       }
+-      const input = trimStreamingArtifacts(smoothedText);
++      const input = trimStreamingArtifacts(parsedText);
+       return parseMarkdownIncremental(input, incrementalStateRef.current, parseOptions);
+     }
+-    return parseMarkdown(children, parseOptions);
+-  }, [display, smoothedText, children, isStreaming, parseOptions]);
++    return parseMarkdown(parsedText, parseOptions);
++  }, [display, parsedText, isStreaming, parseOptions]);
+@@ -1120,6 +1119,6 @@ export function Markdown({
+     if (display !== 'inline') {
+       return [];
+     }
+-    const input = isStreaming ? trimStreamingArtifacts(smoothedText) : children;
++    const input = isStreaming ? trimStreamingArtifacts(parsedText) : parsedText;
+     return parseInline(input, parseOptions);
+-  }, [display, smoothedText, children, isStreaming, parseOptions]);
++  }, [display, parsedText, isStreaming, parseOptions]);
+@@ -1139,17 +1137,25 @@ export function Markdown({
      const tickMs = tick != null ? Math.max(4, Math.round(tick / 10)) : 50;
      return Math.min(Math.ceil(duration / tickMs), 12);
    }, [token]);
@@ -244,7 +282,7 @@ index 0fd8329..7e4ec57 100644
    const cursor = {
      offset: 0,
      boundaries,
-@@ -1174,9 +1185,6 @@ export function Markdown({
+@@ -1174,9 +1180,6 @@ export function Markdown({
        children: inlineNodes.map((node, i) => renderInline(node, i, onLinkClick, cursor, citationCtx, LinkComponent, inlinePlugins, components))
      });
  
@@ -254,7 +292,7 @@ index 0fd8329..7e4ec57 100644
      return renderedInline;
    }
    const rendered = /*#__PURE__*/_jsx("div", {
-@@ -1189,11 +1197,6 @@ export function Markdown({
+@@ -1189,11 +1192,6 @@ export function Markdown({
      children: blocks.map((block, i) => renderBlock(block, i, blocks.length, density, headingLevelStart, onLinkClick, cursor, citationCtx, contentWidth ? typeof contentWidth === 'number' ? `${contentWidth}px` : contentWidth : null, contentAlign, LinkComponent, inlinePlugins, components, t, headingIdMap))
    });
  
@@ -265,8 +303,9 @@ index 0fd8329..7e4ec57 100644
 -  prevInlineNodesRef.current = [];
    return rendered;
  }
- Markdown.displayName = 'Markdown';
+-Markdown.displayName = 'Markdown';
 \ No newline at end of file
++Markdown.displayName = 'Markdown';
 diff --git a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts b/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts
 index e7b8e00..fad2e72 100644
 --- a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts
@@ -541,24 +580,27 @@ index ea918b4..d83af73 100644
  import type React from 'react';
  import {Fragment} from 'react';
  import * as stylex from '@stylexjs/stylex';
-@@ -145,6 +145,8 @@ export interface MarkdownProps extends BaseProps<HTMLElement> {
+@@ -145,6 +145,10 @@ export interface MarkdownProps extends BaseProps<HTMLElement> {
     */
    headingLevelStart?: 1 | 2 | 3 | 4 | 5 | 6;
    isStreaming?: boolean;
 +  /** Source text the host has authoritatively marked as already presented. */
 +  settledText?: string;
++  /** Transform displayed source immediately before Markdown parsing. */
++  transformSource?: (source: string) => string;
    onLinkClick?: (
      href: string,
      event: React.MouseEvent<HTMLAnchorElement>,
-@@ -1610,6 +1612,7 @@ export function Markdown({
+@@ -1610,6 +1614,8 @@ export function Markdown({
    density = 'default',
    headingLevelStart = 1,
    isStreaming = false,
 +  settledText,
++  transformSource,
    onLinkClick,
    sources,
    citationStyle = 'label',
-@@ -1638,7 +1641,9 @@ export function Markdown({
+@@ -1638,7 +1644,10 @@ export function Markdown({
  
    // Smooth bursty streamed chunks into a steady character-by-character reveal.
    // When not streaming, the hook returns children unchanged (no-op).
@@ -566,10 +608,44 @@ index ea918b4..d83af73 100644
 +  const smoothedText = useStreamingText(children, isStreaming, {
 +    settledText,
 +  });
++  const parsedText = transformSource ? transformSource(smoothedText) : smoothedText;
  
    const incrementalStateRef = useRef<IncrementalState>(
      createIncrementalState(),
-@@ -1713,20 +1718,43 @@ export function Markdown({
+@@ -1648,7 +1657,0 @@ export function Markdown({
+-  // Reset incremental cache when the autolink option toggles — cached
+-  // settled blocks were parsed with the previous setting.
+-  const prevAutolinkRef = useRef(autolink);
+-  if (prevAutolinkRef.current !== autolink) {
+-    incrementalStateRef.current = createIncrementalState();
+-    prevAutolinkRef.current = autolink;
+-  }
+@@ -1660,12 +1662,12 @@ export function Markdown({
+         incrementalStateRef.current = createIncrementalState();
+         return [];
+       }
+-      const input = trimStreamingArtifacts(smoothedText);
++      const input = trimStreamingArtifacts(parsedText);
+       return parseMarkdownIncremental(
+         input,
+         incrementalStateRef.current,
+         parseOptions,
+       );
+     }
+-    return parseMarkdown(children, parseOptions);
+-  }, [display, smoothedText, children, isStreaming, parseOptions]);
++    return parseMarkdown(parsedText, parseOptions);
++  }, [display, parsedText, isStreaming, parseOptions]);
+@@ -1695,6 +1704,6 @@ export function Markdown({
+     if (display !== 'inline') {
+       return [];
+     }
+-    const input = isStreaming ? trimStreamingArtifacts(smoothedText) : children;
++    const input = isStreaming ? trimStreamingArtifacts(parsedText) : parsedText;
+     return parseInline(input, parseOptions);
+-  }, [display, smoothedText, children, isStreaming, parseOptions]);
++  }, [display, parsedText, isStreaming, parseOptions]);
+@@ -1713,20 +1722,43 @@ export function Markdown({
      return Math.min(Math.ceil(duration / tickMs), 12);
    }, [token]);
  
@@ -627,7 +703,7 @@ index ea918b4..d83af73 100644
  
    const cursor: StreamingCursor = {
      offset: 0,
-@@ -1766,10 +1794,6 @@ export function Markdown({
+@@ -1766,10 +1798,6 @@ export function Markdown({
        </span>
      );
  
@@ -638,7 +714,7 @@ index ea918b4..d83af73 100644
      return renderedInline;
    }
  
-@@ -1810,12 +1834,6 @@ export function Markdown({
+@@ -1810,12 +1838,6 @@ export function Markdown({
      </div>
    );
  

--- a/patches/README.md
+++ b/patches/README.md
@@ -76,5 +76,8 @@ Streaming text and Markdown expose an explicit `settledText` seam so the
 renderer can verify and advance the exact prefix already presented without
 replaying it. The default remains progressive for a genuinely new stream, and
 rewritten or later text still reveals and fades from a parsed-visible boundary.
+Markdown can also transform the displayed prefix immediately before its
+existing incremental parser, so host syntax such as math stays behind the
+streaming cursor without adding another parser or scheduler.
 
 Delete each hunk when the corresponding behavior ships in Astryx.


### PR DESCRIPTION
## Summary

Streaming math previously transformed both the full Markdown source and `settledText` on every React render, before Astryx applied its own streaming cursor and incremental block parser. This change keeps Runtime Host text authoritative, lets Astryx smooth the raw text first, and incrementally prepares only the parser-facing math tail from the last safe boundary.

The implementation remains one path: `MarkdownBody → useStreamingText → math source transform → Astryx incremental parser`. It removes the dynamic token namespace, two per-render token maps, and the separate transformed `settledText` path. It does not touch Desktop transcript range, virtualization, scroll ownership, or content visibility.

## Results

- Math preparation CPU fell by **80.8% at 64 KiB** and **83.2% at 256 KiB**, with B winning **7/7 pairs** at both sizes.
- On this machine, that local CPU reduction did **not** become an end-to-end latency win: median event-to-rendered-frame changed by +0.9% / +63.4%, with 2/7 and 4/7 wins.
- Total Renderer busy CPU changed by -1.9% / +18.0%. First-token and final-flush results were mixed, so no whole-renderer improvement is claimed.
- At 256 KiB, LoAF count improved 4 → 2 (5/7 wins), while LoAF-duration P95 regressed 9.2%. Post-GC heap was flat; transient 64 KiB peak-heap median was +26.7% with only 1/7 wins, so neither memory nor long-frame tails are claimed as wins.
- Correctness passed in all 28 A/B trials. This PR records a proven reduction in math-preparation work, but it does not meet the original merge gate for end-to-end performance on this CPU.

| Size / metric | A median | B median | Δ | A P95 / P99 | B P95 / P99 | MAD / median A → B | B wins |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 64 KiB rendered-frame median (ms) | 16.50 | 16.65 | +0.9% | 16.65 / 16.65 | 17.77 / 18.11 | 0.6% → 0.3% | 2/7 |
| 256 KiB rendered-frame median (ms) | 54.65 | 89.30 | +63.4% | 95.82 / 96.08 | 93.89 / 94.86 | 7.0% → 6.5% | 4/7 |
| 64 KiB math preparation CPU (ms) | 9.90 | 1.90 | -80.8% | 12.75 / 13.59 | 2.96 / 3.15 | 4.0% → 21.1% | 7/7 |
| 256 KiB math preparation CPU (ms) | 73.70 | 12.40 | -83.2% | 77.92 / 78.78 | 14.47 / 14.73 | 2.3% → 10.5% | 7/7 |
| 64 KiB Renderer busy CPU (ms) | 257.95 | 252.95 | -1.9% | 347.74 / 351.64 | 334.30 / 359.47 | 1.7% → 1.1% | 5/7 |
| 256 KiB Renderer busy CPU (ms) | 1302.02 | 1536.52 | +18.0% | 1797.01 / 1801.05 | 1753.14 / 1775.97 | 19.1% → 9.8% | 3/7 |

### A/B method and limits

A is baseline `bb1256241eddb2384715f4131fb16c7599f92a8d`; B is the product code in `fffe591a2203b60019a499be9912112543c01ba5`. Both modes ran in the same minified production React/Markdown fixture bundle (`sha256:d790dff180e4baa9054eb4873033e3bc28c27caf8c9f063eebcc71111bfd805a`; recorded result `sha256:bdc6cab7cdd08ac0ca1ade74963f93b8320fcba88e573e41f018bb8a18908bea`). The 64 KiB and 256 KiB fixtures each exercised ordinary Markdown, inline/display math, a long growing code fence, settled math plus a live tail, and final non-streaming flush. Seven interleaved paired runs alternated A/B and size order. CDP and the React hook were read-only; the temporary mode switch only selected A or B in the throwaway measurement bundle.

The harness is intentionally not published with the product change: doing so would retain a benchmark-only product mode and a second fixture protocol. The recorded temporary command was:

```bash
./node_modules/.bin/esbuild /private/tmp/pr4207-perf-entry.tsx --bundle --minify --keep-names --platform=browser --format=iife --define:process.env.NODE_ENV='"production"' --outfile=/private/tmp/pr4207-perf-bundle.js
PR4207_PERF_PAIRS=7 PR4207_PERF_OUTPUT=/private/tmp/pr4207-final-ab-v3.json node /private/tmp/pr4207-perf-runner.mjs
```

These paths are not present in a fresh checkout. This is a bare minified React/Markdown composition fixture, not a Desktop or Runtime Host E2E. The rendered-frame metric waits two `requestAnimationFrame` callbacks and is not labeled literal next paint. `math preparation CPU` is direct transform instrumentation; `Renderer busy CPU`, GC, heap, long tasks, and LoAF come from CDP. The current full-string input contract still requires `source.startsWith(previousSource)` to detect rewrites, so this removes repeated full math lexing and the second `settledText` pass, but does not claim that every source identity check is tail-only.

<details>
<summary>Raw 7 paired groups (14 size rows)</summary>

| Pair | KiB | Order | frame median A / B ms | math CPU A / B ms | busy CPU A / B ms | first A / B ms | flush A / B ms | peak heap A / B MiB |
| ---: | ---: | :---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 64 | A→B | 16.40 / 16.75 | 13.80 / 3.20 | 352.62 / 252.39 | 42.40 / 15.00 | 23.20 / 19.20 | 39.49 / 39.67 |
| 1 | 256 | A→B | 51.55 / 89.85 | 72.60 / 14.80 | 1302.02 / 1624.98 | 51.70 / 48.10 | 68.60 / 67.90 | 218.59 / 231.79 |
| 2 | 64 | B→A | 16.65 / 16.50 | 8.80 / 1.80 | 253.51 / 260.89 | 13.60 / 13.10 | 21.10 / 18.50 | 39.19 / 45.72 |
| 2 | 256 | B→A | 54.65 / 50.20 | 75.40 / 12.40 | 1268.40 / 1236.01 | 53.90 / 50.20 | 88.50 / 74.60 | 240.97 / 254.41 |
| 3 | 64 | A→B | 16.50 / 16.65 | 9.90 / 2.40 | 336.34 / 252.95 | 28.00 / 18.20 | 19.40 / 18.90 | 70.75 / 48.89 |
| 3 | 256 | A→B | 96.15 / 95.10 | 71.30 / 13.70 | 1802.06 / 1781.68 | 102.80 / 91.40 | 73.00 / 71.20 | 217.37 / 227.93 |
| 4 | 64 | B→A | 16.45 / 18.20 | 9.50 / 2.10 | 254.77 / 365.76 | 13.80 / 36.50 | 20.80 / 18.30 | 39.12 / 66.40 |
| 4 | 256 | B→A | 54.20 / 73.40 | 79.00 / 11.10 | 1276.26 / 1397.42 | 54.50 / 49.80 | 72.30 / 79.90 | 249.52 / 244.81 |
| 5 | 64 | A→B | 16.60 / 16.60 | 10.30 / 1.90 | 256.96 / 249.20 | 17.60 / 17.70 | 19.90 / 18.70 | 48.33 / 51.54 |
| 5 | 256 | A→B | 50.85 / 91.05 | 73.70 / 11.70 | 1053.32 / 1536.52 | 61.00 / 50.80 | 71.80 / 73.10 | 203.19 / 188.05 |
| 6 | 64 | B→A | 16.65 / 16.65 | 9.30 / 1.10 | 271.83 / 252.96 | 19.50 / 11.50 | 20.60 / 18.10 | 39.17 / 52.29 |
| 6 | 256 | B→A | 95.05 / 50.50 | 75.10 / 10.50 | 1785.23 / 1256.24 | 137.20 / 50.20 | 70.00 / 71.00 | 214.16 / 228.25 |
| 7 | 64 | A→B | 15.95 / 16.70 | 9.90 / 1.50 | 257.95 / 250.28 | 17.20 / 17.40 | 19.50 / 18.10 | 47.93 / 50.05 |
| 7 | 256 | A→B | 91.25 / 89.30 | 71.50 / 13.30 | 1588.18 / 1686.55 | 57.80 / 131.30 | 74.00 / 67.50 | 233.71 / 215.34 |

</details>

## Verification

```bash
npm ci
npm test --workspace @maka/ui                  # 287/287
npm run typecheck --workspace @maka/ui
npm run format:check
git diff --check bb1256241eddb2384715f4131fb16c7599f92a8d...fffe591a2203b60019a499be9912112543c01ba5
```

Coverage includes empty formula fallback; URL/email/Markdown markers inside math; display math across blank, heading, list, and table-looking lines; inline/fenced code isolation including split fence openers through final flush; literal and malformed transport syntax; rewritten/restored text; and real client rerenders that preserve settled KaTeX DOM identity through a growing tail and final flush. A fresh install reapplies the Astryx patch, and a source-condition bundle contains the same `transformSource` seam as the default dist build.

## Entropy ledger

| Dimension | Before | After |
| --- | --- | --- |
| Authority | Runtime Host text; Astryx parser | unchanged |
| Math runtime state | per-render registry + two Maps | one bounded, discardable four-field cache per `MarkdownBody` mount |
| Representations | raw + transformed source/settled + dynamic tokens + AST | raw displayed source + one parser transport + AST |
| Scheduler / parser / observer | `useStreamingText`; one incremental parser; existing observers | unchanged owners and counts |

The required additions are the post-scheduler/pre-parser transform seam, the safe source/text boundary pair, and collision-safe literal transport. They replace the old double full-source transform and map registry in this diff; no second store, parser, scheduler, protocol, observer, or transcript authority is added. The cumulative diff is +624/-178; the added volume is primarily the incremental lexer, behavior tests, and duplicated source/dist dependency patch, while owner and representation counts decrease as shown above.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the repeated preprocessing path, implemented the owner-aligned transform and incremental lexer, added tests, ran the production A/B, and prepared this PR. The commits carry `Generated-by: Codex` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Format, typecheck, dependency patch application, and affected tests pass locally

Does this PR entail a change in behavior?

- [x] Yes — parser-owned math source is now prepared after the streaming cursor and incrementally reused
- [ ] No
