### PR TITLE
feat(runtime-host): project peer Host reachability

### DIFF
--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -30,6 +30,7 @@ import {
   connectOrSpawnRuntimeHost,
   connectRuntimeHostProfile,
   type RuntimeHostPeerClient,
+  type RuntimeHostConnectionPhase,
   type RuntimeHostSshInteraction,
   type RuntimeHostSshTunnel,
   type RuntimeHostSshTunnelInput,
@@ -202,6 +203,7 @@ export interface DesktopRuntimeHostCandidateStartInput
   readonly onExit?: (details: CandidateExitDetails) => void;
   readonly candidateLaunchBarrier?: RuntimeHostCandidateLaunchBarrier;
   readonly peerClient?: RuntimeHostPeerClient;
+  readonly onConnectionPhase?: (phase: RuntimeHostConnectionPhase) => void;
   readonly profileTarget?: {
     readonly profile: PersistedRuntimeHostProfile;
     readonly credential?: string;
@@ -435,6 +437,9 @@ async function startProfileDesktopRuntimeHostCandidate(
       : { handshakeTimeoutMs: input.handshakeTimeoutMs }),
     readyTimeoutMs: input.electionDeadlineMs ?? 45_000,
     ...(input.peerClient === undefined ? {} : { peerClient: input.peerClient }),
+    ...(input.onConnectionPhase === undefined
+      ? {}
+      : { onConnectionPhase: input.onConnectionPhase }),
     ...(profileTarget.sshInteraction === undefined
       ? {}
       : { sshInteraction: profileTarget.sshInteraction }),

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -872,6 +872,9 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
             ipcMain: this.#ipcMain.createTarget(target.epoch),
             isTargetActive: () => this.#ipcMain.isActive(target.epoch),
             isTargetValid: () => target.valid,
+            onConnectionPhase: (phase) => {
+              target.input.onConnectionPhase?.(phase);
+            },
             signal,
             ...(takeoverHostEpoch === undefined ? {} : { takeoverHostEpoch }),
           },
@@ -1154,6 +1157,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       );
     }
   }
+
 }
 
 function trackOwnedProcess(

--- a/packages/runtime-host/src/__tests__/peer-native.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-native.test.ts
@@ -119,10 +119,14 @@ module.exports = {
       },
     });
     const native = await import(nativePath);
+    const phases: string[] = [];
     const abort = new AbortController();
-    const pending = client.connect(peerConnectInput('pending'), abort.signal);
+    const pending = client.connect(peerConnectInput('pending'), abort.signal, (phase) => {
+      phases.push(phase);
+    });
     await waitForRequestCount(native.default.stats, 1);
     assert.equal(routesPrepared, true);
+    assert.deepEqual(phases, ['discovering', 'connecting']);
     abort.abort();
     await assert.rejects(pending, /aborted/u);
 

--- a/packages/runtime-host/src/client/host-profile.ts
+++ b/packages/runtime-host/src/client/host-profile.ts
@@ -43,7 +43,7 @@ import {
   readRuntimeHostPeerAuthenticationResult,
   writeRuntimeHostPeerAuthentication,
 } from '../transport/peer-native.js';
-import type { RuntimeHostPeerClient } from './peer-client.js';
+import type { RuntimeHostPeerClient, RuntimeHostPeerConnectionPhase } from './peer-client.js';
 import { RuntimeHostPermanentReconnectError } from './reconnect-lifecycle.js';
 import { RuntimeHostRemoteCompatibilityError } from './remote-compatibility-error.js';
 import {
@@ -155,6 +155,12 @@ export interface ResolvedRuntimeHostProfile {
   readonly profile: RuntimeHostProfile;
   readonly credential?: string;
 }
+
+export type RuntimeHostConnectionPhase =
+  | RuntimeHostPeerConnectionPhase
+  | 'authenticating'
+  | 'handshaking'
+  | 'waiting_for_ready';
 
 export function sameResolvedRuntimeHostProfileTarget(
   left: ResolvedRuntimeHostProfile,
@@ -272,6 +278,7 @@ export async function connectRuntimeHostProfile(
     readonly readyTimeoutMs?: number;
     readonly sshInteraction?: RuntimeHostSshInteraction;
     readonly peerClient?: RuntimeHostPeerClient;
+    readonly onConnectionPhase?: (phase: RuntimeHostConnectionPhase) => void;
   },
   overrides: {
     connect?: typeof connectRemoteRuntimeHost;
@@ -326,6 +333,7 @@ export async function connectRemoteRuntimeHostProfile(
     readonly readyTimeoutMs?: number;
     readonly sshInteraction?: RuntimeHostSshInteraction;
     readonly peerClient?: RuntimeHostPeerClient;
+    readonly onConnectionPhase?: (phase: RuntimeHostConnectionPhase) => void;
   },
   overrides: {
     connect?: typeof connectRemoteRuntimeHost;
@@ -351,8 +359,12 @@ export async function connectRemoteRuntimeHostProfile(
       ...(input.handshakeTimeoutMs === undefined
         ? {}
         : { handshakeTimeoutMs: input.handshakeTimeoutMs }),
+      ...(input.onConnectionPhase === undefined
+        ? {}
+        : { onConnectionPhase: input.onConnectionPhase }),
     });
   } else {
+    notifyConnectionPhase(input.onConnectionPhase, 'connecting');
     const activation =
       transport.kind === 'ssh' && transport.activation
         ? await (overrides.activateSshOperator ?? activateRuntimeHostSshOperator)({
@@ -420,6 +432,7 @@ export async function connectRemoteRuntimeHostProfile(
   }
   try {
     input.signal?.throwIfAborted();
+    notifyConnectionPhase(input.onConnectionPhase, 'waiting_for_ready');
     await (overrides.waitForReady ?? waitForRuntimeHostReady)(
       connection,
       input.readyTimeoutMs ?? 45_000,
@@ -454,6 +467,7 @@ export async function connectPeerRuntimeHost(input: {
   readonly signal?: AbortSignal;
   readonly connectTimeoutMs?: number;
   readonly handshakeTimeoutMs?: number;
+  readonly onConnectionPhase?: (phase: RuntimeHostConnectionPhase) => void;
 }): Promise<RuntimeHostConnection> {
   input.signal?.throwIfAborted();
   const stream = await input.peerClient.connect(
@@ -464,6 +478,7 @@ export async function connectPeerRuntimeHost(input: {
       directDeadlineMs: Math.min(input.connectTimeoutMs ?? 40_000, 120_000),
     },
     input.signal,
+    input.onConnectionPhase,
   );
   const abort = () => stream.abort();
   input.signal?.addEventListener('abort', abort, { once: true });
@@ -471,6 +486,7 @@ export async function connectPeerRuntimeHost(input: {
   let transferred = false;
   try {
     input.signal?.throwIfAborted();
+    notifyConnectionPhase(input.onConnectionPhase, 'authenticating');
     await writeRuntimeHostPeerAuthentication(stream, input.credential);
     const authentication = await readRuntimeHostPeerAuthenticationResult(
       stream,
@@ -481,6 +497,7 @@ export async function connectPeerRuntimeHost(input: {
         `Runtime Host profile ${input.profileId} rejected its access credential`,
       );
     }
+    notifyConnectionPhase(input.onConnectionPhase, 'handshaking');
     const result = await connectRuntimeHostMessageTransport({
       transport: new FramedByteStreamTransport(
         new RuntimeHostPeerByteStream(stream, authentication.remainder),
@@ -509,6 +526,17 @@ export async function connectPeerRuntimeHost(input: {
   } finally {
     input.signal?.removeEventListener('abort', abort);
     if (!transferred) stream.abort();
+  }
+}
+
+function notifyConnectionPhase(
+  observer: ((phase: RuntimeHostConnectionPhase) => void) | undefined,
+  phase: RuntimeHostConnectionPhase,
+): void {
+  try {
+    observer?.(phase);
+  } catch {
+    // Connection progress is diagnostic state and cannot control the connection.
   }
 }
 

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -62,6 +62,7 @@ export {
   type RuntimeHostProfile,
   type RuntimeHostProfileAccess,
   type RuntimeHostProfileCatalog,
+  type RuntimeHostConnectionPhase,
   type RuntimeHostProfileDocument,
 } from './host-profile.js';
 export {

--- a/packages/runtime-host/src/client/peer-client.ts
+++ b/packages/runtime-host/src/client/peer-client.ts
@@ -39,6 +39,8 @@ export interface RuntimeHostPeerConnectInput {
   readonly directDeadlineMs: number;
 }
 
+export type RuntimeHostPeerConnectionPhase = 'discovering' | 'connecting';
+
 export interface RuntimeHostPeerRouteResolver {
   resolveRoutes(peerId: string):
     | {
@@ -67,6 +69,7 @@ export interface RuntimeHostPeerClient {
   connect(
     input: RuntimeHostPeerConnectInput,
     signal?: AbortSignal,
+    onPhase?: (phase: RuntimeHostPeerConnectionPhase) => void,
   ): Promise<RuntimeHostPeerNativeStream>;
   connectMeshControl(
     input: RuntimeHostPeerConnectInput,
@@ -204,8 +207,11 @@ class RuntimeHostPeerClientImpl implements RuntimeHostPeerClient {
   async connect(
     input: RuntimeHostPeerConnectInput,
     signal?: AbortSignal,
+    onPhase?: (phase: RuntimeHostPeerConnectionPhase) => void,
   ): Promise<RuntimeHostPeerNativeStream> {
+    notifyPhase(onPhase, 'discovering');
     await this.#prepareRoutes(input, signal);
+    notifyPhase(onPhase, 'connecting');
     return this.#connect(input, signal, 'application');
   }
 
@@ -471,6 +477,17 @@ interface InboundConsumer {
   readonly onStream: (stream: RuntimeHostPeerNativeStream) => void;
   readonly resolve: () => void;
   readonly reject: (error: Error) => void;
+}
+
+function notifyPhase(
+  observer: ((phase: RuntimeHostPeerConnectionPhase) => void) | undefined,
+  phase: RuntimeHostPeerConnectionPhase,
+): void {
+  try {
+    observer?.(phase);
+  } catch {
+    // Connection progress is diagnostic state and cannot control the connection.
+  }
 }
 
 function waitForPeerConnectTurn(previous: Promise<void>, signal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Project demanded Runtime Host connectivity as explicit ephemeral phases: discovery, connection, authentication, handshake, and ready waiting. Shared-Session targets remain sparse and become ready only after the authenticated Host handshake; membership or cached route knowledge alone never reports a usable Host.

Cancellation and target-generation fencing prevent a late connection attempt from publishing readiness after removal. This PR is stacked on #4274.

</details>

<details>
<summary>中文</summary>

将按需 Runtime Host 连接投影为明确的临时阶段：发现、连接、认证、握手和等待就绪。共享 Session target 保持稀疏，只有完成经过认证的 Host 握手后才会 ready；仅有 membership 或缓存路由绝不会被显示成可用 Host。

取消传播与 target generation fence 会阻止已移除连接的迟到结果发布 readiness。本 PR stack 在 #4274 之上。

</details>

Refs #3842
Refs #3843

## Verification

<details open>
<summary>English</summary>

- Runtime Host build passes.
- Focused native peer connection tests pass (4 tests).
- Desktop Runtime Host manager suite passes (43 tests), including cancellation and stale-generation fencing.
- Affected lint and diff checks pass.

</details>

<details>
<summary>中文</summary>

- Runtime Host 构建通过。
- 原生 peer 连接聚焦测试通过（4 项）。
- Desktop Runtime Host manager 测试通过（43 项），包括取消和过期 generation 隔离。
- 受影响文件的 lint 与 diff 检查通过。

</details>

## Review focus

Connection phases are ephemeral observations, not durable Mesh or mount state. Membership must not create all-to-all application streams.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex — architecture planning, implementation, focused tests, and review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
