### PR TITLE
fix: pin Desktop Nightly feed channel

### DIFF
--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -287,7 +287,7 @@ export function resolveDesktopBuilderConfig(environment = process.env) {
       runtimeHostSetupPackage: resolveRuntimeHostSetupPackage(rootManifest.version, environment),
       makaUpdateChannel: 'nightly',
     },
-    publish: [{ provider: 'generic', url: DESKTOP_NIGHTLY_FEED_URL }],
+    publish: [{ provider: 'generic', url: DESKTOP_NIGHTLY_FEED_URL, channel: 'latest' }],
   };
 }
 

--- a/scripts/desktop-nightly.test.mjs
+++ b/scripts/desktop-nightly.test.mjs
@@ -25,6 +25,7 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { resolveDesktopBuilderConfig } from '../apps/desktop/electron-builder.config.mjs';
 import { resolveDesktopBuildVersion, resolveRuntimeHostSetupPackage } from './desktop-nightly.mjs';
+import { assertPackagedUpdateConfiguration } from './desktop-update-contract.mjs';
 
 const run = promisify(execFile);
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -38,12 +39,30 @@ test('a nightly package embeds only the Apache Nightlies update authority', () =
   assert.equal(config.extraMetadata.version, version);
   assert.equal(config.extraMetadata.runtimeHostSetupPackage, `maka-agent@${version}`);
   assert.equal(config.extraMetadata.makaUpdateChannel, 'nightly');
-  assert.deepEqual(config.publish, [
-    {
-      provider: 'generic',
-      url: 'https://nightlies.apache.org/maka/desktop/',
-    },
-  ]);
+  assert.equal(config.publish.length, 1);
+  assert.equal(config.publish[0].provider, 'generic');
+  assert.equal(config.publish[0].url, 'https://nightlies.apache.org/maka/desktop/');
+});
+
+test('a dev Nightly identity still advances the latest Desktop feed', () => {
+  const config = resolveDesktopBuilderConfig({
+    MAKA_DESKTOP_NIGHTLY_VERSION: '0.2.0-dev.42.20260829',
+  });
+
+  assert.equal(config.publish[0].channel, 'latest');
+});
+
+test('a packaged Nightly accepts the pinned latest update channel', async () => {
+  const packagedConfiguration = `provider: generic
+url: https://nightlies.apache.org/maka/desktop/
+channel: latest
+updaterCacheDirName: '@makadesktop-updater'
+`;
+
+  await assertPackagedUpdateConfiguration('/fixture', {
+    channel: 'nightly',
+    read: async () => packagedConfiguration,
+  });
 });
 
 test('formal release checks ignore the ambient Nightly packaging environment', async () => {

--- a/scripts/desktop-update-contract.mjs
+++ b/scripts/desktop-update-contract.mjs
@@ -33,6 +33,7 @@ export const DESKTOP_UPDATE_PROVIDER = Object.freeze({
 export const DESKTOP_NIGHTLY_UPDATE_PROVIDER = Object.freeze({
   provider: 'generic',
   url: 'https://nightlies.apache.org/maka/desktop/',
+  channel: 'latest',
   updaterCacheDirName: '@makadesktop-updater',
 });
 


### PR DESCRIPTION
## Summary

Pin the Desktop Nightly generic publisher to the `latest` channel so electron-builder writes `latest-mac.yml` and `latest.yml` for prerelease versions.

The first live Desktop Nightly built both platform payloads successfully, but electron-builder inferred the channel `dev` from `0.2.0-dev.3.20260830`. Both jobs then failed at the final metadata assertion because the repository contract and updater read the `latest` feed filenames. The channel now comes from the same Nightly publisher configuration that owns the feed URL instead of implicit version inference, and the packaged-app verifier requires that resolved channel explicitly.

## Verification

- `node --test scripts/desktop-nightly.test.mjs` — 5/5 passed
- `node --test --test-name-pattern='Desktop packaging derives|platform package verifiers' scripts/product-release.test.mjs` — 2/2 passed
- `npm run format:check` — 1,772 files checked, no fixes needed
- TDD red: the publisher regression test observed an undefined explicit channel before the fix; the packaged-app regression test reproduced rejection of electron-builder's four-field `app-update.yml`
- Live failure evidence: GitHub Actions run 33313018091 built the signed and notarized macOS payload and the Windows payload, then both failed only on the missing `latest` metadata filename

Not run: a second live Nightly publish. It requires this change to merge and a fresh npm Nightly identity.

The broader `scripts/product-release.test.mjs` invocation was also attempted; its unrelated Eval asset-declaration case requires a prebuilt `packages/eval/dist` in the local worktree. The two affected Desktop cases pass when run directly as shown above.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the live failure, implemented the configuration and packaged-verifier contract fix, and added the regression tests. The human contributor will review the final diff and owns submission and merge.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
