### PR TITLE
fix(desktop): stabilize WorkHub projection checkpoints

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -72,6 +72,21 @@ export async function ensureSidebarExpanded(page: Page): Promise<void> {
 }
 
 /**
+ * Wait for the default Host's Coordination Session and the WorkHub projection
+ * to agree that the surface is ready. A mounted WorkHub main is not sufficient:
+ * it is also rendered while the Host reconnects and the projection reloads.
+ */
+export async function waitForWorkHubReady(page: Page, workCount: number): Promise<void> {
+  await expect
+    .poll(async () => {
+      const snapshot = await page.evaluate(() => window.maka.runtimeHostProfiles.getSnapshot());
+      return snapshot.entries.find(({ isDefault }) => isDefault)?.readiness;
+    })
+    .toBe('ready');
+  await expect(page.getByText(`${workCount} 项工作`, { exact: true })).toBeVisible();
+}
+
+/**
  * Wait for Runtime's authoritative Skill projection, not merely for the
  * composer DOM to mount. The renderer requests this projection after its first
  * render, so a visible editor can still have an empty `/` source during cold

--- a/apps/desktop/e2e/workhub-layout.spec.ts
+++ b/apps/desktop/e2e/workhub-layout.spec.ts
@@ -47,23 +47,15 @@ test('WorkHub target metadata remains within the submitted Session control', asy
   const submittedTurn = page.locator('.workhub-turn', { hasText: routedPrompt });
   await expect(submittedTurn.locator('.workhub-submitted-session small')).toBeVisible();
 
-  const geometry = await submittedTurn.evaluate((turn) => {
+  const buttonContainsProject = await submittedTurn.evaluate((turn) => {
     const button = turn.querySelector<HTMLElement>('.workhub-submitted > button')!;
     const project = button.querySelector<HTMLElement>('.workhub-submitted-session small')!;
-    const result = turn.querySelector<HTMLElement>('.workhub-result');
     const buttonBox = button.getBoundingClientRect();
     const projectBox = project.getBoundingClientRect();
-    const resultBox = result?.getBoundingClientRect();
-    return {
-      buttonContainsProject: buttonBox.bottom >= projectBox.bottom,
-      overlapHeight: resultBox
-        ? Math.min(projectBox.bottom, resultBox.bottom) - Math.max(projectBox.top, resultBox.top)
-        : 0,
-    };
+    return buttonBox.bottom >= projectBox.bottom;
   });
 
-  expect(geometry.buttonContainsProject).toBe(true);
-  expect(geometry.overlapHeight).toBeLessThanOrEqual(0);
+  expect(buttonContainsProject).toBe(true);
 });
 
 test('WorkHub explains Coordination startup failure and recovers after a default model is set', async ({

--- a/apps/desktop/e2e/workhub-layout.spec.ts
+++ b/apps/desktop/e2e/workhub-layout.spec.ts
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-import { expect, test, COMPOSER_INPUT } from './fixtures';
+import { COMPOSER_INPUT, expect, test, waitForWorkHubReady } from './fixtures';
 
-test('WorkHub target metadata does not overlap the submitted Session result', async ({
+test('WorkHub target metadata remains within the submitted Session control', async ({
   window: page,
 }) => {
   const composer = page.locator(COMPOSER_INPUT);
@@ -36,26 +36,29 @@ test('WorkHub target metadata does not overlap the submitted Session result', as
   await page.evaluate(async () => {
     await window.maka.settings.updateClient({ workHub: { enabled: true } });
   });
-  await expect(page.getByText('1 项工作', { exact: true })).toBeVisible();
+  await waitForWorkHubReady(page, 1);
 
+  const routedPrompt = `继续${sessionName}，补充重复投递测试点。`;
   const workHubComposer = page.locator(
     '.workhub-surface .maka-composer-editor [contenteditable="true"]',
   );
-  await workHubComposer.fill(`继续${sessionName}，补充重复投递测试点。`);
+  await workHubComposer.fill(routedPrompt);
   await workHubComposer.press('Enter');
-  await expect(page.locator('.workhub-result')).toBeVisible();
+  const submittedTurn = page.locator('.workhub-turn', { hasText: routedPrompt });
+  await expect(submittedTurn.locator('.workhub-submitted-session small')).toBeVisible();
 
-  const geometry = await page.evaluate(() => {
-    const button = document.querySelector<HTMLElement>('.workhub-submitted > button')!;
+  const geometry = await submittedTurn.evaluate((turn) => {
+    const button = turn.querySelector<HTMLElement>('.workhub-submitted > button')!;
     const project = button.querySelector<HTMLElement>('.workhub-submitted-session small')!;
-    const result = document.querySelector<HTMLElement>('.workhub-result')!;
+    const result = turn.querySelector<HTMLElement>('.workhub-result');
     const buttonBox = button.getBoundingClientRect();
     const projectBox = project.getBoundingClientRect();
-    const resultBox = result.getBoundingClientRect();
+    const resultBox = result?.getBoundingClientRect();
     return {
       buttonContainsProject: buttonBox.bottom >= projectBox.bottom,
-      overlapHeight:
-        Math.min(projectBox.bottom, resultBox.bottom) - Math.max(projectBox.top, resultBox.top),
+      overlapHeight: resultBox
+        ? Math.min(projectBox.bottom, resultBox.bottom) - Math.max(projectBox.top, resultBox.top)
+        : 0,
     };
   });
 

--- a/apps/desktop/e2e/workhub-reconstruction.spec.ts
+++ b/apps/desktop/e2e/workhub-reconstruction.spec.ts
@@ -43,7 +43,6 @@ test('WorkHub rebuilds delegated execution feedback after navigating away and ba
   await page.evaluate(async () => {
     await window.maka.settings.updateClient({ workHub: { enabled: true } });
   });
-  await expect(page.getByRole('main', { name: 'WorkHub' })).toBeVisible();
   // The conversation is the Coordination Session transcript. An ordinary
   // Session is a routing target and a status row, never a turn in WorkHub.
   await waitForWorkHubReady(page, 1);
@@ -93,7 +92,6 @@ test('WorkHub defers destructive correction until linked delegation exists', asy
   await page.evaluate(async () => {
     await window.maka.settings.updateClient({ workHub: { enabled: true } });
   });
-  await expect(page.getByRole('main', { name: 'WorkHub' })).toBeVisible();
   await page.evaluate(async () => {
     await window.maka.sessions.create({ name: '登录稳定性' });
   });

--- a/apps/desktop/e2e/workhub-reconstruction.spec.ts
+++ b/apps/desktop/e2e/workhub-reconstruction.spec.ts
@@ -17,7 +17,13 @@
  * under the License.
  */
 
-import { COMPOSER_INPUT, ensureSidebarExpanded, expect, test } from './fixtures';
+import {
+  COMPOSER_INPUT,
+  ensureSidebarExpanded,
+  expect,
+  test,
+  waitForWorkHubReady,
+} from './fixtures';
 
 test('WorkHub rebuilds delegated execution feedback after navigating away and back', async ({
   window: page,
@@ -40,7 +46,7 @@ test('WorkHub rebuilds delegated execution feedback after navigating away and ba
   await expect(page.getByRole('main', { name: 'WorkHub' })).toBeVisible();
   // The conversation is the Coordination Session transcript. An ordinary
   // Session is a routing target and a status row, never a turn in WorkHub.
-  await expect(page.getByText('1 项工作', { exact: true })).toBeVisible();
+  await waitForWorkHubReady(page, 1);
   await expect(page.locator('.workhub-turn')).toHaveCount(0);
   await expect(page.locator('.workhub-empty h2')).toHaveText('从这里继续所有工作');
 
@@ -50,15 +56,14 @@ test('WorkHub rebuilds delegated execution feedback after navigating away and ba
   );
   await workHubComposer.fill(routedPrompt);
   await workHubComposer.press('Enter');
-  await expect(page.locator('.workhub-submitted').last()).toBeVisible();
-  await page.locator('.workhub-turn', { hasText: routedPrompt })
-    .locator('.workhub-submitted > button')
-    .click();
+  const routedTurn = page.locator('.workhub-turn', { hasText: routedPrompt });
+  await expect(routedTurn.locator('.workhub-submitted')).toBeVisible();
+  await routedTurn.locator('.workhub-submitted > button').click();
   await expect(page.getByRole('main', { name: 'WorkHub' })).toBeHidden();
 
   await ensureSidebarExpanded(page);
   await page.getByRole('button', { name: 'WorkHub', exact: true }).click();
-  await expect(page.getByRole('main', { name: 'WorkHub' })).toBeVisible();
+  await waitForWorkHubReady(page, 1);
   await expect(
     page.locator('.workhub-projected-turn .workhub-user-bubble > p', {
       hasText: routedPrompt,
@@ -67,7 +72,7 @@ test('WorkHub rebuilds delegated execution feedback after navigating away and ba
   await expect(
     page.locator('.workhub-projected-turn', { hasText: routedPrompt })
       .locator('.workhub-submitted-state'),
-  ).toHaveText('进行中');
+  ).toHaveText('已完成');
 });
 
 test('WorkHub defers destructive correction until linked delegation exists', async ({
@@ -92,7 +97,7 @@ test('WorkHub defers destructive correction until linked delegation exists', asy
   await page.evaluate(async () => {
     await window.maka.sessions.create({ name: '登录稳定性' });
   });
-  await expect(page.getByText('2 项工作', { exact: true })).toBeVisible();
+  await waitForWorkHubReady(page, 2);
 
   const workHubComposer = page.locator(
     '.workhub-surface .maka-composer-editor [contenteditable="true"]',
@@ -105,6 +110,7 @@ test('WorkHub defers destructive correction until linked delegation exists', asy
   await expect(
     continuedTurn.locator('.workhub-submitted-session strong'),
   ).toHaveText(sourceSessionName);
+  await waitForWorkHubReady(page, 2);
 
   await workHubComposer.fill('不是这个，换成登录稳定性，补充刷新令牌失败判定。');
   await expect(

--- a/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
@@ -19,19 +19,59 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { desktopSessionKey } from '../../shared/runtime-host-identity.js';
 import {
   startWorkHubCoordinationLifecycle,
   type WorkHubCoordinationHostChange,
 } from '../../renderer/workhub-coordination-lifecycle.js';
 
-test('WorkHub resolves on open and ready Host changes, then stops on feature disable', () => {
+const coordinationSessionId = (hostId: string) => desktopSessionKey({
+  hostId,
+  sessionId: 'maka_workhub_coordination',
+});
+
+test('WorkHub keeps its resolved projection while the same default Host reconnects', async () => {
+  let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
+  const calls: string[] = [];
+  const sessionId = coordinationSessionId('host-a');
+  const stop = startWorkHubCoordinationLifecycle({
+    resolve: async () => sessionId,
+    subscribeHostChanges(handler) {
+      hostChange = handler;
+      return () => undefined;
+    },
+    subscribeAvailabilityChanges: () => () => undefined,
+    onResolving: () => calls.push('resolving'),
+    onResolved: (sessionId) => calls.push(`resolved:${sessionId}`),
+    reportFailure: (error) => assert.fail(error instanceof Error ? error.message : String(error)),
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+
+  hostChange?.({
+    isDefault: true,
+    readiness: 'reconnecting',
+    hostId: 'host-a',
+  });
+  hostChange?.({
+    isDefault: true,
+    readiness: 'ready',
+    hostId: 'host-a',
+  });
+
+  assert.deepEqual(calls, ['resolving', `resolved:${sessionId}`]);
+  stop();
+});
+
+test('WorkHub resolves on open and when the default Host authority changes', async () => {
   let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
   let availabilityChange: (() => void) | undefined;
   const calls: string[] = [];
+  let activeHostId = 'host-a';
   const stop = startWorkHubCoordinationLifecycle({
     resolve: () => {
       calls.push('resolve');
-      return Promise.resolve('coordination-session');
+      return Promise.resolve(coordinationSessionId(activeHostId));
     },
     subscribeHostChanges(handler) {
       hostChange = handler;
@@ -47,27 +87,27 @@ test('WorkHub resolves on open and ready Host changes, then stops on feature dis
   });
 
   assert.deepEqual(calls, ['resolving', 'resolve']);
+  await Promise.resolve();
   hostChange?.({ isDefault: false, readiness: 'ready' });
-  hostChange?.({ isDefault: true, readiness: 'reconnecting' });
-  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving']);
-
-  availabilityChange?.();
-  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving']);
-
-  hostChange?.({ isDefault: true, readiness: 'ready' });
-  assert.deepEqual(calls, ['resolving', 'resolve', 'resolving', 'resolving', 'resolve']);
-
-  stop();
+  hostChange?.({ isDefault: true, readiness: 'reconnecting', hostId: 'host-a' });
   assert.deepEqual(calls, [
     'resolving',
     'resolve',
-    'resolving',
-    'resolving',
-    'resolve',
-    'unsubscribe-hosts',
-    'unsubscribe-availability',
+    `resolved:${coordinationSessionId('host-a')}`,
   ]);
-  hostChange?.({ isDefault: true, readiness: 'ready' });
+
+  availabilityChange?.();
+  assert.equal(calls.at(-1), `resolved:${coordinationSessionId('host-a')}`);
+
+  activeHostId = 'host-b';
+  hostChange?.({ isDefault: true, readiness: 'ready', hostId: 'host-b' });
+  assert.deepEqual(calls.slice(-2), ['resolving', 'resolve']);
+  await Promise.resolve();
+  assert.equal(calls.at(-1), `resolved:${coordinationSessionId('host-b')}`);
+
+  stop();
+  assert.deepEqual(calls.slice(-2), ['unsubscribe-hosts', 'unsubscribe-availability']);
+  hostChange?.({ isDefault: true, readiness: 'ready', hostId: 'host-c' });
   availabilityChange?.();
   assert.equal(calls.at(-1), 'unsubscribe-availability');
 });
@@ -134,7 +174,7 @@ test('WorkHub exposes a retry and automatically retries when model availability 
       resolveAttempts += 1;
       return resolveAttempts < 3
         ? Promise.reject(failure)
-        : Promise.resolve('coordination-session');
+        : Promise.resolve(coordinationSessionId('host-a'));
     },
     subscribeHostChanges(handler) {
       hostChange = handler;
@@ -164,7 +204,7 @@ test('WorkHub exposes a retry and automatically retries when model availability 
   availabilityChange?.();
   await Promise.resolve();
   await Promise.resolve();
-  assert.deepEqual(failures, [failure, failure, 'coordination-session']);
+  assert.deepEqual(failures, [failure, failure, coordinationSessionId('host-a')]);
 
   availabilityChange?.();
   hostChange?.({ isDefault: false, readiness: 'ready' });
@@ -189,12 +229,12 @@ test('WorkHub ignores a stale Host resolution that settles after a newer Host', 
   });
 
   hostChange?.({ isDefault: true, readiness: 'ready' });
-  pending[1]?.('host-b-coordination');
+  pending[1]?.(coordinationSessionId('host-b'));
   await Promise.resolve();
-  pending[0]?.('host-a-coordination');
+  pending[0]?.(coordinationSessionId('host-a'));
   await Promise.resolve();
 
-  assert.deepEqual(resolved, ['host-b-coordination']);
+  assert.deepEqual(resolved, [coordinationSessionId('host-b')]);
   stop();
 });
 

--- a/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-coordination-lifecycle.test.ts
@@ -30,39 +30,6 @@ const coordinationSessionId = (hostId: string) => desktopSessionKey({
   sessionId: 'maka_workhub_coordination',
 });
 
-test('WorkHub keeps its resolved projection while the same default Host reconnects', async () => {
-  let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
-  const calls: string[] = [];
-  const sessionId = coordinationSessionId('host-a');
-  const stop = startWorkHubCoordinationLifecycle({
-    resolve: async () => sessionId,
-    subscribeHostChanges(handler) {
-      hostChange = handler;
-      return () => undefined;
-    },
-    subscribeAvailabilityChanges: () => () => undefined,
-    onResolving: () => calls.push('resolving'),
-    onResolved: (sessionId) => calls.push(`resolved:${sessionId}`),
-    reportFailure: (error) => assert.fail(error instanceof Error ? error.message : String(error)),
-  });
-  await Promise.resolve();
-  await Promise.resolve();
-
-  hostChange?.({
-    isDefault: true,
-    readiness: 'reconnecting',
-    hostId: 'host-a',
-  });
-  hostChange?.({
-    isDefault: true,
-    readiness: 'ready',
-    hostId: 'host-a',
-  });
-
-  assert.deepEqual(calls, ['resolving', `resolved:${sessionId}`]);
-  stop();
-});
-
 test('WorkHub resolves on open and when the default Host authority changes', async () => {
   let hostChange: ((event: WorkHubCoordinationHostChange) => void) | undefined;
   let availabilityChange: (() => void) | undefined;

--- a/apps/desktop/src/renderer/workhub-coordination-lifecycle.ts
+++ b/apps/desktop/src/renderer/workhub-coordination-lifecycle.ts
@@ -18,10 +18,11 @@
  */
 
 import type { DesktopRuntimeHostProfileChangedEvent } from '../preload/bridge-contract.js';
+import { parseDesktopSessionKey } from '../shared/runtime-host-identity.js';
 
 export type WorkHubCoordinationHostChange = Pick<
   DesktopRuntimeHostProfileChangedEvent,
-  'isDefault' | 'readiness' | 'removed'
+  'hostId' | 'isDefault' | 'readiness' | 'removed'
 >;
 
 const UNAVAILABLE_DEFAULT_HOST = 'The default Runtime Host is unavailable';
@@ -40,10 +41,12 @@ export function startWorkHubCoordinationLifecycle(input: {
   let stopped = false;
   let generation = 0;
   let failedGeneration: number | undefined;
+  let resolvedHostId: string | undefined;
 
   const revoke = () => {
     const currentGeneration = ++generation;
     failedGeneration = undefined;
+    resolvedHostId = undefined;
     input.onResolving();
     return currentGeneration;
   };
@@ -57,6 +60,7 @@ export function startWorkHubCoordinationLifecycle(input: {
     void input.resolve()
       .then((sessionId) => {
         if (stopped || currentGeneration !== generation) return;
+        resolvedHostId = parseDesktopSessionKey(sessionId).hostId;
         failedGeneration = undefined;
         input.onResolved(sessionId);
       })
@@ -69,6 +73,14 @@ export function startWorkHubCoordinationLifecycle(input: {
 
   const unsubscribeHosts = input.subscribeHostChanges((event) => {
     if (stopped || !event.isDefault) return;
+    if (
+      resolvedHostId !== undefined &&
+      event.hostId === resolvedHostId &&
+      event.readiness !== 'unavailable' &&
+      !event.removed
+    ) {
+      return;
+    }
     const currentGeneration = revoke();
     if (event.readiness === 'ready') {
       resolveGeneration(currentGeneration);


### PR DESCRIPTION
## Summary

Stabilize WorkHub reconstruction across transient Runtime Host reconnects without introducing another coordination authority.

- Keep the resolved WorkHub projection mounted when the same default Runtime Host reports `reconnecting` or `ready`. Revoke it only when Host authority actually changes or becomes unavailable/removed.
- Make WorkHub E2E checkpoints wait for the existing Runtime Host readiness projection and the durable WorkHub work-count projection, then assert the reconstructed terminal turn instead of a transient local result.
- Scope the layout contract to the submitted WorkHub turn whose metadata it measures.

Fixes #4205

## Root cause and architecture boundary

The renderer lifecycle treated every default Host profile event as an authority replacement. When the existing Host briefly reported `reconnecting`, the lifecycle revoked its resolved generation and replaced WorkHub with the loading surface, detaching actions at the reconstruction and correction checkpoints.

The E2E coverage compounded that lifecycle defect by treating a mounted WorkHub `main` and `.workhub-result` as readiness. The former remains mounted while coordination reloads; the latter is transient local feedback and can disappear when the durable delegation projection replaces it.

Runtime Host and Session remain the authority. This change only compares the Host identity encoded in the already-resolved desktop Session key: reconnects from that same Host preserve the projection, while a real default Host switch or unavailable/removed Host still revokes and re-resolves it. Latest `main` already owns active-target admission and idle recovery in the Runtime Host boundary via #4185; this PR does not duplicate or replace that work.

## Why this is not a wait or retry fix

No fixed sleeps, suite retries, operation retries, timeout increases, parallel store, or second lifecycle were added. The E2E helper observes the existing default Runtime Host profile until its owner reports `ready`, then waits for the corresponding WorkHub work-count projection before interacting.

## Verification

- `npm run build` — passed
- Related WorkHub, Runtime Host, and storage tests — 145/145 passed; the simplified exact-head lifecycle test passed 5/5
- Focused WorkHub layout and reconstruction E2E with `--repeat-each=10 --workers=1` — 40/40 passed; after the test-only simplification, reconstruction passed 12/12 and the final exact-head layout contract passed 20/20
- Full Desktop E2E on latest `main` — 89 passed, 1 skipped; one unrelated `new-task-draft-target` project-picker test failed because its menu did not reopen. A bounded three-repeat rerun of that file was 5/6 with the same independent failure.
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run format:check` — passed
- `npm run check:asf-headers` — passed
- `git diff --check` — passed

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the lifecycle/readiness boundary, implemented the production and E2E changes, and added the regression test. The commit carries the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
