### PR TITLE
fix: bootstrap the Desktop Nightly destination

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -312,6 +312,11 @@ jobs:
             echo "RSYNC_RSH=ssh -i $ssh_directory/key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $NIGHTLIES_RSYNC_PORT"
           } >> "$GITHUB_ENV"
 
+      - name: Ensure the Nightly destination exists
+        run: |
+          mkdir -p .nightly-empty
+          rsync -rlptDz --mkpath --protect-args .nightly-empty/ "$NIGHTLIES_RSYNC_TARGET/"
+
       - name: Require the Desktop Nightly feed to advance
         env:
           NIGHTLY_VERSION: ${{ needs.identity.outputs.version }}

--- a/scripts/desktop-nightly-workflow-policy.test.mjs
+++ b/scripts/desktop-nightly-workflow-policy.test.mjs
@@ -107,6 +107,22 @@ test('a failed Desktop Nightly is retried through a fresh npm Nightly', async ()
   assert.equal(download.with.pattern, 'desktop-nightly-*');
 });
 
+test('the first Desktop Nightly creates its empty destination before reading the feed', async () => {
+  const workflow = await readWorkflow('desktop-nightly.yml');
+  const steps = workflow.jobs.publish.steps;
+  const bootstrap = steps.find((step) => step.name === 'Ensure the Nightly destination exists');
+  const feedGuardPosition = steps.findIndex(
+    (step) => step.name === 'Require the Desktop Nightly feed to advance',
+  );
+
+  assert.ok(bootstrap);
+  assert.match(bootstrap.run, /mkdir -p \.nightly-empty/u);
+  assert.match(bootstrap.run, /rsync -rlptDz --mkpath --protect-args/u);
+  assert.match(bootstrap.run, /\.nightly-empty\/ "\$NIGHTLIES_RSYNC_TARGET\/"/u);
+  assert.doesNotMatch(bootstrap.run, /\.nightly-publish/u);
+  assert.ok(steps.indexOf(bootstrap) < feedGuardPosition);
+});
+
 test('the protected Desktop publisher appends payloads before advancing the feed', async () => {
   const workflow = await readWorkflow('desktop-nightly.yml');
   const publish = workflow.jobs.publish;

--- a/scripts/desktop-nightly-workflow-policy.test.mjs
+++ b/scripts/desktop-nightly-workflow-policy.test.mjs
@@ -117,7 +117,7 @@ test('the first Desktop Nightly creates its empty destination before reading the
 
   assert.ok(bootstrap);
   assert.match(bootstrap.run, /mkdir -p \.nightly-empty/u);
-  assert.match(bootstrap.run, /rsync -rlptDz --mkpath --protect-args/u);
+  assert.match(bootstrap.run, /^rsync -rlptDz --mkpath --protect-args /mu);
   assert.match(bootstrap.run, /\.nightly-empty\/ "\$NIGHTLIES_RSYNC_TARGET\/"/u);
   assert.doesNotMatch(bootstrap.run, /\.nightly-publish/u);
   assert.ok(steps.indexOf(bootstrap) < feedGuardPosition);
@@ -164,11 +164,18 @@ test('the protected Desktop publisher appends payloads before advancing the feed
     'https://github.com/${{ github.repository }}/.github/workflows/desktop-nightly.yml@refs/heads/main',
   );
   for (const name of [
+    'Ensure the Nightly destination exists',
+    'Publish immutable Nightly payloads',
+    'Advance the Nightly update feed last',
+  ]) {
+    const step = steps.find((candidate) => candidate.name === name);
+    assert.doesNotMatch(step.run, /--delete/u);
+  }
+  for (const name of [
     'Publish immutable Nightly payloads',
     'Advance the Nightly update feed last',
   ]) {
     const step = steps.find((candidate) => candidate.name === name);
     assert.match(step.run, /^rsync -rlptDvz --protect-args /u);
-    assert.doesNotMatch(step.run, /--delete/u);
   }
 });


### PR DESCRIPTION
## Summary

The first live Desktop Nightly built and verified both macOS and Windows artifacts, then stopped before publication because the remote `/maka/desktop` directory did not exist yet. The feed-advance guard tried to read that directory before any step could create it, so the initial publish was permanently blocked.

This change bootstraps the empty Nightlies destination with `rsync --mkpath` before reading the current feed. It transfers no release payload during bootstrap and preserves the existing order: compare the current feed, publish immutable versioned payloads, then advance the feed last.

Live failure: [Desktop Nightly run 33319934020](https://github.com/apache/maka/actions/runs/33319934020).

## Verification

- TDD red: the workflow had no destination-bootstrap step before the feed guard
- `node --test scripts/desktop-nightly-workflow-policy.test.mjs` — 5/5 passed
- `actionlint .github/workflows/desktop-nightly.yml`
- `npm run format:check` — 1,773 files checked, no fixes needed
- `git diff --check`

Not run: another live Nightly publish. A fresh npm Nightly must trigger it after this change reaches `main`; the failed workflow must not be rerun in place.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the first-publish bootstrap deadlock from the live workflow log, implemented the minimal destination bootstrap, and added regression coverage. The human contributor must review the final diff and owns submission and merge.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No