### PR TITLE
fix(desktop): enable relay discovery for Peer Mesh

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-peer-client.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-peer-client.test.ts
@@ -62,6 +62,7 @@ test('development uses the native peer addon only for the peer-enabled launch', 
   }), {
     nativePath,
     keyPath: join(clientDataRoot, 'runtime-host-client.peer.key'),
+    automaticRelayDiscovery: true,
   });
   assert.equal(peerEnvironment.MAKA_RUNTIME_HOST_PEER_NATIVE_PATH, nativePath);
 });

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -254,7 +254,9 @@ if (runtimeHostPeerConfiguration) {
     });
   } catch (error) {
     console.error('[runtime-host] Peer Mesh is unavailable; continuing with Direct peer:', error);
-    runtimeHostPeerClient = createRuntimeHostPeerClientFromEnvironment();
+    runtimeHostPeerClient = createRuntimeHostPeerClientFromEnvironment(process.env, {
+      automaticRelayDiscovery: runtimeHostPeerConfiguration.automaticRelayDiscovery,
+    });
   }
 }
 const runtimeHostDirectPeerAvailable = runtimeHostPeerClient !== undefined;

--- a/apps/desktop/src/main/runtime-host-peer-client.ts
+++ b/apps/desktop/src/main/runtime-host-peer-client.ts
@@ -29,13 +29,21 @@ export async function configureDesktopRuntimeHostPeerClient(input: {
   readonly resourcesPath: string;
   readonly clientDataRoot: string;
   readonly environment?: NodeJS.ProcessEnv;
-}): Promise<{ readonly nativePath: string; readonly keyPath: string } | undefined> {
+}): Promise<{
+  readonly nativePath: string;
+  readonly keyPath: string;
+  readonly automaticRelayDiscovery: true;
+} | undefined> {
   const environment = input.environment ?? process.env;
   const explicitNativePath = environment.MAKA_RUNTIME_HOST_PEER_NATIVE_PATH?.trim();
   const explicitKeyPath = environment.MAKA_RUNTIME_HOST_PEER_KEY_PATH?.trim();
   if (explicitNativePath || explicitKeyPath) {
     return explicitNativePath && explicitKeyPath
-      ? { nativePath: explicitNativePath, keyPath: explicitKeyPath }
+      ? {
+          nativePath: explicitNativePath,
+          keyPath: explicitKeyPath,
+          automaticRelayDiscovery: true,
+        }
       : undefined;
   }
   if (!input.isPackaged && !input.enableDevelopmentPeer) return undefined;
@@ -59,5 +67,5 @@ export async function configureDesktopRuntimeHostPeerClient(input: {
   environment.MAKA_RUNTIME_HOST_PEER_NATIVE_PATH = nativePath;
   const keyPath = join(input.clientDataRoot, 'runtime-host-client.peer.key');
   environment.MAKA_RUNTIME_HOST_PEER_KEY_PATH = keyPath;
-  return { nativePath, keyPath };
+  return { nativePath, keyPath, automaticRelayDiscovery: true };
 }

--- a/apps/desktop/src/renderer/settings/runtime-host-peer-mesh-dialog.tsx
+++ b/apps/desktop/src/renderer/settings/runtime-host-peer-mesh-dialog.tsx
@@ -55,6 +55,7 @@ type PeerMeshDialogView =
       readonly meshId: string;
       readonly code: string;
       readonly expiresAt: number;
+      readonly hasCoordinationRelay: boolean;
     };
 
 export function RuntimeHostPeerMeshDialog(props: {
@@ -126,6 +127,7 @@ export function RuntimeHostPeerMeshDialog(props: {
         meshId,
         code: JSON.stringify(result.invitation),
         expiresAt: result.invitation.expiresAt,
+        hasCoordinationRelay: result.invitation.coordinationRelays.length > 0,
       });
       setSnapshot(result.snapshot);
     } catch (failure) {
@@ -474,6 +476,14 @@ function InvitationView(props: {
           {props.copy.invitationWarning}
         </Text>
       </div>
+      {!props.invitation.hasCoordinationRelay ? (
+        <div className="settingsPeerMeshInvitationNote">
+          <Network size={ICON_SIZE.control} aria-hidden="true" />
+          <Text type="supporting" color="secondary">
+            {props.copy.invitationDirectOnly}
+          </Text>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -740,6 +750,8 @@ function peerMeshCopy(locale: string) {
         invitationTitle: '邀请成员',
         invitationFor: (value: string) => `Mesh ${value}`,
         invitationWarning: '该代码只能使用一次；获得代码的人可以让一个 peer 加入此 Mesh。',
+        invitationDirectOnly:
+          '尚未连接到协调节点。此邀请码只包含直接地址，跨 NAT 时可能无法连接。',
         invitationExpires: (value: string) => `有效期至 ${value}`,
         invitationCopied: '邀请码已复制',
         copyInvitation: '复制邀请码',
@@ -807,6 +819,8 @@ function peerMeshCopy(locale: string) {
         invitationFor: (value: string) => `Mesh ${value}`,
         invitationWarning:
           'This code works once. Anyone holding it can admit one peer to this Mesh.',
+        invitationDirectOnly:
+          'No coordination peer is available yet. This invitation contains direct routes only and may not work across NATs.',
         invitationExpires: (value: string) => `Expires ${value}`,
         invitationCopied: 'Invitation copied',
         copyInvitation: 'Copy invitation',


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Enable automatic coordination relay discovery for the Desktop-owned Peer Mesh endpoint and its direct-peer fallback. Existing Meshes keep their identity and state; their normal reconciliation picks up accepted reservations, and newly created invitations include them.

When discovery has not produced a reservation yet, the invitation view now states that the code contains direct routes only and may not work across NATs.

The verified invitation below contains two accepted `coordinationRelays` (the code view is scrolled past its one-time secret):

![](https://github.com/apache/maka/blob/ee7a6de68d5e79147dd0c7cf1dc8381ddaf3b207/desktop-peer-mesh-relays.png?raw=true)

## Verification

- `node --test --test-name-pattern='development uses the native peer addon only for the peer-enabled launch' apps/desktop/dist/main/__tests__/runtime-host-peer-client.test.js`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- Real Desktop run with the release peer native addon: an existing Mesh acquired two accepted coordination relays, and a newly generated invitation contained both addresses

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the change and ran the checks under the contributor's direction. The contributor will review and decide whether to merge it.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 摘要

为 Desktop 自己持有的 Peer Mesh endpoint 及其 direct-peer 降级路径启用自动协调节点发现。已有 Mesh 保持原有 identity 和状态，由现有 reconciliation 接收成功的 reservation；之后生成的邀请码会包含这些地址。

如果 discovery 尚未取得 reservation，邀请界面会明确说明该代码只包含直接地址，跨 NAT 时可能无法连接。

下图中已验证的邀请码包含两个成功的 `coordinationRelays`（代码视图已滚过一次性 secret）：

![](https://github.com/apache/maka/blob/ee7a6de68d5e79147dd0c7cf1dc8381ddaf3b207/desktop-peer-mesh-relays.png?raw=true)

## 验证

- `node --test --test-name-pattern='development uses the native peer addon only for the peer-enabled launch' apps/desktop/dist/main/__tests__/runtime-host-peer-client.test.js`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- 使用 release peer native addon 真实运行 Desktop：已有 Mesh 成功取得两个协调节点 reservation，新生成的邀请码包含这两个地址

## AI 使用

- [ ] 没有生成式工具作出实质性贡献
- [x] 生成式工具作出了实质性贡献

工具与范围：OpenAI Codex 在贡献者指导下实现改动并执行检查；贡献者将审核并决定是否合并。

## 检查清单

- [x] 测试覆盖本次改动，且在缺少改动时会失败
- [x] lint、格式、类型检查及相关测试已在本地通过

本 PR 是否改变行为？

- [x] 是——已在上方摘要说明
- [ ] 否

</details>
