### PR TITLE
fix: support rsync 3.1 for Nightly bootstrap

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -308,14 +308,15 @@ jobs:
           umask 077
           printf '%s\n' "$NIGHTLIES_RSYNC_KEY" > "$ssh_directory/key"
           {
+            echo "NIGHTLIES_RSYNC_BASE=$NIGHTLIES_RSYNC_USER@$NIGHTLIES_RSYNC_HOST:${NIGHTLIES_RSYNC_PATH%/}"
             echo "NIGHTLIES_RSYNC_TARGET=$NIGHTLIES_RSYNC_USER@$NIGHTLIES_RSYNC_HOST:${NIGHTLIES_RSYNC_PATH%/}/maka/desktop"
             echo "RSYNC_RSH=ssh -i $ssh_directory/key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $NIGHTLIES_RSYNC_PORT"
           } >> "$GITHUB_ENV"
 
       - name: Ensure the Nightly destination exists
         run: |
-          mkdir -p .nightly-empty
-          rsync -rlptDz --mkpath --protect-args .nightly-empty/ "$NIGHTLIES_RSYNC_TARGET/"
+          mkdir -p .nightly-empty/maka/desktop
+          rsync -rlptDz --protect-args .nightly-empty/maka/ "$NIGHTLIES_RSYNC_BASE/maka/"
 
       - name: Require the Desktop Nightly feed to advance
         env:

--- a/scripts/desktop-nightly-workflow-policy.test.mjs
+++ b/scripts/desktop-nightly-workflow-policy.test.mjs
@@ -19,7 +19,9 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 import { parse } from 'yaml';
 
@@ -107,20 +109,40 @@ test('a failed Desktop Nightly is retried through a fresh npm Nightly', async ()
   assert.equal(download.with.pattern, 'desktop-nightly-*');
 });
 
-test('the first Desktop Nightly creates its empty destination before reading the feed', async () => {
+test('the first Desktop Nightly creates its destination with rsync 3.1-compatible flags', async () => {
   const workflow = await readWorkflow('desktop-nightly.yml');
   const steps = workflow.jobs.publish.steps;
+  const transport = steps.find(
+    (step) => step.name === 'Prepare authenticated Nightlies SSH transport',
+  );
   const bootstrap = steps.find((step) => step.name === 'Ensure the Nightly destination exists');
   const feedGuardPosition = steps.findIndex(
     (step) => step.name === 'Require the Desktop Nightly feed to advance',
   );
 
   assert.ok(bootstrap);
-  assert.match(bootstrap.run, /mkdir -p \.nightly-empty/u);
-  assert.match(bootstrap.run, /^rsync -rlptDz --mkpath --protect-args /mu);
-  assert.match(bootstrap.run, /\.nightly-empty\/ "\$NIGHTLIES_RSYNC_TARGET\/"/u);
+  assert.match(transport.run, /NIGHTLIES_RSYNC_BASE=/u);
+  assert.match(bootstrap.run, /mkdir -p \.nightly-empty\/maka\/desktop/u);
+  assert.match(bootstrap.run, /^rsync -rlptDz --protect-args /mu);
+  assert.doesNotMatch(bootstrap.run, /--mkpath/u);
+  assert.match(bootstrap.run, /\.nightly-empty\/maka\/ "\$NIGHTLIES_RSYNC_BASE\/maka\/"/u);
   assert.doesNotMatch(bootstrap.run, /\.nightly-publish/u);
   assert.ok(steps.indexOf(bootstrap) < feedGuardPosition);
+
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-nightly-bootstrap-'));
+  const remoteBase = join(workspace, 'remote');
+  await mkdir(remoteBase);
+  try {
+    const localBootstrap = bootstrap.run.replace('--protect-args ', '');
+    const result = spawnSync('bash', ['-c', localBootstrap], {
+      cwd: workspace,
+      env: { ...process.env, NIGHTLIES_RSYNC_BASE: remoteBase },
+    });
+    assert.equal(result.status, 0, result.stderr.toString());
+    assert.ok((await stat(join(remoteBase, 'maka', 'desktop'))).isDirectory());
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
 });
 
 test('the protected Desktop publisher appends payloads before advancing the feed', async () => {


### PR DESCRIPTION
## Summary

The first Desktop Nightly reached the protected publisher but failed before reading or writing the feed because the Apache Nightlies server runs rsync 3.1.3, which rejects `--mkpath`.

Bootstrap `maka/desktop` as a nested empty directory tree from the Infra-provided base path using rsync's long-supported directory-copy behavior. This keeps publication rsync-only, avoids requiring remote shell access, and preserves the append-only payload / feed-last protocol.

## Verification

- `node --test scripts/desktop-nightly-workflow-policy.test.mjs scripts/desktop-nightly-stage.test.mjs scripts/desktop-nightly.test.mjs` (12/12 passed)
- `npx biome check scripts/desktop-nightly-workflow-policy.test.mjs`
- `git diff --check`
- Original failure: https://github.com/apache/maka/actions/runs/33323426713
- End-to-end Nightlies publication requires merging this workflow change and starting a fresh npm Nightly; in-place reruns remain intentionally rejected.

## Root cause

The publisher assumed both ends supported rsync 3.2's `--mkpath`. GitHub's sender is 3.2.7, but the Nightlies receiver is 3.1.3, so the remote parser rejected the command before any destination directory was created.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the failed workflow, implemented the compatibility fix, and added the regression coverage. The human contributor must review the final diff and own the submission.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
