### PR TITLE
fix(desktop): remove first-send empty hero flash

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
@@ -302,7 +302,7 @@ describe('composer first-send cleanup', () => {
     assert.deepEqual(removed, []);
   });
 
-  it('waits for the new session observation before submitting its first message', async () => {
+  it('projects the first message before activation while waiting to submit until observation', async () => {
     const observation = deferred<void>();
     const order: string[] = [];
     const activeIdRef = { current: undefined as string | undefined };
@@ -325,6 +325,9 @@ describe('composer first-send cleanup', () => {
       const sending = createAppShellChatActions({
         ...createActionsDeps(),
         activeIdRef,
+        addTransientMessage: () => {
+          order.push('optimistic');
+        },
         activateSessionForFirstSend: async (sessionId) => {
           order.push('observe');
           activeIdRef.current = sessionId;
@@ -333,11 +336,11 @@ describe('composer first-send cleanup', () => {
         },
       }).send('hello');
       await new Promise((resolve) => setImmediate(resolve));
-      assert.deepEqual(order, ['create', 'observe']);
+      assert.deepEqual(order, ['create', 'optimistic', 'observe']);
 
       observation.resolve();
       assert.equal(await sending, true);
-      assert.deepEqual(order, ['create', 'observe', 'seeded', 'submit']);
+      assert.deepEqual(order, ['create', 'optimistic', 'observe', 'seeded', 'submit']);
     } finally {
       restoreWindow();
     }

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -115,6 +115,29 @@ describe('single live-turn handoff', () => {
     assert.match(markup, />send now</);
   });
 
+  it('does not flash the empty-chat Maka hero before a first transient message', () => {
+    const markup = renderWithLocale(createElement(ChatView, {
+      activeSession: {
+        id: 'session-1', name: 'pending', status: 'active', backend: 'ai-sdk',
+        labels: [], isFlagged: false, isArchived: false, hasUnread: false,
+        llmConnectionSlug: 'conn', connectionLocked: false, model: 'model', permissionMode: 'ask',
+      },
+      messages: [],
+      transientMessages: [
+        {
+          id: 'message-pending', ts: 1,
+          text: 'inspect this image', transientPlacement: 'current_turn',
+        },
+      ],
+      scrollBehavior: 'smooth',
+      onNew() {},
+    } satisfies Parameters<typeof ChatView>[0]));
+
+    assert.match(markup, /data-transient-message-id="message-pending"/);
+    assert.match(markup, />inspect this image</);
+    assert.doesNotMatch(markup, /maka-hero-empty-chat/);
+  });
+
   it('shows a loading transient before its real live Turn answer', () => {
     const markup = renderWithLocale(createElement(ChatView, {
       activeSession: {

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -463,19 +463,11 @@ export function createAppShellChatActions(deps: {
         });
         unsentSessionId = session.id;
         optimisticSessionId = session.id;
-        // Consumed: the choice is now the created Session's, not the next
-        // draft's. A failed create leaves it in place so a retry keeps it.
-        if (newChatPermissionChoice) clearNewChatPermissionChoice();
-        // Active-stream snapshots can only restore assistant segments that
-        // are still streaming. Wait until the observer is ready before the
-        // first admission so a completed segment in a still-running Turn
-        // cannot become durable text without live identity.
-        await activateSessionForFirstSend(session.id);
-        if (activeIdRef.current !== session.id) {
-          await discardUnsentSession();
-          return false;
-        }
         optimisticMessageId = messageId;
+        // Stage the first row before activation. `setActiveId` projects this
+        // session-owned transient in the same state transition that replaces
+        // the new-chat surface, so the empty-session Maka hero cannot paint
+        // between observation settling and the submitted content appearing.
         showTransientUserMessage(
           session.id,
           messageId,
@@ -486,6 +478,19 @@ export function createAppShellChatActions(deps: {
             inlineReferences: [],
           },
         );
+        // Consumed: the choice is now the created Session's, not the next
+        // draft's. A failed create leaves it in place so a retry keeps it.
+        if (newChatPermissionChoice) clearNewChatPermissionChoice();
+        // Active-stream snapshots can only restore assistant segments that
+        // are still streaming. Wait until the observer is ready before the
+        // first admission so a completed segment in a still-running Turn
+        // cannot become durable text without live identity.
+        await activateSessionForFirstSend(session.id);
+        if (activeIdRef.current !== session.id) {
+          removeOptimisticUserMessage(session.id, messageId);
+          await discardUnsentSession();
+          return false;
+        }
         if (exactTurn) armTurnActive(session.id, messageId);
         const attachmentItems =
           pending && pending.length > 0

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -700,7 +700,14 @@ export function ChatView(props: {
         >
           {showEmptyState ? null : (
             <>
-              {chat.length === 0 && !streamingActive ? emptyContent : null}
+              {/* A transient is already the first visible conversation row.
+                  Do not prepend the empty-chat Maka hero while that optimistic
+                  message waits for durable transcript or live-turn identity. */}
+              {chat.length === 0
+                && transientMessages.length === 0
+                && !streamingActive
+                ? emptyContent
+                : null}
               {turns.map((turn) => {
                 return (
                   <div


### PR DESCRIPTION
## Summary

The first submitted prompt could share a render with the empty-chat Maka hero while its new Session was activating. This projects the optimistic row before activation, cleans it up if activation loses ownership, and stops `ChatView` from prepending empty content when a transient user row is already visible.

Fixes #4245

## Before / after

Both images capture the first real Electron renderer mutation batch containing the submitted transient message. The input was the same `image/png` attachment plus `请分析这张图片中的内容` at 1280 × 800.

| Before | After |
|---|---|
| ![Before: the empty-chat Maka hero and submitted prompt are visible together](https://gist.githubusercontent.com/Sun-GLiang/ac50714f9728b10238bbbbb2b0c7e418/raw/issue-4245-before.svg) | ![After: only the submitted prompt is visible](https://gist.githubusercontent.com/Sun-GLiang/ac50714f9728b10238bbbbb2b0c7e418/raw/issue-4245-after.svg) |

## Verification

- Isolated Electron E2E before/after capture: 1/1 passed on each version
- Focused first-send and streaming-handoff suites: 32/32 passed
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka diagnosed the render-order gap, implemented the optimistic projection and empty-state guard, added regression tests, and produced the isolated Electron E2E evidence. The material commit includes a `Generated-by: Maka` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
