### PR TITLE
Closes #3825: fix(cli): statusline never abbreviates home-relative paths on Windows

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -42,6 +42,7 @@ import {
   makaPiToolPresentationStatus,
   retireCancelledTransientMessages,
   replaceTranscriptWithStoredMessages,
+  shortenCwd,
   submitCompactToTranscript,
   toggleAllThinkingExpansion,
   toggleAllToolExpansion,
@@ -381,6 +382,22 @@ describe('Maka Pi TUI transcript', () => {
     // leaving an empty segment dangling after the separator.
     assert.doesNotMatch(line, /C:\\/);
     assert.doesNotMatch(line, /·\s*$/);
+  });
+
+  test('shortens cwd under home with either path separator', () => {
+    assert.equal(
+      shortenCwd('/Users/alice/workspace/project', '/Users/alice'),
+      '~/workspace/project',
+    );
+    assert.equal(
+      shortenCwd('C:\\Users\\alice\\Videos\\project', 'C:\\Users\\alice'),
+      '~\\Videos\\project',
+    );
+    assert.equal(shortenCwd('C:\\Users\\alice', 'C:\\Users\\alice'), '~');
+    assert.equal(
+      shortenCwd('C:\\Users\\alice2\\project', 'C:\\Users\\alice'),
+      'C:\\Users\\alice2\\project',
+    );
   });
 
   test('status line never drops mode, model, goal, or ctx at narrow widths (#3421)', () => {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1922,10 +1922,14 @@ function firstLinePreview(text: string): string {
  * `/Users/alice/workspace/project` → `~/workspace/project`.
  * Falls back to the original path if it is not under the home directory.
  */
-function shortenCwd(cwd: string, homeDir?: string): string {
+export function shortenCwd(cwd: string, homeDir?: string): string {
   const home = homeDir ?? homedir();
-  if (home && cwd.startsWith(home + '/')) return `~${cwd.slice(home.length)}`;
-  if (home && cwd === home) return '~';
+  const normalizedHome = home.replace(/\\/g, '/');
+  const normalizedCwd = cwd.replace(/\\/g, '/');
+  if (home && normalizedCwd.startsWith(normalizedHome + '/')) {
+    return `~${cwd.slice(home.length)}`;
+  }
+  if (home && normalizedCwd === normalizedHome) return '~';
   return cwd;
 }
 


### PR DESCRIPTION
Closes #3825.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.
**Scope:** this repository does not build as a whole in the sandbox that produced this, so the check ran over the packages this patch touches and their dependencies. The rest of the repository was not built or tested here - please treat CI as the first check over the whole tree.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_mVftFwOr5_TJWiIPZH__Sw -->