### PR TITLE
fix(ui): allow composer attachments while a turn is running

### DIFF
--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -74,6 +74,7 @@ interface ChatComposerRegionProps
     | 'hidden'
     | 'draftKey'
     | 'stopPending'
+    | 'allowAttachmentImportWhileStreaming'
     // Read from ComposerMentionsProvider, so a catalog reload repaints the
     // popups without re-rendering the shell that would otherwise pass them.
     | 'mentionSkills'

--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -217,6 +217,10 @@ export function ChatComposerRegion({
       <Composer
         ref={composerRef}
         {...composerRest}
+        // AppShell carries staged attachments into both queued and steering
+        // follow-ups. Other Composer hosts remain gated by default because a
+        // text-only running-turn submission would leave attachments behind.
+        allowAttachmentImportWhileStreaming
         mentionSkills={mentions?.mentionSkills}
         mentionSkillsUnavailable={mentions?.mentionSkillsUnavailable}
         mentionSkillsLoading={mentions?.mentionSkillsLoading}

--- a/packages/ui/src/__tests__/composer-running-attachments.test.tsx
+++ b/packages/ui/src/__tests__/composer-running-attachments.test.tsx
@@ -25,7 +25,7 @@ import { parseHTML } from 'linkedom';
 import { Composer } from '../composer.js';
 import { LocaleProvider } from '../locale-context.js';
 
-test('accepts a pasted image while the current turn is running', async () => {
+test('only an attachment-capable running-turn host accepts a pasted image', async () => {
   const original = {
     document: globalThis.document,
     window: globalThis.window,
@@ -45,12 +45,26 @@ test('accepts a pasted image while the current turn is running', async () => {
   assert.ok(container);
   const root = createRoot(container);
   const attached: File[][] = [];
+  const image = new window.File(['image'], 'screenshot.png', { type: 'image/png' });
 
-  try {
+  function pasteImage(): Event {
+    const paste = new window.Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, 'clipboardData', {
+      value: {
+        files: [image],
+        getData: () => '',
+      },
+    });
+    return paste;
+  }
+
+  async function render(allowAttachmentImportWhileStreaming: boolean): Promise<void> {
     await act(() => root.render(
       <LocaleProvider locale="en">
         <Composer
           streaming
+          allowAttachmentImportWhileStreaming={allowAttachmentImportWhileStreaming}
+          onPickAttachments={() => undefined}
           onAttachFilePaths={(files) => {
             attached.push(files);
           }}
@@ -59,26 +73,42 @@ test('accepts a pasted image while the current turn is running', async () => {
         />
       </LocaleProvider>,
     ));
+  }
 
+  function attachmentPickerItem(): HTMLElement | undefined {
+    return [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find(
+      (item) => item.textContent?.includes('Add file or directory'),
+    );
+  }
+
+  try {
+    // Text-only steering hosts, such as Workbar side chat, retain the default
+    // gate so a successful text submit cannot leave a staged image behind.
+    await render(false);
     const form = container.querySelector('form');
-    assert.equal(form?.getAttribute('data-maka-file-drop-target'), 'true');
     const input = container.querySelector<HTMLElement>('[role="textbox"]');
     assert.ok(input);
-    const image = new window.File(['image'], 'screenshot.png', { type: 'image/png' });
-    const paste = new window.Event('paste', { bubbles: true, cancelable: true });
-    Object.defineProperty(paste, 'clipboardData', {
-      value: {
-        files: [image],
-        getData: () => '',
-      },
-    });
-
+    assert.equal(form?.getAttribute('data-maka-file-drop-target'), null);
+    assert.equal(attachmentPickerItem()?.getAttribute('aria-disabled'), 'true');
+    const rejectedPaste = pasteImage();
     await act(async () => {
-      input.dispatchEvent(paste);
+      input.dispatchEvent(rejectedPaste);
       await Promise.resolve();
     });
+    assert.equal(rejectedPaste.defaultPrevented, true);
+    assert.deepEqual(attached, []);
 
-    assert.equal(paste.defaultPrevented, true);
+    // AppShell opts in because both its queued and steering follow-ups carry
+    // the staged attachment into the submitted message.
+    await render(true);
+    assert.equal(form?.getAttribute('data-maka-file-drop-target'), 'true');
+    assert.notEqual(attachmentPickerItem()?.getAttribute('aria-disabled'), 'true');
+    const acceptedPaste = pasteImage();
+    await act(async () => {
+      input.dispatchEvent(acceptedPaste);
+      await Promise.resolve();
+    });
+    assert.equal(acceptedPaste.defaultPrevented, true);
     assert.deepEqual(attached, [[image]]);
   } finally {
     await act(() => root.unmount());

--- a/packages/ui/src/__tests__/composer-running-attachments.test.tsx
+++ b/packages/ui/src/__tests__/composer-running-attachments.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { parseHTML } from 'linkedom';
+import { Composer } from '../composer.js';
+import { LocaleProvider } from '../locale-context.js';
+
+test('accepts a pasted image while the current turn is running', async () => {
+  const original = {
+    document: globalThis.document,
+    window: globalThis.window,
+    IS_REACT_ACT_ENVIRONMENT: (globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    }).IS_REACT_ACT_ENVIRONMENT,
+  };
+  const { document, window } = parseHTML('<div id="root"></div>');
+  window.getComputedStyle = () => ({
+    direction: 'ltr',
+    writingMode: 'horizontal-tb',
+    getPropertyValue: () => '',
+  }) as unknown as CSSStyleDeclaration;
+  window.getSelection = () => null;
+  Object.assign(globalThis, { document, window, IS_REACT_ACT_ENVIRONMENT: true });
+  const container = document.querySelector('#root');
+  assert.ok(container);
+  const root = createRoot(container);
+  const attached: File[][] = [];
+
+  try {
+    await act(() => root.render(
+      <LocaleProvider locale="en">
+        <Composer
+          streaming
+          onAttachFilePaths={(files) => {
+            attached.push(files);
+          }}
+          onSend={() => undefined}
+          onStop={() => undefined}
+        />
+      </LocaleProvider>,
+    ));
+
+    const form = container.querySelector('form');
+    assert.equal(form?.getAttribute('data-maka-file-drop-target'), 'true');
+    const input = container.querySelector<HTMLElement>('[role="textbox"]');
+    assert.ok(input);
+    const image = new window.File(['image'], 'screenshot.png', { type: 'image/png' });
+    const paste = new window.Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, 'clipboardData', {
+      value: {
+        files: [image],
+        getData: () => '',
+      },
+    });
+
+    await act(async () => {
+      input.dispatchEvent(paste);
+      await Promise.resolve();
+    });
+
+    assert.equal(paste.defaultPrevented, true);
+    assert.deepEqual(attached, [[image]]);
+  } finally {
+    await act(() => root.unmount());
+    Object.assign(globalThis, original);
+  }
+});

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -240,7 +240,8 @@ export const Composer = forwardRef<
      * Send becomes Stop while the draft is empty. The ＋ menu and permission
      * control stay reachable (#1444); the model and thinking menus stay
      * mounted but lock with an explanatory tooltip, so the footer row never
-     * reflows mid-turn; import stays blocked mid-turn.
+     * reflows mid-turn. Attachment import stays available because the draft
+     * can be queued as the next follow-up while this turn is running.
      */
     streaming?: boolean;
     /**
@@ -1224,7 +1225,7 @@ export const Composer = forwardRef<
   }
 
   async function runImportAction(actionId: ComposerImportActionId, action: (() => void | Promise<void>) | undefined) {
-    if (!action || props.disabled || props.streaming) return;
+    if (!action || props.disabled) return;
     await importActionOwnerRef.current?.run(actionId, async () => {
       await action();
     });
@@ -1295,7 +1296,9 @@ export const Composer = forwardRef<
   }
 
   function canAcceptDroppedFiles(): boolean {
-    return Boolean(props.onAttachFilePaths && !props.disabled && !props.streaming && !importActionOwnerRef.current?.pending);
+    // A running turn does not lock the draft: text can already be queued as a
+    // follow-up, and its staged files belong to that same next submission.
+    return Boolean(props.onAttachFilePaths && !props.disabled && !importActionOwnerRef.current?.pending);
   }
 
   function hasDraggedFiles(event: DragEvent<HTMLFormElement>): boolean {
@@ -1809,7 +1812,7 @@ export const Composer = forwardRef<
                       <DropdownMenuItem
                         label={pendingImportAction === 'pick' ? copy.addingAttachment : copy.addFileOrDirectory}
                         icon={<Upload size={ICON_SIZE.control} aria-hidden="true" />}
-                        isDisabled={props.disabled || props.streaming === true || importActionBusy}
+                        isDisabled={props.disabled || importActionBusy}
                         onClick={() => {
                           void runImportAction('pick', props.onPickAttachments);
                         }}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -240,10 +240,17 @@ export const Composer = forwardRef<
      * Send becomes Stop while the draft is empty. The ＋ menu and permission
      * control stay reachable (#1444); the model and thinking menus stay
      * mounted but lock with an explanatory tooltip, so the footer row never
-     * reflows mid-turn. Attachment import stays available because the draft
-     * can be queued as the next follow-up while this turn is running.
+     * reflows mid-turn. Attachment import remains blocked unless the host opts
+     * in via `allowAttachmentImportWhileStreaming`.
      */
     streaming?: boolean;
+    /**
+     * Keep attachment paste, drop, and picker imports available during a
+     * running turn. Only hosts whose running-turn submission carries staged
+     * attachments into a follow-up should opt in; text-only steering hosts
+     * must retain the default gate so text cannot leave its attachment behind.
+     */
+    allowAttachmentImportWhileStreaming?: boolean;
     /**
      * #646: retained for hosts that still track first-token wait vs mid-turn
      * lull. Quiet composer no longer surfaces long status copy from these;
@@ -1224,8 +1231,13 @@ export const Composer = forwardRef<
     void sendCurrent();
   }
 
+  const attachmentImportBlocked = Boolean(
+    props.disabled
+      || (props.streaming && !props.allowAttachmentImportWhileStreaming),
+  );
+
   async function runImportAction(actionId: ComposerImportActionId, action: (() => void | Promise<void>) | undefined) {
-    if (!action || props.disabled) return;
+    if (!action || attachmentImportBlocked) return;
     await importActionOwnerRef.current?.run(actionId, async () => {
       await action();
     });
@@ -1296,9 +1308,11 @@ export const Composer = forwardRef<
   }
 
   function canAcceptDroppedFiles(): boolean {
-    // A running turn does not lock the draft: text can already be queued as a
-    // follow-up, and its staged files belong to that same next submission.
-    return Boolean(props.onAttachFilePaths && !props.disabled && !importActionOwnerRef.current?.pending);
+    return Boolean(
+      props.onAttachFilePaths
+        && !attachmentImportBlocked
+        && !importActionOwnerRef.current?.pending,
+    );
   }
 
   function hasDraggedFiles(event: DragEvent<HTMLFormElement>): boolean {
@@ -1812,7 +1826,7 @@ export const Composer = forwardRef<
                       <DropdownMenuItem
                         label={pendingImportAction === 'pick' ? copy.addingAttachment : copy.addFileOrDirectory}
                         icon={<Upload size={ICON_SIZE.control} aria-hidden="true" />}
-                        isDisabled={props.disabled || importActionBusy}
+                        isDisabled={attachmentImportBlocked || importActionBusy}
                         onClick={() => {
                           void runImportAction('pick', props.onPickAttachments);
                         }}


### PR DESCRIPTION
Keep attachment imports available in the main composer while a turn is running, so pasted images, dropped files, and picker selections can be staged with the next queued or steering follow-up. Running-turn import is an explicit host capability: the queue-capable AppShell opts in, while text-only steering hosts such as Workbar side chat retain the default gate so a submitted instruction cannot leave its attachment behind.

Fixes #4188

## Verification

- `npm run lint` — passed (2,940 files)
- `npm run format:check` — passed (1,764 files)
- `npm run typecheck` — passed for all workspaces
- `npm test --workspace @maka/ui` — passed (277 tests)
- User-visible evidence: the regression test verifies that a default text-only running-turn host rejects paste/drop/picker attachment import, then opts the host in and verifies that the same pasted image reaches `onAttachFilePaths` while drop and picker availability are restored.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka investigated the composer attachment gates, implemented the fix and regression test, handled review feedback, and drafted the issue and PR text. The affected commits include `Generated-by: Maka` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
