### PR TITLE
fix(desktop): clear consumed steering queue cards

### DIFF
--- a/apps/desktop/src/main/__tests__/message-queue-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/message-queue-ui-state.test.ts
@@ -109,6 +109,16 @@ test('queue_update events drive the independent desktop queue projection', () =>
     content: { text: 'adjust this run' },
   });
   assert.deepEqual(removedTransientMessageIds, ['message-steer']);
+  assert.deepEqual(controller.getState().messageQueueBySession['session-1'], {
+    queueRevision: 3,
+    entries: [{
+      entryId: 'entry-next',
+      messageId: 'message-next',
+      content: { text: 'do this next' },
+      placement: 'next_turn',
+      state: 'queued',
+    }],
+  });
 
   handlers.handleEvent('session-1', {
     type: 'queue_update',
@@ -146,6 +156,52 @@ test('queue_update events drive the independent desktop queue projection', () =>
     outcome: 'retracted',
   });
   assert.deepEqual(removedTransientMessageIds, ['message-steer', 'message-next']);
+});
+
+test('steering delivery clears a promoted follow-up from the desktop queue', () => {
+  const controller = createAppShellSessionUiStateController();
+  const handlers = createAppShellSessionEventHandlers({
+    uiLocale: 'en',
+    activeIdRef: { current: 'session-1' },
+    liveTurnBySessionRef: controller.liveTurnBySessionRef,
+    refreshMessages: async () => true,
+    refreshSessions: async () => [],
+    setLiveTurnBySession: controller.setLiveTurnBySession,
+    setInteractionBySession: controller.setInteractionBySession,
+    setMessageQueueBySession: controller.setMessageQueueBySession,
+    showModelSetupToast() {},
+    toastApi: { error() {} },
+  });
+
+  handlers.handleEvent('session-1', {
+    type: 'queue_update',
+    id: 'queue-followup',
+    turnId: 'turn-1',
+    ts: 1,
+    queueRevision: 1,
+    steering: [],
+    followup: ['adjust this run'],
+    steeringEntries: [],
+    followupEntries: [{
+      entryId: 'entry-followup',
+      messageId: 'message-followup',
+      content: { text: 'adjust this run' },
+      placement: 'next_turn',
+      state: 'queued',
+    }],
+  });
+  assert.equal(controller.getState().messageQueueBySession['session-1']?.entries.length, 1);
+
+  handlers.handleEvent('session-1', {
+    type: 'steering_message',
+    id: 'steering-message-followup',
+    turnId: 'turn-1',
+    messageId: 'message-followup',
+    ts: 2,
+    content: { text: 'adjust this run' },
+  });
+
+  assert.equal(controller.getState().messageQueueBySession['session-1'], undefined);
 });
 
 test('complete events deliver the durable context compaction outcome to Desktop', () => {

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -367,9 +367,21 @@ export function createAppShellSessionEventHandlers(options: {
         break;
       case 'steering_message':
         // The live Turn projection now renders this same messageId in place.
-        // Retire only the renderer-owned tail row; a later nack queue_update
-        // will project it again if the Host returns the message to the queue.
+        // Retire the renderer-owned tail row and its pending-queue card; a
+        // later nack queue_update will project both again if the Host returns
+        // the message to the queue.
         removeTransientMessage?.(sessionId, event.messageId);
+        setMessageQueueBySession?.((current) => {
+          const queue = current[sessionId];
+          if (!queue?.entries.some((entry) => entry.messageId === event.messageId)) return current;
+          const entries = queue.entries.filter((entry) => entry.messageId !== event.messageId);
+          if (entries.length > 0) {
+            return { ...current, [sessionId]: { ...queue, entries } };
+          }
+          const next = { ...current };
+          delete next[sessionId];
+          return next;
+        });
         break;
       case 'text_complete':
         void refreshMessages(sessionId, { requiredAssistantMessageId: event.messageId }).catch(() => false);


### PR DESCRIPTION
## Summary

- retire a queued Desktop card as soon as its matching `steering_message` is delivered
- preserve unrelated follow-ups while allowing a later nack `queue_update` to project the message again
- cover promotion of a queued follow-up into the active turn with a regression test

Fixes #4191

## Before / After

Compare both screenshots at the same lifecycle point: the follow-up has already been accepted as an immediate direction adjustment and the active turn has finished.

| Before | After |
| --- | --- |
| The consumed follow-up (for example, `然后评论“take”`) still appears in the pending card above the composer with **Edit** and **Delete** actions, even though the result confirms that it ran. | The consumed follow-up card disappears as soon as its matching `steering_message` is delivered. The composer returns to its normal empty state. |

The intended visual difference is limited to removing the consumed row. Any unrelated queued follow-ups remain visible and editable; the transcript and completed result do not change.

### Isolated Electron E2E comparison

The image below is not a mock, Storybook story, or reconstructed UI. Both sides are actual full-page `page.screenshot()` captures from separate isolated Electron E2E runs at the same post-completion lifecycle point.

| Before — `6fca2f51e` | After — `45f4b9102` |
| --- | --- |
| ![Before fix: actual isolated Electron E2E page capture](https://gist.githubusercontent.com/Sun-GLiang/475359b69d14a062239cac4f79c2d896/raw/issue-4191-before.svg) | ![After fix: actual isolated Electron E2E page capture](https://gist.githubusercontent.com/Sun-GLiang/475359b69d14a062239cac4f79c2d896/raw/issue-4191-after.svg) |

The comparison uses the real Electron window, Playwright, the deterministic fake backend, and a separate temporary user-data directory for every run. Both captures submit `然后评论“take”` as a follow-up, promote it with **调整方向**, wait until the backend confirms `Acknowledged steering`, and capture the UI after the turn ends.

To deterministically reproduce the observed race, the harness delivers the authoritative `steering_message` consumption event but withholds the later queue-convergence update. Production code is unchanged by the harness.

| Build | Injected race | Queue card visible after completion |
| --- | --- | --- |
| Before — `6fca2f51e` | Yes | **Yes** — stale consumed card remains |
| After — `45f4b9102` | Yes | **No** — consumed card is cleared |
| Before — `6fca2f51e` control | No | No — normal queue convergence masks the race |

The control result explains why this is not reliably reproducible manually: when the later queue update arrives normally, even the pre-fix build clears the card.

## Verification

- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run clean:main && npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/message-queue-ui-state.test.js` — 3 passed
- `npx --no-install biome check apps/desktop/src/renderer/app-shell-session-events.ts apps/desktop/src/main/__tests__/message-queue-ui-state.test.ts`
- confirmed the new focused test fails against the pre-fix event handler

The full `npm --workspace @maka/desktop test` command did not run to completion in the isolated worktree because its workspace-dependency prebuild could not resolve the installed Slack SDK packages and reported an installed `https-proxy-agent` type mismatch. The affected Desktop suite and Desktop typecheck pass.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Maka traced the Desktop queue projection, implemented the consumed-steering cleanup and regression coverage, and drafted this PR description.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
