### PR TITLE
fix(cli): project turn.stop inputs to protocol fields

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -672,6 +672,7 @@ describe('Runtime Host maka run adapter', () => {
     const prepareStarted = deferred<void>();
     const fixture = runFixture({
       graph: true,
+      strictTurnStopInput: true,
       prepareGate: prepareGate.promise,
       onPrepareStarted: () => prepareStarted.resolve(),
     });
@@ -868,6 +869,7 @@ function runFixture(input: {
   onGraphStop?: () => void;
   initialMessages?: StoredMessage[];
   finalMessages?: StoredMessage[];
+  strictTurnStopInput?: boolean;
 }) {
   const switches: string[] = [];
   const moves: string[] = [];
@@ -1008,6 +1010,13 @@ function runFixture(input: {
         return { rootSessionId: requestInput.rootSessionId, graphId: 'graph-1' };
       }
       if (operation === 'turn.stop') {
+        if (input.strictTurnStopInput) {
+          const allowed = new Set(['sessionId', 'turnId', 'runId']);
+          const unexpected = Object.keys(requestInput).filter((key) => !allowed.has(key));
+          if (unexpected.length > 0) {
+            throw new Error(`Unknown turn.stop input field: ${unexpected.join(', ')}`);
+          }
+        }
         exactTurnStops.push({
           sessionId: String(requestInput.sessionId),
           turnId: String(requestInput.turnId),

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -464,7 +464,11 @@ class RuntimeHostRunRuntime implements MakaRunRuntime {
   }
 
   async #stopTurn(turn: { sessionId: string; turnId: string; runId: string }): Promise<void> {
-    await this.#connection.request('turn.stop', turn);
+    await this.#connection.request('turn.stop', {
+      sessionId: turn.sessionId,
+      turnId: turn.turnId,
+      runId: turn.runId,
+    });
   }
 
   async #stopGraph(sessionId: string): Promise<void> {


### PR DESCRIPTION

## Summary

Send `turn.stop` with a fresh object containing only `sessionId`, `turnId`, and `runId`. The active Turn's local `outcome` classifier stays outside the protocol payload, so timeout and SIGINT requests reach the Host and abort the foreground tool.

Add strict fixture validation to the existing stop-before-start test. The fixture rejects every extra `turn.stop` field and records the exact accepted payload. Scope is limited to the `#stopTurn` projection and `strictTurnStopInput` fixture.

Fixes #4304

## Verification

```text
mise exec node@24.19.0 -- npx -y npm@11.19.0 --workspace maka-agent run build
mise exec node@24.19.0 -- node --test --test-name-pattern "stops a Turn that starts after cancellation was requested" packages/cli/dist/__tests__/runtime-host-run-command.test.js
Before fix: 0 pass, 1 fail, exit 1
After fix: 1 pass, 0 fail, exit 0
```

Before the fix, the strict fixture rejected `outcome` as an unknown `turn.stop` input field.

```text
mise exec node@24.19.0 -- node --test packages/cli/dist/__tests__/runtime-host-run-command.test.js
35 pass, 0 fail, exit 0
```

A live `maka run --yolo --timeout 10` returned `1` in 10.949 seconds. The marker was absent at return and remained absent after 45 seconds.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (gpt-5.6-sol), human-reviewed

## Checklist

- [x] Tests cover the change, with a red test recorded before the fix
- [x] The CLI build and affected test file pass locally

Does this PR entail a change in behavior?

- [x] Yes, described under Summary above
- [ ] No
