### PR TITLE
fix(desktop): adapt MCP schemas for native capabilities

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
@@ -23,6 +23,7 @@ import type { McpToolBinding } from '@maka/core/mcp';
 import { buildComputerUseTools, type ComputerUseToolSet } from '@maka/runtime/computer-use-tools';
 import { type CuDispatchBackend } from '@maka/runtime/computer-use-types';
 import { buildMcpTools, type McpToolProvider } from '@maka/runtime/mcp-tools';
+import { ToolParameterValidationError } from '@maka/runtime/tool-parameters';
 import { type MakaTool, type MakaToolContext } from '@maka/runtime/tool-runtime';
 import type { ClientCapabilityProvider } from '@maka/runtime-host/client';
 import {
@@ -183,9 +184,18 @@ test('publishes and invokes MCP JSON Schema tools through Desktop native capabil
             name: 'echo',
             description: 'Echo one value',
             inputSchema: {
+              $schema: 'https://json-schema.org/draft/2020-12/schema',
               type: 'object',
-              properties: { value: { type: 'string' } },
-              required: ['value'],
+              properties: {
+                mode: { enum: ['echo', 'silent'] },
+                value: { type: 'string' },
+              },
+              required: ['mode'],
+              if: {
+                properties: { mode: { const: 'echo' } },
+                required: ['mode'],
+              },
+              then: { required: ['value'] },
               additionalProperties: false,
             },
           },
@@ -216,9 +226,18 @@ test('publishes and invokes MCP JSON Schema tools through Desktop native capabil
   const offer = provider.offers()[0];
   assert.equal(offer?.offerId, 'desktop_mcp');
   assert.deepEqual(offer?.tools[0]?.inputSchema, {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
     type: 'object',
-    properties: { value: { type: 'string' } },
-    required: ['value'],
+    properties: {
+      mode: { enum: ['echo', 'silent'] },
+      value: { type: 'string' },
+    },
+    required: ['mode'],
+    if: {
+      properties: { mode: { const: 'echo' } },
+      required: ['mode'],
+    },
+    then: { required: ['value'] },
     additionalProperties: false,
   });
   assert.deepEqual(
@@ -228,12 +247,12 @@ test('publishes and invokes MCP JSON Schema tools through Desktop native capabil
         offerId: 'desktop_mcp',
         serverId: 'desktop_mcp',
         toolName: 'mcp__fixture__echo',
-        arguments: { value: 'ok' },
+        arguments: { mode: 'echo', value: 'ok' },
       }),
     ),
     { content: [{ type: 'text', text: 'echo:ok' }] },
   );
-  assert.deepEqual(receivedArguments, { value: 'ok' });
+  assert.deepEqual(receivedArguments, { mode: 'echo', value: 'ok' });
 
   let admitted = false;
   await assert.rejects(
@@ -244,13 +263,13 @@ test('publishes and invokes MCP JSON Schema tools through Desktop native capabil
           offerId: 'desktop_mcp',
           serverId: 'desktop_mcp',
           toolName: 'mcp__fixture__echo',
-          arguments: { value: 1 },
+          arguments: { mode: 'echo' },
         }),
         () => {
           admitted = true;
         },
       ),
-    (error: unknown) => error instanceof z.ZodError,
+    (error: unknown) => error instanceof ToolParameterValidationError,
   );
   assert.equal(admitted, false);
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
@@ -240,6 +240,11 @@ test('publishes and invokes MCP JSON Schema tools through Desktop native capabil
     then: { required: ['value'] },
     additionalProperties: false,
   });
+  const canonical = decodeClientCapabilityReplaceInput({
+    registrationId: 'registration',
+    offers: provider.offers(),
+  });
+  assert.deepEqual(canonical.offers[0]?.tools[0]?.inputSchema, offer?.tools[0]?.inputSchema);
   assert.deepEqual(
     await call(
       provider,

--- a/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
@@ -19,8 +19,10 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import type { McpToolBinding } from '@maka/core/mcp';
 import { buildComputerUseTools, type ComputerUseToolSet } from '@maka/runtime/computer-use-tools';
 import { type CuDispatchBackend } from '@maka/runtime/computer-use-types';
+import { buildMcpTools, type McpToolProvider } from '@maka/runtime/mcp-tools';
 import { type MakaTool, type MakaToolContext } from '@maka/runtime/tool-runtime';
 import type { ClientCapabilityProvider } from '@maka/runtime-host/client';
 import {
@@ -167,6 +169,90 @@ test('publishes every production Desktop-owned tool schema through the protocol'
       offers: provider.offers(),
     }),
   );
+});
+
+test('publishes and invokes MCP JSON Schema tools through Desktop native capabilities', async () => {
+  let receivedArguments: Record<string, unknown> | undefined;
+  const mcpProvider: McpToolProvider = {
+    toolSnapshot: () => ({
+      revision: 1,
+      tools: [
+        {
+          descriptor: {
+            serverId: 'fixture',
+            name: 'echo',
+            description: 'Echo one value',
+            inputSchema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+            },
+          },
+          binding: 'fixture-echo' as McpToolBinding,
+        },
+      ],
+    }),
+    async callTool(_binding, args) {
+      receivedArguments = args;
+      return { content: [{ type: 'text', text: `echo:${String(args.value)}` }] };
+    },
+  };
+  const provider = createDesktopNativeCapabilityProvider({
+    browserTools: [],
+    releaseBrowserSession() {},
+    computerUseTools: computerTools(),
+    releaseComputerUseSession() {},
+    additionalGroups: () => [
+      {
+        offerId: 'desktop_mcp',
+        label: 'MCP',
+        description: 'MCP tools',
+        tools: buildMcpTools(mcpProvider),
+      },
+    ],
+  });
+
+  const offer = provider.offers()[0];
+  assert.equal(offer?.offerId, 'desktop_mcp');
+  assert.deepEqual(offer?.tools[0]?.inputSchema, {
+    type: 'object',
+    properties: { value: { type: 'string' } },
+    required: ['value'],
+    additionalProperties: false,
+  });
+  assert.deepEqual(
+    await call(
+      provider,
+      capabilityFrame({
+        offerId: 'desktop_mcp',
+        serverId: 'desktop_mcp',
+        toolName: 'mcp__fixture__echo',
+        arguments: { value: 'ok' },
+      }),
+    ),
+    { content: [{ type: 'text', text: 'echo:ok' }] },
+  );
+  assert.deepEqual(receivedArguments, { value: 'ok' });
+
+  let admitted = false;
+  await assert.rejects(
+    () =>
+      call(
+        provider,
+        capabilityFrame({
+          offerId: 'desktop_mcp',
+          serverId: 'desktop_mcp',
+          toolName: 'mcp__fixture__echo',
+          arguments: { value: 1 },
+        }),
+        () => {
+          admitted = true;
+        },
+      ),
+    (error: unknown) => error instanceof z.ZodError,
+  );
+  assert.equal(admitted, false);
 });
 
 test('publishes and admits additional Desktop native-effect services', async () => {

--- a/apps/desktop/src/main/runtime-host-native-capabilities.ts
+++ b/apps/desktop/src/main/runtime-host-native-capabilities.ts
@@ -20,6 +20,7 @@
 import { Buffer } from "node:buffer";
 import type { ComputerUseToolSet } from '@maka/runtime/computer-use-tools';
 import type { MakaTool } from '@maka/runtime/tool-runtime';
+import { parseToolParameters } from '@maka/runtime/tool-parameters';
 import {
   createOAuthPresentationClientProvider,
   type ClientCapabilityProvider,
@@ -328,8 +329,7 @@ async function invokeNativeTool(
   }
   const signal = AbortSignal.any([options.signal, invocation.signal]);
   signal.throwIfAborted();
-  const parameters = requireZodSchema(binding.tool);
-  const args = await parameters.parseAsync(frame.arguments);
+  const args = await parseToolParameters(binding.tool.parameters, frame.arguments);
   signal.throwIfAborted();
   await options.accept();
   signal.throwIfAborted();
@@ -399,29 +399,30 @@ function capabilityOffer(
 }
 
 function toolInputSchema(tool: MakaTool): Record<string, unknown> {
-  const schema = toJSONSchema(requireZodSchema(tool), {
-    io: "input",
-    target: "draft-07",
-    unrepresentable: "any",
-    cycles: "ref",
-    reused: "inline",
-  });
-  delete schema.$schema;
-  if (schema.type !== "object") {
-    throw new Error(
-      `Desktop native capability tool schema must be an object: ${tool.name}`,
-    );
-  }
-  return Object.freeze(schema);
-}
-
-function requireZodSchema(tool: MakaTool): z.ZodType {
-  if (!(tool.parameters instanceof z.ZodType)) {
+  const parameters = tool.parameters as { readonly jsonSchema?: unknown };
+  const zodParameters = tool.parameters instanceof z.ZodType ? tool.parameters : undefined;
+  const schema = zodParameters
+    ? toJSONSchema(zodParameters, {
+        io: "input",
+        target: "draft-07",
+        unrepresentable: "any",
+        cycles: "ref",
+        reused: "inline",
+      })
+    : structuredClone(parameters.jsonSchema ?? tool.parameters);
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     throw new Error(
       `Desktop native capability tool has an invalid schema: ${tool.name}`,
     );
   }
-  return tool.parameters;
+  const objectSchema = schema as Record<string, unknown>;
+  if (zodParameters) delete objectSchema.$schema;
+  if (objectSchema.type !== "object") {
+    throw new Error(
+      `Desktop native capability tool schema must be an object: ${tool.name}`,
+    );
+  }
+  return Object.freeze(objectSchema);
 }
 
 function indexBindings(

--- a/packages/runtime-host/src/__tests__/client-capability-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-protocol.test.ts
@@ -257,6 +257,10 @@ describe('Client Capability protocol', () => {
     for (const inputSchema of [
       { type: 'string' },
       { type: 'object', unsupportedKeyword: true },
+      { type: 'object', $schema: 'https://example.test/custom-schema' },
+      { type: 'object', if: 'not-a-schema' },
+      { type: 'object', dependentRequired: { value: [] } },
+      { type: 'object', prefixItems: 'not-an-array' },
       { type: 'object', properties: { value: { $ref: 'https://example.test/schema' } } },
       { type: 'object', properties: { value: { $ref: '#/$defs/missing' } } },
     ]) {
@@ -294,6 +298,43 @@ describe('Client Capability protocol', () => {
                       anyOf: [{ type: 'string', maxLength: 128 }, { type: 'null' }],
                     },
                   },
+                },
+              },
+            ],
+          },
+        ]),
+      ),
+    );
+    assert.doesNotThrow(() =>
+      decodeClientFrame(
+        replaceFrame([
+          {
+            ...offer('conditional_schema', 'evaluate'),
+            tools: [
+              {
+                ...offer('conditional_schema', 'evaluate').tools[0],
+                inputSchema: {
+                  $schema: 'https://json-schema.org/draft/2020-12/schema',
+                  $id: 'https://example.test/conditional-schema',
+                  $comment: 'Exercises the bounded modern schema contract.',
+                  type: 'object',
+                  properties: {
+                    mode: { enum: ['echo', 'silent'] },
+                    value: { type: 'string' },
+                    tags: {
+                      type: 'array',
+                      prefixItems: [{ type: 'string' }],
+                      contains: { type: 'string', minLength: 1 },
+                      minContains: 1,
+                    },
+                  },
+                  patternProperties: { '^x-': { type: 'string' } },
+                  dependentRequired: { mode: ['value'] },
+                  dependentSchemas: { tags: { required: ['mode'] } },
+                  if: { properties: { mode: { const: 'echo' } }, required: ['mode'] },
+                  then: { required: ['value'] },
+                  else: { not: { required: ['value'] } },
+                  unevaluatedProperties: false,
                 },
               },
             ],

--- a/packages/runtime-host/src/protocol/client-capability.ts
+++ b/packages/runtime-host/src/protocol/client-capability.ts
@@ -687,39 +687,71 @@ const CLIENT_CAPABILITY_SCHEMA_TYPES = new Set([
   'object',
   'string',
 ]);
+const CLIENT_CAPABILITY_SCHEMA_DIALECTS = new Set([
+  'http://json-schema.org/draft-07/schema',
+  'http://json-schema.org/draft-07/schema#',
+  'https://json-schema.org/draft-07/schema',
+  'https://json-schema.org/draft-07/schema#',
+  'https://json-schema.org/draft/2019-09/schema',
+  'https://json-schema.org/draft/2020-12/schema',
+]);
 const CLIENT_CAPABILITY_SCHEMA_KEYWORDS = new Set([
+  '$comment',
   '$defs',
+  '$id',
   '$ref',
+  '$schema',
+  'additionalItems',
   'additionalProperties',
   'allOf',
   'anyOf',
+  'contains',
+  'contentEncoding',
+  'contentMediaType',
+  'contentSchema',
   'const',
   'default',
   'definitions',
+  'dependencies',
+  'dependentRequired',
+  'dependentSchemas',
+  'deprecated',
   'description',
+  'else',
   'enum',
   'examples',
   'exclusiveMaximum',
   'exclusiveMinimum',
   'format',
+  'if',
   'items',
+  'maxContains',
   'maxItems',
   'maxLength',
   'maxProperties',
   'maximum',
+  'minContains',
   'minItems',
   'minLength',
   'minProperties',
   'minimum',
   'multipleOf',
+  'not',
   'oneOf',
   'pattern',
+  'patternProperties',
+  'prefixItems',
   'propertyNames',
   'properties',
+  'readOnly',
   'required',
+  'then',
   'title',
   'type',
+  'unevaluatedItems',
+  'unevaluatedProperties',
   'uniqueItems',
+  'writeOnly',
 ]);
 
 function validateToolInputSchema(root: Record<string, unknown>): void {
@@ -734,10 +766,25 @@ function validateToolInputSchema(root: Record<string, unknown>): void {
       throw invalidProtocolFrame('Unsupported Client Capability tool schema keyword');
     }
     if (schema.type !== undefined) validateSchemaType(schema.type);
-    for (const key of ['title', 'description', 'format', 'pattern'] as const) {
+    for (const key of [
+      '$comment',
+      '$id',
+      'title',
+      'description',
+      'format',
+      'pattern',
+      'contentEncoding',
+      'contentMediaType',
+    ] as const) {
       if (schema[key] !== undefined && typeof schema[key] !== 'string') {
         throw invalidProtocolFrame(`Invalid Client Capability tool schema ${key}`);
       }
+    }
+    if (
+      schema.$schema !== undefined &&
+      (typeof schema.$schema !== 'string' || !CLIENT_CAPABILITY_SCHEMA_DIALECTS.has(schema.$schema))
+    ) {
+      throw invalidProtocolFrame('Unsupported Client Capability tool schema dialect');
     }
     if (typeof schema.pattern === 'string') {
       try {
@@ -766,6 +813,8 @@ function validateToolInputSchema(root: Record<string, unknown>): void {
     for (const key of [
       'minItems',
       'maxItems',
+      'minContains',
+      'maxContains',
       'minLength',
       'maxLength',
       'minProperties',
@@ -778,13 +827,30 @@ function validateToolInputSchema(root: Record<string, unknown>): void {
         throw invalidProtocolFrame(`Invalid Client Capability tool schema ${key}`);
       }
     }
-    if (schema.uniqueItems !== undefined && typeof schema.uniqueItems !== 'boolean') {
-      throw invalidProtocolFrame('Invalid Client Capability tool schema uniqueItems');
+    for (const key of ['deprecated', 'readOnly', 'uniqueItems', 'writeOnly'] as const) {
+      if (schema[key] !== undefined && typeof schema[key] !== 'boolean') {
+        throw invalidProtocolFrame(`Invalid Client Capability tool schema ${key}`);
+      }
     }
-    for (const key of ['properties', '$defs', 'definitions'] as const) {
+    for (const key of [
+      'properties',
+      'patternProperties',
+      'dependentSchemas',
+      '$defs',
+      'definitions',
+    ] as const) {
       if (schema[key] === undefined) continue;
       const entries = requireRecord(schema[key], `Client Capability tool schema ${key}`);
-      for (const nested of Object.values(entries)) visit(nested);
+      for (const [name, nested] of Object.entries(entries)) {
+        if (key === 'patternProperties') {
+          try {
+            new RegExp(name);
+          } catch {
+            throw invalidProtocolFrame('Invalid Client Capability tool schema patternProperties');
+          }
+        }
+        visit(nested);
+      }
     }
     if (schema.required !== undefined) {
       if (
@@ -795,14 +861,20 @@ function validateToolInputSchema(root: Record<string, unknown>): void {
         throw invalidProtocolFrame('Invalid Client Capability tool schema required');
       }
     }
-    if (
-      schema.additionalProperties !== undefined &&
-      typeof schema.additionalProperties !== 'boolean'
-    ) {
-      visit(schema.additionalProperties);
-    }
-    if (schema.propertyNames !== undefined) {
-      visit(schema.propertyNames);
+    for (const key of [
+      'additionalItems',
+      'additionalProperties',
+      'contains',
+      'contentSchema',
+      'else',
+      'if',
+      'not',
+      'propertyNames',
+      'then',
+      'unevaluatedItems',
+      'unevaluatedProperties',
+    ] as const) {
+      if (schema[key] !== undefined) visit(schema[key]);
     }
     if (schema.items !== undefined) {
       if (Array.isArray(schema.items)) {
@@ -813,6 +885,12 @@ function validateToolInputSchema(root: Record<string, unknown>): void {
       } else {
         visit(schema.items);
       }
+    }
+    if (schema.prefixItems !== undefined) {
+      if (!Array.isArray(schema.prefixItems) || schema.prefixItems.length === 0) {
+        throw invalidProtocolFrame('Invalid Client Capability tool schema prefixItems');
+      }
+      for (const nested of schema.prefixItems) visit(nested);
     }
     for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
       if (schema[key] === undefined) continue;
@@ -826,6 +904,12 @@ function validateToolInputSchema(root: Record<string, unknown>): void {
     }
     if (schema.examples !== undefined && !Array.isArray(schema.examples)) {
       throw invalidProtocolFrame('Invalid Client Capability tool schema examples');
+    }
+    if (schema.dependentRequired !== undefined) {
+      validateSchemaDependencies(schema.dependentRequired, 'dependentRequired', false, visit);
+    }
+    if (schema.dependencies !== undefined) {
+      validateSchemaDependencies(schema.dependencies, 'dependencies', true, visit);
     }
     if (schema.$ref !== undefined) {
       if (
@@ -842,6 +926,31 @@ function validateToolInputSchema(root: Record<string, unknown>): void {
     if (!resolveLocalSchemaReference(root, reference)) {
       throw invalidProtocolFrame('Client Capability tool schema reference is unresolved');
     }
+  }
+}
+
+function validateSchemaDependencies(
+  value: unknown,
+  keyword: 'dependencies' | 'dependentRequired',
+  allowSchemas: boolean,
+  visit: (value: unknown) => void,
+): void {
+  const entries = requireRecord(value, `Client Capability tool schema ${keyword}`);
+  for (const dependency of Object.values(entries)) {
+    if (Array.isArray(dependency)) {
+      if (
+        dependency.length === 0 ||
+        dependency.some((entry) => typeof entry !== 'string') ||
+        new Set(dependency).size !== dependency.length
+      ) {
+        throw invalidProtocolFrame(`Invalid Client Capability tool schema ${keyword}`);
+      }
+      continue;
+    }
+    if (!allowSchemas) {
+      throw invalidProtocolFrame(`Invalid Client Capability tool schema ${keyword}`);
+    }
+    visit(dependency);
   }
 }
 

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -95,7 +95,9 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 76 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 77 as const;
+// 77: Client Capability tool schemas admit bounded modern JSON Schema keywords.
+// Older peers reject valid MCP offers that use those applicators or annotations.
 // 76: Peer Mesh endpoint and Mesh display names are signed, persisted facts
 // managed through Host operations rather than local-only Client labels.
 // 75: Peer Mesh routes identify whether a peer is a Client or Runtime Host so

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -109,6 +109,7 @@
     "./tool-result-archive": "./dist/tool-result-archive.js",
     "./tool-result-archive-capability": "./dist/tool-result-archive-capability.js",
     "./tool-result-archive-resource": "./dist/tool-result-archive-resource.js",
+    "./tool-parameters": "./dist/tool-parameters.js",
     "./tool-runtime": "./dist/tool-runtime.js",
     "./web-fetch-tool": "./dist/web-fetch-tool.js",
     "./web-search-tool": "./dist/web-search-tool.js",

--- a/packages/runtime/src/__tests__/tool-parameters.test.ts
+++ b/packages/runtime/src/__tests__/tool-parameters.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseToolParameters, ToolParameterValidationError } from '../tool-parameters.js';
+
+test('validates complete asynchronous JSON Schemas without converting them to Zod', async () => {
+  const parameters = {
+    jsonSchema: Promise.resolve({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties: {
+        card: { type: 'string' },
+        billingAddress: { type: 'string' },
+      },
+      dependentRequired: { card: ['billingAddress'] },
+      unevaluatedProperties: false,
+    }),
+  };
+
+  assert.deepEqual(
+    await parseToolParameters(parameters, { card: '1234', billingAddress: 'home' }),
+    { card: '1234', billingAddress: 'home' },
+  );
+  await assert.rejects(
+    () => parseToolParameters(parameters, { card: '1234' }),
+    (error: unknown) => error instanceof ToolParameterValidationError,
+  );
+  await assert.rejects(
+    () => parseToolParameters(parameters, { unexpected: true }),
+    (error: unknown) => error instanceof ToolParameterValidationError,
+  );
+});

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -122,13 +122,12 @@ import type {
   UserContent,
 } from './model-protocol.js';
 import type { ModelCallCommit } from '@maka/core/agent-run';
-import Ajv, { type AnySchema, type ErrorObject, type ValidateFunction } from 'ajv';
-import Ajv2019 from 'ajv/dist/2019.js';
-import Ajv2020 from 'ajv/dist/2020.js';
+import type { ErrorObject } from 'ajv';
 import { z } from 'zod';
 
 import { AsyncEventQueue } from './async-queue.js';
 import { AdmissionLimiter } from './admission-limiter.js';
+import { parseToolParameters } from './tool-parameters.js';
 import {
   type CodeModeExecutionResult,
   DEFAULT_CODE_MODE_EXECUTION_POLICY,
@@ -579,70 +578,12 @@ function nestableToolSnapshot(
   );
 }
 
-const codeModeJsonSchemaOptions = {
-  allErrors: true,
-  strict: false,
-  validateFormats: false,
-} as const;
-const codeModeDraft7Validator = new Ajv(codeModeJsonSchemaOptions);
-const codeModeDraft2019Validator = new Ajv2019(codeModeJsonSchemaOptions);
-const codeModeDraft2020Validator = new Ajv2020(codeModeJsonSchemaOptions);
-const codeModeCompiledSchemas = new WeakMap<object, ValidateFunction>();
-
 async function validateCodeModeToolInput(tool: MakaTool, input: unknown): Promise<unknown> {
-  const parameters = tool.parameters as {
-    safeParseAsync?: (
-      value: unknown,
-    ) => Promise<{ success: true; data: unknown } | { success: false; error: unknown }>;
-    safeParse?: (
-      value: unknown,
-    ) => { success: true; data: unknown } | { success: false; error: unknown };
-    validate?: (
-      value: unknown,
-    ) =>
-      | { success: true; value: unknown }
-      | { success: false; error: unknown }
-      | Promise<{ success: true; value: unknown } | { success: false; error: unknown }>;
-    jsonSchema?: unknown;
-  };
-  const parserResult = parameters.safeParseAsync
-    ? await parameters.safeParseAsync(input)
-    : parameters.safeParse?.(input);
-  if (parserResult) {
-    if (parserResult.success) return parserResult.data;
-    throw invalidCodeModeToolArguments(tool.name, parserResult.error);
+  try {
+    return await parseToolParameters(tool.parameters, input);
+  } catch (error) {
+    throw invalidCodeModeToolArguments(tool.name, error);
   }
-
-  if (parameters.validate) {
-    const validationResult = await parameters.validate(input);
-    if (validationResult.success) return validationResult.value;
-    throw invalidCodeModeToolArguments(tool.name, validationResult.error);
-  }
-
-  const schema = await parameters.jsonSchema;
-  const validator = compileCodeModeJsonSchema(schema ?? tool.parameters);
-  if (!validator || validator(input)) return input;
-  throw invalidCodeModeToolArguments(tool.name, validator.errors);
-}
-
-function compileCodeModeJsonSchema(schema: unknown): ValidateFunction | undefined {
-  if (typeof schema === 'boolean') return codeModeDraft2020Validator.compile(schema);
-  if (typeof schema !== 'object' || schema === null || Array.isArray(schema)) return undefined;
-  const cached = codeModeCompiledSchemas.get(schema);
-  if (cached) return cached;
-  const declaredDialect = (schema as { readonly $schema?: unknown }).$schema;
-  const dialect = typeof declaredDialect === 'string' ? declaredDialect : '';
-  const validator = dialect.includes('draft-07')
-    ? codeModeDraft7Validator
-    : dialect.includes('2019-09')
-      ? codeModeDraft2019Validator
-      : codeModeDraft2020Validator;
-  const schemaForCompile = dialect.startsWith('https://json-schema.org/draft-07/schema')
-    ? { ...schema, $schema: dialect.replace('https://', 'http://') }
-    : schema;
-  const compiled = validator.compile(schemaForCompile as AnySchema);
-  codeModeCompiledSchemas.set(schema, compiled);
-  return compiled;
 }
 
 function invalidCodeModeToolArguments(toolName: string, error: unknown): Error {

--- a/packages/runtime/src/mcp-tools.ts
+++ b/packages/runtime/src/mcp-tools.ts
@@ -18,7 +18,6 @@
  */
 
 import { createHash } from 'node:crypto';
-import { jsonSchema } from 'ai';
 import type { ToolActivityKind } from '@maka/core/events';
 import type {
   McpCallResult,
@@ -28,6 +27,7 @@ import type {
 } from '@maka/core/mcp';
 import type { ToolCategory } from '@maka/core/permission';
 import type { ToolRecoveryMode } from '@maka/core/runtime-event';
+import { z } from 'zod';
 import type { ToolResultContentPart, ToolResultOutput } from './model-protocol.js';
 import type { MakaTool } from './tool-runtime.js';
 
@@ -96,7 +96,9 @@ export function buildMcpTools(
       // ordinary MCP servers retain the side-effecting network default.
       categoryHint: options.categoryHint ?? 'network_send',
       ...(options.recoveryMode ? { recoveryMode: options.recoveryMode } : {}),
-      parameters: jsonSchema(descriptor.inputSchema),
+      // Client capabilities publish and validate Zod schemas before admission.
+      // Preserve that boundary when an MCP descriptor starts as JSON Schema.
+      parameters: z.fromJSONSchema(descriptor.inputSchema),
       impl: async (args: unknown, context) => {
         // Managed network authority applies equally to Direct and nested CodeMode dispatch.
         if (

--- a/packages/runtime/src/mcp-tools.ts
+++ b/packages/runtime/src/mcp-tools.ts
@@ -18,6 +18,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { jsonSchema } from 'ai';
 import type { ToolActivityKind } from '@maka/core/events';
 import type {
   McpCallResult,
@@ -27,7 +28,6 @@ import type {
 } from '@maka/core/mcp';
 import type { ToolCategory } from '@maka/core/permission';
 import type { ToolRecoveryMode } from '@maka/core/runtime-event';
-import { z } from 'zod';
 import type { ToolResultContentPart, ToolResultOutput } from './model-protocol.js';
 import type { MakaTool } from './tool-runtime.js';
 
@@ -96,9 +96,9 @@ export function buildMcpTools(
       // ordinary MCP servers retain the side-effecting network default.
       categoryHint: options.categoryHint ?? 'network_send',
       ...(options.recoveryMode ? { recoveryMode: options.recoveryMode } : {}),
-      // Client capabilities publish and validate Zod schemas before admission.
-      // Preserve that boundary when an MCP descriptor starts as JSON Schema.
-      parameters: z.fromJSONSchema(descriptor.inputSchema),
+      // Preserve the MCP server's complete JSON Schema. Callers validate it through
+      // the shared tool-parameter boundary instead of a partial schema conversion.
+      parameters: jsonSchema(descriptor.inputSchema),
       impl: async (args: unknown, context) => {
         // Managed network authority applies equally to Direct and nested CodeMode dispatch.
         if (

--- a/packages/runtime/src/tool-parameters.ts
+++ b/packages/runtime/src/tool-parameters.ts
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Ajv, { type AnySchema, type ValidateFunction } from 'ajv';
+import Ajv2019 from 'ajv/dist/2019.js';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const jsonSchemaOptions = {
+  allErrors: true,
+  strict: false,
+  validateFormats: false,
+} as const;
+const draft7Validator = new Ajv(jsonSchemaOptions);
+const draft2019Validator = new Ajv2019(jsonSchemaOptions);
+const draft2020Validator = new Ajv2020(jsonSchemaOptions);
+const compiledSchemas = new WeakMap<object, ValidateFunction>();
+
+interface ToolParameterSchema {
+  safeParseAsync?: (
+    value: unknown,
+  ) => PromiseLike<{ success: true; data: unknown } | { success: false; error: unknown }>;
+  safeParse?: (
+    value: unknown,
+  ) => { success: true; data: unknown } | { success: false; error: unknown };
+  validate?: (
+    value: unknown,
+  ) =>
+    | { success: true; value: unknown }
+    | { success: false; error: unknown }
+    | PromiseLike<{ success: true; value: unknown } | { success: false; error: unknown }>;
+  jsonSchema?: unknown;
+  '~standard'?: {
+    validate?: (
+      value: unknown,
+    ) =>
+      | { value: unknown }
+      | { issues: readonly unknown[] }
+      | PromiseLike<{ value: unknown } | { issues: readonly unknown[] }>;
+  };
+}
+
+export class ToolParameterValidationError extends Error {
+  readonly issues: readonly unknown[];
+
+  constructor(issues: readonly unknown[]) {
+    super('Tool arguments failed declared schema validation', { cause: issues });
+    this.name = 'ToolParameterValidationError';
+    this.issues = issues;
+  }
+}
+
+export async function parseToolParameters(parameters: unknown, input: unknown): Promise<unknown> {
+  if (!parameters || (typeof parameters !== 'object' && typeof parameters !== 'function')) {
+    return input;
+  }
+  const schema = parameters as ToolParameterSchema;
+  if (typeof schema.safeParseAsync === 'function') {
+    const parsed = await schema.safeParseAsync(input);
+    if (parsed.success) return parsed.data;
+    throw parsed.error;
+  }
+  if (typeof schema.safeParse === 'function') {
+    const parsed = schema.safeParse(input);
+    if (parsed.success) return parsed.data;
+    throw parsed.error;
+  }
+  if (typeof schema.validate === 'function') {
+    const parsed = await schema.validate(input);
+    if (parsed.success) return parsed.value;
+    throw parsed.error;
+  }
+  if (typeof schema['~standard']?.validate === 'function') {
+    const parsed = await schema['~standard'].validate(input);
+    if ('value' in parsed) return parsed.value;
+    throw new ToolParameterValidationError(parsed.issues);
+  }
+
+  const declaredJsonSchema = await schema.jsonSchema;
+  const validator = compileJsonSchema(declaredJsonSchema ?? parameters);
+  if (!validator || (await validator(input))) return input;
+  throw new ToolParameterValidationError(validator.errors ?? []);
+}
+
+function compileJsonSchema(schema: unknown): ValidateFunction | undefined {
+  if (typeof schema === 'boolean') return draft2020Validator.compile(schema);
+  if (typeof schema !== 'object' || schema === null || Array.isArray(schema)) return undefined;
+  const cached = compiledSchemas.get(schema);
+  if (cached) return cached;
+  const declaredDialect = (schema as { readonly $schema?: unknown }).$schema;
+  const dialect = typeof declaredDialect === 'string' ? declaredDialect : '';
+  const validator = dialect.includes('draft-07')
+    ? draft7Validator
+    : dialect.includes('2019-09')
+      ? draft2019Validator
+      : draft2020Validator;
+  const schemaForCompile = dialect.startsWith('https://json-schema.org/draft-07/schema')
+    ? { ...schema, $schema: dialect.replace('https://', 'http://') }
+    : schema;
+  const compiled = validator.compile(schemaForCompile as AnySchema);
+  compiledSchemas.set(schema, compiled);
+  return compiled;
+}

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -91,6 +91,7 @@ import {
   type ToolRecoveryMode,
 } from './runtime-commit-sink.js';
 import { AdmissionLimiter } from './admission-limiter.js';
+import { parseToolParameters } from './tool-parameters.js';
 import type { AgentProfile } from './agent-catalog.js';
 import type { SubagentExecutionRef } from './subagent-execution.js';
 import {
@@ -151,7 +152,7 @@ export interface MakaTool<P = any, R = unknown> {
   name: string;
   /** Human-readable description shown to the model. */
   description: string;
-  /** Zod schema describing the tool's argument shape. */
+  /** Declared schema describing and validating the tool's argument shape. */
   parameters: unknown;
   /** Optional UI display name. */
   displayName?: string;
@@ -2846,52 +2847,7 @@ export class ToolRuntime {
 }
 
 async function validateDeclaredToolArgs(parameters: unknown, args: unknown): Promise<void> {
-  if (!parameters || (typeof parameters !== 'object' && typeof parameters !== 'function')) {
-    return;
-  }
-  const schema = parameters as {
-    safeParseAsync?: (
-      value: unknown,
-    ) => PromiseLike<{ success: true; data: unknown } | { success: false; error: unknown }>;
-    safeParse?: (
-      value: unknown,
-    ) => { success: true; data: unknown } | { success: false; error: unknown };
-    validate?: (
-      value: unknown,
-    ) =>
-      | { success: true; value: unknown }
-      | { success: false; error: unknown }
-      | PromiseLike<{ success: true; value: unknown } | { success: false; error: unknown }>;
-    '~standard'?: {
-      validate?: (
-        value: unknown,
-      ) =>
-        | { value: unknown }
-        | { issues: readonly unknown[] }
-        | PromiseLike<{ value: unknown } | { issues: readonly unknown[] }>;
-    };
-  };
-
-  if (typeof schema.safeParseAsync === 'function') {
-    const parsed = await schema.safeParseAsync(args);
-    if (parsed.success) return;
-    throw parsed.error;
-  }
-  if (typeof schema.safeParse === 'function') {
-    const parsed = schema.safeParse(args);
-    if (parsed.success) return;
-    throw parsed.error;
-  }
-  if (typeof schema.validate === 'function') {
-    const parsed = await schema.validate(args);
-    if (parsed.success) return;
-    throw parsed.error;
-  }
-  if (typeof schema['~standard']?.validate === 'function') {
-    const parsed = await schema['~standard'].validate(args);
-    if ('value' in parsed) return;
-    throw new Error('Tool arguments failed declared schema validation', { cause: parsed.issues });
-  }
+  await parseToolParameters(parameters, args);
 }
 
 function isInteractionControlError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

- preserve complete MCP JSON Schema descriptors instead of converting them into partial Zod schemas
- validate Zod, AI SDK, Standard Schema, and draft-07/2019-09/2020-12 JSON Schema through one shared tool-parameter boundary
- publish original MCP schemas through Desktop native capabilities and validate arguments before admission
- align the bounded Client Capability protocol contract with supported modern JSON Schema applicator and validation keywords
- add regressions for protocol canonicalization, conditional schemas, asynchronous schemas, `dependentRequired`, and `unevaluatedProperties`

## Testing

- `npm run build:test`
- `node --test packages/runtime-host/dist/__tests__/client-capability-protocol.test.js packages/runtime/dist/__tests__/mcp-tools.test.js packages/runtime/dist/__tests__/tool-parameters.test.js apps/desktop/dist/main/__tests__/runtime-host-native-capabilities.test.js apps/desktop/dist/main/__tests__/mcp-runtime-e2e.test.js` (28 passed)
- `npm run typecheck`
- `npm run check:asf-headers`
- `npm run lint`

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex — schema-boundary design, implementation, regression tests, and validation.

Fixes #4209.

<details>
<summary>中文</summary>

## 摘要

- 保留完整的 MCP JSON Schema 描述，不再将其转换为能力不完整的 Zod schema
- 通过统一的工具参数边界校验 Zod、AI SDK、Standard Schema，以及 draft-07/2019-09/2020-12 JSON Schema
- 通过 Desktop native capability 发布原始 MCP schema，并在 admission 前校验参数
- 让受限的 Client Capability 协议契约支持相应的现代 JSON Schema applicator 与 validation 关键字
- 增加协议 canonicalization、条件 schema、异步 schema、`dependentRequired` 和 `unevaluatedProperties` 回归测试

## 验证

- `npm run build:test`
- `node --test packages/runtime-host/dist/__tests__/client-capability-protocol.test.js packages/runtime/dist/__tests__/mcp-tools.test.js packages/runtime/dist/__tests__/tool-parameters.test.js apps/desktop/dist/main/__tests__/runtime-host-native-capabilities.test.js apps/desktop/dist/main/__tests__/mcp-runtime-e2e.test.js`（28 项通过）
- `npm run typecheck`
- `npm run check:asf-headers`
- `npm run lint`

## AI 使用

- [ ] 没有生成式工具作出实质性贡献
- [x] 生成式工具作出了实质性贡献

工具及范围：Codex — schema 边界设计、实现、回归测试和验证。

修复 #4209。

</details>