### PR TITLE
fix(desktop): realign renderer architecture ledger with source

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -390,7 +390,7 @@
           "@maka/ui": 1
         },
         "importSpecifiers": 39,
-        "nonTriviaTokens": 4363
+        "nonTriviaTokens": 4376
       },
       "src/renderer/app-shell-chrome-actions.tsx": {
         "importDeclarations": 5,
@@ -714,7 +714,7 @@
           "@maka/ui": 1
         },
         "importSpecifiers": 23,
-        "nonTriviaTokens": 2931
+        "nonTriviaTokens": 3042
       },
       "src/renderer/app-shell-session-settings-actions.ts": {
         "importDeclarations": 9,
@@ -3146,9 +3146,9 @@
           "setTimeout": 2
         },
         "hookCalls": {
-          "useEffect": 4,
+          "useEffect": 5,
           "useMountedRef": 1,
-          "useRef": 3,
+          "useRef": 5,
           "useRuntimeHostSettingsTarget": 1,
           "useState": 18,
           "useUiLocale": 1


### PR DESCRIPTION
## Summary

The `Check renderer architecture` CI job has been failing on `main` — and on every branch cut from it — since #4246. The committed `apps/desktop/renderer-architecture.json` ledger records stale metrics for three debt-tracked renderer files whose source drifted after the ledger was last regenerated in #4249, each merging without a paired ledger update. Regenerating the snapshot (`--write`) realigns the ledger with the current source. This is a data-only change with no runtime impact.

Fixes #4257

## Verification

- `npm run check:renderer-architecture` → passes
- `npm run check:renderer-architecture -- --base <HEAD~1>` (exactly as CI invokes it) → passes
- Diff is limited to `apps/desktop/renderer-architecture.json` (4 values); no source or runtime files touched.

Not run: repo-wide lint / format / typecheck — the change is a generated JSON ledger with no code, so only the architecture check is affected.

## Root cause

| Commit | PR | Drift | CI |
|---|---|---|---|
| `9ff267510` | #4249 | ledger regenerated, matches source | ✅ green |
| `bdb103d59` | #4246 | `app-shell-chat-actions.ts` nonTriviaTokens 4363 → 4376 | ❌ first red |
| `838936c80` | #4232 | + `app-shell-session-events.ts` nonTriviaTokens 2931 → 3042 | ❌ red |
| `2db04c2b8` | #3905 | + `import-tasks-settings-page.tsx` hookCalls useEffect 4→5, useRef 3→5 | ❌ red |

Each PR modified a debt-tracked renderer file without running `--write`; each one's own push CI was already red, yet they still landed on `main`. Worth a separate look at why a failing required check merged (tracked in #4257).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Opus 4.8) — diagnosed the CI failure, ran the deterministic ledger regeneration (`--write`), and drafted the commit message, this PR, and linked issue #4257. Commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it — the `Check renderer architecture` job fails without the ledger update and passes with it
- [x] Lint, format, typecheck and the affected suites pass locally — affected suite is the architecture check; JSON-only change, no source code

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
