### PR TITLE
fix(runtime): fall back when Codex compaction is rejected

### DIFF
--- a/docs/architecture/llm-compaction-events-log-projection-draft.md
+++ b/docs/architecture/llm-compaction-events-log-projection-draft.md
@@ -38,7 +38,7 @@ This chapter builds on Chapter 1's log-first Runtime and Chapter 2's distinction
 
 The primary subject is **RuntimeEvent history compaction**: a compactor produces either a continuation summary or provider-native compact state, the checkpoint covers a safe prefix of RuntimeEvents, and later requests use that projection in place of the prefix. The same planner and checkpoint transaction serve manual, pre-turn, mid-turn, and overflow triggers. The chapter does not fully cover active or stale pruning of individual Tool Results; those reduce provider messages without creating another LLM compaction mechanism.
 
-This chapter describes the implementation current as of 2026-08-28. Ledger-backed checkpoints use schema V2 for text summaries and schema V3 for provider-native state. OpenAI Codex subscription models use Codex remote compaction V2 by default; other providers retain text-summary behavior.
+This chapter describes the implementation current as of 2026-08-30. Ledger-backed checkpoints use schema V2 for text summaries and schema V3 for provider-native state. OpenAI Codex subscription models prefer Codex remote compaction V2 and retain the text summarizer as a narrow liveness fallback; other providers use text-summary behavior directly.
 
 ## Start with a long-running Session
 
@@ -232,9 +232,11 @@ The LLM is therefore the generator of the projection value, not the projection a
 
 When the selected connection has `providerType: openai-codex`, Maka uses Codex's server-side compactor by default instead of asking the model for a text summary. The provider request is still built from the validated RuntimeEvent prefix. The dedicated compactor sets `providerOptions.openai.compactionTrigger: true`, which appends one terminal `{ "type": "compaction_trigger" }` input item. The compactor uses the streaming Responses path and consumes the full stream because a compaction-only response has no ordinary generated-text result. Ordinary Codex requests do not set this option and are unchanged.
 
+The portable text summarizer remains a bounded liveness fallback. Maka retries once through it when the native request receives a non-retryable protocol `RequestRejected`, returns no unique valid compact state, or cannot fit its native history projection. Cancellation, authentication, billing, rate-limit, and provider-availability failures retain their original outcome instead of doubling traffic through the same unhealthy connection. The two physical attempts share one logical compaction call but record `provider_native` and `text_summary` independently in telemetry.
+
 Compaction input preserves assistant-step chronology. Because the Responses converter cannot resend provider-executed tool results under `store:false`, a settled hosted call/result is lowered only for this compaction request into a paired ordinary function call and output, followed by the grounded assistant text. This keeps the available tool evidence in the request without producing an orphan output.
 
-The compaction call receives the active history-input budget. If its RuntimeEvent projection exceeds that estimate, Maka replaces older Tool Result payloads with a fixed omission marker while retaining every call/result pair and all later grounded text. If the remaining non-tool history still cannot fit, Runtime does not dispatch an already over-capacity compaction request and follows the normal fail-open path.
+The compaction call receives the active history-input budget. If its RuntimeEvent projection exceeds that estimate, Maka replaces older Tool Result payloads with a fixed omission marker while retaining every call/result pair and all later grounded text. If the remaining non-tool history still cannot fit, Runtime does not dispatch an already over-capacity native request and gives the text summarizer its one fallback opportunity before following the normal fail-open path.
 
 This is deliberately a history-only contract. Maka does not send the current system prompt or tool catalog to the remote compactor, unlike the Codex CLI's whole-request assembly. Those values are neither part of checkpoint source coverage nor frozen into the checkpoint; the subsequent model request always applies its current system prompt and tools. This keeps provider-native and text-summary compactors behind the same small contract, at the cost of not giving the compactor that extra request-shape context.
 
@@ -393,8 +395,8 @@ Compaction crosses token estimation, an LLM call, schema construction, durable a
 | Below high water | Keep the existing projection or apply ordinary budget selection | Create an unsourced summary as a speculative optimization |
 | LLM returns an empty summary | Record no new checkpoint. Automatic pre-turn compaction keeps the original source-derived projection and, if it remains over budget, terminates with `context_budget_exhausted` without writing a failure note; manual compaction records one visible `context_compaction_failed_open` note | Treat an empty projection as covered history |
 | Text summary is malformed | Spend one stricter repair attempt, then fail open with a granular reason; do not redispatch an unchanged failed fingerprint | Persist incomplete structure or loop on the same doomed compaction input |
-| Codex returns no unique valid compact item | Record no new checkpoint and use the same fail-open path | Persist partial or ambiguous provider state |
-| Compaction input cannot fit after bounded Tool Result omission | Do not dispatch the compaction request; use the same fail-open path | Ask the provider to compact an already over-capacity request |
+| Codex returns no unique valid compact item | Try one portable text-summary checkpoint, then fail open if that also fails | Persist partial or ambiguous provider state |
+| Native compaction input cannot fit after bounded Tool Result omission | Do not dispatch the native request; try one bounded text-summary checkpoint | Ask the provider to compact an already over-capacity request |
 | Rolling summarizer fails | Reuse the old checkpoint if it still matches and fits, then add the newest complete raw Turns that fit | Pretend the old checkpoint covers newly evicted events |
 | Durable checkpoint append fails | Do not use the candidate; fall back to the old checkpoint or safe tail | Put an uncommitted projection into the model and later claim it is recoverable |
 | Prefix or digest mismatch | Reject the checkpoint | Replace canonical events through approximate matching |

--- a/docs/architecture/llm-compaction-events-log-projection-draft.zh-CN.md
+++ b/docs/architecture/llm-compaction-events-log-projection-draft.zh-CN.md
@@ -38,7 +38,7 @@ owners:
 
 本文主要讨论 **RuntimeEvent history compaction**：compactor 生成 continuation summary 或 provider-native compact state，checkpoint 覆盖一段安全的 RuntimeEvent 前缀，并在以后请求中用该投影替代前缀。手动、pre-turn、mid-turn 与 overflow 触发器共用同一个 planner 和 checkpoint transaction。本文不完整展开单个 Tool Result 的 active/stale prune；它们会缩小 provider messages，但不会形成另一套 LLM compaction 机制。
 
-本文描述截至 2026-08-28 的当前实现。ledger-backed checkpoint 中，schema V2 保存文本摘要，schema V3 保存 provider-native state。OpenAI Codex 订阅模型默认使用 Codex remote compaction V2，其他 provider 维持文本摘要行为。
+本文描述截至 2026-08-30 的当前实现。ledger-backed checkpoint 中，schema V2 保存文本摘要，schema V3 保存 provider-native state。OpenAI Codex 订阅模型优先使用 Codex remote compaction V2，并保留文本 summarizer 作为范围严格的 liveness fallback；其他 provider 直接使用文本摘要行为。
 
 ## 从一个长期会话开始
 
@@ -232,9 +232,11 @@ Repair 之外的 malformed retry 也有上限。Runtime 为每个 Session backen
 
 当所选 connection 的 `providerType` 为 `openai-codex` 时，Maka 默认使用 Codex 服务端 compactor，不再让模型生成文本摘要。provider request 仍由已校验的 RuntimeEvent prefix 构建。专用 compactor 会设置 `providerOptions.openai.compactionTrigger: true`，从而追加唯一一个位于 input 末尾的 `{ "type": "compaction_trigger" }` item。compactor 使用流式 Responses 路径并消费完整 stream，因为只有 compaction output 的响应不存在普通 generated-text result；普通 Codex 请求不会设置这个选项，因此行为不变。
 
+可移植的文本 summarizer 仍作为有界的 liveness fallback。当 native request 收到不可重试的协议级 `RequestRejected`、没有返回唯一合法的 compact state，或无法容纳 native history projection 时，Maka 会通过文本 summarizer 重试一次。Cancellation、鉴权、计费、限流和 provider 不可用仍保留原始结果，不会向同一个异常连接发送双倍流量。两次物理请求属于同一个逻辑 compaction call，但 telemetry 会分别记录 `provider_native` 与 `text_summary`。
+
 Compaction input 会保留 assistant step 的时序。由于 Responses converter 在 `store:false` 下无法重新发送 provider-executed tool result，已经完整结算的 hosted call/result 只在这次 compaction request 中降级为成对的普通 function call 与 output，之后再放 grounded assistant text。这样既保留了现有 tool evidence，也不会生成悬空 output。
 
-Compaction call 会收到当前 history input budget。若 RuntimeEvent projection 超出该估算值，Maka 会把较旧的 Tool Result payload 替换为固定 omission marker，同时保留每一组 call/result 配对和之后的 grounded text。若剩余的非工具历史仍无法容纳，Runtime 不会发送一条已经超出容量的 compaction request，而是进入正常 fail-open 路径。
+Compaction call 会收到当前 history input budget。若 RuntimeEvent projection 超出该估算值，Maka 会把较旧的 Tool Result payload 替换为固定 omission marker，同时保留每一组 call/result 配对和之后的 grounded text。若剩余的非工具历史仍无法容纳，Runtime 不会发送一条已经超出容量的 native request，而是先给文本 summarizer 一次 fallback 机会，再进入正常 fail-open 路径。
 
 这是有意设计成 history-only 的契约。与 Codex CLI 的 whole-request assembly 不同，Maka 不会把当前 system prompt 或 tool catalog 发给 remote compactor；它们既不属于 checkpoint source coverage，也不会被冻结进 checkpoint，后续模型请求始终使用当时最新的 system prompt 和 tools。这样 provider-native 与 text-summary compactor 可以共享同一份小契约，代价是 compactor 无法利用这部分额外的 request-shape context。
 
@@ -393,8 +395,8 @@ Compaction 跨越 token estimation、LLM call、schema construction、durable ap
 | 未超过 high water | 保持原投影或普通预算裁剪 | 为了“提前优化”制造无来源摘要 |
 | LLM 返回空 summary | 不记录新 checkpoint。自动 pre-turn compaction 保留原有的 source-derived projection；如果它仍然超出预算，则以 `context_budget_exhausted` 结束且不写入失败 note；手动 compaction 则记录一次可见的 `context_compaction_failed_open` note | 把空 projection 当作 covered history |
 | Text summary 格式不合法 | 只进行一次更严格的 repair，之后以细分 reason fail open；同一失败 fingerprint 不再 dispatch | 持久化不完整结构，或在相同 doomed input 上循环 |
-| Codex 没有返回唯一且合法的 compact item | 不记录新 checkpoint，走同一 fail-open 路径 | 持久化残缺或有歧义的 provider state |
-| Compaction input 在有界省略 Tool Result 后仍无法容纳 | 不发送 compaction request，走同一 fail-open 路径 | 要求 provider 压缩一条已经超出容量的请求 |
+| Codex 没有返回唯一且合法的 compact item | 尝试一次可移植文本摘要 checkpoint；若仍失败再 fail open | 持久化残缺或有歧义的 provider state |
+| Native compaction input 在有界省略 Tool Result 后仍无法容纳 | 不发送 native request，尝试一次有界文本摘要 checkpoint | 要求 provider 压缩一条已经超出容量的请求 |
 | Rolling summarizer 失败 | 若旧 checkpoint 仍匹配且符合当前限制，则复用它并拼接能容纳的最新完整 raw Turns | 假装旧 checkpoint 已覆盖 newly evicted events |
 | Durable checkpoint append 失败 | 不使用 candidate；回退旧 checkpoint 或安全 tail | 让未提交 projection 进入模型后再声称可恢复 |
 | Prefix 或 digest 不匹配 | 拒绝 checkpoint | 用近似匹配替代 canonical events |

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -676,10 +676,24 @@ test('provider dispatch fails closed when the Run Composition commit fails', asy
   }
 });
 
-test('Codex OAuth history compaction uses the provider-native route and preserves failure facts', async () => {
+test('Codex OAuth history compaction falls back to a text checkpoint after native rejection', async () => {
   const modelId = 'gpt-5.6-sol';
   const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
   const attempts: ModelCallAttempt[] = [];
+  let recordedTextCheckpoint = false;
+  const fallbackSummary = [
+    '## Goal',
+    'Continue the existing task.',
+    '',
+    '## Progress',
+    '- Preserved the completed work.',
+    '',
+    '## Next Steps',
+    '1. Continue from the recent context.',
+    '',
+    '## Critical Context',
+    '- The portable fallback remains available.',
+  ].join('\n');
   const oauthTokens: OAuthSubscriptionTokens = {
     access_token: codexAccessToken('compact-account'),
     refresh_token: 'compact-refresh-token',
@@ -716,21 +730,59 @@ test('Codex OAuth history compaction uses the provider-native route and preserve
         secretMaterial: { connection: { secret: 'oauth-material' } },
       }),
       readPricing: async () => ({ revision: 0, overrides: [] }),
-      recordHistoryCompactCheckpoint: async () => undefined,
+      recordHistoryCompactCheckpoint: async (checkpoint) => {
+        recordedTextCheckpoint = 'summary' in checkpoint;
+      },
       recordModelCallAttempt: async ({ attempt }) => {
         attempts.push(attempt);
       },
       createFetchTransport: () => ({
         fetch: async (url, init) => {
+          const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
           requests.push({
             url: String(url),
-            body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+            body,
           });
+          const providerInput = Array.isArray(body.input) ? body.input : [];
+          if (
+            !providerInput.some(
+              (item) =>
+                typeof item === 'object' &&
+                item !== null &&
+                'type' in item &&
+                item.type === 'compaction_trigger',
+            )
+          ) {
+            return Response.json({
+              id: 'resp-text-fallback',
+              object: 'response',
+              created_at: 1,
+              status: 'completed',
+              model: modelId,
+              output: [
+                {
+                  type: 'message',
+                  id: 'msg-text-fallback',
+                  status: 'completed',
+                  role: 'assistant',
+                  content: [
+                    {
+                      type: 'output_text',
+                      text: fallbackSummary,
+                      annotations: [],
+                      logprobs: [],
+                    },
+                  ],
+                },
+              ],
+              usage: { input_tokens: 4_000, output_tokens: 60, total_tokens: 4_060 },
+            });
+          }
           return Response.json(
             {
               error: {
                 message: 'request rejected without echoing this body',
-                code: 'invalid_request_error',
+                code: 'missing_required_parameter',
               },
             },
             {
@@ -774,23 +826,31 @@ test('Codex OAuth history compaction uses the provider-native route and preserve
       runtimeContext,
     });
 
-    assert.equal(requests.length, 1, JSON.stringify(result));
+    assert.equal(requests.length, 2, JSON.stringify(result));
     assert.match(requests[0]!.url, /\/codex\/responses$/);
-    const requestText = JSON.stringify(requests[0]!.body);
-    assert.match(requestText, /"type":"compaction_trigger"/);
-    assert.doesNotMatch(requestText, /context summarization assistant/i);
-    assert.deepEqual(result.outcome, { kind: 'failed', reason: 'provider_error' });
-    assert.equal(result.contextBudget?.compactionDecisions?.[0]?.decision, 'failedOpen');
-    assert.equal(attempts.length, 1);
+    assert.match(requests[1]!.url, /\/codex\/responses$/);
+    const nativeRequestText = JSON.stringify(requests[0]!.body);
+    const fallbackRequestText = JSON.stringify(requests[1]!.body);
+    assert.match(nativeRequestText, /"type":"compaction_trigger"/);
+    assert.doesNotMatch(nativeRequestText, /context summarization assistant/i);
+    assert.doesNotMatch(fallbackRequestText, /"type":"compaction_trigger"/);
+    assert.match(fallbackRequestText, /context summarization assistant/i);
+    assert.equal(result.outcome.kind, 'compacted');
+    assert.equal(recordedTextCheckpoint, true);
+    assert.equal(attempts.length, 2);
     assert.equal(attempts[0]?.callKind, 'history_compact');
     assert.equal(attempts[0]?.providerId, 'openai-codex');
     assert.equal(attempts[0]?.historyCompactRoute, 'provider_native');
     assert.equal(attempts[0]?.status, 'failed');
     assert.equal(attempts[0]?.errorClass, 'RequestRejected');
     assert.equal(attempts[0]?.httpStatus, 400);
-    assert.equal(attempts[0]?.providerCode, 'invalid_request_error');
+    assert.equal(attempts[0]?.providerCode, 'missing_required_parameter');
     assert.equal(attempts[0]?.providerRequestId, 'req-codex-compact');
     assert.equal(attempts[0]?.retryable, false);
+    assert.equal(attempts[1]?.logicalCallId, attempts[0]?.logicalCallId);
+    assert.equal(attempts[1]?.attempt, 1);
+    assert.equal(attempts[1]?.historyCompactRoute, 'text_summary');
+    assert.equal(attempts[1]?.status, 'completed');
   } finally {
     await backend.dispose();
   }

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -30,7 +30,10 @@ import {
   resolveSelectedModelContextWindow,
 } from '@maka/runtime/context-budget-policy';
 import { buildLlmHistorySummarizer } from '@maka/runtime/history-compact-summarizer';
-import { buildOpenAiCodexHistoryCompactor } from '@maka/runtime/openai-codex-history-compactor';
+import {
+  buildOpenAiCodexHistoryCompactor,
+  withOpenAiCodexHistoryCompactionFallback,
+} from '@maka/runtime/openai-codex-history-compactor';
 import { buildPricingLookup, recordToolInvocation } from '@maka/runtime/telemetry';
 import { buildProviderOptions, getAIModel } from '@maka/runtime/model-factory';
 import { createProviderRequestCaptureRecorder } from '@maka/runtime/provider-request-telemetry';
@@ -188,18 +191,22 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
       fetch: modelFetch,
       requestHeaders: target.requestHeaders,
     });
+  const textHistorySummarizer = buildLlmHistorySummarizer({
+    resolveModel: resolveHistoryCompactModel,
+    providerOptions,
+  });
   const summarizeHistoryCompact =
     target.connection.providerType === 'openai-codex'
-      ? buildOpenAiCodexHistoryCompactor({
-          resolveModel: resolveHistoryCompactModel,
-          connectionSlug: target.connection.slug,
-          modelId: target.model,
-          providerOptions,
-        })
-      : buildLlmHistorySummarizer({
-          resolveModel: resolveHistoryCompactModel,
-          providerOptions,
-        });
+      ? withOpenAiCodexHistoryCompactionFallback(
+          buildOpenAiCodexHistoryCompactor({
+            resolveModel: resolveHistoryCompactModel,
+            connectionSlug: target.connection.slug,
+            modelId: target.model,
+            providerOptions,
+          }),
+          textHistorySummarizer,
+        )
+      : textHistorySummarizer;
   const historyCompactRoute =
     target.connection.providerType === 'openai-codex' ? 'provider_native' : 'text_summary';
   let telemetryDrainRequested = false;

--- a/packages/runtime/src/__tests__/openai-codex-history-compactor.test.ts
+++ b/packages/runtime/src/__tests__/openai-codex-history-compactor.test.ts
@@ -22,7 +22,11 @@ import { describe, test } from 'node:test';
 import {
   extractOpenAiCodexCompactionState,
   fitOpenAiCodexCompactionMessages,
+  shouldFallbackFromOpenAiCodexHistoryCompaction,
+  withOpenAiCodexHistoryCompactionFallback,
 } from '../openai-codex-history-compactor.js';
+import { HistoryCompactSummarizerError } from '../history-compact-error.js';
+import type { HistoryCompactSummaryInput } from '../ai-sdk-compaction-contract.js';
 
 test('preserves the provider-specific input-fitting export', () => {
   assert.deepEqual(
@@ -32,6 +36,68 @@ test('preserves the provider-specific input-fitting export', () => {
     ),
     [{ role: 'user', content: [{ type: 'text', text: 'bounded history' }] }],
   );
+});
+
+describe('OpenAI Codex compaction fallback', () => {
+  const input: HistoryCompactSummaryInput = {
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    source: { foldedRuntimeEvents: [] },
+  };
+
+  test('falls back after a non-retryable native protocol rejection', async () => {
+    const providerError = Object.assign(new Error('private provider message'), {
+      statusCode: 400,
+      data: { error: { code: 'missing_required_parameter' } },
+    });
+    const nativeError = new HistoryCompactSummarizerError('provider_error', {
+      cause: providerError,
+    });
+    let fallbackCalls = 0;
+    const summarize = withOpenAiCodexHistoryCompactionFallback(
+      async () => {
+        throw nativeError;
+      },
+      async () => {
+        fallbackCalls += 1;
+        return 'portable checkpoint';
+      },
+    );
+
+    assert.equal(await summarize(input), 'portable checkpoint');
+    assert.equal(fallbackCalls, 1);
+  });
+
+  test('falls back when native state is unusable or its projection cannot fit', () => {
+    assert.equal(
+      shouldFallbackFromOpenAiCodexHistoryCompaction(
+        new HistoryCompactSummarizerError('invalid_provider_state'),
+      ),
+      true,
+    );
+    assert.equal(
+      shouldFallbackFromOpenAiCodexHistoryCompaction(
+        new HistoryCompactSummarizerError('input_too_large'),
+      ),
+      true,
+    );
+  });
+
+  test('does not fall back on cancellation, rate limits, or provider availability', () => {
+    const rateLimit = new HistoryCompactSummarizerError('provider_error', {
+      cause: Object.assign(new Error('private provider message'), { statusCode: 429 }),
+    });
+    const unavailable = new HistoryCompactSummarizerError('provider_error', {
+      cause: Object.assign(new Error('private provider message'), { statusCode: 503 }),
+    });
+    const aborted = new HistoryCompactSummarizerError('provider_error', {
+      cause: new DOMException('cancelled', 'AbortError'),
+    });
+
+    assert.equal(shouldFallbackFromOpenAiCodexHistoryCompaction(rateLimit), false);
+    assert.equal(shouldFallbackFromOpenAiCodexHistoryCompaction(unavailable), false);
+    assert.equal(shouldFallbackFromOpenAiCodexHistoryCompaction(aborted), false);
+  });
 });
 
 describe('OpenAI Codex compaction output', () => {

--- a/packages/runtime/src/__tests__/provider-request-telemetry.test.ts
+++ b/packages/runtime/src/__tests__/provider-request-telemetry.test.ts
@@ -1045,6 +1045,64 @@ describe('canonical model-call accounting', () => {
     assert.doesNotMatch(JSON.stringify(attempt), /private|prompt|response body/i);
   });
 
+  test('records the physical route when one compaction call falls back', async () => {
+    const recorded: ModelCallAttempt[] = [];
+    const tracker = accountingTracker({
+      callKind: 'history_compact',
+      historyCompactRoute: 'provider_native',
+      record: ({ attempt }) => {
+        recorded.push(attempt);
+      },
+    });
+    const rejection = Object.assign(new Error('native protocol rejected'), {
+      statusCode: 400,
+      data: { error: { code: 'missing_required_parameter' } },
+    });
+
+    await assert.rejects(
+      tracker.trackGenerate({
+        providerId: 'openai.responses',
+        modelId: 'gpt-codex-test',
+        historyCompactRoute: 'provider_native',
+        params: preparedParams('native compact'),
+        doGenerate: async () => {
+          throw rejection;
+        },
+      }),
+      (error) => error === rejection,
+    );
+    await tracker.trackGenerate({
+      providerId: 'openai.responses',
+      modelId: 'gpt-codex-test',
+      historyCompactRoute: 'text_summary',
+      params: preparedParams('portable summary'),
+      doGenerate: async () => ({ finishReason: 'stop' }),
+    });
+
+    assert.deepEqual(
+      recorded.map((attempt) => ({
+        logicalCallId: attempt.logicalCallId,
+        attempt: attempt.attempt,
+        route: attempt.historyCompactRoute,
+        status: attempt.status,
+      })),
+      [
+        {
+          logicalCallId: recorded[0]?.logicalCallId,
+          attempt: 0,
+          route: 'provider_native',
+          status: 'failed',
+        },
+        {
+          logicalCallId: recorded[0]?.logicalCallId,
+          attempt: 1,
+          route: 'text_summary',
+          status: 'completed',
+        },
+      ],
+    );
+  });
+
   test('a call the provider reported no usage for records usageBasis missing', async () => {
     // The alternative is a record claiming zero tokens, which is a measurement
     // nobody made. `missing` says the call happened and the meter did not read.

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -129,6 +129,7 @@ export function buildLlmHistorySummarizer(options: BuildLlmHistorySummarizerOpti
             model: options.resolveModel(),
             wrapLanguageModel: ai!.wrapLanguageModel,
             tracker: providerRequestTracker,
+            historyCompactRoute: 'text_summary',
             ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
           })
         : options.resolveModel();

--- a/packages/runtime/src/openai-codex-history-compactor.ts
+++ b/packages/runtime/src/openai-codex-history-compactor.ts
@@ -17,7 +17,10 @@
  * under the License.
  */
 
-import type { HistoryCompactSummaryInput } from './ai-sdk-compaction-contract.js';
+import type {
+  HistoryCompactSummarizer,
+  HistoryCompactSummaryInput,
+} from './ai-sdk-compaction-contract.js';
 import { HistoryCompactSummarizerError } from './history-compact-error.js';
 import {
   historyCompactCheckpointToModelMessage,
@@ -33,6 +36,7 @@ import {
 } from './model-history.js';
 import { withProviderStreamTracking } from './provider-request-telemetry.js';
 import { toolResultOutput } from './tool-result-output.js';
+import { providerFailureDiagnostic } from './provider-error-classification.js';
 
 export { fitHistoryCompactMessages as fitOpenAiCodexCompactionMessages } from './history-compact-input-fit.js';
 
@@ -84,6 +88,7 @@ export function buildOpenAiCodexHistoryCompactor(options: BuildOpenAiCodexHistor
             model: options.resolveModel(),
             wrapLanguageModel: ai.wrapLanguageModel,
             tracker: providerRequestTracker,
+            historyCompactRoute: 'provider_native',
             ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
           })
         : options.resolveModel();
@@ -116,6 +121,52 @@ export function buildOpenAiCodexHistoryCompactor(options: BuildOpenAiCodexHistor
       throw new HistoryCompactSummarizerError('provider_error', { cause: error });
     }
   };
+}
+
+/**
+ * Prefer the Codex-native checkpoint, but retain a portable liveness path when
+ * the native protocol is unavailable for this request. The fallback is narrow:
+ * provider capacity/auth/transient failures keep their original outcome rather
+ * than doubling traffic through the same unhealthy connection.
+ */
+export function withOpenAiCodexHistoryCompactionFallback(
+  preferred: HistoryCompactSummarizer,
+  fallback: HistoryCompactSummarizer,
+): HistoryCompactSummarizer {
+  return async (input) => {
+    try {
+      return await preferred(input);
+    } catch (error) {
+      if (!shouldFallbackFromOpenAiCodexHistoryCompaction(error, input.abortSignal)) throw error;
+      return await fallback(input);
+    }
+  };
+}
+
+export function shouldFallbackFromOpenAiCodexHistoryCompaction(
+  error: unknown,
+  abortSignal?: AbortSignal,
+): boolean {
+  if (abortSignal?.aborted || hasAbortCause(error)) return false;
+  if (!(error instanceof HistoryCompactSummarizerError)) return false;
+  if (error.reason === 'input_too_large' || error.reason === 'invalid_provider_state') return true;
+  if (error.reason !== 'provider_error') return false;
+  const diagnostic = providerFailureDiagnostic(error);
+  return diagnostic.errorClass === 'RequestRejected' && !diagnostic.retryable;
+}
+
+function hasAbortCause(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+  for (let depth = 0; depth < 6 && current !== undefined && !seen.has(current); depth += 1) {
+    seen.add(current);
+    if (current instanceof Error && current.name === 'AbortError') return true;
+    current =
+      typeof current === 'object' && current !== null && 'cause' in current
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+  return false;
 }
 
 /**

--- a/packages/runtime/src/provider-request-telemetry.ts
+++ b/packages/runtime/src/provider-request-telemetry.ts
@@ -19,6 +19,7 @@
 
 import {
   MODEL_CALL_ATTEMPT_SCHEMA_VERSION,
+  type HistoryCompactRoute,
   type ModelCallAttempt,
   type ModelCallKind,
   type ModelCallUsageBasis,
@@ -217,6 +218,8 @@ export interface TrackProviderStreamInput {
    * may never have seen.
    */
   historyCompactBoundary?: ContextDiagnosticsCompaction;
+  /** Physical history-compaction route used by this provider request. */
+  historyCompactRoute?: HistoryCompactRoute;
 }
 
 export interface TrackProviderGenerateInput {
@@ -224,6 +227,8 @@ export interface TrackProviderGenerateInput {
   modelId: string;
   /** As `TrackProviderStreamInput.historyCompactBoundary`. */
   historyCompactBoundary?: ContextDiagnosticsCompaction;
+  /** Physical history-compaction route used by this provider request. */
+  historyCompactRoute?: HistoryCompactRoute;
   params: Record<string, unknown>;
   abortSignal?: AbortSignal;
   doGenerate: () => PromiseLike<ProviderGenerateResult>;
@@ -255,6 +260,7 @@ export function withProviderGenerateTracking(input: {
   wrapLanguageModel: (input: Record<string, unknown>) => unknown;
   tracker: ProviderRequestTracker;
   abortSignal?: AbortSignal;
+  historyCompactRoute?: HistoryCompactRoute;
 }): unknown {
   return input.wrapLanguageModel({
     model: input.model,
@@ -265,6 +271,7 @@ export function withProviderGenerateTracking(input: {
           modelId: model.modelId,
           params,
           ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
+          ...(input.historyCompactRoute ? { historyCompactRoute: input.historyCompactRoute } : {}),
           doGenerate,
         }),
     },
@@ -277,6 +284,7 @@ export function withProviderStreamTracking(input: {
   wrapLanguageModel: (input: Record<string, unknown>) => unknown;
   tracker: ProviderRequestTracker;
   abortSignal?: AbortSignal;
+  historyCompactRoute?: HistoryCompactRoute;
 }): unknown {
   return input.wrapLanguageModel({
     model: input.model,
@@ -287,6 +295,7 @@ export function withProviderStreamTracking(input: {
           modelId: model.modelId,
           params,
           ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
+          ...(input.historyCompactRoute ? { historyCompactRoute: input.historyCompactRoute } : {}),
           doStream,
         }),
     },
@@ -476,7 +485,7 @@ export class ProviderRequestTracker {
     capture: StoredCapture,
     input: Pick<
       TrackProviderStreamInput | TrackProviderGenerateInput,
-      'providerId' | 'modelId' | 'abortSignal' | 'historyCompactBoundary'
+      'providerId' | 'modelId' | 'abortSignal' | 'historyCompactBoundary' | 'historyCompactRoute'
     >,
   ): {
     observeOutput(): void;
@@ -563,6 +572,8 @@ export class ProviderRequestTracker {
           // mid-flight by another turn cannot be sealed into a prompt built
           // before it existed.
           historyCompactBoundary: input.historyCompactBoundary,
+          historyCompactRoute:
+            input.historyCompactRoute ?? this.input.accounting?.historyCompactRoute,
         });
       });
       await accountingSettlement;
@@ -601,6 +612,7 @@ export class ProviderRequestTracker {
       usage: ProviderRequestUsage | undefined;
       contextWindow: number | undefined;
       historyCompactBoundary: ContextDiagnosticsCompaction | undefined;
+      historyCompactRoute: HistoryCompactRoute | undefined;
     },
   ): Promise<void> {
     const accounting = this.input.accounting;
@@ -629,8 +641,8 @@ export class ProviderRequestTracker {
       step: Math.max(0, record.step),
       attempt: Math.max(0, record.attempt - 1),
       callKind: accounting.callKind,
-      ...(accounting.historyCompactRoute !== undefined
-        ? { historyCompactRoute: accounting.historyCompactRoute }
+      ...(context.historyCompactRoute !== undefined
+        ? { historyCompactRoute: context.historyCompactRoute }
         : {}),
       providerId: accounting.providerId ?? record.providerId,
       modelId: record.modelId,


### PR DESCRIPTION
## Summary

Keep Codex provider-native history compaction as the preferred route, but fall back once to the portable text summarizer when the native request is rejected as a non-retryable protocol error, returns invalid state, or cannot fit its projection.

The fallback preserves session liveness for failures such as `missing_required_parameter` while avoiding duplicate traffic for cancellation, authentication, billing, rate-limit, and provider-availability failures. Telemetry records the native and fallback physical attempts under one logical compaction call with their actual routes.

Fixes #4251

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- Runtime compactor and provider-request telemetry suites: 41 passed
- Runtime-host execution model composition suite under the bundled Node 24.18.1 runtime: 27 passed

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the failure, implemented the fallback and telemetry routing, added tests and documentation, and prepared this pull request. The human contributor remains responsible for review and submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
