### PR TITLE
fix(desktop): preserve Git filenames in @ search

### DIFF
--- a/apps/desktop/src/main/__tests__/workspace-file-search.test.ts
+++ b/apps/desktop/src/main/__tests__/workspace-file-search.test.ts
@@ -32,10 +32,10 @@ type ExecFileCallback = (
   cb: (error: ExecFileException | null, stdout: string, stderr: string) => void,
 ) => void;
 
-/** Fake `git ls-files` returning a fixed newline-joined path list. */
+/** Fake `git ls-files -z` returning a fixed NUL-delimited path list. */
 function fakeGit(stdout: string, error: ExecFileException | null = null): ExecFileCallback {
   return (_file, args, _options, cb) => {
-    assert.deepEqual(args, ['ls-files', '--cached', '--others', '--exclude-standard']);
+    assert.deepEqual(args, ['ls-files', '-z', '--cached', '--others', '--exclude-standard']);
     cb(error, stdout, '');
   };
 }
@@ -63,7 +63,7 @@ async function withPlainDir(run: (root: string) => Promise<void>): Promise<void>
 describe('searchWorkspaceFiles', () => {
   it('filters with AND-of-substring tokens, case-insensitively', async () => {
     await withGitRepo(async (root) => {
-      const execFileImpl = fakeGit('src/app.tsx\nsrc/main.tsx\ndocs/app.md\n');
+      const execFileImpl = fakeGit('src/app.tsx\0src/main.tsx\0docs/app.md\0');
       const result = await searchWorkspaceFiles(root, { query: 'SRC app', execFileImpl });
       assert.ok(result.ok);
       const paths = result.ok ? result.files.map((f) => f.relativePath) : [];
@@ -73,7 +73,7 @@ describe('searchWorkspaceFiles', () => {
 
   it('ranks shorter paths first, then lexicographically', async () => {
     await withGitRepo(async (root) => {
-      const execFileImpl = fakeGit('a/b/c/app.tsx\napp.tsx\nlib/app.tsx\n');
+      const execFileImpl = fakeGit('a/b/c/app.tsx\0app.tsx\0lib/app.tsx\0');
       const result = await searchWorkspaceFiles(root, { query: 'app', execFileImpl });
       assert.ok(result.ok);
       const paths = result.ok ? result.files.map((f) => f.relativePath) : [];
@@ -81,9 +81,19 @@ describe('searchWorkspaceFiles', () => {
     });
   });
 
+  it('preserves Git filenames that require an unambiguous delimiter', async () => {
+    await withGitRepo(async (root) => {
+      const execFileImpl = fakeGit('普通.md\0 leading.txt\0trailing.txt \0line\nbreak.txt\0');
+      const result = await searchWorkspaceFiles(root, { query: '', limit: 10, execFileImpl });
+      assert.ok(result.ok);
+      const paths = result.ok ? result.files.map((file) => file.relativePath) : [];
+      assert.deepEqual(paths, ['普通.md', ' leading.txt', 'trailing.txt ', 'line\nbreak.txt']);
+    });
+  });
+
   it('caps the result count at the requested limit', async () => {
     await withGitRepo(async (root) => {
-      const many = Array.from({ length: 200 }, (_v, i) => `file-${i}.ts`).join('\n');
+      const many = `${Array.from({ length: 200 }, (_v, i) => `file-${i}.ts`).join('\0')}\0`;
       const execFileImpl = fakeGit(many);
       const result = await searchWorkspaceFiles(root, { query: '', limit: 5, execFileImpl });
       assert.ok(result.ok);

--- a/apps/desktop/src/main/workspace-file-search.ts
+++ b/apps/desktop/src/main/workspace-file-search.ts
@@ -70,14 +70,14 @@ function runGitLsFiles(
   return new Promise((resolve) => {
     execFileImpl(
       'git',
-      ['ls-files', '--cached', '--others', '--exclude-standard'],
+      ['ls-files', '-z', '--cached', '--others', '--exclude-standard'],
       { cwd, timeout: LS_TIMEOUT_MS, windowsHide: true, maxBuffer: 32 * 1024 * 1024 },
       (error, stdout) => {
         if (error) {
           resolve({ ok: false });
           return;
         }
-        const files = stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+        const files = stdout.split('\0').filter(Boolean);
         resolve({ ok: true, files });
       },
     );


### PR DESCRIPTION
## Summary

Preserve valid Git filenames in the Desktop Composer's `@` file search by requesting NUL-delimited `git ls-files` output and parsing it without trimming path data.

Git's default quoted output can encode non-ASCII paths such as `普通.md`, while newline splitting cannot represent embedded newlines and `trim()` changes leading or trailing spaces. Using `git ls-files -z` makes the path boundary unambiguous and returns the original filename bytes for the existing UTF-8 child-process decoding.

Fixes #4335

## Verification

- Regression test added for non-ASCII filenames, embedded newlines, and leading/trailing whitespace. Confirmed it fails before the production change and passes afterward.
- `node --test apps/desktop/dist/main/__tests__/workspace-file-search.test.js` — 7 passed, 0 failed.
- `npm --workspace @maka/desktop test` — 1,733 passed, 0 failed.
- `npm --workspace @maka/desktop run typecheck` — passed.
- `npx biome check apps/desktop/src/main/workspace-file-search.ts apps/desktop/src/main/__tests__/workspace-file-search.test.ts` — passed.
- Real Git repository smoke check returned `普通.md`, an embedded-newline filename, and filenames with leading/trailing spaces unchanged.
- `npm test` was also run. Desktop and the affected suites passed, but the aggregate command was not fully green because of unrelated environment-sensitive failures: Storage's child-process test treats Node 24's SQLite experimental warning on stderr as a failure, and Eval requires Python 3.10+ syntax while the local `python3` is 3.9.6. Runtime and CLI passed when rerun independently; the other transient Storage lease test passed when rerun alone.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex — reproduced and diagnosed the filename parsing defect, implemented the NUL-delimited Git protocol change, added the regression test, and ran local verification. The commit carries a `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
