### PR TITLE
fix(runtime): normalize linked worktree Git boundaries

### DIFF
--- a/packages/runtime/src/__tests__/sandbox-boundary-path.test.ts
+++ b/packages/runtime/src/__tests__/sandbox-boundary-path.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, test } from 'node:test';
+
+import { normalizeSandboxBoundaryExpansion } from '../sandbox-boundary-path.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('normalizeSandboxBoundaryExpansion', () => {
+  test('normalizes a linked-worktree gitdir read subtree to its commondir', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-boundary-linked-worktree-'));
+    roots.push(root);
+    const commonDir = join(root, 'repository', '.git');
+    const gitDir = join(commonDir, 'worktrees', 'linked');
+    const worktree = join(root, 'linked');
+    await mkdir(gitDir, { recursive: true });
+    await mkdir(worktree, { recursive: true });
+    await writeFile(join(gitDir, 'commondir'), '../..\n', 'utf8');
+
+    const normalized = await normalizeSandboxBoundaryExpansion(
+      {
+        filesystem: {
+          entries: [{ path: gitDir, access: 'read', scope: 'subtree' }],
+        },
+      },
+      worktree,
+    );
+
+    assert.deepEqual(normalized.filesystem?.entries, [
+      { path: await realpath(commonDir), access: 'read', scope: 'subtree' },
+    ]);
+  });
+
+  test('leaves a linked-worktree gitdir write subtree unchanged', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-boundary-linked-worktree-write-'));
+    roots.push(root);
+    const commonDir = join(root, 'repository', '.git');
+    const gitDir = join(commonDir, 'worktrees', 'linked');
+    const worktree = join(root, 'linked');
+    await mkdir(gitDir, { recursive: true });
+    await mkdir(worktree, { recursive: true });
+    await writeFile(join(gitDir, 'commondir'), '../..\n', 'utf8');
+
+    const normalized = await normalizeSandboxBoundaryExpansion(
+      {
+        filesystem: {
+          entries: [{ path: gitDir, access: 'write', scope: 'subtree' }],
+        },
+      },
+      worktree,
+    );
+
+    assert.deepEqual(normalized.filesystem?.entries, [
+      { path: await realpath(gitDir), access: 'write', scope: 'subtree' },
+    ]);
+  });
+
+  test('leaves an ordinary directory containing a commondir file unchanged', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-boundary-ordinary-'));
+    roots.push(root);
+    const requested = join(root, 'ordinary');
+    const target = join(root, 'target');
+    await mkdir(requested, { recursive: true });
+    await mkdir(target, { recursive: true });
+    await writeFile(join(requested, 'commondir'), '../target\n', 'utf8');
+
+    const normalized = await normalizeSandboxBoundaryExpansion(
+      {
+        filesystem: {
+          entries: [{ path: requested, access: 'read', scope: 'subtree' }],
+        },
+      },
+      root,
+    );
+
+    assert.deepEqual(normalized.filesystem?.entries, [
+      { path: await realpath(requested), access: 'read', scope: 'subtree' },
+    ]);
+  });
+});

--- a/packages/runtime/src/sandbox-boundary-path.ts
+++ b/packages/runtime/src/sandbox-boundary-path.ts
@@ -18,7 +18,7 @@
  */
 
 import { promises as fs } from 'node:fs';
-import { resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { realpathAllowMissing } from './path-containment.js';
 import {
   MAX_SANDBOX_BOUNDARY_PATH_CHARS,
@@ -94,8 +94,12 @@ export async function normalizeSandboxBoundaryExpansion(
           'An exact sandbox boundary cannot target a directory; use subtree for directory access.',
         );
       }
+      const linkedWorktreeCommonDir =
+        normalized.access === 'read' && normalized.scope === 'subtree'
+          ? await linkedWorktreeCommonDirForBoundary(normalized.enforcementPath)
+          : undefined;
       return {
-        path: normalized.enforcementPath,
+        path: linkedWorktreeCommonDir ?? normalized.enforcementPath,
         access: normalized.access,
         scope: normalized.scope,
       };
@@ -107,6 +111,43 @@ export async function normalizeSandboxBoundaryExpansion(
   });
   if (!normalized.ok) throw new SandboxBoundaryDeclarationError(normalized.message);
   return normalized.expansion;
+}
+
+/**
+ * A linked worktree's admin directory is only the worktree-specific half of
+ * Git's metadata authority. Git reads refs, objects, config, and hooks through
+ * the sibling `commondir`; approving only `.git/worktrees/<name>` can therefore
+ * make `git status` report a false unborn tree and make `git log` call the
+ * branch broken. Normalize a read-scoped linked-worktree admin shape to the
+ * common metadata root before the user sees and approves the expansion. Write
+ * requests retain their exact path so shared metadata writes require their own
+ * approval.
+ *
+ * The structural check keeps an unrelated directory containing a file named
+ * `commondir` from widening its boundary. Any unreadable or malformed marker
+ * stays on the ordinary path-normalization route.
+ */
+async function linkedWorktreeCommonDirForBoundary(path: string): Promise<string | undefined> {
+  const worktreesDir = dirname(path);
+  if (basename(worktreesDir) !== 'worktrees') return undefined;
+  const expectedCommonDir = dirname(worktreesDir);
+
+  let declaration: string;
+  try {
+    declaration = (await fs.readFile(join(path, 'commondir'), 'utf8')).trim();
+  } catch {
+    return undefined;
+  }
+  if (!declaration || declaration.includes('\0') || declaration.includes('\n')) return undefined;
+
+  try {
+    const commonDir = await fs.realpath(resolve(path, declaration));
+    if (commonDir !== expectedCommonDir) return undefined;
+    if (!(await fs.stat(commonDir)).isDirectory()) return undefined;
+    return commonDir;
+  } catch {
+    return undefined;
+  }
 }
 
 async function targetTypeFor(path: string): Promise<NormalizedSandboxBoundaryPath['targetType']> {


### PR DESCRIPTION

## Summary

Normalize a standard linked-worktree admin subtree to its validated `commondir` before presenting a sandbox boundary request. Normalization applies to read-scoped requests only; write requests keep their exact path. The expansion widens only when the requested path matches `<common>/worktrees/<name>`, its `commondir` marker resolves to `<common>`, and the target is a directory. Ordinary directories containing a file named `commondir` keep their existing behavior.

Alternative considered: The Seatbelt policy could automatically add a linked worktree's gitdir and commondir to workspace roots, following #4237's treatment of ancestor directories. This PR keeps normalization in the approval path because writes to the main repository's `.git` directory are outside the linked worktree and should retain user approval. Maintainer feedback on this choice is welcome.

Industry comparison: codex 0.149.1 in workspace-write rejects direct `.git` writes, including `git commit`; Claude Code relies on command-level approval. Keeping the exact write path aligns with both approaches by avoiding commondir-wide write expansion.

Fixes #4336

## Verification

```text
mise exec node@24.19.0 -- npx -y npm@11.19.0 run build --workspace @maka/runtime
mise exec node@24.19.0 -- node --test packages/runtime/dist/__tests__/sandbox-boundary-path.test.js
Before fix: 1 pass, 1 fail, exit 1
Previous patch with the write regression added: 2 pass, 1 fail, exit 1
After amended fix: 3 pass, 0 fail, exit 0
```

Before the original fix, the read test returned the requested `.git/worktrees/<name>` path; it expected the shared `.git` directory. The write regression failed on the previous patch because it returned the shared `.git` directory; it expected the requested worktree admin path.

```text
mise exec node@24.19.0 -- node --test packages/runtime/dist/__tests__/macos-seatbelt.test.js packages/runtime/dist/__tests__/macos-seatbelt-smoke.test.js
25 pass, 0 fail, exit 0

mise exec node@24.19.0 -- npx -y npm@11.19.0 run typecheck --workspace @maka/runtime
exit 0
```

A codex-cli 0.149.1 workspace-write probe returned `GITWRITE=1`, reported `Operation not permitted` for `.git/probe-file`, and failed `git commit` because `.git/index.lock` could not be created.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (gpt-5.6-sol), human-reviewed

## Checklist

- [x] Tests cover the change, with a red test recorded before the fix
- [x] The affected suites and runtime typecheck pass locally

Does this PR entail a change in behavior?

- [x] Yes, described under Summary above
- [ ] No
