### PR TITLE
docs(readme): link Desktop Nightly downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,9 @@
   machine, through one Runtime Host.
 </p>
 
-<h3 align="center">
-  <a href="https://nightlies.apache.org/maka/desktop/">Download Desktop Nightly →</a>
-</h3>
-
 <p align="center">
-  Daily builds from <code>main</code> for developers and testers.<br/>
-  Not an ASF release or intended for production use.
+  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/Download%20Desktop%20Nightly-1F6FEB?style=for-the-badge" alt="Download Desktop Nightly" /></a><br/>
+  Daily builds from <code>main</code> for developers and testers. Not an ASF release, not intended for production use.
 </p>
 
 ![Maka — Your work. Your agent.](./.github/assets/maka-hero.en.png)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 
 <p align="center">
   <a href="https://github.com/apache/maka/stargazers"><img src="https://img.shields.io/github/stars/apache/maka?style=flat&label=%E2%98%85&color=4C8DFF" alt="GitHub stars" /></a>
-  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/Desktop-Nightly-4C8DFF?style=flat" alt="Desktop Nightly" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-4C8DFF?style=flat" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/macOS-arm64-4C8DFF?style=flat&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   <img src="https://img.shields.io/badge/Windows-preview-9BB8F0?style=flat&logo=windows&logoColor=white" alt="Windows unsigned preview" />
@@ -44,13 +43,22 @@
   machine, through one Runtime Host.
 </p>
 
+<p align="center">
+  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/Download-Desktop%20Nightly-4C8DFF?style=for-the-badge" alt="Download Desktop Nightly" /></a>
+</p>
+
+<p align="center">
+  Daily builds from <code>main</code> for developers and testers.<br/>
+  Not an ASF release. Not intended for production use.
+</p>
+
 ![Maka — Your work. Your agent.](./.github/assets/maka-hero.en.png)
 
 > [!NOTE]
 > Apache Maka (Incubating) is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision-making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF. [DISCLAIMER-WIP](./DISCLAIMER-WIP) records the issues the project is currently aware of.
 
 > [!IMPORTANT]
-> Maka is under active development. The macOS Apple Silicon desktop build is an early public release; data formats, CLI commands, and experimental capabilities may still change.
+> Maka is under active development. Desktop Nightly is an early developer build; data formats, CLI commands, and experimental capabilities may still change.
 
 ## Why Maka
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 <p align="center">
   <a href="https://github.com/apache/maka/stargazers"><img src="https://img.shields.io/github/stars/apache/maka?style=flat&label=%E2%98%85&color=4C8DFF" alt="GitHub stars" /></a>
-  <a href="https://github.com/apache/maka/releases"><img src="https://img.shields.io/github/downloads/apache/maka/total?style=flat&label=downloads&color=4C8DFF" alt="GitHub downloads" /></a>
+  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/Desktop-Nightly-4C8DFF?style=flat" alt="Desktop Nightly" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-4C8DFF?style=flat" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/macOS-arm64-4C8DFF?style=flat&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   <img src="https://img.shields.io/badge/Windows-preview-9BB8F0?style=flat&logo=windows&logoColor=white" alt="Windows unsigned preview" />
@@ -100,7 +100,7 @@ Apache Maka has not made an Apache release yet. Everything currently published f
 
 Once Apache releases exist, the official release is the source release published by the ASF and approved by the podling PPMC and the Incubator PMC. A package built from that source and distributed elsewhere, for example through a package registry or as a Desktop installer, is a convenience artifact rather than the release itself, and it is valid only when it is built from an approved source release. [`.github/ASF_SOURCE_RELEASE.md`](./.github/ASF_SOURCE_RELEASE.md) holds the candidate contract, signing path, and verification steps.
 
-Until an approved source release exists, this README recommends no prebuilt download. Build and run Maka from source as described below. Desktop currently targets Apple Silicon Macs (`arm64`). Intel Macs and Linux are not supported yet. [Windows](docs/windows-support.md) is an unsigned preview, not a supported release tier.
+[Desktop Nightly](https://nightlies.apache.org/maka/desktop/) is built daily from `main` for developers and testers. It is not an ASF release and is not intended for production use. Desktop currently targets Apple Silicon Macs (`arm64`). Intel Macs and Linux are not supported yet. [Windows](docs/windows-support.md) is an unsigned preview, not a supported release tier.
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@
   <img src="https://img.shields.io/badge/Windows-preview-9BB8F0?style=flat&logo=windows&logoColor=white" alt="Windows unsigned preview" />
   <img src="https://img.shields.io/badge/Linux-soon-D0D4DA?style=flat&logo=linux&logoColor=6B7280" alt="Linux not yet supported" />
   <a href="https://deepwiki.com/apache/maka"><img src="https://img.shields.io/badge/DeepWiki-third--party%20AI%20docs-9BB8F0?style=flat" alt="DeepWiki: third-party AI-generated docs" /></a>
-</p>
-
-<p align="center">
   <a href="./README.zh-CN.md"><img src="https://img.shields.io/badge/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3-4C8DFF?style=flat" alt="中文文档" /></a>
 </p>
 
@@ -43,13 +40,13 @@
   machine, through one Runtime Host.
 </p>
 
-<p align="center">
-  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/Download-Desktop%20Nightly-4C8DFF?style=for-the-badge" alt="Download Desktop Nightly" /></a>
-</p>
+<h3 align="center">
+  <a href="https://nightlies.apache.org/maka/desktop/">Download Desktop Nightly →</a>
+</h3>
 
 <p align="center">
   Daily builds from <code>main</code> for developers and testers.<br/>
-  Not an ASF release. Not intended for production use.
+  Not an ASF release or intended for production use.
 </p>
 
 ![Maka — Your work. Your agent.](./.github/assets/maka-hero.en.png)
@@ -58,7 +55,7 @@
 > Apache Maka (Incubating) is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision-making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF. [DISCLAIMER-WIP](./DISCLAIMER-WIP) records the issues the project is currently aware of.
 
 > [!IMPORTANT]
-> Maka is under active development. Desktop Nightly is an early developer build; data formats, CLI commands, and experimental capabilities may still change.
+> Maka is under active development. Data formats, CLI commands, and experimental capabilities may still change.
 
 ## Why Maka
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,6 @@
 
 <p align="center">
   <a href="https://github.com/apache/maka/stargazers"><img src="https://img.shields.io/github/stars/apache/maka?style=flat&label=%E2%98%85&color=4C8DFF" alt="GitHub stars" /></a>
-  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/Desktop-Nightly-4C8DFF?style=flat" alt="Desktop Nightly" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-4C8DFF?style=flat" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/macOS-arm64-4C8DFF?style=flat&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   <img src="https://img.shields.io/badge/Windows-preview-9BB8F0?style=flat&logo=windows&logoColor=white" alt="Windows 未签名预览" />
@@ -42,13 +41,22 @@
   Maka 在沙箱边界下阅读项目、执行工具，并把模型消息和工具调用保存为可恢复的运行事实——数据在本机，执行走同一个 Runtime Host。
 </p>
 
+<p align="center">
+  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/%E4%B8%8B%E8%BD%BD-Desktop%20Nightly-4C8DFF?style=for-the-badge" alt="下载 Desktop Nightly" /></a>
+</p>
+
+<p align="center">
+  每天从 <code>main</code> 构建，面向开发者和测试者。<br/>
+  不是 ASF release，不适合生产使用。
+</p>
+
 ![Maka——你的工作，你的 Agent。](./.github/assets/maka-hero.zh-CN.png)
 
 > [!NOTE]
 > Apache Maka (Incubating) 是一个正在 Apache 软件基金会（ASF）孵化的项目，由 Apache Incubator PMC 提供 sponsor。所有新接受的项目都必须经过孵化，直到进一步审查表明其基础设施、沟通方式和决策流程已经稳定到与其他成功的 ASF 项目一致的程度。孵化状态并不必然反映代码的完成度或稳定性，但它确实表明该项目尚未得到 ASF 的完全认可。项目当前已知的问题记录在 [DISCLAIMER-WIP](./DISCLAIMER-WIP)（以英文原文为准）。
 
 > [!IMPORTANT]
-> Maka 仍在活跃开发中。macOS Apple Silicon 桌面版是首个早期公开版本，数据格式、CLI 和实验能力仍可能变化。
+> Maka 仍在活跃开发中。Desktop Nightly 是面向开发者的早期构筑，数据格式、CLI 和实验能力仍可能变化。
 
 ## 为什么是 Maka
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,13 +38,9 @@
   Maka 在沙箱边界下阅读项目、执行工具，并把模型消息和工具调用保存为可恢复的运行事实——数据在本机，执行走同一个 Runtime Host。
 </p>
 
-<h3 align="center">
-  <a href="https://nightlies.apache.org/maka/desktop/">下载 Desktop Nightly →</a>
-</h3>
-
 <p align="center">
-  每天从 <code>main</code> 构建，面向开发者和测试者。<br/>
-  不是 ASF release，也不适合生产使用。
+  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/%E4%B8%8B%E8%BD%BD%20Desktop%20Nightly-1F6FEB?style=for-the-badge" alt="下载 Desktop Nightly" /></a><br/>
+  每天从 <code>main</code> 构建，面向开发者和测试者。不是 ASF release，也不适合生产使用。
 </p>
 
 ![Maka——你的工作，你的 Agent。](./.github/assets/maka-hero.zh-CN.png)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@
 
 <p align="center">
   <a href="https://github.com/apache/maka/stargazers"><img src="https://img.shields.io/github/stars/apache/maka?style=flat&label=%E2%98%85&color=4C8DFF" alt="GitHub stars" /></a>
-  <a href="https://github.com/apache/maka/releases"><img src="https://img.shields.io/github/downloads/apache/maka/total?style=flat&label=downloads&color=4C8DFF" alt="GitHub downloads" /></a>
+  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/Desktop-Nightly-4C8DFF?style=flat" alt="Desktop Nightly" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-4C8DFF?style=flat" alt="License: Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/macOS-arm64-4C8DFF?style=flat&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   <img src="https://img.shields.io/badge/Windows-preview-9BB8F0?style=flat&logo=windows&logoColor=white" alt="Windows 未签名预览" />
@@ -98,7 +98,7 @@ Apache Maka 目前还没有发布过 Apache release。当前从本仓库或包�
 
 在 Apache release 出现之后，官方 release 指的是由 ASF 发布、并经 podling PPMC 和 Incubator PMC 批准的源码 release。由该源码构建并通过其他渠道分发的包，例如包管理器中的包或 Desktop 安装程序，属于 convenience artifact，本身不是 release，并且只有在由获批源码 release 构建时才有效。候选契约、签名路径和验包步骤见 [`.github/ASF_SOURCE_RELEASE.md`](./.github/ASF_SOURCE_RELEASE.md)。
 
-在获批源码 release 出现之前，本 README 不推荐任何预构建下载，请按下文从源码构建并运行 Maka。Desktop 目前面向 Apple Silicon Mac（`arm64`）。暂不支持 Intel Mac 和 Linux。[Windows](docs/windows-support.md) 是未签名预览，不是正式支持的发布层级。
+[Desktop Nightly](https://nightlies.apache.org/maka/desktop/) 面向开发者和测试者，每天从 `main` 构建。它不是 ASF release，不适合生产使用。Desktop 目前面向 Apple Silicon Mac（`arm64`）。暂不支持 Intel Mac 和 Linux。[Windows](docs/windows-support.md) 是未签名预览，不是正式支持的发布层级。
 
 ### 环境要求
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,9 +30,6 @@
   <img src="https://img.shields.io/badge/Windows-preview-9BB8F0?style=flat&logo=windows&logoColor=white" alt="Windows 未签名预览" />
   <img src="https://img.shields.io/badge/Linux-soon-D0D4DA?style=flat&logo=linux&logoColor=6B7280" alt="Linux 尚未支持" />
   <a href="https://deepwiki.com/apache/maka"><img src="https://img.shields.io/badge/DeepWiki-%E7%AC%AC%E4%B8%89%E6%96%B9%20AI%20%E6%96%87%E6%A1%A3-9BB8F0?style=flat" alt="DeepWiki：第三方 AI 生成文档" /></a>
-</p>
-
-<p align="center">
   <a href="./README.md"><img src="https://img.shields.io/badge/English-4C8DFF?style=flat" alt="English" /></a>
 </p>
 
@@ -41,13 +38,13 @@
   Maka 在沙箱边界下阅读项目、执行工具，并把模型消息和工具调用保存为可恢复的运行事实——数据在本机，执行走同一个 Runtime Host。
 </p>
 
-<p align="center">
-  <a href="https://nightlies.apache.org/maka/desktop/"><img src="https://img.shields.io/badge/%E4%B8%8B%E8%BD%BD-Desktop%20Nightly-4C8DFF?style=for-the-badge" alt="下载 Desktop Nightly" /></a>
-</p>
+<h3 align="center">
+  <a href="https://nightlies.apache.org/maka/desktop/">下载 Desktop Nightly →</a>
+</h3>
 
 <p align="center">
   每天从 <code>main</code> 构建，面向开发者和测试者。<br/>
-  不是 ASF release，不适合生产使用。
+  不是 ASF release，也不适合生产使用。
 </p>
 
 ![Maka——你的工作，你的 Agent。](./.github/assets/maka-hero.zh-CN.png)
@@ -56,7 +53,7 @@
 > Apache Maka (Incubating) 是一个正在 Apache 软件基金会（ASF）孵化的项目，由 Apache Incubator PMC 提供 sponsor。所有新接受的项目都必须经过孵化，直到进一步审查表明其基础设施、沟通方式和决策流程已经稳定到与其他成功的 ASF 项目一致的程度。孵化状态并不必然反映代码的完成度或稳定性，但它确实表明该项目尚未得到 ASF 的完全认可。项目当前已知的问题记录在 [DISCLAIMER-WIP](./DISCLAIMER-WIP)（以英文原文为准）。
 
 > [!IMPORTANT]
-> Maka 仍在活跃开发中。Desktop Nightly 是面向开发者的早期构筑，数据格式、CLI 和实验能力仍可能变化。
+> Maka 仍在活跃开发中。数据格式、CLI 和实验能力仍可能变化。
 
 ## 为什么是 Maka
 


### PR DESCRIPTION
## Summary

Improve Desktop Nightly discoverability without blurring the ASF release boundary:

- replace the stale GitHub Releases download badge with a focused, high-contrast Desktop Nightly call to action above the hero image;
- keep the daily `main` build, developer/tester audience, non-ASF-release status, and production warning visible in the same compact CTA unit;
- retain the formal ASF source-release explanation and mirror the landing-page wording in the Chinese README.

This is a documentation/discoverability fix only. It does not add GitHub Releases, move tags, or change publication workflows.

## Verification

- `git diff --check`
- Rendered both README files through GitHub's GFM Markdown API and confirmed both Nightly links, CTA labels, and warnings in each output
- Confirmed `https://nightlies.apache.org/maka/desktop/` returns HTTP 200 and currently identifies itself as a developer snapshot, not an Apache release, with macOS arm64 and Windows x64 downloads
- Confirmed both localized Shields.io CTA assets return HTTP 200
- Confirmed the old GitHub Releases link and no-prebuilt-download wording are absent from both README files
- Visually checked the actual README rendering on the pushed GitHub branch; Claude Opus also checked approximate desktop and mobile renders for wrapping and clipping
- Full lint, build, typecheck, and test suites not run (documentation-only change)

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Opus designed and directly implemented the final CTA composition; Codex adjudicated the external change, removed a GitHub-incompatible caption treatment, and verified the real GitHub rendering. The affected commit includes a `Generated-by: Claude Opus` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
