### PR TITLE
fix: select update signature digests at crypto owners

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -261,6 +261,53 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+Sigstore dependency patch
+
+Source: https://www.npmjs.com/package/@sigstore/core/v/4.0.1
+Repository: https://github.com/sigstore/sigstore-js/tree/main/packages/core
+Version: 4.0.1
+Dependency patch: patches/@sigstore+core+4.0.1.patch
+Copyright 2023 The Sigstore Authors
+License: Apache-2.0
+
+Maka redistributes a source patch that selects the signature digest in
+@sigstore/core. The patch modifies Apache-2.0 source and is covered by the
+Apache License, Version 2.0 reproduced above.
+
+TUF metadata models dependency patch
+
+Source: https://www.npmjs.com/package/@tufjs/models/v/5.0.0
+Repository: https://github.com/theupdateframework/tuf-js/tree/main/packages/models
+Version: 5.0.0
+Dependency patch: patches/@tufjs+models+5.0.0.patch
+Copyright (c) 2022 GitHub and the TUF Contributors
+License: MIT
+
+Maka redistributes a source patch that selects the signature digest in
+@tufjs/models. The following MIT License applies to that material:
+
+MIT License
+
+Copyright (c) 2022 GitHub and the TUF Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 node-pty dependency patch
 
 Source: https://www.npmjs.com/package/node-pty/v/1.2.0-beta.15

--- a/apps/desktop/src/main/__tests__/app-update-attestation.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-attestation.test.ts
@@ -19,8 +19,10 @@
 
 import type { Bundle } from '@sigstore/bundle';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -28,6 +30,21 @@ import {
   desktopUpdateChannelFromManifest,
   verifyDownloadedUpdateAttestation,
 } from '../app-update-attestation.js';
+
+const require = createRequire(import.meta.url);
+
+function assertElectronVerification(script: string, failureMessage: string): void {
+  const verification = spawnSync(require('electron') as string, ['-e', script], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+  });
+  assert.equal(
+    verification.status,
+    0,
+    `${failureMessage}:\n${verification.stderr || verification.stdout}`,
+  );
+}
 
 function provenanceBundle(name: string, sha256: string): Bundle {
   const statement = {
@@ -161,5 +178,48 @@ test('packaged update trust accepts only an explicit release or nightly channel'
   assert.throws(
     () => desktopUpdateChannelFromManifest({ makaUpdateChannel: 'preview' }),
     /does not declare a trusted update channel/u,
+  );
+});
+
+test('TUF verifies ECDSA without breaking Ed25519 in the packaged Electron runtime', () => {
+  assertElectronVerification(
+    String.raw`
+        const { generateKeyPairSync, sign } = require('node:crypto');
+        const { dirname, join } = require('node:path');
+        const modelsEntry = require.resolve('@tufjs/models');
+        const { canonicalize } = require('@tufjs/canonical-json');
+        const { verifySignature } = require(join(dirname(modelsEntry), 'utils', 'verify.js'));
+        const metadata = { _type: 'root', expires: '2030-01-01T00:00:00Z', version: 1 };
+        const data = Buffer.from(canonicalize(metadata));
+        for (const { type, options, algorithm } of [
+          { type: 'ec', options: { namedCurve: 'prime256v1' }, algorithm: 'sha256' },
+          { type: 'ed25519', options: {}, algorithm: null },
+        ]) {
+          const { privateKey, publicKey } = generateKeyPairSync(type, options);
+          const signature = sign(algorithm, data, privateKey).toString('hex');
+          if (!verifySignature(metadata, { key: publicKey }, signature)) process.exit(1);
+        }
+      `,
+    'Electron TUF verification failed',
+  );
+});
+
+test('Sigstore verifies ECDSA without breaking Ed25519 in the packaged Electron runtime', () => {
+  assertElectronVerification(
+    String.raw`
+        const { generateKeyPairSync, sign } = require('node:crypto');
+        const { crypto } = require('@sigstore/core');
+        const data = Buffer.from('signed update metadata');
+        for (const { type, options, algorithm } of [
+          { type: 'ec', options: { namedCurve: 'prime256v1' }, algorithm: 'sha256' },
+          { type: 'ed25519', options: {}, algorithm: null },
+        ]) {
+          const { privateKey, publicKey } = generateKeyPairSync(type, options);
+          const signature = sign(algorithm, data, privateKey);
+          if (!crypto.verify(data, publicKey, signature)) process.exit(1);
+        }
+        if (crypto.verify(data, 'not a public key', Buffer.alloc(0))) process.exit(1);
+      `,
+    'Electron Sigstore verification failed',
   );
 });

--- a/patches/@sigstore+core+4.0.1.patch
+++ b/patches/@sigstore+core+4.0.1.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@sigstore/core/dist/crypto.js b/node_modules/@sigstore/core/dist/crypto.js
+--- a/node_modules/@sigstore/core/dist/crypto.js
++++ b/node_modules/@sigstore/core/dist/crypto.js
+@@ -51,4 +51,12 @@ function verify(data, key, signature, algorithm) {
+     // The try/catch is to work around an issue in Node 14.x where verify throws
+     // an error in some scenarios if the signature is invalid.
+     try {
++        if (algorithm === undefined) {
++            const keyObject = key instanceof crypto_1.default.KeyObject
++                ? key
++                : key?.key instanceof crypto_1.default.KeyObject
++                    ? key.key
++                    : crypto_1.default.createPublicKey(key);
++            algorithm = keyObject.asymmetricKeyType === 'ed25519' || keyObject.asymmetricKeyType === 'ed448' ? null : 'sha256';
++        }
+         return crypto_1.default.verify(algorithm, data, key, signature);

--- a/patches/@tufjs+models+5.0.0.patch
+++ b/patches/@tufjs+models+5.0.0.patch
@@ -1,0 +1,11 @@
+diff --git a/node_modules/@tufjs/models/dist/utils/verify.js b/node_modules/@tufjs/models/dist/utils/verify.js
+--- a/node_modules/@tufjs/models/dist/utils/verify.js
++++ b/node_modules/@tufjs/models/dist/utils/verify.js
+@@ -9,5 +9,6 @@ const crypto_1 = __importDefault(require("crypto"));
+ const verifySignature = (metaDataSignedData, key, signature) => {
+     const canonicalData = Buffer.from((0, canonical_json_1.canonicalize)(metaDataSignedData));
+-    return crypto_1.default.verify(undefined, canonicalData, key, Buffer.from(signature, 'hex'));
++    const algorithm = key.key.asymmetricKeyType === 'ed25519' ? null : 'sha256';
++    return crypto_1.default.verify(algorithm, canonicalData, key, Buffer.from(signature, 'hex'));
+ };
+ exports.verifySignature = verifySignature;

--- a/patches/README.md
+++ b/patches/README.md
@@ -27,6 +27,18 @@ Keep this directory small. Prefer product code that uses the dependency's
 published API; only patch for bugs that block shipping and cannot be worked
 around at the call site.
 
+## `@tufjs/models@5.0.0` and `@sigstore/core@4.0.1`
+
+The published ECDSA verification paths rely on Node choosing a digest when
+`crypto.verify` receives `undefined`. Electron 43's crypto runtime rejects that
+call with `ERR_OSSL_EVP_NO_DEFAULT_DIGEST`, so packaged Desktop cannot load the
+Sigstore TUF root or verify Rekor and DSSE signatures for an update. The patches
+select SHA-256 for RSA/ECDSA and preserve digest-free EdDSA verification at the
+two shared crypto seams.
+
+Delete each patch when the corresponding package ships explicit SHA-256
+verification and the Electron regression tests pass without it.
+
 ## `node-pty@1.2.0-beta.15`
 
 On Unix, `CustomWriteStream` submits raw file-descriptor writes through libuv.


### PR DESCRIPTION
## Summary

- Restore packaged Desktop update verification under Electron 43 by selecting the implicit signature digest at the two shared crypto owners in `@tufjs/models` and `@sigstore/core`.
- Use SHA-256 for RSA/ECDSA while preserving digest-free Ed25519/Ed448 verification and the existing false-on-invalid-key contract.
- Preserve the fail-closed workflow identity, provenance subject, and downloaded-byte checks; inventory both redistributed source patches in the root release `LICENSE`.

## Root cause

Electron 43's crypto runtime rejects ECDSA `crypto.verify(undefined, ...)` with `ERR_OSSL_EVP_NO_DEFAULT_DIGEST`. TUF and Sigstore rely on Node choosing SHA-256 implicitly, so a valid update cannot pass inside the packaged app. Selecting the default at the two crypto seams covers TUF root, Rekor, checkpoint, and DSSE verification without duplicating the rule at each consumer.

## Verification

- Confirmed the Electron tests fail before the owner-level patches: ECDSA fails with no default digest, while an unconditional SHA-256 fix breaks Ed25519.
- Confirmed an unparsable Sigstore key failed the Electron contract before key derivation moved into the existing false-normalizing `try` boundary.
- `npm ci` applies only the two owner-level dependency patches from a clean install.
- `npm run build:test`
- `node --test apps/desktop/dist/main/__tests__/app-update-attestation.test.js` — 5/5 passed, including ECDSA, Ed25519, and invalid-key rejection under Electron.
- `npm run check:asf-source` — 94/94 passed after inventorying both patches and their applicable licenses.
- `node --test scripts/asf-license-headers.test.mjs scripts/ci-test-plan.test.mjs` — 92/92 passed.
- `npx biome lint apps/desktop/src/main/__tests__/app-update-attestation.test.ts`
- `npm run format:check`
- `npm run check:asf-headers`
- Ran the full `verifyDownloadedUpdateAttestation` path under Electron 43 against the downloaded `Maka-0.2.0-dev.10.20260831-mac-arm64.zip` (SHA-256 `a0d2f1791cc2be507f50f1cd897eb6ba8c72f710d8b6b130b17ec165698633bb`) and its live GitHub Release provenance; verification passed with the upper Sigstore call sites unmodified.

Not run: repository-wide tests or a newly packaged installer/update cycle.

<details>
<summary>中文说明</summary>

Electron 43 不接受未明确指定摘要算法的 ECDSA 验签。本 PR 不再修改 Rekor、checkpoint 和 DSSE 等具体消费者，而是在 TUF 与 Sigstore 的两个共享 crypto seam 统一选择算法：RSA/ECDSA 使用 SHA-256，Ed25519/Ed448 保持无摘要验签，不可解析 key 继续返回 false。两个 Electron 合同测试覆盖修复与不回归；根 LICENSE 已记录两份源码补丁及适用许可，现有失败关闭、工作流身份、产物名称和下载字节哈希检查保持不变。

</details>

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the Electron/runtime compatibility boundary, authored and simplified the dependency patches and regression tests, adjudicated review feedback, added the required release-license inventory, and ran the listed verification. The human contributor must review the final diff and owns the submission and merge decision.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
