### PR TITLE
refactor(desktop): move Goal controller ownership below AppShell

### DIFF
--- a/apps/desktop/e2e/goal-dialog-budget.spec.ts
+++ b/apps/desktop/e2e/goal-dialog-budget.spec.ts
@@ -82,4 +82,20 @@ test('an unsendable budget blocks Start instead of arming a different one', asyn
       };
     })
     .toEqual({ condition: '所有测试通过', maxIterations: 25, tokenBudget: 5000 });
+
+  // The Host read above proves persistence; this proves the same broadcast now
+  // reaches the provider-owned chat projection without AppShell reading it.
+  const goalContext = page
+    .getByRole('region', { name: '任务上下文' })
+    .filter({ visible: true });
+  await expect(
+    goalContext
+      .getByText(/目标 0 \/ 25 · .* · 0 \/ 5k/)
+      .filter({ visible: true }),
+  ).toBeVisible();
+  await expect(
+    goalContext
+      .getByRole('button', { name: '暂停自主执行目标（已进行 0/25 轮）' })
+      .filter({ visible: true }),
+  ).toBeVisible();
 });

--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -921,7 +921,6 @@
           "useCommandPalette": 1,
           "useComposerAttachments": 1,
           "useEffect": 14,
-          "useGoalController": 1,
           "useKeyboardHelp": 1,
           "useLayoutEffect": 2,
           "useModuleHubController": 1,
@@ -1060,8 +1059,8 @@
           "@maka/ui/icons": 1,
           "react": 1
         },
-        "importSpecifiers": 187,
-        "nonTriviaTokens": 15855
+        "importSpecifiers": 186,
+        "nonTriviaTokens": 15825
       },
       "src/renderer/use-app-shell-composer-quotes.ts": {
         "importDeclarations": 3,

--- a/apps/desktop/scripts/check-renderer-architecture.test.mjs
+++ b/apps/desktop/scripts/check-renderer-architecture.test.mjs
@@ -1054,6 +1054,52 @@ describe('renderer architecture checker fixtures', () => {
     );
   });
 
+  it('rejects a feature controller Hook returning to AppShell after provider migration', async () => {
+    const providerOwnedAppShell = `
+      import { GoalProvider } from './features/goals/index.js';
+      export const AppShell = GoalProvider;
+    `;
+    await withDesktopFixture(
+      {
+        [TRANSITIVE_APP_SHELL_PATH]: providerOwnedAppShell,
+        'src/renderer/features/goals/index.ts': `
+          export const GoalProvider = true;
+          export function useGoalController() { return true; }
+        `,
+      },
+      async (desktopRoot) => {
+        const seedConfig = transitiveAppShellSeedConfig();
+        const providerOwnedConfig = generateArchitectureConfig(desktopRoot, seedConfig);
+
+        await writeFile(
+          join(desktopRoot, TRANSITIVE_APP_SHELL_PATH),
+          `
+            import { GoalProvider, useGoalController } from './features/goals/index.js';
+            export const AppShell = [GoalProvider, useGoalController()];
+          `,
+          'utf8',
+        );
+        const regressedConfig = generateArchitectureConfig(
+          desktopRoot,
+          providerOwnedConfig,
+        );
+        const violations = violationsFor(
+          desktopRoot,
+          regressedConfig,
+          providerOwnedConfig,
+        );
+
+        assertHasViolation(
+          violations,
+          /^src\/renderer\/app-shell\.ts: hookCalls debt increased from 0 to 1$/u,
+        );
+        assertHasViolation(
+          violations,
+          /^src\/renderer\/app-shell\.ts: new or increased hookCalls debt useGoalController$/u,
+        );
+      },
+    );
+  });
   it('rejects bridge and environment capability growth inside a transitive legacy AppShell helper', async () => {
     await withDesktopFixture(
       transitiveAppShellFiles(`

--- a/apps/desktop/src/main/__tests__/goal-provider-scope.test.ts
+++ b/apps/desktop/src/main/__tests__/goal-provider-scope.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { act, createElement, Fragment } from 'react';
+import type { GoalState } from '@maka/core/goal';
+import {
+  LocaleProvider,
+  useChatViewGoalProjection,
+  useComposerGoalProjection,
+} from '@maka/ui';
+import { cleanupFakeDom, installReactRenderer } from './fake-dom.js';
+import {
+  createFakeGoalServices,
+  GoalProvider,
+  GoalServicesProvider,
+  type GoalServices,
+} from '../../renderer/features/goals/testing.js';
+
+type ComposerProbeProps = ReturnType<typeof useComposerGoalProjection>;
+type IndicatorProbeProps = ReturnType<typeof useChatViewGoalProjection>;
+
+let shellRenders = 0;
+let composerRenders = 0;
+let indicatorRenders = 0;
+let latestComposer: ComposerProbeProps | undefined;
+let latestIndicator: IndicatorProbeProps | undefined;
+
+function ComposerProbe() {
+  const props = useComposerGoalProjection();
+  composerRenders += 1;
+  latestComposer = props;
+  return null;
+}
+
+function IndicatorProbe() {
+  const props = useChatViewGoalProjection();
+  indicatorRenders += 1;
+  latestIndicator = props;
+  return null;
+}
+
+function ShellProbe() {
+  shellRenders += 1;
+  return createElement(
+    Fragment,
+    null,
+    createElement(ComposerProbe),
+    createElement(IndicatorProbe),
+  );
+}
+
+function goal(tokensNow: number): GoalState {
+  return {
+    id: 'goal-a',
+    revision: tokensNow,
+    sessionId: 'a',
+    condition: 'Finish a',
+    status: 'active',
+    setAt: 100,
+    iterations: 2,
+    maxIterations: 9,
+    consecutiveNoProgress: 0,
+    blockCap: 3,
+    tokenBudget: 500,
+    tokensAtStart: 10,
+    tokensNow,
+    tokensBaselinePending: false,
+  };
+}
+
+function renderProvider(
+  root: ReturnType<typeof installReactRenderer>['root'],
+  services: GoalServices,
+  reportError: (sessionId: string, title: string, description?: string) => void,
+  enabled = true,
+) {
+  root.render(
+    createElement(LocaleProvider, {
+      locale: 'en',
+      children: createElement(
+        GoalServicesProvider,
+        { services },
+        createElement(
+          GoalProvider,
+          { activeSessionId: 'a', canOpenDialog: enabled, reportError },
+          createElement(ShellProbe),
+        ),
+      ),
+    }),
+  );
+}
+
+afterEach(() => {
+  shellRenders = 0;
+  composerRenders = 0;
+  indicatorRenders = 0;
+  latestComposer = undefined;
+  latestIndicator = undefined;
+  cleanupFakeDom();
+});
+
+describe('GoalProvider render scope', () => {
+  it('updates only the projection whose reader changed', async () => {
+    const { root } = installReactRenderer();
+    let current = goal(60);
+    let emit: ((sessionId: string | undefined) => void) | undefined;
+    const defaults = createFakeGoalServices();
+    const services = createFakeGoalServices({
+      goal: {
+        ...defaults.goal,
+        get: async () => current,
+        subscribeChanges: (handler) => {
+          emit = handler;
+          return () => undefined;
+        },
+      },
+    });
+
+    await act(async () => renderProvider(root, services, () => undefined));
+    assert.equal(latestComposer?.goalActive, true);
+    assert.equal(latestIndicator?.goalIndicator?.tokensSpent, 60);
+    assert.equal(shellRenders, 1);
+
+    const composerBeforeRefresh = composerRenders;
+    const indicatorBeforeRefresh = indicatorRenders;
+    current = goal(75);
+    await act(async () => emit?.('a'));
+
+    assert.equal(shellRenders, 1);
+    assert.equal(composerRenders, composerBeforeRefresh);
+    assert.equal(indicatorRenders, indicatorBeforeRefresh + 1);
+    assert.equal(latestIndicator?.goalIndicator?.tokensSpent, 75);
+
+    const composerBeforeDialog = composerRenders;
+    const indicatorBeforeDialog = indicatorRenders;
+    await act(async () => latestComposer?.onSetGoal?.());
+    assert.equal(shellRenders, 1);
+    assert.equal(composerRenders, composerBeforeDialog);
+    assert.equal(indicatorRenders, indicatorBeforeDialog);
+
+    await act(async () => root.unmount());
+  });
+
+  it('withholds the command when disabled and reports failures to the latest owner', async () => {
+    const { root } = installReactRenderer();
+    const firstErrors: string[] = [];
+    const latestErrors: string[] = [];
+    const defaults = createFakeGoalServices();
+    const services = createFakeGoalServices({
+      goal: {
+        ...defaults.goal,
+        get: async () => goal(60),
+        pause: async () => {
+          throw new Error('offline');
+        },
+      },
+    });
+
+    await act(async () =>
+      renderProvider(
+        root,
+        services,
+        (_sessionId, _title, description) => firstErrors.push(description ?? ''),
+        false,
+      ),
+    );
+    assert.equal(latestComposer?.goalActive, true);
+    assert.equal(latestComposer?.onSetGoal, undefined);
+
+    await act(async () =>
+      renderProvider(
+        root,
+        services,
+        (_sessionId, _title, description) => latestErrors.push(description ?? ''),
+      ),
+    );
+    assert.equal(typeof latestComposer?.onSetGoal, 'function');
+    await act(async () => {
+      latestIndicator?.goalIndicator?.onPause?.();
+      await Promise.resolve();
+    });
+
+    assert.deepEqual(firstErrors, []);
+    assert.equal(latestErrors.length, 1);
+    assert.match(latestErrors[0] ?? '', /still be continuing/);
+
+    await act(async () => root.unmount());
+  });
+
+  it('defaults standalone UI readers to an inactive Goal projection', async () => {
+    const { root } = installReactRenderer();
+    await act(async () => root.render(createElement(ShellProbe)));
+    assert.equal(latestComposer?.goalActive, false);
+    assert.equal(latestComposer?.onSetGoal, undefined);
+    assert.equal(latestIndicator?.goalIndicator, undefined);
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/desktop/src/main/__tests__/goals-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/goals-boundary.test.ts
@@ -24,6 +24,7 @@ import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const desktopRoot = resolve(fileURLToPath(new URL('../../../', import.meta.url)));
+const repoRoot = resolve(desktopRoot, '..', '..');
 const featureRoot = join(desktopRoot, 'src', 'renderer', 'features', 'goals');
 
 function sourceFiles(root: string): string[] {
@@ -56,7 +57,8 @@ describe('Goals feature boundary', () => {
   });
 
   it('is consumed outside the feature only through public entries', () => {
-    const allowed = /\/features\/goals\/(?:index|testing)(?:\.js)?$/;
+    const productionEntry = /\/features\/goals\/index(?:\.js)?$/;
+    const testingEntry = /\/features\/goals\/testing(?:\.js)?$/;
     const violations: string[] = [];
     for (const root of [join(desktopRoot, 'src'), join(desktopRoot, 'stories')]) {
       for (const path of sourceFiles(root)) {
@@ -68,7 +70,13 @@ describe('Goals feature boundary', () => {
           const explicitEntry = normalized.endsWith('/features/goals')
             ? `${normalized}/index`
             : normalized;
-          if (!allowed.test(explicitEntry)) {
+          const consumer = relative(desktopRoot, path).replace(/\\/g, '/');
+          const testConsumer =
+            consumer.includes('/__tests__/') || consumer.startsWith('stories/');
+          if (
+            !productionEntry.test(explicitEntry) &&
+            !(testConsumer && testingEntry.test(explicitEntry))
+          ) {
             violations.push(`${relative(desktopRoot, path)}: ${imported}`);
           }
         }
@@ -81,9 +89,144 @@ describe('Goals feature boundary', () => {
     const productionEntry = readFileSync(join(featureRoot, 'index.ts'), 'utf8');
     assert.equal(productionEntry.includes('createFakeGoalServices'), false);
     assert.equal(productionEntry.includes("from './testing"), false);
+    assert.equal(productionEntry.includes('useGoalController'), false);
   });
 
-  it('keeps Goal state, controls, and dialog ownership out of AppShell', () => {
+  it('keeps the controller owned by GoalProvider and out of renderer roots', () => {
+    const controllerOwner = join(featureRoot, 'ui', 'goal-provider.tsx');
+    const consumers: string[] = [];
+    for (const path of sourceFiles(join(desktopRoot, 'src', 'renderer'))) {
+      if (!/\.tsx?$/.test(path) || path.endsWith('use-goal-controller.ts')) continue;
+      const source = readFileSync(path, 'utf8');
+      if (/\buseGoalController\s*\(/.test(source)) {
+        consumers.push(relative(desktopRoot, path));
+      }
+    }
+    assert.deepEqual(consumers, [relative(desktopRoot, controllerOwner)]);
+  });
+
+  it('keeps the controller module behind GoalProvider and the testing entry', () => {
+    const importers: string[] = [];
+    for (const path of sourceFiles(featureRoot)) {
+      if (!/\.tsx?$/.test(path)) continue;
+      const source = readFileSync(path, 'utf8');
+      for (const match of source.matchAll(/from\s+['"]([^'"]+)['"]/g)) {
+        if (match[1]?.includes('controller/use-goal-controller')) {
+          importers.push(relative(desktopRoot, path));
+        }
+      }
+    }
+    assert.deepEqual(importers.sort(), [
+      'src/renderer/features/goals/testing.ts',
+      'src/renderer/features/goals/ui/goal-provider.tsx',
+    ]);
+  });
+
+  it('binds separate projection contexts at the authoritative UI readers', () => {
+    const provider = readFileSync(
+      join(featureRoot, 'ui', 'goal-provider.tsx'),
+      'utf8',
+    );
+    for (const required of [
+      'ChatViewGoalProjectionProvider,',
+      'ComposerGoalProjectionProvider,',
+      '<ComposerGoalProjectionProvider value={composer}>',
+      '<ChatViewGoalProjectionProvider value={indicator}>',
+    ]) {
+      assert.equal(provider.includes(required), true, required);
+    }
+    assert.equal(provider.includes('cloneElement'), false);
+
+    const composer = readFileSync(
+      join(desktopRoot, 'src', 'renderer', 'chat-composer-region.tsx'),
+      'utf8',
+    );
+    const messageSurface = readFileSync(
+      join(desktopRoot, 'src', 'renderer', 'chat-message-surface.tsx'),
+      'utf8',
+    );
+    const uiComposer = readFileSync(
+      join(repoRoot, 'packages', 'ui', 'src', 'composer.tsx'),
+      'utf8',
+    );
+    const uiChatView = readFileSync(
+      join(repoRoot, 'packages', 'ui', 'src', 'chat-view.tsx'),
+      'utf8',
+    );
+    const uiGoalProjection = readFileSync(
+      join(repoRoot, 'packages', 'ui', 'src', 'goal-projection-context.ts'),
+      'utf8',
+    );
+    for (const [source, required] of [
+      [composer, 'ComposerGoalProjectionConsumer,'],
+      [composer, '<ComposerGoalProjectionConsumer>'],
+      [composer, 'goalActive={goalProjection.goalActive}'],
+      [composer, 'onSetGoal={goalProjection.onSetGoal}'],
+      [messageSurface, 'ChatViewGoalProjectionConsumer,'],
+      [messageSurface, '<ChatViewGoalProjectionConsumer>'],
+      [messageSurface, 'goalIndicator={goalProjection.goalIndicator}'],
+      [uiComposer, 'export interface ComposerGoalProps {'],
+      [uiComposer, '} & ComposerGoalProps'],
+      [uiChatView, 'export interface ChatViewGoalIndicatorProps {'],
+      [uiChatView, '} & ChatViewGoalIndicatorProps)'],
+      [uiGoalProjection, 'export interface ComposerGoalProjection {'],
+      [uiGoalProjection, "ComposerGoalProps['goalActive']"],
+      [uiGoalProjection, "ComposerGoalProps['onSetGoal']"],
+      [uiGoalProjection, 'export interface ChatViewGoalProjection {'],
+      [uiGoalProjection, "ChatViewGoalIndicatorProps['goalIndicator']"],
+      [uiGoalProjection, 'export const ComposerGoalProjectionConsumer ='],
+      [uiGoalProjection, 'export const ChatViewGoalProjectionConsumer ='],
+    ] as const) {
+      assert.equal(source.includes(required), true, required);
+    }
+    assert.equal(composer.includes("from './features/goals"), false);
+    assert.equal(messageSurface.includes("from './features/goals"), false);
+    assert.equal(composer.includes('useComposerGoalProjection'), false);
+    assert.equal(messageSurface.includes('useChatViewGoalProjection'), false);
+    assert.equal(uiComposer.includes('goal-projection-context'), false);
+    assert.equal(uiChatView.includes('goal-projection-context'), false);
+  });
+
+  it('keeps Goal projection consumers exclusive to the authorized renderer leaves', () => {
+    const rendererRoot = join(desktopRoot, 'src', 'renderer');
+    const productionSources = sourceFiles(rendererRoot).filter((path) => {
+      const name = relative(desktopRoot, path).replace(/\\/g, '/');
+      return /\.tsx?$/.test(path) && !name.includes('/__tests__/');
+    });
+    const importersOf = (name: string) =>
+      productionSources
+        .filter((path) => readFileSync(path, 'utf8').includes(name))
+        .map((path) => relative(desktopRoot, path).replace(/\\/g, '/'))
+        .sort();
+
+    assert.deepEqual(importersOf('ComposerGoalProjectionConsumer'), [
+      'src/renderer/chat-composer-region.tsx',
+    ]);
+    assert.deepEqual(importersOf('ChatViewGoalProjectionConsumer'), [
+      'src/renderer/chat-message-surface.tsx',
+    ]);
+    assert.deepEqual(importersOf('useComposerGoalProjection'), []);
+    assert.deepEqual(importersOf('useChatViewGoalProjection'), []);
+
+    const composer = readFileSync(
+      join(rendererRoot, 'chat-composer-region.tsx'),
+      'utf8',
+    );
+    const messageSurface = readFileSync(
+      join(rendererRoot, 'chat-message-surface.tsx'),
+      'utf8',
+    );
+    for (const omitted of ["| 'goalActive'", "| 'onSetGoal'"]) {
+      assert.equal(composer.includes(omitted), true, omitted);
+    }
+    assert.equal(
+      messageSurface.includes("| 'goalIndicator'"),
+      true,
+      'goalIndicator',
+    );
+  });
+
+  it('keeps Goal state, controls, and dialog reads below AppShell', () => {
     const appShell = readFileSync(
       join(desktopRoot, 'src', 'renderer', 'app-shell.tsx'),
       'utf8',
@@ -94,10 +237,28 @@ describe('Goals feature boundary', () => {
       'pendingGoalControlSessionIdsRef',
       'goalDialogSessionId',
       'setGoalDialogSessionId',
+      'useGoalController',
+      'goals.commands',
+      'goals.selectors',
+      'goals.host',
+      '<GoalHost model=',
+      'onSetGoal=',
+      'goalActive=',
+      'goalIndicator=',
+      '<Goals.GoalComposerBoundary',
+      '<Goals.GoalIndicatorBoundary',
+      'ComposerGoalProjectionConsumer',
+      'ChatViewGoalProjectionConsumer',
+      'useComposerGoalProjection',
+      'useChatViewGoalProjection',
     ]) {
       assert.equal(appShell.includes(forbidden), false, forbidden);
     }
-    assert.equal(appShell.includes('const goals = useGoalController({'), true);
-    assert.equal(appShell.includes('<GoalHost model={goals.host} />'), true);
+    for (const required of [
+      '<Goals.GoalProvider',
+      '<Goals.GoalHost />',
+    ]) {
+      assert.equal(appShell.includes(required), true, required);
+    }
   });
 });

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -91,7 +91,7 @@ import {
   WorkbarTitlebarActions,
   useWorkbarController,
 } from './features/workbar';
-import { GoalHost, useGoalController } from './features/goals';
+import * as Goals from './features/goals';
 import { ModuleHubHost, useModuleHubController } from './features/module-hub';
 import {
   SessionNavigationProvider,
@@ -813,10 +813,6 @@ function AppShellContent({
     resumeInterruptedSession,
   } = useShellResume({ activeId: ownerActiveId, toastApi, shellCopy, uiLocale });
   const rendererMountedRef = useRef(true);
-  const goals = useGoalController({
-    activeSessionId: ownerActiveId,
-    reportError: showSessionError,
-  });
   // Set of session ids whose backend / connection is no longer usable —
   // drives the sidebar "已过期" pill (PR108g, paired with the PR108e chat
   // header banner). Derivation is pure (see `stale-sessions.ts`) so the
@@ -2728,9 +2724,13 @@ function AppShellContent({
         : 'im_hub';
 
   return (
-    // Wraps the whole frame rather than each composer, so one projection serves
-    // the main composer and every side-chat panel. Left un-indented on purpose:
-    // re-indenting 500 lines of JSX would bury the change that matters.
+    // Goal state lives below the shell and wakes only its three readers. Composer
+    // mentions still wrap the frame so one projection serves every composer.
+    <Goals.GoalProvider
+      activeSessionId={ownerActiveId}
+      canOpenDialog={activeBoundarySurface.localInteractionAvailable}
+      reportError={showSessionError}
+    >
     <ComposerMentionsProvider {...composerMentionsSurface}>
     <div
       className="appFrame agents-layout-root"
@@ -3098,12 +3098,6 @@ function AppShellContent({
                   onOrchestrationModeChange={(mode) => {
                     void setOrchestrationMode(mode);
                   }}
-                  onSetGoal={
-                    activeId && activeBoundarySurface.localInteractionAvailable
-                      ? goals.commands.openDialog
-                      : undefined
-                  }
-                  goalActive={goals.selectors.active}
                   goalDisabledReason={
                     activeStreamingLive || (activeId && turnActive)
                       ? shellCopy.goalTurnActive
@@ -3143,7 +3137,6 @@ function AppShellContent({
                 userLabel={userLabel}
                 memoryActive={memoryActive}
                 onOpenMemorySettings={sharedSessionActive ? undefined : () => openSettingsSection('memory')}
-                goalIndicator={goals.selectors.indicator}
                 messageLoadError={activeId ? messageLoadErrorBySession[activeId] : undefined}
                 messageLoadRetryPending={activeId ? messageRetryPendingBySession[activeId] === true : false}
                 onRetryMessages={activeId ? () => void retryMessages(activeId) : undefined}
@@ -3277,7 +3270,7 @@ function AppShellContent({
           contextKey={activeId}
         />
       )}
-      <GoalHost model={goals.host} />
+      <Goals.GoalHost />
       <TaskEntryHost model={taskEntry.host} />
       <RuntimeHostSshTerminalDialog />
       {sharedSessionDialog.target ? (
@@ -3345,5 +3338,6 @@ function AppShellContent({
       />
     </div>
     </ComposerMentionsProvider>
+    </Goals.GoalProvider>
   );
 }

--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -23,10 +23,11 @@ import {
   Button,
   ClientCapabilityPrompt,
   Composer,
+  ComposerGoalProjectionConsumer,
   SandboxBoundaryPrompt,
   UserQuestionPrompt,
 } from '@maka/ui';
-import type { ComposerHandle, ComposerInteraction } from '@maka/ui';
+import type { ComposerHandle } from '@maka/ui';
 import { useComposerMentionsContext } from './composer-mentions.js';
 import {
   readNewTaskReloadDraft,
@@ -60,6 +61,11 @@ interface BoundaryUnreadableNotice {
   onRetry(): void;
 }
 
+type ComposerInteraction =
+  | ComponentProps<typeof SandboxBoundaryPrompt>['request']
+  | ComponentProps<typeof ClientCapabilityPrompt>['request']
+  | ComponentProps<typeof UserQuestionPrompt>['request'];
+
 /**
  * The composer region of the chat surface (issue #1043): the composer
  * interaction slot (permission / user-question prompts) plus the always-mounted
@@ -81,6 +87,8 @@ interface ChatComposerRegionProps
     | 'hidden'
     | 'draftKey'
     | 'stopPending'
+    | 'goalActive'
+    | 'onSetGoal'
     | 'allowAttachmentImportWhileStreaming'
     // Read from ComposerMentionsProvider, so a catalog reload repaints the
     // popups without re-rendering the shell that would otherwise pass them.
@@ -241,26 +249,32 @@ export function ChatComposerRegion({
           />
         )}
       </div>
-      <Composer
-        ref={composerRef}
-        {...composerRest}
-        // AppShell carries staged attachments into both queued and steering
-        // follow-ups. Other Composer hosts remain gated by default because a
-        // text-only running-turn submission would leave attachments behind.
-        allowAttachmentImportWhileStreaming
-        mentionSkills={mentions?.mentionSkills}
-        mentionSkillsUnavailable={mentions?.mentionSkillsUnavailable}
-        mentionSkillsLoading={mentions?.mentionSkillsLoading}
-        onSearchMentionFiles={mentions?.searchMentionFiles}
-        {...directoryComposerProps}
-        onPickDirectory={
-          directoryPickerEnabled ? directoryComposerProps.onPickDirectory : undefined
-        }
-        hidden={!active || onboardingComposerHidden || Boolean(activeInteraction)}
-        draftKey={activeId ?? newTaskDraftKey}
-        draftPersistence={newTaskDraftPersistence}
-        stopPending={activeId ? stopPendingBySession[activeId] === true : false}
-      />
+      <ComposerGoalProjectionConsumer>
+        {(goalProjection) => (
+          <Composer
+            ref={composerRef}
+            {...composerRest}
+            // AppShell carries staged attachments into both queued and steering
+            // follow-ups. Other Composer hosts remain gated by default because a
+            // text-only running-turn submission would leave attachments behind.
+            allowAttachmentImportWhileStreaming
+            mentionSkills={mentions?.mentionSkills}
+            mentionSkillsUnavailable={mentions?.mentionSkillsUnavailable}
+            mentionSkillsLoading={mentions?.mentionSkillsLoading}
+            onSearchMentionFiles={mentions?.searchMentionFiles}
+            {...directoryComposerProps}
+            onPickDirectory={
+              directoryPickerEnabled ? directoryComposerProps.onPickDirectory : undefined
+            }
+            hidden={!active || onboardingComposerHidden || Boolean(activeInteraction)}
+            draftKey={activeId ?? newTaskDraftKey}
+            draftPersistence={newTaskDraftPersistence}
+            stopPending={activeId ? stopPendingBySession[activeId] === true : false}
+            goalActive={goalProjection.goalActive}
+            onSetGoal={goalProjection.onSetGoal}
+          />
+        )}
+      </ComposerGoalProjectionConsumer>
     </>
   );
 }

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -25,8 +25,8 @@ import { type SettingsSection } from '@maka/core/settings';
 import { Skeleton } from '@astryxdesign/core';
 import {
   ChatView,
+  ChatViewGoalProjectionConsumer,
   useUiLocale,
-  type LiveContentActivationSnapshot,
   type LiveTurnProjection,
 } from '@maka/ui';
 import { OnboardingHero } from './onboarding-hero';
@@ -61,6 +61,7 @@ interface ChatMessageSurfaceProps extends Omit<
   | 'initialLiveContentSnapshot'
   | 'liveTurn'
   | 'shellRunUpdates'
+  | 'goalIndicator'
 > {
   /**
    * #1985: the live projection and the shell-run records are the only session
@@ -95,9 +96,7 @@ interface ChatMessageSurfaceProps extends Omit<
   onReturnToLatestHistory: () => Promise<void> | void;
 }
 
-function captureLiveContent(
-  liveTurn: LiveTurnProjection | undefined,
-): LiveContentActivationSnapshot | undefined {
+function captureLiveContent(liveTurn: LiveTurnProjection | undefined) {
   if (!liveTurn) return undefined;
   return {
     turnId: liveTurn.turnId,
@@ -235,25 +234,30 @@ export function ChatMessageSurface({
 
   return (
     <>
-      <ChatView
-        {...chatViewRest}
-        liveTurn={seededLiveTurn}
-        // Every branch above reseeds `sessionId` to `activeSessionId`, and a
-        // render-phase setState re-runs this body before anything commits, so
-        // the activation reaching the DOM is always this session's.
-        initialLiveContentSnapshot={activation.initialLiveContent}
-        shellRunUpdates={shellRunUpdates}
-        deepResearchRun={deepResearchRun}
-        emptyOverride={emptyOverride}
-        hasOlderHistory={hasOlderHistory}
-        onLoadEarlierHistory={onLoadEarlierHistory}
-        returnToLatest={hasNewerHistory ? {
-          title: transcriptCopy.partialHistoryTitle,
-          label: transcriptCopy.returnLatest,
-          isPending: historyLoadPending,
-          onClick: onReturnToLatestHistory,
-        } : undefined}
-      />
+      <ChatViewGoalProjectionConsumer>
+        {(goalProjection) => (
+          <ChatView
+            {...chatViewRest}
+            liveTurn={seededLiveTurn}
+            // Every branch above reseeds `sessionId` to `activeSessionId`, and a
+            // render-phase setState re-runs this body before anything commits, so
+            // the activation reaching the DOM is always this session's.
+            initialLiveContentSnapshot={activation.initialLiveContent}
+            shellRunUpdates={shellRunUpdates}
+            deepResearchRun={deepResearchRun}
+            emptyOverride={emptyOverride}
+            goalIndicator={goalProjection.goalIndicator}
+            hasOlderHistory={hasOlderHistory}
+            onLoadEarlierHistory={onLoadEarlierHistory}
+            returnToLatest={hasNewerHistory ? {
+              title: transcriptCopy.partialHistoryTitle,
+              label: transcriptCopy.returnLatest,
+              isPending: historyLoadPending,
+              onClick: onReturnToLatestHistory,
+            } : undefined}
+          />
+        )}
+      </ChatViewGoalProjectionConsumer>
       {taskReadinessNotice && (
         <ChatRecoveryNotice
           status={taskReadinessNotice.tone === 'destructive' ? 'error' : 'warning'}

--- a/apps/desktop/src/renderer/features/goals/README.md
+++ b/apps/desktop/src/renderer/features/goals/README.md
@@ -28,11 +28,16 @@ the Goal indicator projection consumed by the chat surface.
 - Consumers import production APIs from `features/goals`.
 - Tests and stories may additionally import `features/goals/testing`.
 - Goals may use shared renderer copy, core types, and Maka UI.
+- Projection transport contexts live with the authoritative Maka UI prop
+  contracts. GoalProvider writes them; the two authorized Desktop leaves read
+  and hand them to the real UI prop sites without owning or accepting those
+  values from AppShell. The feature must not import the leaves back into the slice.
 - Goals must not import `AppShell`, the preload implementation, or the main process.
 - Desktop I/O enters through `GoalServices`; feature code never reads the
   Desktop global bridge directly.
-- `AppShell` supplies the active Session id and a session-scoped error reporter.
-  It consumes only `<GoalHost>`, commands, and selectors.
+- `AppShell` supplies the active Session id, whether the current interaction may
+  open the dialog, and a session-scoped error-reporting intent. It does not read
+  the controller, its model, or a Goal context.
 
 ## Lifecycle invariants
 
@@ -52,12 +57,29 @@ the Goal indicator projection consumed by the chat surface.
 - Form input and errors reset on each open. Budgets are validated against core
   bounds and are never silently clamped.
 
-## Public surface
+## Public surface and render ownership
 
-- `host` is passed intact to `<GoalHost model={goals.host} />`.
-- `commands.openDialog` is the shell entry for the composer action.
-- `selectors.active` disables duplicate Goal creation and
-  `selectors.indicator` feeds the active chat surface.
+- `<GoalProvider>` is the only production caller of `useGoalController`. The
+  controller hook is intentionally absent from the production barrel.
+- `ChatComposerRegion` consumes only `openDialog` and `active`, then binds them
+  at the authoritative `Composer` props.
+- `ChatMessageSurface` consumes only the Goal indicator, then binds it at the
+  authoritative `ChatView` prop.
+- `<GoalHost>` reads the dialog model directly from the provider.
+
+The three projections use separate contexts. Iteration/token updates therefore
+do not repaint the Composer, and dialog state does not repaint either chat
+surface. A non-reader child under `GoalProvider` retains the element built by
+its parent and does not re-render for Goal-only updates. The transport keeps
+AppShell out of the values and gives TypeScript a checked prop handoff at each
+actual UI reader instead of relying on a structurally loose cloned element.
+Other Composer and ChatView instances under AppShell do not consume these
+contexts, so WorkHub and Workbar cannot inherit the main Session's Goal.
+
+Production code must not export or invoke `useGoalController` outside
+`GoalProvider`, pass a controller model back through `AppShell`, or replace the
+narrow contexts with one catch-all controller context. The AppShell hook gate,
+renderer debt ledger, and Goals boundary tests lock those constraints.
 
 The Desktop adapter is created once in the renderer composition root. Tests
 use `createFakeGoalServices` from `testing.ts`; production code must not import

--- a/apps/desktop/src/renderer/features/goals/index.ts
+++ b/apps/desktop/src/renderer/features/goals/index.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-export { GoalHost } from './ui/goal-host';
-export { GoalServicesProvider } from './services-context';
-export { useGoalController } from './controller/use-goal-controller';
-export type { GoalServices } from './ports';
+export { GoalHost } from './ui/goal-host.js';
+export { GoalProvider } from './ui/goal-provider.js';
+export { GoalServicesProvider } from './services-context.js';
+export type { GoalServices } from './ports.js';

--- a/apps/desktop/src/renderer/features/goals/testing.ts
+++ b/apps/desktop/src/renderer/features/goals/testing.ts
@@ -21,6 +21,7 @@ import type { GoalServices } from './ports.js';
 
 export { GoalServicesProvider } from './services-context.js';
 export { GoalDialog } from './ui/goal-dialog.js';
+export { GoalProvider } from './ui/goal-provider.js';
 export { readGoalBudget } from './model/goal-budget.js';
 export { isLiveGoal } from './model/live-goal.js';
 export { interpretGoalArmOutcome } from './model/goal-arm-outcome.js';

--- a/apps/desktop/src/renderer/features/goals/ui/goal-host.tsx
+++ b/apps/desktop/src/renderer/features/goals/ui/goal-host.tsx
@@ -19,6 +19,7 @@
 
 import type { GoalArmInput, GoalArmOutcome } from '../ports.js';
 import { GoalDialog } from './goal-dialog.js';
+import { useGoalHostModel } from './goal-provider.js';
 
 export interface GoalHostModel {
   dialogSessionId?: string;
@@ -26,7 +27,12 @@ export interface GoalHostModel {
   closeDialog(): void;
 }
 
-export function GoalHost({ model }: { model: GoalHostModel }) {
+export function GoalHost() {
+  return <GoalHostView model={useGoalHostModel()} />;
+}
+
+/** Environment-free view seam for focused tests and Storybook. */
+export function GoalHostView({ model }: { model: GoalHostModel }) {
   return (
     <GoalDialog
       {...(model.dialogSessionId

--- a/apps/desktop/src/renderer/features/goals/ui/goal-provider.tsx
+++ b/apps/desktop/src/renderer/features/goals/ui/goal-provider.tsx
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from 'react';
+import {
+  ChatViewGoalProjectionProvider,
+  ComposerGoalProjectionProvider,
+  type ChatViewGoalProjection,
+  type ComposerGoalProjection,
+} from '@maka/ui';
+import {
+  useGoalController,
+  type UseGoalControllerInput,
+} from '../controller/use-goal-controller.js';
+import type { GoalHostModel } from './goal-host.js';
+
+const GoalHostContext = createContext<GoalHostModel | null>(null);
+
+export interface GoalProviderProps extends UseGoalControllerInput {
+  readonly canOpenDialog: boolean;
+  readonly children?: ReactNode;
+}
+
+/**
+ * Owns the Goal controller below AppShell and publishes only reader-local data.
+ *
+ * Controller updates re-render this provider and the matching narrow UI
+ * context reader. `children` is the element AppShell already built, so React
+ * can retain the unrelated frame instead of widening Goal state back to the
+ * renderer root.
+ */
+export function GoalProvider({
+  activeSessionId,
+  canOpenDialog,
+  reportError: reportErrorInput,
+  children,
+}: GoalProviderProps) {
+  const reportErrorRef = useRef(reportErrorInput);
+  useLayoutEffect(() => {
+    reportErrorRef.current = reportErrorInput;
+  }, [reportErrorInput]);
+  const reportError = useCallback<UseGoalControllerInput['reportError']>(
+    (...args) => reportErrorRef.current(...args),
+    [],
+  );
+  const controller = useGoalController({ activeSessionId, reportError });
+
+  const composer = useMemo<ComposerGoalProjection>(
+    () => ({
+      goalActive: controller.selectors.active,
+      onSetGoal:
+        canOpenDialog && activeSessionId
+          ? controller.commands.openDialog
+          : undefined,
+    }),
+    [
+      activeSessionId,
+      canOpenDialog,
+      controller.commands.openDialog,
+      controller.selectors.active,
+    ],
+  );
+  const indicator = useMemo<ChatViewGoalProjection>(
+    () => ({ goalIndicator: controller.selectors.indicator }),
+    [controller.selectors.indicator],
+  );
+  const host = useMemo<GoalHostModel>(
+    () => ({
+      ...(controller.host.dialogSessionId
+        ? { dialogSessionId: controller.host.dialogSessionId }
+        : {}),
+      arm: controller.host.arm,
+      closeDialog: controller.host.closeDialog,
+    }),
+    [
+      controller.host.arm,
+      controller.host.closeDialog,
+      controller.host.dialogSessionId,
+    ],
+  );
+
+  return (
+    <ComposerGoalProjectionProvider value={composer}>
+      <ChatViewGoalProjectionProvider value={indicator}>
+        <GoalHostContext.Provider value={host}>
+          {children}
+        </GoalHostContext.Provider>
+      </ChatViewGoalProjectionProvider>
+    </ComposerGoalProjectionProvider>
+  );
+}
+
+export function useGoalHostModel(): GoalHostModel {
+  const model = useContext(GoalHostContext);
+  if (!model) throw new Error('GoalProvider is missing');
+  return model;
+}

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -6,7 +6,7 @@ Generated against `@astryxdesign/core@0.5.2` (194 component exports).
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 234 files — blocker 0, reimplementation 0, polish 1, aligned 233.
+**Totals:** 235 files — blocker 0, reimplementation 0, polish 1, aligned 234.
 
 ## Exclusions (explicit)
 
@@ -45,6 +45,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/features/goals/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/goals/ui/goal-dialog.tsx` | dialog-overlay | Button, Dialog, DialogHeader, HStack, Layout, LayoutContent, LayoutFooter, Text, TextArea, TextInput, VStack | aligned — uses Astryx (Button, Dialog, DialogHeader, HStack, Layout, LayoutContent, LayoutFooter, Text) | aligned |
 | `apps/desktop/src/renderer/features/goals/ui/goal-host.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
+| `apps/desktop/src/renderer/features/goals/ui/goal-provider.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/module-hub/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/module-hub/ui/module-hub-host.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/runtime-host-management/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |

--- a/docs/astryx-surface-file-inventory.paths
+++ b/docs/astryx-surface-file-inventory.paths
@@ -16,6 +16,7 @@ apps/desktop/src/renderer/error-boundary.tsx
 apps/desktop/src/renderer/features/goals/services-context.tsx
 apps/desktop/src/renderer/features/goals/ui/goal-dialog.tsx
 apps/desktop/src/renderer/features/goals/ui/goal-host.tsx
+apps/desktop/src/renderer/features/goals/ui/goal-provider.tsx
 apps/desktop/src/renderer/features/module-hub/services-context.tsx
 apps/desktop/src/renderer/features/module-hub/ui/module-hub-host.tsx
 apps/desktop/src/renderer/features/runtime-host-management/services-context.tsx

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -79,6 +79,18 @@ export interface TranscriptHistoryNoticeProps {
   onReturnToLatest(): Promise<void> | void;
 }
 
+export interface ChatViewGoalIndicatorProps {
+  /**
+   * Active autonomous-goal indicator for the session, or undefined when no
+   * goal is running. Surfaces the loop (turn counter, elapsed, tokens) with
+   * pause/resume/clear affordances so a token-burning goal is never invisible
+   * or uncontrollable — this IS the desktop kill switch. `onClear` stops
+   * autonomous continuation; `onPause`/`onResume` control it without a model
+   * turn.
+   */
+  goalIndicator?: SessionContextGoal;
+}
+
 /** Persistent navigation position with a direct path back to the transcript tail. */
 export function TranscriptHistoryNotice({
   title,
@@ -205,15 +217,6 @@ export function ChatView(props: {
     renderWhenAnchorMissing?: boolean;
     content: ReactNode;
   }>;
-  /**
-   * Active autonomous-goal indicator for the session, or undefined when no
-   * goal is running. Surfaces the loop (turn counter, elapsed, tokens) with
-   * pause/resume/clear affordances so a token-burning goal is never invisible
-   * or uncontrollable — this IS the desktop kill switch. `onClear` stops
-   * autonomous continuation; `onPause`/`onResume` control it without a model
-   * turn.
-   */
-  goalIndicator?: SessionContextGoal;
   /** Error from loading the active session's persisted message log. */
   messageLoadError?: string;
   messageLoadRetryPending?: boolean;
@@ -333,7 +336,7 @@ export function ChatView(props: {
    * seeded with the quote. Omitted by hosts that don't support the side panel.
    */
   onAskAboutSelection?(input: { text: string; turnId: string }): void;
-}) {
+} & ChatViewGoalIndicatorProps) {
   const locale = useUiLocale();
   const conversationCopy = getConversationCopy(locale);
   const copy = conversationCopy.chat;

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -47,6 +47,7 @@ export { ChatSurfaceLayout } from './chat-surface-layout.js';
 export type { ChatSurfaceLayoutProps } from './chat-surface-layout.js';
 export {
   ChatView,
+  type ChatViewGoalIndicatorProps,
   type LiveContentActivationSnapshot,
   type TransientUserMessageProjection,
 } from './chat-view.js';
@@ -69,11 +70,22 @@ export type {
 export { ScheduledTasksPage, DailyReviewPage, SkillsPage } from './module-pages.js';
 export { Composer } from './composer.js';
 export type {
+  ComposerGoalProps,
   ComposerProps,
   ComposerHandle,
   ComposerSendMetadata,
   ComposerSlashCommandOption,
 } from './composer.js';
+export {
+  ChatViewGoalProjectionConsumer,
+  ChatViewGoalProjectionProvider,
+  ComposerGoalProjectionConsumer,
+  ComposerGoalProjectionProvider,
+  useChatViewGoalProjection,
+  useComposerGoalProjection,
+  type ChatViewGoalProjection,
+  type ComposerGoalProjection,
+} from './goal-projection-context.js';
 export {
   getPermissionModeMeta,
   PERMISSION_MODE_ORDER,

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -227,6 +227,21 @@ export interface ComposerSendMetadata {
 
 type ComposerImportActionId = 'pick' | 'attach' | 'directory';
 
+export interface ComposerGoalProps {
+  /**
+   * Open the host's Goal dialog. The composer offers the entry and nothing
+   * else: a Goal names a condition and two budgets, which is a form, and the
+   * ＋ menu is a menu. Absent handler, no entry — the same rule the other
+   * ＋ entries follow.
+   */
+  onSetGoal?(): void | Promise<void>;
+  /**
+   * A Goal is already running here. Arming refuses a second one, so the
+   * entry says so up front instead of spending the user's click on an error.
+   */
+  goalActive?: boolean;
+}
+
 export const Composer = forwardRef<
   ComposerHandle,
   {
@@ -441,18 +456,6 @@ export const Composer = forwardRef<
     orchestrationModeDisabledReason?: string;
     onOrchestrationModeChange?(mode: OrchestrationMode): void | Promise<void>;
     /**
-     * Open the host's Goal dialog. The composer offers the entry and nothing
-     * else: a Goal names a condition and two budgets, which is a form, and the
-     * ＋ menu is a menu. Absent handler, no entry — the same rule the other
-     * ＋ entries follow.
-     */
-    onSetGoal?(): void | Promise<void>;
-    /**
-     * A Goal is already running here. Arming refuses a second one, so the
-     * entry says so up front instead of spending the user's click on an error.
-     */
-    goalActive?: boolean;
-    /**
      * Why a Goal cannot be set right now — a running Turn, typically. A Goal
      * takes hold on the Turn after it is armed, so arming during one reads as
      * having done nothing; the host names the reason and the entry shows it.
@@ -494,7 +497,7 @@ export const Composer = forwardRef<
     mentionSkillsLoading?: boolean;
     slashCommands?: ReadonlyArray<ComposerSlashCommandOption>;
     onSearchMentionFiles?(query: string): Promise<ReadonlyArray<{ relativePath: string }>>;
-  }
+  } & ComposerGoalProps
 >(function Composer(props, ref) {
   const formRef = useRef<HTMLFormElement>(null);
   /** Astryx's imperative handle on the contentEditable input. */

--- a/packages/ui/src/goal-projection-context.ts
+++ b/packages/ui/src/goal-projection-context.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createContext, useContext } from 'react';
+import type { ChatViewGoalIndicatorProps } from './chat-view.js';
+import type { ComposerGoalProps } from './composer.js';
+
+/** The required transport shape for the optional Goal props on Composer. */
+export interface ComposerGoalProjection {
+  readonly goalActive: NonNullable<ComposerGoalProps['goalActive']>;
+  readonly onSetGoal: ComposerGoalProps['onSetGoal'] | undefined;
+}
+
+/** The required transport shape for the optional Goal indicator on ChatView. */
+export interface ChatViewGoalProjection {
+  readonly goalIndicator: ChatViewGoalIndicatorProps['goalIndicator'] | undefined;
+}
+
+const inactiveComposerGoalProjection: ComposerGoalProjection = {
+  goalActive: false,
+  onSetGoal: undefined,
+};
+const inactiveChatViewGoalProjection: ChatViewGoalProjection = {
+  goalIndicator: undefined,
+};
+
+const ComposerGoalProjectionContext = createContext<ComposerGoalProjection>(
+  inactiveComposerGoalProjection,
+);
+const ChatViewGoalProjectionContext = createContext<ChatViewGoalProjection>(
+  inactiveChatViewGoalProjection,
+);
+
+export const ComposerGoalProjectionProvider = ComposerGoalProjectionContext.Provider;
+export const ChatViewGoalProjectionProvider = ChatViewGoalProjectionContext.Provider;
+export const ComposerGoalProjectionConsumer = ComposerGoalProjectionContext.Consumer;
+export const ChatViewGoalProjectionConsumer = ChatViewGoalProjectionContext.Consumer;
+
+/** Defaults to an inactive projection for Composer hosts outside Desktop. */
+export function useComposerGoalProjection(): ComposerGoalProjection {
+  return useContext(ComposerGoalProjectionContext);
+}
+
+/** Defaults to no indicator for ChatView hosts outside Desktop. */
+export function useChatViewGoalProjection(): ChatViewGoalProjection {
+  return useContext(ChatViewGoalProjectionContext);
+}

--- a/scripts/check-app-shell-hooks.mjs
+++ b/scripts/check-app-shell-hooks.mjs
@@ -119,7 +119,6 @@ export const ALLOWED = {
     useCommandPalette: 1,
     useComposerAttachments: 1,
     useEffect: 14,
-    useGoalController: 1,
     useKeyboardHelp: 1,
     useLayoutEffect: 2,
     useModuleHubController: 1,


### PR DESCRIPTION
## Summary

Move production Goal controller ownership out of AppShell and into `GoalProvider`.

- Publish separate composer, indicator, and dialog projections at their actual reader boundaries.
- Tie the projection transport to the authoritative `Composer` / `ChatView` prop contracts and perform explicit, compile-checked handoff at the two authorized Desktop leaves.
- Keep WorkHub and Workbar isolated: their `Composer` / `ChatView` instances do not consume the Session Goal projections.
- Remove Goal controller/model reads and Goal prop plumbing from AppShell; keep `useGoalController` out of the production barrel.
- Prevent ownership return with unique-controller, unique-production-consumer, forbidden-hook, leaf-`Omit`, AppShell Hook-budget, and renderer-architecture guards.
- Rebase onto `920d7142d` and regenerate the Astryx 0.5.2 surface inventory while resolving the documentation conflict.

This intentionally changes one transient UI state: while the selected Session is not yet owner-backed by the hydrated catalog, the unusable **Set Goal...** entry stays hidden instead of briefly appearing and doing nothing. Goal business behavior otherwise remains in `use-goal-controller.ts` unchanged. Stabilizing the producer of `reportError` is left to #4315, where the duplication is visible.

## Performance evidence

Measured on final head `3b47b2c35` against `920d7142d` in a 12-Session fixture. Each workload ran legacy/scoped ownership as alternating pairs inside the same Electron process; root-mode changes and resynchronization stayed outside the measurement window. The controller-only workload used 6 pairs and the complete `goal.pause` workload used 12. Renderer profiling sampled at 100 microseconds; the Fiber probe was disabled during each busy-JS window. Values below are conventional medians.

| Workload | Legacy owner | Scoped owner | Change | Paired result |
| --- | ---: | ---: | ---: | ---: |
| Controller-only token update: rendered fibers | 629 | 49 | -92.2% | 6/6 improved |
| Controller-only token update: renderer busy JS | 5.016 ms | 1.061 ms | -78.9% | 6/6 improved |
| Controller-only token update: commits | 1 | 1 | unchanged | 6/6 tied |
| Complete `goal.pause`: renderer busy JS | 24.879 ms | 23.637 ms | -5.0% | 9/12 improved |
| Complete `goal.pause`: summed rendered fibers | 3,053.5 | 3,063 | +0.3% | 6/12 improved |
| Complete `goal.pause`: commits | 6.5 | 7 | +7.7% | 2/12 improved, 4 tied |

The controller-only result is strong and stable: both ranges are disjoint (`629-629` vs `49-49` fibers; `4.199-5.633` vs `0.769-1.363` ms), and every pair improved.

The complete pause workload covers `preload -> IPC -> Host -> broadcast -> get -> controller -> React`. Its busy-JS ranges overlap (`21.848-29.949` vs `20.729-26.598` ms), while commits and fibers did not improve. The performance claim is therefore limited to controller-owned renderer work. The complete-path result is directional only and does not establish an end-to-end pause speedup; renderer busy JS also excludes Electron main-process CPU and I/O.

The temporary dual-owner switch, probes, performance spec, results, and worktrees were removed after measurement and are not part of this PR.

## Verification

- `npm run rebuild` - passed, including the production renderer build.
- `npm --workspace @maka/desktop run test:dist` - 1,845/1,845 passed.
- `npm exec -w @maka/desktop -- playwright test --config e2e/playwright.config.ts e2e/goal-dialog-budget.spec.ts --workers=1 --reporter=line` - 1/1 passed.
- `npm run typecheck` - passed.
- `npm run lint` and `npm run format:check` - passed (3,055 linted / 1,833 formatted files).
- `npx knip --workspace @maka/desktop --no-progress` and `npx knip --workspace packages/ui --no-progress` - passed.
- `npm run check:app-shell-hooks` - passed at 42 Hooks / 80 call sites.
- `npm run check:renderer-architecture -- --base 920d7142d001e81868bcd50a28a5bb3898415e3b` - 61/61 fixtures passed.
- `npm run astryx:surface-inventory` - passed at 235 files / 1 exclusion.
- `NODE_NO_WARNINGS=1 npm --workspace @maka/storage run test:dist` - 1,077 passed / 8 skipped.
- `git range-diff`, `git diff --check upstream/main...HEAD`, `git merge-base --is-ancestor upstream/main HEAD`, and `git merge-tree --write-tree --messages upstream/main HEAD` - passed.

Screenshots are not applicable; the only visible change removes a transient unusable menu entry during catalog hydration.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex - renderer architecture, implementation, tests, performance measurement, review handling, conflict resolution, and documentation.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes - described under Summary above
- [ ] No
