### PR TITLE
test(desktop): stop the picker spec racing two upstream guards

### DIFF
--- a/apps/desktop/e2e/new-task-draft-target.spec.ts
+++ b/apps/desktop/e2e/new-task-draft-target.spec.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { COMPOSER_INPUT, NEW_TASK_PROJECT_NAME, expect, test } from './fixtures';
 
 /**
@@ -50,6 +50,15 @@ async function settle(page: Page): Promise<void> {
   );
 }
 
+// Picking an item hides the menu, and DropdownMenu then swallows a reopen
+// click for 50ms.
+async function openPicker(page: Page, picker: Locator): Promise<void> {
+  await expect(async () => {
+    await picker.click();
+    await expect(page.getByRole('menuitem').first()).toBeVisible({ timeout: 500 });
+  }).toPass({ timeout: 10_000 });
+}
+
 test('the new-task draft follows the Project chosen under the composer', async ({
   newTaskTargetWindow: page,
 }) => {
@@ -74,7 +83,7 @@ test('the new-task draft follows the Project chosen under the composer', async (
   await settle(page);
   await expect(composer).toHaveText(DRAFT);
 
-  await picker.click();
+  await openPicker(page, picker);
   await page.getByRole('menuitem', { name: NEW_TASK_PROJECT_NAME, exact: true }).click();
   await expect(picker).toHaveAttribute('aria-label', new RegExp(NEW_TASK_PROJECT_NAME));
   await settle(page);

--- a/apps/desktop/e2e/new-task-draft-target.spec.ts
+++ b/apps/desktop/e2e/new-task-draft-target.spec.ts
@@ -71,7 +71,9 @@ test('the new-task draft follows the Project chosen under the composer', async (
   await expect(picker).toHaveAttribute('aria-label', new RegExp(NEW_TASK_PROJECT_NAME));
 
   await composer.click();
-  await page.keyboard.type(DRAFT);
+  // Two keystrokes in one frame — no human rate — make ChatComposerInput
+  // rewrite the editor and reset the caret.
+  await page.keyboard.type(DRAFT, { delay: 20 });
   await expect(composer).toHaveText(DRAFT);
 
   await picker.click();


### PR DESCRIPTION
Fixes #4224

`new-task-draft-target.spec.ts` fails every run on macOS: after choosing 无项目 it reopens the workspace picker, and that click opens nothing, so the wait for the Project menu item times out at 30s. Two separate races were in the way; both live in `@astryxdesign/core`, and neither is reachable at human speed.

**The reopen.** `DropdownMenu` drops a trigger click that lands within 50ms of the menu hiding:

```js
if (Date.now() - lastHideTimeRef.current < 50) {
  return;
}
```

The guard exists so iOS Safari's light dismiss — pointerdown hides the menu, then the trigger's own click arrives — cannot instantly reopen it. But `usePopover({ onHide: handleLayerHide })` stamps that timestamp on *every* hide, so choosing a menu item arms it the same way. Whether the reopen survives then depends on how long the assertions between the two clicks happen to take. The spec now waits for the menu it asked for instead of assuming the click took, which also holds if that 50ms ever changes.

**The typing.** With the reopen fixed, a ~4% failure the first one had been masking surfaced: the draft came back scrambled (`"idraft written before choosing a project"`, `"drafet written before choosing a project"` — one character displaced to an earlier offset). `ChatComposerInput` absorbs exactly one echo of its own `onChange`; a second keystroke inside the same frame overwrites that marker, so the pending echo is read as an external override:

```js
editable.textContent = controlledValue;
// Setting `textContent` tears down the existing text node,
// which collapses any Selection inside this editable to
// offset 0.
```

A keystroke landing between that rewrite and the caret restore goes in at offset 0. `page.keyboard.type` with no delay is the only thing that types two characters inside one frame, so the spec now types at 20ms/char.

Before / after, 50 runs of this spec each:

```
2 failed
  e2e/new-task-draft-target.spec.ts:62:1 › the new-task draft follows the Project chosen under the composer
  e2e/new-task-draft-target.spec.ts:62:1 › the new-task draft follows the Project chosen under the composer
48 passed (3.1m)

50 passed (3.1m)
```

(The 50-run "before" is already past the reopen fix — with the original spec the failure is 100%, not 4%.)

Both are test-side fixes on purpose. The dropdown guard is load-bearing on iOS Safari, and the composer's echo window is one frame: no user clicks a trigger 50ms after picking from its menu, and none types two characters in 16ms.

Generative tooling: Claude Code (Opus 5) investigated and wrote this change; the commits carry a `Generated-by` trailer.
