### PR TITLE
fix(cli): refresh connection identities after /setup saves a connection

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -223,7 +223,7 @@ function savedOnboardingResult(
       slug: 'openai',
       providerType: 'openai',
     },
-    refresh: { kind: 'ok', modelChoices },
+    refresh: { kind: 'ok', modelChoices, connectionIdentities: [] },
   };
 }
 
@@ -7759,6 +7759,109 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
     await waitFor(() => driver.modelConnectionIds.length === 1);
     assert.deepEqual(driver.modelConnectionIds, ['connection-b']);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('refreshes connection identities after setup before adopting the new model', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    driver.hostSummary = {
+      llmConnectionId: 'connection-b',
+      llmConnectionSlug: 'new-account',
+      model: 'gpt-5.5',
+    };
+    const newConnectionChoice: ModelChoice = {
+      connectionId: 'connection-b',
+      connectionSlug: 'new-account',
+      connectionName: 'New account',
+      providerType: 'openai',
+      model: 'gpt-5.5',
+      isDefaultConnection: true,
+    };
+    const saveCalls: OnboardingSaveInput[] = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      locale: 'en',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionId: 'connection-a',
+      connectionSlug: 'existing-account',
+      providerType: 'anthropic',
+      connectionIdentities: [
+        { connectionId: 'connection-a', connectionSlug: 'existing-account', enabled: true },
+      ],
+      modelChoices: [
+        {
+          connectionId: 'connection-a',
+          connectionSlug: 'existing-account',
+          connectionName: 'Existing account',
+          providerType: 'anthropic',
+          model: 'claude-sonnet-4-5',
+          isDefaultConnection: true,
+        },
+      ],
+      permissionMode: 'ask',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        verify: async () => ({ kind: 'ok', models: [{ id: 'gpt-5.5' }] }),
+        save: async (input) => {
+          saveCalls.push(input);
+          const refresh = {
+            kind: 'ok' as const,
+            modelChoices: [newConnectionChoice],
+            connectionIdentities: [
+              { connectionId: 'connection-a', connectionSlug: 'existing-account', enabled: true },
+              { connectionId: 'connection-b', connectionSlug: 'new-account', enabled: true },
+            ],
+          };
+          return {
+            kind: 'ok' as const,
+            connection: {
+              connectionId: 'connection-b',
+              revision: 1,
+              slug: 'new-account',
+              providerType: 'openai' as const,
+            },
+            refresh,
+          };
+        },
+      }),
+    });
+
+    await waitForTuiPaint(terminal);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    terminal.input(' ');
+    terminal.input('\r');
+    await waitFor(() => saveCalls.length === 1);
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Models enabled'));
+    terminal.input('\r');
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('Models enabled'));
+
+    terminal.input('/model');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('New account'));
+    terminal.input('\r');
+    await waitFor(() => driver.modelConnectionIds.length === 1);
+    assert.deepEqual(driver.modelConnectionIds, ['connection-b']);
+
+    terminal.input('hello');
+    terminal.input('\r');
+    await waitFor(() => driver.prompts.length === 1 && driver.streamPulls === 1);
+    await waitForTuiPaint(terminal);
+    assert.doesNotMatch(
+      plainTerminalOutput(terminal.screenOutput()),
+      /The original account was deleted/,
+    );
 
     exitMaka(terminal);
     await run;

--- a/packages/cli/src/pi-tui-contracts.ts
+++ b/packages/cli/src/pi-tui-contracts.ts
@@ -50,6 +50,12 @@ export interface ModelChoice {
   thinkingLevels?: readonly ThinkingLevel[];
 }
 
+export type ConnectionIdentity = {
+  readonly connectionId: string;
+  readonly connectionSlug: string;
+  readonly enabled: boolean;
+};
+
 export interface OnboardableProvider {
   providerType: ProviderType;
   label: string;
@@ -126,7 +132,11 @@ export type OnboardingSaveResult =
       kind: 'ok';
       connection: OnboardingSavedConnection;
       refresh:
-        | { kind: 'ok'; modelChoices: ModelChoice[] }
+        | {
+            kind: 'ok';
+            modelChoices: ModelChoice[];
+            connectionIdentities: readonly ConnectionIdentity[];
+          }
         | { kind: 'failed'; reason: 'catalog_unavailable' };
     }
   | OnboardingFailure;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -65,6 +65,7 @@ import type { TurnOrchestration } from '@maka/core/runtime-inputs';
 import type { SessionActivityLease } from '@maka/runtime/goal-turn-lifecycle';
 import { listApiKeyOnboardableProviders } from './onboarding-catalog.js';
 import type {
+  ConnectionIdentity,
   MakaForeignSessionReader,
   MakaOnboardingSurface,
   MakaPiTuiTurnActivitySurface,
@@ -186,11 +187,7 @@ export interface MakaPiTuiInput {
    */
   modelChoices?: readonly ModelChoice[];
   connectionId?: string;
-  connectionIdentities?: readonly {
-    readonly connectionId: string;
-    readonly connectionSlug: string;
-    readonly enabled: boolean;
-  }[];
+  connectionIdentities?: readonly ConnectionIdentity[];
   connectionSlug: string;
   providerType?: ProviderType;
   permissionMode: PermissionMode;
@@ -1177,6 +1174,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // in place after `/setup` saves so newly configured models are immediately
   // available — the single source the picker and connection/model lookups read.
   let modelChoices = input.modelChoices;
+  let connectionIdentities = input.connectionIdentities;
   // Monotonic attempt id: each setup submit captures one, and any transition
   // that abandons the in-flight attempt (back, re-pick, close) increments it so
   // a late verify/save settlement cannot clobber a newer attempt.
@@ -1461,7 +1459,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     connectionSlug = summary.llmConnectionSlug;
     const identityNotice = sessionConnectionIdentityNotice(
       summary,
-      input.connectionIdentities,
+      connectionIdentities,
       input.locale ?? 'en',
     );
     if (announceIdentity && identityNotice && identityNotice !== connectionIdentityNotice) {
@@ -2194,6 +2192,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           // attempt must not overwrite choices refreshed by a newer save.
           if (result.refresh.kind === 'ok') {
             modelChoices = result.refresh.modelChoices;
+            connectionIdentities = result.refresh.connectionIdentities;
           }
           if (input.firstRun) {
             beginClose();

--- a/packages/cli/src/runtime-host-onboarding.ts
+++ b/packages/cli/src/runtime-host-onboarding.ts
@@ -25,6 +25,7 @@ import {
 } from '@maka/runtime-host/client';
 import { listApiKeyOnboardableProviders } from './onboarding-catalog.js';
 import type {
+  ConnectionIdentity,
   MakaOnboardingSurface,
   ModelChoice,
   OnboardingProviderEntry,
@@ -61,14 +62,14 @@ export function createRuntimeHostOnboardingSurface(
           return result;
         }
         try {
+          const catalog = await readRuntimeHostConnectionCatalog(connection);
           return {
             kind: 'ok',
             connection: result.connection,
             refresh: {
               kind: 'ok',
-              modelChoices: projectRuntimeHostModelChoices(
-                await readRuntimeHostConnectionCatalog(connection),
-              ),
+              modelChoices: projectRuntimeHostModelChoices(catalog),
+              connectionIdentities: projectRuntimeHostConnectionIdentities(catalog),
             },
           };
         } catch {
@@ -118,6 +119,16 @@ export function projectRuntimeHostModelChoices(catalog: ConnectionCatalogSnapsho
     }
   }
   return choices;
+}
+
+export function projectRuntimeHostConnectionIdentities(
+  catalog: ConnectionCatalogSnapshot,
+): ConnectionIdentity[] {
+  return catalog.connections.map((connection) => ({
+    connectionId: connection.connectionId,
+    connectionSlug: connection.slug,
+    enabled: connection.enabled,
+  }));
 }
 
 export function projectProviders(catalog: ConnectionCatalogSnapshot): OnboardingProviderEntry[] {

--- a/packages/cli/src/runtime-host-tui-context.ts
+++ b/packages/cli/src/runtime-host-tui-context.ts
@@ -49,6 +49,7 @@ import {
   resolveRuntimeHostCliTarget,
 } from './runtime-host-cli-context.js';
 import type {
+  ConnectionIdentity,
   MakaPiTuiTurnActivitySurface,
   ModelChoice,
   SessionRecapGenerator,
@@ -59,6 +60,7 @@ import {
 } from './runtime-host-session-driver.js';
 import {
   createRuntimeHostOnboardingSurface,
+  projectRuntimeHostConnectionIdentities,
   projectRuntimeHostModelChoices,
 } from './runtime-host-onboarding.js';
 import {
@@ -73,11 +75,7 @@ export interface RuntimeHostTuiContext {
   readonly cwd: string;
   readonly connectionSlug: string;
   readonly connectionId?: string;
-  readonly connectionIdentities: readonly {
-    readonly connectionId: string;
-    readonly connectionSlug: string;
-    readonly enabled: boolean;
-  }[];
+  readonly connectionIdentities: readonly ConnectionIdentity[];
   readonly connectionName: string;
   readonly providerType?: ConnectionCatalogEntry['providerType'];
   readonly model: string;
@@ -181,11 +179,7 @@ export async function createRuntimeHostTuiContext(
       ...(selectedTarget.connectionId === undefined
         ? {}
         : { connectionId: selectedTarget.connectionId }),
-      connectionIdentities: catalog.connections.map((entry) => ({
-        connectionId: entry.connectionId,
-        connectionSlug: entry.slug,
-        enabled: entry.enabled,
-      })),
+      connectionIdentities: projectRuntimeHostConnectionIdentities(catalog),
       connectionName: selectedTarget.connection?.name ?? selectedTarget.connectionSlug,
       ...(selectedTarget.connection
         ? { providerType: selectedTarget.connection.providerType }


### PR DESCRIPTION
## Summary

Refresh the running TUI's connection identities together with model choices after `/setup` saves a connection. The Runtime Host onboarding adapter now projects both values from one catalog read, and the runner uses the refreshed identity set when adopting Host session metadata.

A shared `ConnectionIdentity` type keeps the onboarding result, TUI input, and Runtime Host context on one contract. The regression test creates connection B after startup, selects it through `/model`, adopts a Host summary for B, and verifies that the deleted-account notice stays absent.

Fixes #4261

## Verification

```text
mise exec node@24.19.0 -- node --test <pi-tui-runner.test.js>
On current main (fix behaviorally reverted): 169 pass, 1 fail — the test fails with the exact on-screen `The original account was deleted` transcript entry.
With the fix: 170 pass, 0 fail, exit 0.
```

Also verified live against a real Runtime Host and an OpenAI-compatible relay: on the patched build, `/setup` → `/model` → first prompt shows only the model-change note, with no deleted-account error.

```text
npm run format:check: exit 0
npm run lint: exit 0
npm --workspace maka-agent run typecheck: exit 0
npm --workspace maka-agent run build: exit 0
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (gpt-5.6-sol), human-reviewed

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
