### PR TITLE
fix(runtime-host): preserve complete transcript edge turns

### DIFF
--- a/packages/runtime-host/src/__tests__/session-transcript-pager.test.ts
+++ b/packages/runtime-host/src/__tests__/session-transcript-pager.test.ts
@@ -417,6 +417,55 @@ test('admits a latest Turn exactly at the Host range message bound', async () =>
   }
 });
 
+test('excludes a partial far-edge Turn when the complete range would exceed its bound', async () => {
+  const durable: StoredMessage[] = [
+    ...Array.from({ length: 3 }, (_, index) => ({
+      ...assistantMessage(index),
+      turnId: 'turn-far-edge',
+    })),
+    ...Array.from({ length: 254 }, (_, index) => assistantMessage(index + 3)),
+  ];
+  const reader = transcriptReader(durable);
+  const { bootstrap, state } = await createSessionTranscriptBootstrap({
+    reader,
+    sessionId: 'session-1',
+    subscriptionId: 'subscription-1',
+    throughSequence: durable.length - 1,
+    rootTurn: null,
+    activeAssistantStreams: [],
+    maxBytes: 512 * 1024,
+    projection: 'owner',
+  });
+
+  assert.deepEqual(
+    bootstrap.durable.fragments.map((fragment) => fragment.kind === 'durable' && fragment.sequence),
+    Array.from({ length: 254 }, (_, index) => 256 - index),
+  );
+  assert.equal(bootstrap.durable.rangeBoundarySequence, 3);
+  assert.equal(bootstrap.durable.protectedTurnSequence, 256);
+  assert.ok(bootstrap.durable.nextCursor);
+
+  const page = await readSessionTranscriptPage({
+    reader,
+    state,
+    request: {
+      subscriptionId: 'subscription-1',
+      source: 'durable',
+      direction: 'older',
+      throughSequence: durable.length - 1,
+      cursor: bootstrap.durable.nextCursor,
+      anchorSequence: null,
+      maxBytes: 512 * 1024,
+    },
+  });
+  assert.deepEqual(
+    page.fragments.map((fragment) => fragment.kind === 'durable' && fragment.sequence),
+    [2, 1, 0],
+  );
+  assert.equal(page.rangeBoundarySequence, 0);
+  assert.equal(page.protectedTurnSequence, 2);
+});
+
 test('admits a forward Turn exactly at the Host range message bound', async () => {
   for (const projection of ['owner', 'shared'] as const) {
     const durable: StoredMessage[] = [{ ...assistantMessage(0), turnId: 'turn-before' }];
@@ -458,6 +507,73 @@ test('admits a forward Turn exactly at the Host range message bound', async () =
     assert.equal(page.rangeBoundarySequence, 256);
     assert.equal(page.protectedTurnSequence, 256);
     assert.ok(page.nextCursor);
+  }
+});
+
+test('defers a partial forward edge Turn to the next complete range', async () => {
+  for (const projection of ['owner', 'shared'] as const) {
+    const durable: StoredMessage[] = [{ ...assistantMessage(0), turnId: 'turn-before' }];
+    const reader = transcriptReader(durable);
+    const subscriptionId = `subscription-${projection}`;
+    const { state } = await createSessionTranscriptBootstrap({
+      reader,
+      sessionId: 'session-1',
+      subscriptionId,
+      throughSequence: 0,
+      rootTurn: null,
+      activeAssistantStreams: [],
+      maxBytes: 16 * 1024,
+      projection,
+    });
+    durable.push(
+      ...Array.from({ length: 254 }, (_, index) => assistantMessage(index + 1)),
+      ...Array.from({ length: 3 }, (_, index) => ({
+        ...assistantMessage(index + 255),
+        turnId: 'turn-far-edge',
+      })),
+    );
+    assert.equal(updateSubscriberTranscriptHighWater(state, durable.length - 1), true);
+
+    const first = await readSessionTranscriptPage({
+      reader,
+      state,
+      request: {
+        subscriptionId,
+        source: 'durable',
+        direction: 'newer',
+        throughSequence: durable.length - 1,
+        cursor: null,
+        anchorSequence: 0,
+        maxBytes: 512 * 1024,
+      },
+    });
+    assert.deepEqual(
+      first.fragments.map((fragment) => fragment.kind === 'durable' && fragment.sequence),
+      Array.from({ length: 254 }, (_, index) => index + 1),
+    );
+    assert.equal(first.rangeBoundarySequence, 254);
+    assert.equal(first.protectedTurnSequence, 254);
+    assert.ok(first.nextCursor);
+
+    const second = await readSessionTranscriptPage({
+      reader,
+      state,
+      request: {
+        subscriptionId,
+        source: 'durable',
+        direction: 'newer',
+        throughSequence: durable.length - 1,
+        cursor: first.nextCursor,
+        anchorSequence: null,
+        maxBytes: 512 * 1024,
+      },
+    });
+    assert.deepEqual(
+      second.fragments.map((fragment) => fragment.kind === 'durable' && fragment.sequence),
+      [255, 256, 257],
+    );
+    assert.equal(second.rangeBoundarySequence, 257);
+    assert.equal(second.protectedTurnSequence, 257);
   }
 });
 

--- a/packages/runtime-host/src/server/session-transcript-pager.ts
+++ b/packages/runtime-host/src/server/session-transcript-pager.ts
@@ -40,11 +40,6 @@ import { projectSharedSessionTranscriptMessage } from './shared-session-transcri
 
 type SessionTranscriptProjection = 'owner' | 'shared';
 
-// Leave one identity for completing the far-edge Turn without exceeding the
-// 256-message active range. The full-range scan below admits an exactly-full
-// Turn and rejects only when the lookahead proves that the Turn continues.
-const DURABLE_RANGE_SEED_MAX_MESSAGES = SESSION_TRANSCRIPT_RANGE_MAX_MESSAGES - 1;
-
 interface TranscriptCursorState {
   readonly version: 1;
   readonly subscriptionId: string;
@@ -117,7 +112,7 @@ export async function createSessionTranscriptBootstrap(input: {
       direction: 'older',
       throughSequence: input.throughSequence,
       maxBytes: durableBudget,
-      maxMessages: DURABLE_RANGE_SEED_MAX_MESSAGES,
+      maxMessages: SESSION_TRANSCRIPT_RANGE_MAX_MESSAGES,
     } as const;
     const durableStorage =
       projection === 'shared'
@@ -151,7 +146,7 @@ export async function createSessionTranscriptBootstrap(input: {
         state,
         'durable',
         'older',
-        durableSelection,
+        rangeEdges.selected,
         input.throughSequence,
         rangeEdges.rangeBoundarySequence,
         rangeEdges.protectedTurnSequence,
@@ -264,7 +259,7 @@ export async function readSessionTranscriptPage(input: {
     state,
     'durable',
     request.direction,
-    selected,
+    rangeEdges.selected,
     request.throughSequence,
     rangeEdges.rangeBoundarySequence,
     rangeEdges.protectedTurnSequence,
@@ -278,29 +273,39 @@ async function readRangeEdges(input: {
   throughSequence: number | null;
   selected: SelectedFragments;
 }): Promise<{
+  readonly selected: SelectedFragments;
   readonly rangeBoundarySequence: number | null;
   readonly protectedTurnSequence: number | null;
 }> {
   if (input.throughSequence === null) {
-    return { rangeBoundarySequence: null, protectedTurnSequence: null };
+    return {
+      selected: input.selected,
+      rangeBoundarySequence: null,
+      protectedTurnSequence: null,
+    };
   }
   const selectedSequences = input.selected.fragments.flatMap((fragment) =>
     fragment.kind === 'durable' ? [fragment.sequence] : [],
   );
   if (selectedSequences.length === 0) {
-    return { rangeBoundarySequence: null, protectedTurnSequence: null };
+    return {
+      selected: input.selected,
+      rangeBoundarySequence: null,
+      protectedTurnSequence: null,
+    };
   }
   const boundaryCandidate =
     input.direction === 'older' ? Math.min(...selectedSequences) : Math.max(...selectedSequences);
   const scanPosition =
     input.direction === 'older' ? Math.max(...selectedSequences) : Math.min(...selectedSequences);
+  const rangeRecords: Array<{
+    readonly sequence: number;
+    readonly turnId: string | undefined;
+    readonly bytes: number;
+  }> = [];
   let targetTurnId: string | undefined;
-  let boundary: number | null = null;
-  let protectedTurnId: string | undefined;
-  let protectedTurnSequence: number | null = null;
-  let latestTurnSequence: number | null = null;
-  let rangeBytes = 0;
-  let rangeMessages = 0;
+  let targetStart: number | null = null;
+  let candidateReached = false;
   let hiddenBytes = 0;
   let reachedFarEdge = false;
   let position: number | null = scanPosition;
@@ -325,35 +330,40 @@ async function readRangeEdges(input: {
         continue;
       }
       const turnId = messageTurnId(message);
-      if (boundary !== null && turnId !== targetTurnId) {
+      if (targetStart !== null && turnId !== targetTurnId) {
         reachedFarEdge = true;
         break;
       }
-      rangeMessages += 1;
-      rangeBytes += Buffer.byteLength(JSON.stringify(message), 'utf8');
-      if (
-        rangeMessages > SESSION_TRANSCRIPT_RANGE_MAX_MESSAGES ||
-        rangeBytes > SESSION_TRANSCRIPT_RANGE_MAX_BYTES
-      ) {
-        throw new RangeError('Session transcript Turn range exceeds its capacity limit');
-      }
-      if (input.direction === 'newer' && turnId !== undefined) {
-        latestTurnSequence = record.sequence;
-      }
-      if (input.direction === 'older' && protectedTurnSequence === null) {
-        if (protectedTurnId === undefined && turnId !== undefined) protectedTurnId = turnId;
-        if (turnId === protectedTurnId) protectedTurnSequence = record.sequence;
-      }
-      if (targetTurnId === undefined && record.sequence === boundaryCandidate) {
+      rangeRecords.push({
+        sequence: record.sequence,
+        turnId,
+        bytes: Buffer.byteLength(JSON.stringify(message), 'utf8'),
+      });
+      if (!candidateReached && record.sequence === boundaryCandidate) {
+        candidateReached = true;
         if (turnId === undefined) {
-          boundary = record.sequence;
           reachedFarEdge = true;
           break;
         }
         targetTurnId = turnId;
+        targetStart = rangeRecords.length - 1;
+        while (targetStart > 0 && rangeRecords[targetStart - 1]?.turnId === targetTurnId) {
+          targetStart -= 1;
+        }
       }
-      if (turnId === targetTurnId) {
-        boundary = record.sequence;
+      if (targetStart !== null) {
+        const targetRecords = rangeRecords.slice(targetStart);
+        const targetBytes = targetRecords.reduce((sum, target) => sum + target.bytes, 0);
+        if (
+          targetRecords.length > SESSION_TRANSCRIPT_RANGE_MAX_MESSAGES ||
+          targetBytes > SESSION_TRANSCRIPT_RANGE_MAX_BYTES
+        ) {
+          if (targetStart === 0) {
+            throw new RangeError('Session transcript Turn range exceeds its capacity limit');
+          }
+          reachedFarEdge = true;
+          break;
+        }
       }
     }
     if (reachedFarEdge || scanned.nextPosition === null) {
@@ -365,64 +375,70 @@ async function readRangeEdges(input: {
     }
     position = scanned.nextPosition;
   }
-  if (boundary === null) {
+  if (!candidateReached || rangeRecords.length === 0) {
     throw new Error('Session transcript range did not reach its authoritative Turn');
   }
-  if (!reachedFarEdge && position !== null) {
-    const lookahead = await readNextProjectedDurableRecord({
-      reader: input.reader,
-      state: input.state,
-      direction: input.direction,
-      throughSequence: input.throughSequence,
-      position,
-    });
-    if (lookahead && messageTurnId(lookahead.message) === targetTurnId) {
-      throw new RangeError('Session transcript Turn range exceeds its capacity limit');
-    }
-  }
-  return {
-    rangeBoundarySequence: boundary,
-    protectedTurnSequence:
-      input.direction === 'older'
-        ? (protectedTurnSequence ?? boundary)
-        : (latestTurnSequence ?? boundary),
-  };
-}
-
-async function readNextProjectedDurableRecord(input: {
-  reader: SessionTranscriptReader;
-  state: SubscriberTranscriptState;
-  direction: SessionTranscriptPageDirection;
-  throughSequence: number;
-  position: number;
-}): Promise<{ readonly sequence: number; readonly message: StoredMessage } | null> {
-  let position: number | null = input.position;
-  let hiddenBytes = 0;
-  while (position !== null) {
-    const scanned = await input.reader.readDurableRecords(input.state.sessionId, {
-      direction: input.direction,
-      throughSequence: input.throughSequence,
-      position,
-      maxStoredBytes: SESSION_TRANSCRIPT_RANGE_MAX_BYTES,
-      maxMessages: SESSION_TRANSCRIPT_RANGE_MAX_MESSAGES,
-    });
-    for (const record of scanned.records) {
-      const projected =
-        input.state.projection === 'shared'
-          ? projectSharedSessionTranscriptMessage(record.message, input.state.sessionId)
-          : record.message;
-      if (projected) return { sequence: record.sequence, message: projected };
-      hiddenBytes += Buffer.byteLength(JSON.stringify(record.message), 'utf8');
-      if (hiddenBytes > SESSION_TRANSCRIPT_RANGE_MAX_BYTES) {
-        throw new RangeError('Session transcript projection scan exceeds its capacity limit');
+  let retainedEnd = 0;
+  let retainedMessages = 0;
+  let retainedBytes = 0;
+  while (retainedEnd < rangeRecords.length) {
+    const groupStart = retainedEnd;
+    const groupTurnId = rangeRecords[groupStart]!.turnId;
+    let groupEnd = groupStart + 1;
+    if (groupTurnId !== undefined) {
+      while (groupEnd < rangeRecords.length && rangeRecords[groupEnd]?.turnId === groupTurnId) {
+        groupEnd += 1;
       }
     }
-    if (scanned.nextPosition === position) {
-      throw new Error('Session transcript projection scan did not advance');
+    const group = rangeRecords.slice(groupStart, groupEnd);
+    const groupBytes = group.reduce((sum, record) => sum + record.bytes, 0);
+    if (
+      group.length > SESSION_TRANSCRIPT_RANGE_MAX_MESSAGES ||
+      groupBytes > SESSION_TRANSCRIPT_RANGE_MAX_BYTES
+    ) {
+      if (groupStart > 0) break;
+      throw new RangeError('Session transcript Turn range exceeds its capacity limit');
     }
-    position = scanned.nextPosition;
+    if (
+      retainedMessages + group.length > SESSION_TRANSCRIPT_RANGE_MAX_MESSAGES ||
+      retainedBytes + groupBytes > SESSION_TRANSCRIPT_RANGE_MAX_BYTES
+    ) {
+      break;
+    }
+    retainedMessages += group.length;
+    retainedBytes += groupBytes;
+    retainedEnd = groupEnd;
   }
-  return null;
+  const retainedRecords = rangeRecords.slice(0, retainedEnd);
+  const boundary = retainedRecords.at(-1)?.sequence;
+  if (boundary === undefined) {
+    throw new RangeError('Session transcript Turn range exceeds its capacity limit');
+  }
+  const selected =
+    retainedEnd === rangeRecords.length
+      ? input.selected
+      : (() => {
+          const retainedSequences = new Set(retainedRecords.map((record) => record.sequence));
+          const fragments = input.selected.fragments.filter(
+            (fragment) => fragment.kind === 'durable' && retainedSequences.has(fragment.sequence),
+          );
+          return {
+            fragments,
+            rawBytes: fragments.reduce(
+              (sum, fragment) => sum + Buffer.from(fragment.data, 'base64').byteLength,
+              0,
+            ),
+            next: { position: rangeRecords[retainedEnd]!.sequence, byteOffset: null },
+          };
+        })();
+  const turnRecords = retainedRecords.filter((record) => record.turnId !== undefined);
+  const protectedTurnSequence =
+    input.direction === 'older' ? turnRecords[0]?.sequence : turnRecords.at(-1)?.sequence;
+  return {
+    selected,
+    rangeBoundarySequence: boundary,
+    protectedTurnSequence: protectedTurnSequence ?? boundary,
+  };
 }
 
 function messageTurnId(message: StoredMessage): string | undefined {
@@ -596,9 +612,9 @@ function continuationMessageLimit(position: {
   rangeBoundarySequence: number | null;
 }): number {
   return position.rangeBoundarySequence === null
-    ? DURABLE_RANGE_SEED_MAX_MESSAGES
+    ? SESSION_TRANSCRIPT_RANGE_MAX_MESSAGES
     : Math.min(
-        DURABLE_RANGE_SEED_MAX_MESSAGES,
+        SESSION_TRANSCRIPT_RANGE_MAX_MESSAGES,
         Math.abs(position.position - position.rangeBoundarySequence) + 1,
       );
 }
@@ -712,6 +728,14 @@ function pageFromSelection(
   rangeBoundarySequence: number | null = null,
   protectedTurnSequence: number | null = null,
 ): SessionTranscriptPage {
+  const cursorRangeBoundarySequence =
+    selected.next !== null &&
+    rangeBoundarySequence !== null &&
+    (direction === 'older'
+      ? selected.next.position < rangeBoundarySequence
+      : selected.next.position > rangeBoundarySequence)
+      ? null
+      : rangeBoundarySequence;
   return {
     kind: 'page',
     sessionId: state.sessionId,
@@ -731,7 +755,7 @@ function pageFromSelection(
             source,
             direction,
             throughSequence,
-            rangeBoundarySequence,
+            rangeBoundarySequence: cursorRangeBoundarySequence,
             ...selected.next,
           },
           state.cursorSecret,


### PR DESCRIPTION
## Summary

Follow-up to #4206. The Runtime Host pager seeded a 256-message range with `maxMessages - 1`, assuming the far-edge Turn needed at most one extra message. A valid multi-message Turn could therefore make the Host reject the transcript or expose an incomplete edge.

This removes that heuristic. The existing Host pager now groups the selected records by complete Turn, keeps the largest complete prefix within the formal message/byte bounds, and signs the next cursor at the first excluded Turn. The same owner covers older/newer and owner/shared projection; the Renderer protocol and state model do not change.

## Performance

A is merged `main` `c33617fd8`; B is this PR `52487f2ea`. Both used production builds, Electron/Chromium 43.4.1, the same 120-Turn fixture and read-only CDP spec, 1000×700, one worker, and the same Apple M5 Pro. Runs were interleaved `A1-B1, B2-A2, A3-B3, B4-A4, A5-B5, B6-A6, A7-B7`.

| Pair | Task A / B (ms) | RecalcStyle A / B (ms) | Frame P95 A / B (ms) |
|---:|---:|---:|---:|
| 1 | 104.5 / 100.4 | 10.3 / 10.3 | 8.5 / 8.9 |
| 2 | 103.3 / 96.3 | 10.5 / 10.3 | 8.9 / 8.9 |
| 3 | 270.4 / 258.2 | 23.3 / 23.1 | 9.7 / 9.9 |
| 4 | 221.4 / 248.9 | 18.8 / 20.7 | 10.1 / 9.7 |
| 5 | 255.4 / 249.5 | 23.8 / 22.5 | 9.4 / 10.0 |
| 6 | 234.0 / 184.4 | 23.4 / 15.5 | 10.1 / 8.5 |
| 7 | 194.2 / 271.2 | 17.4 / 22.7 | 10.0 / 9.9 |

| Metric | A median / P95 / P99 | B median / P95 / P99 | A / B IQR | Paired median | Wins |
|---|---|---|---|---:|---:|
| Task | 221.4 / 265.9 / 269.5 | 248.9 / 267.3 / 270.4 | 95.4 / 111.4 | -3.93% | 5/7 |
| RecalcStyle | 18.8 / 23.7 / 23.8 | 20.7 / 23.0 / 23.1 | 9.4 / 9.7 | -0.83% | 5/7 |

The warm samples are bimodal, so the paired result is the no-regression comparison. Heap paired median was -0.01%; DOM and Nodes were unchanged; frame P95/P99 were unchanged; session switch was +2.65%. All 14 runs reported LoAF support, zero frames over 12.5 ms, and zero LoAF over 50 ms.

The exact-head 640-Turn stress completed two full 126-page sweeps to Turn 1. Mounted Turns stayed at 10; Nodes stayed within 2,815–3,021; full-sweep forced-GC heap endpoint/projected growth was 2.64% / 5.14% and 2.23% / 4.98%, below the predeclared 10% resource gate.

## Entropy ledger

| Scoped concept | Before | After |
|---|---:|---:|
| Transcript authorities | 1 Host | 1 Host |
| Runtime/protocol state owners | 1 / 1 | 1 / 1 |
| Transcript representations | 1 | 1 |
| Schedulers/observers added | 0 | 0 |
| Edge-capacity mechanisms | seed reservation + lookahead | complete-Turn prefix |

The same diff deletes the `maxMessages - 1` reservation and its separate lookahead helper. The only retained mechanism is the complete-Turn selection inside the existing Host pager; it is required to enforce the already-public message/byte bounds without partial Turns.

## Verification

- RED on merged `main`: a three-message far-edge Turn throws `Session transcript Turn range exceeds its capacity limit`
- Runtime Host pager/client focused tests: 40/40
- Desktop transcript range-store tests: 29/29
- prompt-rail, transcript-scroll, and onboarding E2E: 21/21
- Full `npm run build` and `npm run typecheck`
- Biome on changed files and `git diff --check`
- Exact-head 640-Turn two-sweep stress and 7-pair interleaved production CDP A/B
- Three independent adversarial reviewers: GO, no P0–P2 findings

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the edge contract, implemented the Host-owned fix, authored tests, ran the benchmark, and performed delegated review. The material commit includes a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
