### PR TITLE
fix(desktop): report the model actually tested when Test Connection falls back

### DIFF
--- a/apps/desktop/src/renderer/locales/settings-provider-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-provider-copy.ts
@@ -149,6 +149,9 @@ const zhCopy = {
         : '',
     ].filter(Boolean).join(' '),
     connectionSuccess: (name: string) => `连接成功 · ${name}`, connectionFailed: (name: string) => `连接失败 · ${name}`,
+    connectionFallbackTitle: (name: string) => `连接可用 · ${name}`,
+    connectionFallbackDetail: (selected: readonly string[], tested: string) =>
+      `你选择的 ${selected.join('、')} 当前未响应，已改用 ${tested} 验证连接可用；任务中继续使用你选择的模型可能会失败。`,
     connectionTestError: (name: string) => `连接测试出错 · ${name}`, modelsFetched: (count: number, name: string) => `已拉取 ${count} 个模型 · ${name}`,
     modelsFetchFailed: (name: string) => `拉取模型失败 · ${name}`,
     modelsFetchFailedDetail: (message: string, troubleshooting: string) => `${message} · 当前继续显示静态列表，请确认 ${troubleshooting} 后重试。`,
@@ -299,6 +302,9 @@ const enCopy: ProviderSettingsCopy = {
         : '',
     ].filter(Boolean).join(' '),
     connectionSuccess: (name: string) => `Connected · ${name}`, connectionFailed: (name: string) => `Connection failed · ${name}`,
+    connectionFallbackTitle: (name: string) => `Connection works · ${name}`,
+    connectionFallbackDetail: (selected: readonly string[], tested: string) =>
+      `Your selected ${selected.join(', ')} didn't respond; verified the connection with ${tested} instead. Tasks using your selected model may fail.`,
     connectionTestError: (name: string) => `Connection test error · ${name}`, modelsFetched: (count: number, name: string) => `Fetched ${count} ${count === 1 ? 'model' : 'models'} · ${name}`,
     modelsFetchFailed: (name: string) => `Failed to fetch models · ${name}`,
     modelsFetchFailedDetail: (message: string, troubleshooting: string) => `${message} · The static list remains visible. Check ${troubleshooting} and try again.`,

--- a/apps/desktop/src/renderer/settings/use-connection-detail.ts
+++ b/apps/desktop/src/renderer/settings/use-connection-detail.ts
@@ -638,10 +638,32 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
       const result: ConnectionTestResult = await props.bridge.test(connection.slug);
       if (!isConnectionDetailCurrent(lifecycle)) return;
       if (result.ok) {
-        toast.success(
-          copy.connectionSuccess(connection.name),
-          `${result.modelTested} · ${result.latencyMs} ms`,
-        );
+        // The backend probes the enabled models first, then the provider
+        // fallbacks (opencode-free tries each in turn until one answers). When
+        // the model that actually answered isn't one the user enabled, a plain
+        // "connection succeeded · <model>" reads as if their selection never
+        // took — and hides that their chosen model is currently down. Name both
+        // facts instead.
+        const testedId = result.modelTested;
+        const modelLabel = (id: string): string =>
+          models.find((model) => model.id === id)?.displayName ?? id;
+        // Inline the `testedId !== undefined` check so it narrows `testedId` to
+        // string for `modelLabel(testedId)` below.
+        if (
+          testedId !== undefined &&
+          enabledModelIds.length > 0 &&
+          !enabledModelIds.includes(testedId)
+        ) {
+          toast.warning(
+            copy.connectionFallbackTitle(connection.name),
+            copy.connectionFallbackDetail(enabledModelIds.map(modelLabel), modelLabel(testedId)),
+          );
+        } else {
+          toast.success(
+            copy.connectionSuccess(connection.name),
+            `${result.modelTested} · ${result.latencyMs} ms`,
+          );
+        }
       } else {
         reportHostError(
           copy.connectionFailed(connection.name),


### PR DESCRIPTION
## Summary

For an **OpenCode Free** connection, "测试连接 (Test Connection)" probes the enabled models then the provider fallbacks and returns the first model that answers (`testConnectionStrict`, `packages/runtime/src/test-connection.ts:166-195`). When the selected model (e.g. `mimo-v2.5-free`) is rate-limited, temporarily down, or returns an empty completion, the loop falls through to a fallback model (`nemotron-3-ultra-free`, the provider default) and the success toast reports **that** model — reading as if the user's model selection never took, and hiding that their chosen model is currently unavailable.

The probe-until-one-answers behavior is intentional and worth keeping (free models rotate and rate-limit). The fix is scoped to the **renderer**: `runTest` now compares `result.modelTested` against the enabled model ids. When the answering model isn't one the user selected, it shows a `warning` toast that names the unresponsive selection and the model used to verify, instead of a plain green success. When the selected model does answer, behavior is unchanged.

No runtime / IPC / persisted types were touched — the renderer already has both facts (the enabled set and `modelTested`), so the detection lives entirely in `use-connection-detail.ts` plus two new copy strings (zh + en).

Fixes #4222

## Verification

- `npm run typecheck` in `apps/desktop` (preload + main + renderer + storybook) — **passes**.
- Not run: lint/format, unit/e2e suites, and a live app launch — the trigger is an OpenCode Free free-model rate-limit/empty-completion, which isn't reliably reproducible on demand. The success-path (selected model answers) is unchanged; only the fallback path switches to a warning toast.

### Review focus

- The detection guard: `testedId !== undefined && enabledModelIds.length > 0 && !enabledModelIds.includes(testedId)`. For non-`opencode-free` providers the backend returns the first enabled candidate, so `modelTested` is always in the enabled set and the warning never fires. The `length > 0` guard avoids a spurious warning for a zero-model connection that verifies its credential against a fallback.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Opus 4.8) diagnosed the root cause and authored the fix and copy. The affected commit carries a `Generated-by: Claude Code (Opus 4.8)` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

<!-- Note: typecheck passes; no automated test was added — this repo covers renderer toast behavior via stories/e2e rather than hook unit tests, and the branch is pure decision logic over existing state. Happy to extract a testable helper if preferred. -->

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No