### PR TITLE
fix(cli): wait for Host readiness before pairing

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
@@ -31,6 +31,7 @@ import {
   type RuntimeHostManagedDeploymentConfig,
   type RuntimeHostSupervisorProvider,
 } from '@maka/runtime-host/operator';
+import type { connectExistingRuntimeHost } from '@maka/runtime-host/client';
 import { resolveStorageRoot, tryAcquireStateRootOwner } from '@maka/storage/root-authority';
 import type {
   RuntimeHostLifecycleProvider,
@@ -44,6 +45,8 @@ import {
   retireRuntimeHostLifecycleOwner,
   runtimeHostReconciliationTriggerDefinition,
   runtimeHostSupervisorDefinition,
+  verifyRuntimeHostLifecycleReady,
+  type RuntimeHostLifecycleTransactionDeps,
 } from '../runtime-host-lifecycle-transaction.js';
 
 const INTEGRITY = `sha512-${Buffer.alloc(64, 7).toString('base64')}`;
@@ -488,8 +491,53 @@ test('does not consume replacement consent after the supervised Host exits', asy
   assert.equal(retired, false);
 });
 
+test('readiness waits for a reachable Host to leave the starting state', async (t) => {
+  const stateRoot = await mkdtemp(join(tmpdir(), 'maka-lifecycle-ready-'));
+  t.after(() => rm(stateRoot, { recursive: true, force: true }));
+  const capability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+  const supervised = config(capability.canonicalPath, capability.rootId, 1, 'launch_agent');
+  const provider = new FakeLifecycleProvider('launch_agent', 'launch_agent_timer');
+  provider.install(supervised);
+  provider.running = 42;
+  const states: ('starting' | 'ready')[] = ['starting', 'starting', 'ready'];
+  const observed: string[] = [];
+  let closed = 0;
+  const deps: RuntimeHostLifecycleTransactionDeps = {
+    resolveProvider: () => provider,
+    convergeOperator: async () => undefined,
+    verifyOperator: async () => undefined,
+    connectExisting: async () =>
+      ({
+        kind: 'connected',
+        connection: {
+          rootId: capability.rootId,
+          request: async () => ({ pid: 42 }),
+          status: async () => {
+            const state = states.length > 1 ? states.shift() : states[0];
+            observed.push(state ?? 'ready');
+            return { state };
+          },
+          close: async () => {
+            closed += 1;
+          },
+        },
+      }) as unknown as Awaited<ReturnType<typeof connectExistingRuntimeHost>>,
+  };
+
+  await verifyRuntimeHostLifecycleReady(supervised, deps, 2_000);
+  assert.deepEqual(observed, ['starting', 'starting', 'ready']);
+  assert.equal(closed, 1);
+
+  states.splice(0, states.length, 'starting');
+  await assert.rejects(verifyRuntimeHostLifecycleReady(supervised, deps, 200), {
+    code: 'transition_failed',
+    message: /did not become ready/,
+  });
+});
+
 class FakeLifecycleProvider implements RuntimeHostLifecycleProvider {
   static failure: string | undefined;
+  running: number | null = null;
   readonly supervisor;
   readonly reconciliationTrigger;
   #supervisorDefinition: RuntimeHostProviderDefinition | undefined;
@@ -514,9 +562,14 @@ class FakeLifecycleProvider implements RuntimeHostLifecycleProvider {
         provider: supervisorProvider,
         installed: this.#supervisorDefinition !== undefined,
         enabled: this.#supervisorDefinition !== undefined,
-        active: false,
-        state: this.#supervisorDefinition ? ('stopped' as const) : ('not_installed' as const),
-        pid: null,
+        active: this.running !== null,
+        state:
+          this.running !== null
+            ? ('running' as const)
+            : this.#supervisorDefinition
+              ? ('stopped' as const)
+              : ('not_installed' as const),
+        pid: this.running,
         lastExitCode: null,
       }),
       activate: async () => undefined,

--- a/packages/cli/src/runtime-host-access-command.ts
+++ b/packages/cli/src/runtime-host-access-command.ts
@@ -366,7 +366,9 @@ async function connectLocalOwner(rootPath: string, expectedRootId?: string) {
     },
   );
   if (result.kind !== 'connected') {
-    throw new RuntimeHostAccessUnavailableError(result.kind);
+    throw new RuntimeHostAccessUnavailableError(
+      result.kind === 'unavailable' ? result.reason : result.kind,
+    );
   }
   if (expectedRootId && result.connection.rootId !== expectedRootId) {
     await result.connection.close();

--- a/packages/cli/src/runtime-host-lifecycle-transaction.ts
+++ b/packages/cli/src/runtime-host-lifecycle-transaction.ts
@@ -28,6 +28,7 @@ import {
 import {
   connectExistingRuntimeHost,
   prepareConnectedRuntimeHostRetirement,
+  waitForRuntimeHostReady,
 } from '@maka/runtime-host/client';
 import { RUNTIME_HOST_PROTOCOL_VERSION } from '@maka/runtime-host/protocol';
 import {
@@ -52,6 +53,9 @@ import type {
   RuntimeHostLifecycleProvider,
   RuntimeHostProviderDefinition,
 } from './runtime-host-lifecycle-provider.js';
+
+/** The budget a managed Runtime Host has to become reachable after its lifecycle is activated. */
+export const RUNTIME_HOST_READY_TIMEOUT_MS = 45_000;
 
 export interface RuntimeHostLifecycleTransactionDeps {
   readonly resolveProvider: (
@@ -720,7 +724,7 @@ export async function activateRuntimeHostLifecycle(
 export async function verifyRuntimeHostLifecycleReady(
   config: RuntimeHostManagedDeploymentConfig,
   deps: RuntimeHostLifecycleTransactionDeps,
-  timeoutMs = 45_000,
+  timeoutMs = RUNTIME_HOST_READY_TIMEOUT_MS,
 ): Promise<void> {
   const canonical = decodeRuntimeHostManagedDeploymentConfig(config);
   await verifyRuntimeHostLifecycleProjection(canonical, deps);
@@ -745,9 +749,12 @@ export async function verifyRuntimeHostLifecycleReady(
         try {
           const diagnostics = await connected.connection.request('host.diagnostics.query', {});
           if (diagnostics.pid === status.pid && connected.connection.rootId === canonical.root.id) {
+            await waitForRuntimeHostReady(connected.connection, Math.max(1, deadline - Date.now()));
             return;
           }
           lastFailure = new Error('Runtime Host process or Root identity did not match');
+        } catch (error) {
+          lastFailure = error;
         } finally {
           await connected.connection.close().catch(() => undefined);
         }

--- a/packages/cli/src/runtime-host-lifecycle-transaction.ts
+++ b/packages/cli/src/runtime-host-lifecycle-transaction.ts
@@ -66,6 +66,7 @@ export interface RuntimeHostLifecycleTransactionDeps {
     desired: RuntimeHostManagedDeploymentConfig | undefined,
   ) => Promise<void>;
   readonly verifyOperator: (config: RuntimeHostManagedDeploymentConfig) => Promise<void>;
+  readonly connectExisting?: typeof connectExistingRuntimeHost;
   /** Legacy migration keeps the validated old config until commit as its deterministic receipt. */
   readonly uninstallLegacy?: (
     transition: RuntimeHostManagedDeploymentTransition | RuntimeHostManagedDeploymentBlocked,
@@ -735,7 +736,7 @@ export async function verifyRuntimeHostLifecycleReady(
   while (Date.now() < deadline) {
     const status = await provider.supervisor.status();
     if (status.pid !== null && status.active) {
-      const connected = await connectExistingRuntimeHost({
+      const connected = await (deps.connectExisting ?? connectExistingRuntimeHost)({
         rootPath: canonical.root.path,
         protocol: {
           min: RUNTIME_HOST_PROTOCOL_VERSION,

--- a/packages/cli/src/runtime-host-setup-command.ts
+++ b/packages/cli/src/runtime-host-setup-command.ts
@@ -107,6 +107,7 @@ import {
   canDiscardRuntimeHostLifecycleDesiredArtifacts,
   replaceRuntimeHostLifecycle,
   resolveRecoverableRuntimeHostManagedDeployment,
+  RUNTIME_HOST_READY_TIMEOUT_MS,
   type RuntimeHostLifecycleTransactionDeps,
 } from './runtime-host-lifecycle-transaction.js';
 import type {
@@ -120,7 +121,6 @@ import {
 import { activateRuntimeHostManagedDeploymentWithReconciliation } from './runtime-host-activation-command.js';
 
 const SETUP_LOCK_TIMEOUT_MS = 5 * 60_000;
-const PAIRING_AVAILABILITY_TIMEOUT_MS = 10_000;
 const PAIRING_AVAILABILITY_POLL_MS = 100;
 
 export interface RuntimeHostSetupCliOptions {
@@ -1089,7 +1089,7 @@ async function pairAndVerifyRuntimeHostSetup(
       preset: options.preset,
       ...(options.bindPairingToClient ? { bindClientInstance: true } : {}),
     };
-    const deadline = Date.now() + PAIRING_AVAILABILITY_TIMEOUT_MS;
+    const deadline = Date.now() + RUNTIME_HOST_READY_TIMEOUT_MS;
     while (true) {
       try {
         paired = await pairCredential(credentialInput);
@@ -1104,7 +1104,10 @@ async function pairAndVerifyRuntimeHostSetup(
       }
     }
   } catch (error) {
-    const reason = generalizedErrorMessage(error, 'Runtime Host access service is unavailable');
+    const reason =
+      error instanceof RuntimeHostAccessUnavailableError
+        ? error.message
+        : generalizedErrorMessage(error, 'Runtime Host access service is unavailable');
     throw new RuntimeHostSetupError(
       'pairing_failed',
       `Runtime Host could not pair the requested Client identity: ${reason}`,


### PR DESCRIPTION
## Summary

Fixes #4228

A fresh managed Runtime Host setup fails on the first attempt with `The Runtime Host access service is unavailable`, leaves setup pending, and succeeds on an immediate retry.

Root cause: `verifyRuntimeHostLifecycleReady` only checked `host.diagnostics.query`, a bootstrap operation the Host answers while its state is still `starting`. Setup therefore reached pairing before the Host admitted access operations, and `access.credential.prepare` was rejected with `host_not_ready` — a plain RPC error, not `RuntimeHostAccessUnavailableError`, so the pairing retry loop threw immediately rather than waiting out its 10 s budget.

Fix: after the diagnostics identity check, the lifecycle verifier waits for the Host's `ready` state with the existing `waitForRuntimeHostReady` helper (the on-demand activation path already does this), within the same readiness deadline. The pairing wait reuses that readiness budget instead of an unrelated 10 s constant, and the unavailable reason (`not_registered`, `connect_failed`, …) is carried into the setup error so genuine failures stay diagnosable.

Not covered: the in-flight `connection.request` inside pairing has no per-request timeout; Desktop's 10-minute setup bound still applies.

## Verification

Fresh isolated setup on macOS (launchd), running the same `runtime-host setup` command Desktop issues, from a dev tarball built before and after the change:

```
before
 34.96s progress pairing_client
 34.96s error   {"code":"pairing_failed","message":"Runtime Host could not pair the requested Client identity: Runtime Host access service is unavailable"}
exit=1

after
 11.62s progress pairing_client
 11.64s progress verifying_connection
 11.65s complete {"version":"0.2.0-dev-ff2693d05db4","endpoint":"ws://127.0.0.1:58520/runtime-host",...}
exit=0
```

`npm run typecheck` and the full `packages/cli` suite (634 tests) pass. The new lifecycle test drives the verifier with an injected fake Host that reports `starting` twice before `ready`; it fails against the previous verifier (`actual: []`, expected `['starting', 'starting', 'ready']`).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code authored the fix and ran the before/after reproduction; commit carries a `Generated-by` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

https://claude.ai/code/session_015tEEyuYS3GuntgpyBbHGqX

