### PR TITLE
fix(runtime): allow reading workspace ancestor directories under macOS Seatbelt

### DIFF
--- a/packages/runtime/src/__tests__/macos-seatbelt-smoke.test.ts
+++ b/packages/runtime/src/__tests__/macos-seatbelt-smoke.test.ts
@@ -20,7 +20,7 @@
 import assert from 'node:assert/strict';
 import { after, describe, it } from 'node:test';
 import { existsSync } from 'node:fs';
-import { mkdtemp, readFile, realpath, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
@@ -108,6 +108,25 @@ describe('macOS Seatbelt smoke', { skip: !canRunSeatbelt }, () => {
 
     assert.equal(child.status, 0, child.stderr);
     assert.equal(await readFile(join(workspaceRoot, 'allowed.txt'), 'utf8'), 'ok');
+  });
+
+  it('allows ancestor directory reads without exposing ancestor file contents', async () => {
+    const ancestorRoot = await realpath(await mkdtemp(join(tmpdir(), 'maka-seatbelt-ancestors-')));
+    const workspaceRoot = join(ancestorRoot, 'level-one', 'level-two');
+    const ancestorFile = join(ancestorRoot, 'private.txt');
+    await mkdir(workspaceRoot, { recursive: true });
+    await writeFile(ancestorFile, 'private');
+    cleanup.push(ancestorRoot);
+
+    const listAncestor = runSeatbeltCommand(workspaceRoot, '/bin/ls ..');
+    assert.equal(listAncestor.status, 0, listAncestor.stderr);
+
+    const readAncestorFile = runSeatbeltCommand(
+      workspaceRoot,
+      `/bin/cat ${JSON.stringify(ancestorFile)}`,
+    );
+    assert.notEqual(readAncestorFile.status, 0);
+    assert.match(readAncestorFile.stderr, /Operation not permitted/);
   });
 
   it('denies writes outside the workspace root', async () => {

--- a/packages/runtime/src/__tests__/macos-seatbelt.test.ts
+++ b/packages/runtime/src/__tests__/macos-seatbelt.test.ts
@@ -170,6 +170,15 @@ describe('buildSeatbeltPolicy', () => {
     ]);
   });
 
+  it('allows directory reads along every readable root ancestor chain', () => {
+    const policy = policyText(createReadOnlyPermissionProfile());
+
+    assert.match(
+      policy,
+      /\(allow file-read-data\n  \(require-all\n    \(path-ancestors \(param "READABLE_ROOT_0"\)\)\n    \(vnode-type DIRECTORY\)\n  \)\)/,
+    );
+  });
+
   it('keeps workspace metadata writable in the standard workspace profile', () => {
     const policy = policyText(createWorkspaceWritePermissionProfile());
 
@@ -197,6 +206,10 @@ describe('buildSeatbeltPolicy', () => {
     assert.match(
       policy,
       /\(allow file-write\*\n  \(require-all\n    \(subpath \(param "WRITABLE_ROOT_0"\)\)\n    \(require-not \(regex #"\^\/repo\/secret\(\/\.\*\)\?\$"\)\)\n  \)\)/,
+    );
+    assert.match(
+      policy,
+      /\(allow file-read-data\n  \(require-all\n    \(path-ancestors \(param "READABLE_ROOT_0"\)\)\n    \(vnode-type DIRECTORY\)\n    \(require-not \(regex #"\^\/repo\/secret\(\/\.\*\)\?\$"\)\)\n  \)\)/,
     );
   });
 
@@ -235,6 +248,7 @@ describe('buildSeatbeltPolicy', () => {
     assert.match(result.policy, /\(literal \(param "READABLE_ROOT_0"\)\)/);
     assert.match(result.policy, /\(subpath \(param "READABLE_ROOT_1"\)\)/);
     assert.match(result.policy, /\(literal \(param "WRITABLE_ROOT_0"\)\)/);
+    assert.match(result.policy, /\(path-ancestors \(param "READABLE_ROOT_0"\)\)/);
     assert.deepEqual(result.definitionArgs.slice(0, 3), [
       '-DREADABLE_ROOT_0=/outside/file.txt',
       '-DREADABLE_ROOT_1=/outside/tree',

--- a/packages/runtime/src/sandbox/macos-seatbelt.ts
+++ b/packages/runtime/src/sandbox/macos-seatbelt.ts
@@ -421,7 +421,15 @@ function buildReadableRootsPolicy(roots: ResolvedRoots): string {
       accessRootClause(seatbeltPathClause(root, `READABLE_ROOT_${index}`), denyRequirements),
     )
     .join('\n');
-  return `(allow file-read*\n${params})`;
+  const ancestorParams = roots.readableRoots
+    .map((_, index) =>
+      accessRootClause(`(path-ancestors (param "READABLE_ROOT_${index}"))`, [
+        '(vnode-type DIRECTORY)',
+        ...denyRequirements,
+      ]),
+    )
+    .join('\n');
+  return `(allow file-read*\n${params})\n\n(allow file-read-data\n${ancestorParams})`;
 }
 
 function buildWritableRootsPolicy(roots: ResolvedRoots): string {


### PR DESCRIPTION
## Summary

Allow `file-read-data` on directory vnodes along each readable root's ancestor chain. This lets runtimes such as Bun resolve the current workspace while preserving the existing subtree content boundary. The clause applies to exact and subtree roots and reuses explicit-deny requirements; regular files in ancestor directories remain unreadable. For comparison, the Codex CLI and Claude Code macOS sandboxes both allow ancestor directory traversal (their read policies are allow-by-default with deny lists); this clause gives Maka the same reachability without loosening its read allow-list.

Adds policy assertions for the directory-only clause and deny propagation, plus a `sandbox-exec` smoke test covering a two-level-deep workspace, successful ancestor listing, and rejected ancestor-file reads.

Fixes #4236

## Verification

```text
mise exec node@24.19.0 -- node --test <macos-seatbelt unit and smoke tests>
Before fix: 18 pass, 3 fail, exit 1
After fix: 21 pass, 0 fail, exit 0
```

The failing run reproduced `ls: ..: Operation not permitted`; the passing run lists the ancestor directory and still rejects `cat` on an ancestor file.

```text
npm --workspace @maka/runtime run build: exit 0
npm run format:check: exit 0
npm run lint: exit 0
npm run typecheck: exit 0
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (gpt-5.6-sol), human-reviewed

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
