### PR TITLE
feat(desktop): show project and task details on hover

### DIFF
--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -156,7 +156,11 @@ test('project and task rows show contextual hover details', async ({
   const sidebar = page.getByRole('navigation', { name: '任务列表' });
   const taskSessionId = `${LONG_SIDEBAR_SESSION_PREFIX}00`;
   const taskRow = sessionRow(sidebar, taskSessionId);
-  await taskRow.locator('.astryx-side-nav-item').hover();
+  const taskNavigation = taskRow.locator('.astryx-side-nav-item');
+  await expect(taskNavigation).toHaveAccessibleDescription(
+    /已归档第 00 条研究记录。.*glm-5\.1/,
+  );
+  await taskNavigation.hover();
 
   const taskCard = page.locator('.maka-sidebar-hover-card[data-kind="session"]');
   await expect(taskCard).toBeVisible();
@@ -173,7 +177,9 @@ test('project and task rows show contextual hover details', async ({
   const projectRow = sidebar.locator(
     `[data-project-id="project:${LONG_SIDEBAR_PROJECT_ID}"]`,
   );
-  await projectRow.locator(':scope > div > .astryx-side-nav-item').hover();
+  const projectNavigation = projectRow.locator(':scope > div > .astryx-side-nav-item');
+  await expect(projectNavigation).toHaveAccessibleDescription(/3 个任务.*目录可用/);
+  await projectNavigation.hover();
 
   const projectCard = page.locator('.maka-sidebar-hover-card[data-kind="project"]');
   await expect(projectCard).toBeVisible();

--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -147,6 +147,43 @@ test('task row action menu accepts pointer selection', async ({
   await expect(page.getByRole('dialog', { name: '重命名任务' })).toBeVisible();
 });
 
+test('project and task rows show contextual hover details', async ({
+  projectSidebarWindow: page,
+}) => {
+  await page.keyboard.press('Escape');
+  await expect(page.locator('[data-maka-contract="search-modal"]')).not.toBeVisible();
+
+  const sidebar = page.getByRole('navigation', { name: '任务列表' });
+  const taskSessionId = `${LONG_SIDEBAR_SESSION_PREFIX}00`;
+  const taskRow = sessionRow(sidebar, taskSessionId);
+  await taskRow.locator('.astryx-side-nav-item').hover();
+
+  const taskCard = page.locator('.maka-sidebar-hover-card[data-kind="session"]');
+  await expect(taskCard).toBeVisible();
+  await expect(taskCard.locator('.maka-sidebar-hover-card-title')).toHaveText('任务 00');
+  await expect(taskCard.locator('.maka-sidebar-hover-card-preview')).toHaveText(
+    '已归档第 00 条研究记录。',
+  );
+  await expect(taskCard.locator('.maka-sidebar-hover-card-path')).toContainText(
+    'e2e-fixture-sidebar-search-modal-open',
+  );
+  await expect(taskCard.locator('.maka-sidebar-hover-card-meta')).toContainText('glm-5.1');
+
+  await sidebar.getByRole('radio', { name: '按项目', exact: true }).click();
+  const projectRow = sidebar.locator(
+    `[data-project-id="project:${LONG_SIDEBAR_PROJECT_ID}"]`,
+  );
+  await projectRow.locator(':scope > div > .astryx-side-nav-item').hover();
+
+  const projectCard = page.locator('.maka-sidebar-hover-card[data-kind="project"]');
+  await expect(projectCard).toBeVisible();
+  await expect(projectCard.locator('.maka-sidebar-hover-card-title')).toHaveText(
+    LONG_SIDEBAR_PROJECT_NAME,
+  );
+  await expect(projectCard.locator('.maka-sidebar-hover-card-meta')).toContainText('3 个任务');
+  await expect(projectCard.locator('.maka-sidebar-hover-card-meta')).toContainText('目录可用');
+});
+
 test('rail grouping survives a renderer reload', async ({ projectSidebarWindow: page }) => {
   await page.keyboard.press('Escape');
   await expect(page.locator('[data-maka-contract="search-modal"]')).not.toBeVisible();

--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -160,6 +160,9 @@ test('project and task rows show contextual hover details', async ({
   await expect(taskNavigation).toHaveAccessibleDescription(
     /已归档第 00 条研究记录。.*glm-5\.1/,
   );
+  // A new Electron window can open under the cursor left by the prior test;
+  // force a real leave → enter transition so the delayed hover trigger fires.
+  await page.mouse.move(800, 400);
   await taskNavigation.hover();
 
   const taskCard = page.locator('.maka-sidebar-hover-card[data-kind="session"]');
@@ -188,6 +191,12 @@ test('project and task rows show contextual hover details', async ({
   );
   await expect(projectCard.locator('.maka-sidebar-hover-card-meta')).toContainText('3 个任务');
   await expect(projectCard.locator('.maka-sidebar-hover-card-meta')).toContainText('目录可用');
+
+  const ungroupedRow = sidebar.locator('[data-project-id="__ungrouped__"]');
+  await ungroupedRow.locator(':scope > div > .astryx-side-nav-item').focus();
+  await expect(
+    page.getByRole('dialog', { name: '未归属项目 分组详情', exact: true }),
+  ).toBeVisible();
 });
 
 test('rail grouping survives a renderer reload', async ({ projectSidebarWindow: page }) => {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -275,6 +275,74 @@
   padding-inline-start: var(--spacing-2) !important;
 }
 
+/*
+ * Project/task hover details. Astryx owns the floating surface, top-layer
+ * positioning, radius, padding, shadow, and open/close motion. This content
+ * only defines the reading hierarchy inside that established component.
+ */
+.maka-sidebar-hover-card {
+  font: var(--maka-text-supporting);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+  width: min(304px, calc(100vw - var(--space-6)));
+  min-width: 248px;
+  text-align: start;
+}
+
+.maka-sidebar-hover-card-title {
+  font: var(--maka-text-heading-4);
+  min-width: 0;
+  color: var(--foreground);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.maka-sidebar-hover-card-preview {
+  color: var(--foreground-secondary);
+  line-height: var(--leading-relaxed);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+
+.maka-sidebar-hover-card-preview[data-empty="true"],
+.maka-sidebar-hover-card-updated {
+  color: var(--muted-foreground);
+}
+
+.maka-sidebar-hover-card-meta {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-0-5) var(--space-1);
+  color: var(--foreground-secondary);
+}
+
+.maka-sidebar-hover-card-path {
+  font: var(--maka-text-code);
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maka-sidebar-hover-card-updated {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-0-5);
+}
+
+.maka-sidebar-hover-card-updated small {
+  font: inherit;
+}
+
 .maka-session-row-end,
 .maka-project-item-end {
   display: inline-flex;

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -145,6 +145,24 @@ test('renders a scan-friendly compact timestamp in the session rail', () => {
   }
 });
 
+test('wires the session navigation control to its hover card description', () => {
+  const markup = renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <Rail
+        sessions={[session]}
+        onSelectSession={() => undefined}
+      />
+    </LocaleProvider>,
+  );
+  const { document } = parseHTML(markup);
+  const navigation = document.querySelector<HTMLButtonElement>(
+    '.maka-session-row .astryx-side-nav-item',
+  );
+
+  assert.ok(navigation);
+  assert.ok(navigation.getAttribute('aria-describedby'));
+});
+
 test('renders Runtime Host live runs without requiring renderer-local streaming', () => {
   const hostRunning = { ...session, runningTurnIds: ['turn-live'] };
   const markup = renderToStaticMarkup(
@@ -253,5 +271,6 @@ test('renders collapsible project navigation and row actions as sibling controls
     'project navigation precedes its auxiliary action',
   );
   assert.equal(projectButtons.indexOf(action), 1, 'project action precedes nested tasks');
+  assert.ok(navigation.getAttribute('aria-describedby'));
   assertNoNestedButtons(markup);
 });

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -302,3 +302,38 @@ test('renders collapsible project navigation and row actions as sibling controls
   assertDescriptionReferencesResolve(markup);
   assertNoNestedButtons(markup);
 });
+
+test('keeps project running totals aligned with renderer-local task streaming', () => {
+  const locallyStreaming = {
+    ...session,
+    status: 'active' as const,
+    runningTurnIds: [] as string[],
+  };
+  const markup = renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <Rail
+        sessions={[locallyStreaming]}
+        groups={[
+          {
+            id: project.id,
+            label: project.name,
+            project,
+            sessions: [locallyStreaming],
+          },
+        ]}
+        groupVariant="project"
+        streamingSessionIds={new Set([locallyStreaming.id])}
+      />
+    </LocaleProvider>,
+  );
+  const { document } = parseHTML(markup);
+  const projectNavigation = document.querySelector<HTMLButtonElement>(
+    '.maka-project-row > div > .astryx-side-nav-item',
+  );
+  const descriptionId = projectNavigation?.getAttribute('aria-describedby');
+  const description = descriptionId ? document.getElementById(descriptionId) : null;
+
+  assert.match(markup, /aria-label="Responding"/);
+  assert.ok(description);
+  assert.match(description.getAttribute('aria-label') ?? '', /1 running/);
+});

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -108,6 +108,22 @@ function assertNoNestedButtons(markup: string): void {
   }
 }
 
+function assertDescriptionReferencesResolve(markup: string): void {
+  const { document } = parseHTML(markup);
+  for (const element of document.querySelectorAll<HTMLElement>(
+    'button.astryx-side-nav-item[aria-describedby]',
+  )) {
+    const describedBy = element.getAttribute('aria-describedby');
+    assert.ok(describedBy);
+    for (const id of describedBy.split(/\s+/)) {
+      assert.ok(
+        document.getElementById(id),
+        `aria-describedby token ${JSON.stringify(id)} must resolve while the card is closed`,
+      );
+    }
+  }
+}
+
 test('renders session navigation and row actions as sibling controls', () => {
   const markup = renderToStaticMarkup(
     <LocaleProvider locale="en">
@@ -161,6 +177,7 @@ test('wires the session navigation control to its hover card description', () =>
 
   assert.ok(navigation);
   assert.ok(navigation.getAttribute('aria-describedby'));
+  assertDescriptionReferencesResolve(markup);
 });
 
 test('renders Runtime Host live runs without requiring renderer-local streaming', () => {
@@ -272,5 +289,6 @@ test('renders collapsible project navigation and row actions as sibling controls
   );
   assert.equal(projectButtons.indexOf(action), 1, 'project action precedes nested tasks');
   assert.ok(navigation.getAttribute('aria-describedby'));
+  assertDescriptionReferencesResolve(markup);
   assertNoNestedButtons(markup);
 });

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -116,9 +116,19 @@ function assertDescriptionReferencesResolve(markup: string): void {
     const describedBy = element.getAttribute('aria-describedby');
     assert.ok(describedBy);
     for (const id of describedBy.split(/\s+/)) {
+      const description = document.getElementById(id);
       assert.ok(
-        document.getElementById(id),
+        description,
         `aria-describedby token ${JSON.stringify(id)} must resolve while the card is closed`,
+      );
+      assert.equal(
+        description.textContent,
+        '',
+        'the stable description must not duplicate session or project content into DOM text queries',
+      );
+      assert.ok(
+        description.getAttribute('aria-label'),
+        'the stable description keeps its accessible text through aria-label',
       );
     }
   }

--- a/packages/ui/src/__tests__/session-hover-card-copy.test.ts
+++ b/packages/ui/src/__tests__/session-hover-card-copy.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getSessionHoverCardCopy } from '../session-hover-card-copy.js';
+
+test('localizes task and project hover card summaries', () => {
+  const zh = getSessionHoverCardCopy('zh');
+  const en = getSessionHoverCardCopy('en');
+
+  assert.equal(zh.sessionDetailsLabel('发布说明'), '发布说明 任务详情');
+  assert.equal(zh.projectDetailsLabel('Maka'), 'Maka 项目详情');
+  assert.equal(zh.taskCount(3), '3 个任务');
+  assert.equal(en.sessionDetailsLabel('Release notes'), 'Release notes task details');
+  assert.equal(en.projectDetailsLabel('Maka'), 'Maka project details');
+  assert.equal(en.taskCount(1), '1 task');
+  assert.equal(en.taskCount(2), '2 tasks');
+});

--- a/packages/ui/src/__tests__/session-hover-card-copy.test.ts
+++ b/packages/ui/src/__tests__/session-hover-card-copy.test.ts
@@ -27,9 +27,11 @@ test('localizes task and project hover card summaries', () => {
 
   assert.equal(zh.sessionDetailsLabel('发布说明'), '发布说明 任务详情');
   assert.equal(zh.projectDetailsLabel('Maka'), 'Maka 项目详情');
+  assert.equal(zh.groupDetailsLabel('未归属项目'), '未归属项目 分组详情');
   assert.equal(zh.taskCount(3), '3 个任务');
   assert.equal(en.sessionDetailsLabel('Release notes'), 'Release notes task details');
   assert.equal(en.projectDetailsLabel('Maka'), 'Maka project details');
+  assert.equal(en.groupDetailsLabel('No project'), 'No project group details');
   assert.equal(en.taskCount(1), '1 task');
   assert.equal(en.taskCount(2), '2 tasks');
 });

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -21,10 +21,12 @@ import {
   memo,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
   type KeyboardEvent,
   type ReactNode,
+  type RefObject,
 } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
 import type { ProjectRecord } from '@maka/core/project';
@@ -46,7 +48,7 @@ import {
 import { RelativeTime } from './relative-time.js';
 import { formatAbsoluteTimestamp } from '@maka/core/relative-time';
 import { Badge } from '@astryxdesign/core/Badge';
-import { useHoverCard } from '@astryxdesign/core/HoverCard';
+import { useHoverCard, type HoverCardReturn } from '@astryxdesign/core/HoverCard';
 import { MoreMenu } from '@astryxdesign/core/MoreMenu';
 import {
   SideNavItem,
@@ -68,6 +70,43 @@ type SessionHistoryGroupVariant = 'conversation' | 'project';
 
 const SIDEBAR_HOVER_CARD_DELAY_MS = 300;
 const SIDEBAR_HOVER_CARD_HIDE_DELAY_MS = 120;
+
+/**
+ * Attach a hover card without feeding its positioning ref through SideNavItem.
+ *
+ * SideNavItem merges the consumer ref with an internal popover ref. The latter
+ * changes on selection renders, which makes React detach and reattach every
+ * merged ref and churns the CSS anchor name. Positioning is immutable for a
+ * mounted row, while interaction listeners may follow the hook's latest
+ * callbacks, so keep those two lifecycles separate here.
+ */
+function useSidebarHoverCardTrigger(
+  containerRef: RefObject<HTMLElement | null>,
+  hoverCard: Pick<HoverCardReturn, 'positionRef' | 'interactionRef'>,
+): void {
+  const positionRef = useRef(hoverCard.positionRef).current;
+  const interactionRef = hoverCard.interactionRef;
+
+  useEffect(() => {
+    const trigger = containerRef.current?.querySelector<HTMLElement>(
+      'button.astryx-side-nav-item',
+    ) ?? null;
+    positionRef(trigger);
+    return () => {
+      positionRef(null);
+    };
+  }, [containerRef, positionRef]);
+
+  useEffect(() => {
+    const trigger = containerRef.current?.querySelector<HTMLElement>(
+      'button.astryx-side-nav-item',
+    ) ?? null;
+    interactionRef(trigger);
+    return () => {
+      interactionRef(null);
+    };
+  }, [containerRef, interactionRef]);
+}
 
 export interface SessionRowActions {
   onToggleFlag(sessionId: string, next: boolean): void | Promise<void>;
@@ -312,27 +351,18 @@ function ProjectNavRow(props: {
   onStartRename(opener: HTMLElement | null): void;
   renderSession(session: SessionSummary): ReactNode;
 }) {
-  const locale = useUiLocale();
-  const previewCopy = getSessionHoverCardCopy(locale);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const hoverDescriptionId = useId();
   // Collapsible only when there is a real session subtree. An empty VStack is
   // still truthy children for Astryx (!!children) and fabricates a disclosure.
   const hasSessions = props.sessions.length > 0;
   const hasActions = props.project !== undefined && props.projectActions !== undefined;
-  const hoverCard = useHoverCard({
-    placement: 'end',
-    alignment: 'start',
-    delay: SIDEBAR_HOVER_CARD_DELAY_MS,
-    hideDelay: SIDEBAR_HOVER_CARD_HIDE_DELAY_MS,
-    focusTrigger: 'always',
-    label: previewCopy.projectDetailsLabel(props.label),
-  });
   return (
-    <div data-project-id={props.groupKey} className="maka-project-row">
+    <div ref={containerRef} data-project-id={props.groupKey} className="maka-project-row">
       <SideNavItem
-        ref={hoverCard.ref}
         key="navigation"
         label={props.label}
-        aria-describedby={hoverCard.describedBy}
+        aria-describedby={hoverDescriptionId}
         icon={FolderOpen}
         collapsible={hasSessions ? { defaultIsCollapsed: false } : undefined}
         endContent={
@@ -358,17 +388,46 @@ function ProjectNavRow(props: {
           <VStack gap={0.5}>{props.sessions.map((session) => props.renderSession(session))}</VStack>
         ) : undefined}
       </SideNavItem>
-      {hoverCard.renderHoverCard(
-        <ProjectHoverCardContent
-          label={props.label}
-          project={props.project}
-          sessions={props.sessions}
-          locale={locale}
-        />,
-      )}
+      <ProjectHoverCardLayer
+        containerRef={containerRef}
+        descriptionId={hoverDescriptionId}
+        label={props.label}
+        project={props.project}
+        sessions={props.sessions}
+      />
     </div>
   );
 }
+
+const ProjectHoverCardLayer = memo(function ProjectHoverCardLayer(props: {
+  containerRef: RefObject<HTMLElement | null>;
+  descriptionId: string;
+  label: string;
+  project?: ProjectRecord;
+  sessions: SessionSummary[];
+}) {
+  const locale = useUiLocale();
+  const copy = getSessionHoverCardCopy(locale);
+  const hoverCard = useHoverCard({
+    placement: 'end',
+    alignment: 'start',
+    delay: SIDEBAR_HOVER_CARD_DELAY_MS,
+    hideDelay: SIDEBAR_HOVER_CARD_HIDE_DELAY_MS,
+    focusTrigger: 'always',
+    label: copy.projectDetailsLabel(props.label),
+  });
+  useSidebarHoverCardTrigger(props.containerRef, hoverCard);
+
+  return hoverCard.renderHoverCard(
+    <ProjectHoverCardContent
+      descriptionId={props.descriptionId}
+      label={props.label}
+      project={props.project}
+      sessions={props.sessions}
+      locale={locale}
+    />,
+  );
+});
 
 const SessionNavRow = memo(function SessionNavRow(props: {
   session: SessionSummary;
@@ -381,9 +440,10 @@ const SessionNavRow = memo(function SessionNavRow(props: {
   actions?: SessionRowActions;
   onStartRename(target: SessionRenameTarget, opener: HTMLElement | null): void;
 }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const hoverDescriptionId = useId();
   const locale = useUiLocale();
   const copy = getConversationCopy(locale).sessions;
-  const previewCopy = getSessionHoverCardCopy(locale);
   const signals = sessionRowSignals(
     props.session,
     { streaming: props.streaming, stale: props.stale, active: props.active },
@@ -396,14 +456,6 @@ const SessionNavRow = memo(function SessionNavRow(props: {
       : props.session.status,
     locale,
   ).label;
-  const hoverCard = useHoverCard({
-    placement: 'end',
-    alignment: 'start',
-    delay: SIDEBAR_HOVER_CARD_DELAY_MS,
-    hideDelay: SIDEBAR_HOVER_CARD_HIDE_DELAY_MS,
-    focusTrigger: 'always',
-    label: previewCopy.sessionDetailsLabel(props.session.name),
-  });
   // What the row communicates without text and the dot does NOT already say,
   // inside the button so it lands in the accessible name. `signals[0]` is
   // skipped because `StatusDot` carries it; the rest of the list, the worktree
@@ -424,6 +476,7 @@ const SessionNavRow = memo(function SessionNavRow(props: {
 
   return (
     <div
+      ref={containerRef}
       className="maka-session-row"
       data-maka-contract="session-row"
       data-session-id={props.session.id}
@@ -431,9 +484,8 @@ const SessionNavRow = memo(function SessionNavRow(props: {
       data-worktree={props.worktree ? 'true' : undefined}
     >
       <SideNavItem
-        ref={hoverCard.ref}
         label={props.session.name}
-        aria-describedby={hoverCard.describedBy}
+        aria-describedby={hoverDescriptionId}
         size="md"
         isSelected={props.active}
         // Slot 1, the row's leading edge. A fixed gutter every row pays for,
@@ -495,13 +547,13 @@ const SessionNavRow = memo(function SessionNavRow(props: {
           </span>
         }
       />
-      {hoverCard.renderHoverCard(
-        <SessionHoverCardContent
-          session={props.session}
-          status={previewStatus}
-          locale={locale}
-        />,
-      )}
+      <SessionHoverCardLayer
+        containerRef={containerRef}
+        descriptionId={hoverDescriptionId}
+        session={props.session}
+        status={previewStatus}
+        locale={locale}
+      />
       {props.actions && (
         <SessionItemActions
           session={props.session}
@@ -513,7 +565,36 @@ const SessionNavRow = memo(function SessionNavRow(props: {
   );
 });
 
+const SessionHoverCardLayer = memo(function SessionHoverCardLayer(props: {
+  containerRef: RefObject<HTMLElement | null>;
+  descriptionId: string;
+  session: SessionSummary;
+  status: string;
+  locale: UiLocale;
+}) {
+  const copy = getSessionHoverCardCopy(props.locale);
+  const hoverCard = useHoverCard({
+    placement: 'end',
+    alignment: 'start',
+    delay: SIDEBAR_HOVER_CARD_DELAY_MS,
+    hideDelay: SIDEBAR_HOVER_CARD_HIDE_DELAY_MS,
+    focusTrigger: 'always',
+    label: copy.sessionDetailsLabel(props.session.name),
+  });
+  useSidebarHoverCardTrigger(props.containerRef, hoverCard);
+
+  return hoverCard.renderHoverCard(
+    <SessionHoverCardContent
+      descriptionId={props.descriptionId}
+      session={props.session}
+      status={props.status}
+      locale={props.locale}
+    />,
+  );
+});
+
 function SessionHoverCardContent(props: {
+  descriptionId: string;
   session: SessionSummary;
   status: string;
   locale: UiLocale;
@@ -524,7 +605,7 @@ function SessionHoverCardContent(props: {
   const permission = conversationCopy.permissions.mode[session.permissionMode].label;
 
   return (
-    <span className="maka-sidebar-hover-card" data-kind="session">
+    <span id={props.descriptionId} className="maka-sidebar-hover-card" data-kind="session">
       <span className="maka-sidebar-hover-card-title">{session.name}</span>
       <span
         className="maka-sidebar-hover-card-preview"
@@ -558,6 +639,7 @@ function SessionHoverCardContent(props: {
 }
 
 function ProjectHoverCardContent(props: {
+  descriptionId: string;
   label: string;
   project?: ProjectRecord;
   sessions: readonly SessionSummary[];
@@ -574,7 +656,7 @@ function ProjectHoverCardContent(props: {
   );
 
   return (
-    <span className="maka-sidebar-hover-card" data-kind="project">
+    <span id={props.descriptionId} className="maka-sidebar-hover-card" data-kind="project">
       <span className="maka-sidebar-hover-card-title">{props.label}</span>
       {path ? (
         <span className="maka-sidebar-hover-card-path" title={path}>

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -46,6 +46,7 @@ import {
 import { RelativeTime } from './relative-time.js';
 import { formatAbsoluteTimestamp } from '@maka/core/relative-time';
 import { Badge } from '@astryxdesign/core/Badge';
+import { useHoverCard } from '@astryxdesign/core/HoverCard';
 import { MoreMenu } from '@astryxdesign/core/MoreMenu';
 import {
   SideNavItem,
@@ -59,10 +60,14 @@ import { SessionRenameDialog, type SessionRenameTarget } from './session-rename-
 import { useSessionRailData } from './session-rail-context.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
+import { getSessionHoverCardCopy } from './session-hover-card-copy.js';
 
 type SessionRowActionId = 'flag' | 'archive' | 'rename' | 'delete';
 type ProjectRowActionId = 'new' | 'relink' | 'rename' | 'archive' | 'restore';
 type SessionHistoryGroupVariant = 'conversation' | 'project';
+
+const SIDEBAR_HOVER_CARD_DELAY_MS = 300;
+const SIDEBAR_HOVER_CARD_HIDE_DELAY_MS = 120;
 
 export interface SessionRowActions {
   onToggleFlag(sessionId: string, next: boolean): void | Promise<void>;
@@ -307,15 +312,27 @@ function ProjectNavRow(props: {
   onStartRename(opener: HTMLElement | null): void;
   renderSession(session: SessionSummary): ReactNode;
 }) {
+  const locale = useUiLocale();
+  const previewCopy = getSessionHoverCardCopy(locale);
   // Collapsible only when there is a real session subtree. An empty VStack is
   // still truthy children for Astryx (!!children) and fabricates a disclosure.
   const hasSessions = props.sessions.length > 0;
   const hasActions = props.project !== undefined && props.projectActions !== undefined;
+  const hoverCard = useHoverCard({
+    placement: 'end',
+    alignment: 'start',
+    delay: SIDEBAR_HOVER_CARD_DELAY_MS,
+    hideDelay: SIDEBAR_HOVER_CARD_HIDE_DELAY_MS,
+    focusTrigger: 'always',
+    label: previewCopy.projectDetailsLabel(props.label),
+  });
   return (
     <div data-project-id={props.groupKey} className="maka-project-row">
       <SideNavItem
+        ref={hoverCard.ref}
         key="navigation"
         label={props.label}
+        aria-describedby={hoverCard.describedBy}
         icon={FolderOpen}
         collapsible={hasSessions ? { defaultIsCollapsed: false } : undefined}
         endContent={
@@ -341,6 +358,14 @@ function ProjectNavRow(props: {
           <VStack gap={0.5}>{props.sessions.map((session) => props.renderSession(session))}</VStack>
         ) : undefined}
       </SideNavItem>
+      {hoverCard.renderHoverCard(
+        <ProjectHoverCardContent
+          label={props.label}
+          project={props.project}
+          sessions={props.sessions}
+          locale={locale}
+        />,
+      )}
     </div>
   );
 }
@@ -358,12 +383,27 @@ const SessionNavRow = memo(function SessionNavRow(props: {
 }) {
   const locale = useUiLocale();
   const copy = getConversationCopy(locale).sessions;
+  const previewCopy = getSessionHoverCardCopy(locale);
   const signals = sessionRowSignals(
     props.session,
     { streaming: props.streaming, stale: props.stale, active: props.active },
     locale,
   );
   const signal = signals[0];
+  const previewStatus = signal?.tooltip ?? signal?.label ?? presentSessionStatus(
+    props.session.status === 'running' && props.session.runningTurnIds !== undefined
+      ? 'active'
+      : props.session.status,
+    locale,
+  ).label;
+  const hoverCard = useHoverCard({
+    placement: 'end',
+    alignment: 'start',
+    delay: SIDEBAR_HOVER_CARD_DELAY_MS,
+    hideDelay: SIDEBAR_HOVER_CARD_HIDE_DELAY_MS,
+    focusTrigger: 'always',
+    label: previewCopy.sessionDetailsLabel(props.session.name),
+  });
   // What the row communicates without text and the dot does NOT already say,
   // inside the button so it lands in the accessible name. `signals[0]` is
   // skipped because `StatusDot` carries it; the rest of the list, the worktree
@@ -391,7 +431,9 @@ const SessionNavRow = memo(function SessionNavRow(props: {
       data-worktree={props.worktree ? 'true' : undefined}
     >
       <SideNavItem
+        ref={hoverCard.ref}
         label={props.session.name}
+        aria-describedby={hoverCard.describedBy}
         size="md"
         isSelected={props.active}
         // Slot 1, the row's leading edge. A fixed gutter every row pays for,
@@ -453,6 +495,13 @@ const SessionNavRow = memo(function SessionNavRow(props: {
           </span>
         }
       />
+      {hoverCard.renderHoverCard(
+        <SessionHoverCardContent
+          session={props.session}
+          status={previewStatus}
+          locale={locale}
+        />,
+      )}
       {props.actions && (
         <SessionItemActions
           session={props.session}
@@ -463,6 +512,119 @@ const SessionNavRow = memo(function SessionNavRow(props: {
     </div>
   );
 });
+
+function SessionHoverCardContent(props: {
+  session: SessionSummary;
+  status: string;
+  locale: UiLocale;
+}) {
+  const conversationCopy = getConversationCopy(props.locale);
+  const copy = getSessionHoverCardCopy(props.locale);
+  const session = props.session;
+  const permission = conversationCopy.permissions.mode[session.permissionMode].label;
+
+  return (
+    <span className="maka-sidebar-hover-card" data-kind="session">
+      <span className="maka-sidebar-hover-card-title">{session.name}</span>
+      <span
+        className="maka-sidebar-hover-card-preview"
+        data-empty={session.lastMessagePreview ? undefined : 'true'}
+      >
+        {session.lastMessagePreview || copy.noMessages}
+      </span>
+      <span className="maka-sidebar-hover-card-meta">
+        <span>{props.status}</span>
+        <span aria-hidden="true">·</span>
+        <span>{session.model}</span>
+        <span aria-hidden="true">·</span>
+        <span>{permission}</span>
+      </span>
+      {session.cwd ? (
+        <span className="maka-sidebar-hover-card-path" title={session.cwd}>
+          {session.cwd}
+        </span>
+      ) : null}
+      {session.lastMessageAt ? (
+        <span className="maka-sidebar-hover-card-updated">
+          {copy.updated}{' '}
+          <RelativeTime ts={session.lastMessageAt} />
+          <span className="maka-visually-hidden">
+            {formatAbsoluteTimestamp(session.lastMessageAt, props.locale)}
+          </span>
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function ProjectHoverCardContent(props: {
+  label: string;
+  project?: ProjectRecord;
+  sessions: readonly SessionSummary[];
+  locale: UiLocale;
+}) {
+  const copy = getSessionHoverCardCopy(props.locale);
+  const path = preferredProjectPath(props.project);
+  const runningCount = props.sessions.filter(
+    (session) => session.status === 'running' || (session.runningTurnIds?.length ?? 0) > 0,
+  ).length;
+  const latestActivity = props.sessions.reduce<number | undefined>(
+    (latest, session) => Math.max(latest ?? 0, session.lastMessageAt ?? 0) || undefined,
+    undefined,
+  );
+
+  return (
+    <span className="maka-sidebar-hover-card" data-kind="project">
+      <span className="maka-sidebar-hover-card-title">{props.label}</span>
+      {path ? (
+        <span className="maka-sidebar-hover-card-path" title={path}>
+          {path}
+        </span>
+      ) : null}
+      <span className="maka-sidebar-hover-card-meta">
+        <span>{copy.taskCount(props.sessions.length)}</span>
+        {runningCount > 0 ? (
+          <>
+            <span aria-hidden="true">·</span>
+            <span>{copy.runningTaskCount(runningCount)}</span>
+          </>
+        ) : null}
+        {props.project ? (
+          <>
+            <span aria-hidden="true">·</span>
+            <span>
+              {props.project.available ? copy.projectAvailable : copy.projectUnavailable}
+            </span>
+          </>
+        ) : null}
+        {(props.project?.locations.length ?? 0) > 1 ? (
+          <>
+            <span aria-hidden="true">·</span>
+            <span>{copy.locationCount(props.project!.locations.length)}</span>
+          </>
+        ) : null}
+      </span>
+      {latestActivity ? (
+        <span className="maka-sidebar-hover-card-updated">
+          {copy.updated}{' '}
+          <RelativeTime ts={latestActivity} />
+          <span className="maka-visually-hidden">
+            {formatAbsoluteTimestamp(latestActivity, props.locale)}
+          </span>
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function preferredProjectPath(project: ProjectRecord | undefined): string | undefined {
+  if (!project) return undefined;
+  return (
+    project.preferredPath ??
+    project.locations.find((location) => !location.isWorktree)?.path ??
+    project.locations[0]?.path
+  );
+}
 
 function ProjectItemMeta(props: {
   project?: ProjectRecord;

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -22,6 +22,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useMemo,
   useRef,
   useState,
   type KeyboardEvent,
@@ -287,6 +288,7 @@ function SessionListGroups(props: {
           label={group.label}
           project={project}
           sessions={group.sessions}
+          streamingSessionIds={rail.streamingSessionIds}
           projectActions={rail.projectActions}
           onStartRename={(opener) => {
             if (project) {
@@ -347,12 +349,22 @@ function ProjectNavRow(props: {
   label: string;
   project?: ProjectRecord;
   sessions: SessionSummary[];
+  streamingSessionIds?: ReadonlySet<string>;
   projectActions?: ProjectRowActions;
   onStartRename(opener: HTMLElement | null): void;
   renderSession(session: SessionSummary): ReactNode;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const hoverDescriptionId = useId();
+  const hoverSummary = useMemo(
+    () =>
+      createProjectHoverCardSummary(
+        props.project,
+        props.sessions,
+        props.streamingSessionIds,
+      ),
+    [props.project, props.sessions, props.streamingSessionIds],
+  );
   // Collapsible only when there is a real session subtree. An empty VStack is
   // still truthy children for Astryx (!!children) and fabricates a disclosure.
   const hasSessions = props.sessions.length > 0;
@@ -390,14 +402,13 @@ function ProjectNavRow(props: {
       </SideNavItem>
       <ProjectHoverCardDescription
         id={hoverDescriptionId}
-        project={props.project}
-        sessions={props.sessions}
+        summary={hoverSummary}
       />
       <ProjectHoverCardLayer
         containerRef={containerRef}
         label={props.label}
         project={props.project}
-        sessions={props.sessions}
+        summary={hoverSummary}
       />
     </div>
   );
@@ -407,7 +418,7 @@ const ProjectHoverCardLayer = memo(function ProjectHoverCardLayer(props: {
   containerRef: RefObject<HTMLElement | null>;
   label: string;
   project?: ProjectRecord;
-  sessions: SessionSummary[];
+  summary: ProjectHoverCardSummary;
 }) {
   const locale = useUiLocale();
   const copy = getSessionHoverCardCopy(locale);
@@ -417,15 +428,16 @@ const ProjectHoverCardLayer = memo(function ProjectHoverCardLayer(props: {
     delay: SIDEBAR_HOVER_CARD_DELAY_MS,
     hideDelay: SIDEBAR_HOVER_CARD_HIDE_DELAY_MS,
     focusTrigger: 'always',
-    label: copy.projectDetailsLabel(props.label),
+    label: props.project
+      ? copy.projectDetailsLabel(props.label)
+      : copy.groupDetailsLabel(props.label),
   });
   useSidebarHoverCardTrigger(props.containerRef, hoverCard);
 
   return hoverCard.renderHoverCard(
     <ProjectHoverCardContent
       label={props.label}
-      project={props.project}
-      sessions={props.sessions}
+      summary={props.summary}
       locale={locale}
     />,
   );
@@ -670,32 +682,25 @@ function SessionHoverCardContent(props: {
 
 function ProjectHoverCardDescription(props: {
   id: string;
-  project?: ProjectRecord;
-  sessions: readonly SessionSummary[];
+  summary: ProjectHoverCardSummary;
 }) {
   const locale = useUiLocale();
   const copy = getSessionHoverCardCopy(locale);
-  const runningCount = props.sessions.filter(
-    (session) => session.status === 'running' || (session.runningTurnIds?.length ?? 0) > 0,
-  ).length;
-  const latestActivity = props.sessions.reduce<number | undefined>(
-    (latest, session) => Math.max(latest ?? 0, session.lastMessageAt ?? 0) || undefined,
-    undefined,
-  );
+  const summary = props.summary;
   const description = [
-    preferredProjectPath(props.project),
-    copy.taskCount(props.sessions.length),
-    runningCount > 0 ? copy.runningTaskCount(runningCount) : undefined,
-    props.project
-      ? props.project.available
+    summary.path,
+    copy.taskCount(summary.taskCount),
+    summary.runningCount > 0 ? copy.runningTaskCount(summary.runningCount) : undefined,
+    summary.available !== undefined
+      ? summary.available
         ? copy.projectAvailable
         : copy.projectUnavailable
       : undefined,
-    (props.project?.locations.length ?? 0) > 1
-      ? copy.locationCount(props.project!.locations.length)
+    summary.locationCount > 1
+      ? copy.locationCount(summary.locationCount)
       : undefined,
-    latestActivity
-      ? `${copy.updated} ${formatAbsoluteTimestamp(latestActivity, locale)}`
+    summary.latestActivity
+      ? `${copy.updated} ${formatAbsoluteTimestamp(summary.latestActivity, locale)}`
       : undefined,
   ]
     .filter((value): value is string => Boolean(value))
@@ -706,62 +711,87 @@ function ProjectHoverCardDescription(props: {
 
 function ProjectHoverCardContent(props: {
   label: string;
-  project?: ProjectRecord;
-  sessions: readonly SessionSummary[];
+  summary: ProjectHoverCardSummary;
   locale: UiLocale;
 }) {
   const copy = getSessionHoverCardCopy(props.locale);
-  const path = preferredProjectPath(props.project);
-  const runningCount = props.sessions.filter(
-    (session) => session.status === 'running' || (session.runningTurnIds?.length ?? 0) > 0,
-  ).length;
-  const latestActivity = props.sessions.reduce<number | undefined>(
-    (latest, session) => Math.max(latest ?? 0, session.lastMessageAt ?? 0) || undefined,
-    undefined,
-  );
+  const summary = props.summary;
 
   return (
     <span className="maka-sidebar-hover-card" data-kind="project">
       <span className="maka-sidebar-hover-card-title">{props.label}</span>
-      {path ? (
-        <span className="maka-sidebar-hover-card-path" title={path}>
-          {path}
+      {summary.path ? (
+        <span className="maka-sidebar-hover-card-path" title={summary.path}>
+          {summary.path}
         </span>
       ) : null}
       <span className="maka-sidebar-hover-card-meta">
-        <span>{copy.taskCount(props.sessions.length)}</span>
-        {runningCount > 0 ? (
+        <span>{copy.taskCount(summary.taskCount)}</span>
+        {summary.runningCount > 0 ? (
           <>
             <span aria-hidden="true">·</span>
-            <span>{copy.runningTaskCount(runningCount)}</span>
+            <span>{copy.runningTaskCount(summary.runningCount)}</span>
           </>
         ) : null}
-        {props.project ? (
+        {summary.available !== undefined ? (
           <>
             <span aria-hidden="true">·</span>
             <span>
-              {props.project.available ? copy.projectAvailable : copy.projectUnavailable}
+              {summary.available ? copy.projectAvailable : copy.projectUnavailable}
             </span>
           </>
         ) : null}
-        {(props.project?.locations.length ?? 0) > 1 ? (
+        {summary.locationCount > 1 ? (
           <>
             <span aria-hidden="true">·</span>
-            <span>{copy.locationCount(props.project!.locations.length)}</span>
+            <span>{copy.locationCount(summary.locationCount)}</span>
           </>
         ) : null}
       </span>
-      {latestActivity ? (
+      {summary.latestActivity ? (
         <span className="maka-sidebar-hover-card-updated">
           {copy.updated}{' '}
-          <RelativeTime ts={latestActivity} />
+          <RelativeTime ts={summary.latestActivity} />
           <span className="maka-visually-hidden">
-            {formatAbsoluteTimestamp(latestActivity, props.locale)}
+            {formatAbsoluteTimestamp(summary.latestActivity, props.locale)}
           </span>
         </span>
       ) : null}
     </span>
   );
+}
+
+interface ProjectHoverCardSummary {
+  path?: string;
+  taskCount: number;
+  runningCount: number;
+  available?: boolean;
+  locationCount: number;
+  latestActivity?: number;
+}
+
+function createProjectHoverCardSummary(
+  project: ProjectRecord | undefined,
+  sessions: readonly SessionSummary[],
+  streamingSessionIds: ReadonlySet<string> | undefined,
+): ProjectHoverCardSummary {
+  return {
+    path: preferredProjectPath(project),
+    taskCount: sessions.length,
+    runningCount: sessions.filter(
+      (session) =>
+        resolveSessionRunningState(
+          session,
+          streamingSessionIds?.has(session.id) ?? false,
+        ).running,
+    ).length,
+    available: project?.available,
+    locationCount: project?.locations.length ?? 0,
+    latestActivity: sessions.reduce<number | undefined>(
+      (latest, session) => Math.max(latest ?? 0, session.lastMessageAt ?? 0) || undefined,
+      undefined,
+    ),
+  };
 }
 
 function preferredProjectPath(project: ProjectRecord | undefined): string | undefined {
@@ -1049,17 +1079,13 @@ function sessionRowSignals(
 ): SessionRowSignal[] {
   const copy = getConversationCopy(locale).sessions;
   const signals: SessionRowSignal[] = [];
-  const requiresUserAttention =
-    session.status === 'waiting_for_user' || session.status === 'blocked';
+  const runningState = resolveSessionRunningState(session, options.streaming);
 
   // `active`, through the same vocabulary as everything else here: streaming is
   // the system working on it right now, which is what that semantic names.
   // Writing `accent` directly would resolve to the identical colour and reopen
   // the drift this change closed — half the row's dots deciding for themselves.
-  if (
-    !requiresUserAttention &&
-    (options.streaming || (session.runningTurnIds?.length ?? 0) > 0)
-  ) {
+  if (runningState.responding) {
     signals.push({
       variant: dotForStatus('active'),
       label: copy.respondingAriaLabel,
@@ -1069,9 +1095,7 @@ function sessionRowSignals(
   }
 
   const { label, variant } = presentSessionStatus(session.status, locale);
-  const liveStateOwnsRunningStatus =
-    session.status === 'running' && session.runningTurnIds !== undefined;
-  if (variant && !liveStateOwnsRunningStatus) {
+  if (variant && !runningState.liveStateOwnsRunningStatus) {
     const blockedDetail =
       session.status === 'blocked' && session.blockedReason
         ? describeBlockedReason(session.blockedReason, locale)
@@ -1109,6 +1133,41 @@ function sessionRowSignals(
   }
 
   return signals;
+}
+
+interface SessionRunningState {
+  responding: boolean;
+  running: boolean;
+  liveStateOwnsRunningStatus: boolean;
+}
+
+/**
+ * One live-state authority for both task rows and their project summary.
+ *
+ * Renderer-local streaming covers the send-to-catalog synchronization window;
+ * Runtime Host turn ids cover other windows and bot channels. A persisted
+ * `running` status remains the fallback only while Host live state is unknown.
+ */
+function resolveSessionRunningState(
+  session: SessionSummary,
+  rendererStreaming: boolean,
+): SessionRunningState {
+  const requiresUserAttention =
+    session.status === 'waiting_for_user' || session.status === 'blocked';
+  const liveStateOwnsRunningStatus =
+    session.status === 'running' && session.runningTurnIds !== undefined;
+  const responding =
+    !requiresUserAttention &&
+    (rendererStreaming || (session.runningTurnIds?.length ?? 0) > 0);
+  return {
+    responding,
+    running:
+      responding ||
+      (!requiresUserAttention &&
+        session.status === 'running' &&
+        !liveStateOwnsRunningStatus),
+    liveStateOwnsRunningStatus,
+  };
 }
 
 interface SessionGroup {

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -388,9 +388,13 @@ function ProjectNavRow(props: {
           <VStack gap={0.5}>{props.sessions.map((session) => props.renderSession(session))}</VStack>
         ) : undefined}
       </SideNavItem>
+      <ProjectHoverCardDescription
+        id={hoverDescriptionId}
+        project={props.project}
+        sessions={props.sessions}
+      />
       <ProjectHoverCardLayer
         containerRef={containerRef}
-        descriptionId={hoverDescriptionId}
         label={props.label}
         project={props.project}
         sessions={props.sessions}
@@ -401,7 +405,6 @@ function ProjectNavRow(props: {
 
 const ProjectHoverCardLayer = memo(function ProjectHoverCardLayer(props: {
   containerRef: RefObject<HTMLElement | null>;
-  descriptionId: string;
   label: string;
   project?: ProjectRecord;
   sessions: SessionSummary[];
@@ -420,7 +423,6 @@ const ProjectHoverCardLayer = memo(function ProjectHoverCardLayer(props: {
 
   return hoverCard.renderHoverCard(
     <ProjectHoverCardContent
-      descriptionId={props.descriptionId}
       label={props.label}
       project={props.project}
       sessions={props.sessions}
@@ -547,9 +549,14 @@ const SessionNavRow = memo(function SessionNavRow(props: {
           </span>
         }
       />
+      <SessionHoverCardDescription
+        id={hoverDescriptionId}
+        session={props.session}
+        status={previewStatus}
+        locale={locale}
+      />
       <SessionHoverCardLayer
         containerRef={containerRef}
-        descriptionId={hoverDescriptionId}
         session={props.session}
         status={previewStatus}
         locale={locale}
@@ -567,7 +574,6 @@ const SessionNavRow = memo(function SessionNavRow(props: {
 
 const SessionHoverCardLayer = memo(function SessionHoverCardLayer(props: {
   containerRef: RefObject<HTMLElement | null>;
-  descriptionId: string;
   session: SessionSummary;
   status: string;
   locale: UiLocale;
@@ -585,7 +591,6 @@ const SessionHoverCardLayer = memo(function SessionHoverCardLayer(props: {
 
   return hoverCard.renderHoverCard(
     <SessionHoverCardContent
-      descriptionId={props.descriptionId}
       session={props.session}
       status={props.status}
       locale={props.locale}
@@ -593,8 +598,37 @@ const SessionHoverCardLayer = memo(function SessionHoverCardLayer(props: {
   );
 });
 
+function SessionHoverCardDescription(props: {
+  id: string;
+  session: SessionSummary;
+  status: string;
+  locale: UiLocale;
+}) {
+  const conversationCopy = getConversationCopy(props.locale);
+  const copy = getSessionHoverCardCopy(props.locale);
+  const session = props.session;
+  const permission = conversationCopy.permissions.mode[session.permissionMode].label;
+  const description = [
+    props.status,
+    session.lastMessagePreview || copy.noMessages,
+    session.model,
+    permission,
+    session.cwd,
+    session.lastMessageAt
+      ? `${copy.updated} ${formatAbsoluteTimestamp(session.lastMessageAt, props.locale)}`
+      : undefined,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(' · ');
+
+  return (
+    <span id={props.id} className="maka-visually-hidden">
+      {description}
+    </span>
+  );
+}
+
 function SessionHoverCardContent(props: {
-  descriptionId: string;
   session: SessionSummary;
   status: string;
   locale: UiLocale;
@@ -605,7 +639,7 @@ function SessionHoverCardContent(props: {
   const permission = conversationCopy.permissions.mode[session.permissionMode].label;
 
   return (
-    <span id={props.descriptionId} className="maka-sidebar-hover-card" data-kind="session">
+    <span className="maka-sidebar-hover-card" data-kind="session">
       <span className="maka-sidebar-hover-card-title">{session.name}</span>
       <span
         className="maka-sidebar-hover-card-preview"
@@ -638,8 +672,47 @@ function SessionHoverCardContent(props: {
   );
 }
 
+function ProjectHoverCardDescription(props: {
+  id: string;
+  project?: ProjectRecord;
+  sessions: readonly SessionSummary[];
+}) {
+  const locale = useUiLocale();
+  const copy = getSessionHoverCardCopy(locale);
+  const runningCount = props.sessions.filter(
+    (session) => session.status === 'running' || (session.runningTurnIds?.length ?? 0) > 0,
+  ).length;
+  const latestActivity = props.sessions.reduce<number | undefined>(
+    (latest, session) => Math.max(latest ?? 0, session.lastMessageAt ?? 0) || undefined,
+    undefined,
+  );
+  const description = [
+    preferredProjectPath(props.project),
+    copy.taskCount(props.sessions.length),
+    runningCount > 0 ? copy.runningTaskCount(runningCount) : undefined,
+    props.project
+      ? props.project.available
+        ? copy.projectAvailable
+        : copy.projectUnavailable
+      : undefined,
+    (props.project?.locations.length ?? 0) > 1
+      ? copy.locationCount(props.project!.locations.length)
+      : undefined,
+    latestActivity
+      ? `${copy.updated} ${formatAbsoluteTimestamp(latestActivity, locale)}`
+      : undefined,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(' · ');
+
+  return (
+    <span id={props.id} className="maka-visually-hidden">
+      {description}
+    </span>
+  );
+}
+
 function ProjectHoverCardContent(props: {
-  descriptionId: string;
   label: string;
   project?: ProjectRecord;
   sessions: readonly SessionSummary[];
@@ -656,7 +729,7 @@ function ProjectHoverCardContent(props: {
   );
 
   return (
-    <span id={props.descriptionId} className="maka-sidebar-hover-card" data-kind="project">
+    <span className="maka-sidebar-hover-card" data-kind="project">
       <span className="maka-sidebar-hover-card-title">{props.label}</span>
       {path ? (
         <span className="maka-sidebar-hover-card-path" title={path}>

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -621,11 +621,7 @@ function SessionHoverCardDescription(props: {
     .filter((value): value is string => Boolean(value))
     .join(' · ');
 
-  return (
-    <span id={props.id} className="maka-visually-hidden">
-      {description}
-    </span>
-  );
+  return <span id={props.id} className="maka-visually-hidden" aria-label={description} />;
 }
 
 function SessionHoverCardContent(props: {
@@ -705,11 +701,7 @@ function ProjectHoverCardDescription(props: {
     .filter((value): value is string => Boolean(value))
     .join(' · ');
 
-  return (
-    <span id={props.id} className="maka-visually-hidden">
-      {description}
-    </span>
-  );
+  return <span id={props.id} className="maka-visually-hidden" aria-label={description} />;
 }
 
 function ProjectHoverCardContent(props: {

--- a/packages/ui/src/session-hover-card-copy.ts
+++ b/packages/ui/src/session-hover-card-copy.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { UiLocale } from '@maka/core/ui-locale';
+
+interface SessionHoverCardCopy {
+  sessionDetailsLabel(name: string): string;
+  projectDetailsLabel(name: string): string;
+  noMessages: string;
+  updated: string;
+  taskCount(count: number): string;
+  runningTaskCount(count: number): string;
+  locationCount(count: number): string;
+  projectAvailable: string;
+  projectUnavailable: string;
+}
+
+const COPY: Record<UiLocale, SessionHoverCardCopy> = {
+  zh: {
+    sessionDetailsLabel: (name) => `${name} 任务详情`,
+    projectDetailsLabel: (name) => `${name} 项目详情`,
+    noMessages: '尚无消息',
+    updated: '更新于',
+    taskCount: (count) => `${count} 个任务`,
+    runningTaskCount: (count) => `${count} 个进行中`,
+    locationCount: (count) => `${count} 个位置`,
+    projectAvailable: '目录可用',
+    projectUnavailable: '目录不可用',
+  },
+  en: {
+    sessionDetailsLabel: (name) => `${name} task details`,
+    projectDetailsLabel: (name) => `${name} project details`,
+    noMessages: 'No messages yet',
+    updated: 'Updated',
+    taskCount: (count) => `${count} ${count === 1 ? 'task' : 'tasks'}`,
+    runningTaskCount: (count) => `${count} running`,
+    locationCount: (count) => `${count} ${count === 1 ? 'location' : 'locations'}`,
+    projectAvailable: 'Directory available',
+    projectUnavailable: 'Directory unavailable',
+  },
+};
+
+export function getSessionHoverCardCopy(locale: UiLocale): SessionHoverCardCopy {
+  return COPY[locale];
+}

--- a/packages/ui/src/session-hover-card-copy.ts
+++ b/packages/ui/src/session-hover-card-copy.ts
@@ -22,6 +22,7 @@ import type { UiLocale } from '@maka/core/ui-locale';
 interface SessionHoverCardCopy {
   sessionDetailsLabel(name: string): string;
   projectDetailsLabel(name: string): string;
+  groupDetailsLabel(name: string): string;
   noMessages: string;
   updated: string;
   taskCount(count: number): string;
@@ -35,6 +36,7 @@ const COPY: Record<UiLocale, SessionHoverCardCopy> = {
   zh: {
     sessionDetailsLabel: (name) => `${name} 任务详情`,
     projectDetailsLabel: (name) => `${name} 项目详情`,
+    groupDetailsLabel: (name) => `${name} 分组详情`,
     noMessages: '尚无消息',
     updated: '更新于',
     taskCount: (count) => `${count} 个任务`,
@@ -46,6 +48,7 @@ const COPY: Record<UiLocale, SessionHoverCardCopy> = {
   en: {
     sessionDetailsLabel: (name) => `${name} task details`,
     projectDetailsLabel: (name) => `${name} project details`,
+    groupDetailsLabel: (name) => `${name} group details`,
     noMessages: 'No messages yet',
     updated: 'Updated',
     taskCount: (count) => `${count} ${count === 1 ? 'task' : 'tasks'}`,


### PR DESCRIPTION
## Summary
- add delayed hover and keyboard-focus detail cards to project and task rows
- show task preview, status, model, permission, workspace path, and update time
- show project path, task count, running count, availability, locations, and recent activity
- keep cards localized in Chinese and English and reuse the Astryx top-layer HoverCard primitive

## Testing
- npm --workspace @maka/ui run test (278 passed)
- npm --workspace @maka/desktop run typecheck
- npm --workspace @maka/desktop run check:architecture
- npx playwright test --config e2e/playwright.config.ts e2e/sidebar-project-row.spec.ts (3 existing cases passed; the new hover-card case passed on its focused rerun after correcting a fixture-path assertion)