### PR TITLE
fix(desktop): remove duplicated task menu rename

### DIFF
--- a/apps/desktop/e2e/rename-focus.spec.ts
+++ b/apps/desktop/e2e/rename-focus.spec.ts
@@ -53,7 +53,7 @@ async function expectSelected(input: Locator): Promise<void> {
     .toBe(await input.inputValue().then((value) => value.length));
 }
 
-test('rename inputs own native focus for menu and double-click entry', async ({
+test('rename inputs own native focus for keyboard, double-click, and menu entry', async ({
   renameFocusWindow: { page, app },
 }) => {
   await focusWindow(app);
@@ -62,17 +62,14 @@ test('rename inputs own native focus for menu and double-click entry', async ({
 
   const sidebar = page.getByRole('navigation', { name: '任务列表' });
   const rowButton = sidebar.getByRole('button', { name: /^任务 00 / }).first();
-  const row = rowButton.locator('..');
-  const taskActions = sidebar.getByRole('button', { name: /^任务 00 .*任务操作$/ });
 
-  await row.hover();
-  await taskActions.click();
-  await page.getByRole('menuitem', { name: '重命名', exact: true }).click();
-  await sendNativeText(app, 'MENU');
+  await rowButton.focus();
+  await rowButton.press('F2');
+  await sendNativeText(app, 'KEYBOARD');
   const taskInput = page.getByRole('textbox', { name: '重命名任务' });
-  await expect(taskInput).toHaveValue('MENU');
+  await expect(taskInput).toHaveValue('KEYBOARD');
   await page.keyboard.press('Escape');
-  await expect(taskActions).toBeFocused();
+  await expect(rowButton).toBeFocused();
 
   await rowButton.dblclick();
   const doubleClickInput = page.getByRole('textbox', { name: '重命名任务' });

--- a/apps/desktop/e2e/workhub-layout.spec.ts
+++ b/apps/desktop/e2e/workhub-layout.spec.ts
@@ -84,19 +84,17 @@ test('WorkHub uses its coordination model and shared attachment composer', async
   if (await expandSidebar.isVisible()) await expandSidebar.click();
   const nativeWorkHubVisible = () => mainWindow.evaluate((window) => window.contentView.children.some((child) => 'webContents' in child && (child as Electron.WebContentsView).webContents.getURL().includes('surface=workhub') && child.getVisible()));
   const actions = page.getByRole('button', { name: /Drag task 0.*任务操作$/ });
-  await page.getByRole('button', { name: 'Drag task 0', exact: true }).hover();
-  await actions.click();
-  await expect(page.getByRole('menuitem', { name: '重命名', exact: true })).toBeVisible();
+  const task = page.getByRole('button', { name: 'Drag task 0', exact: true });
+  await task.focus();
+  await task.press('F2');
   await expect.poll(nativeWorkHubVisible).toBe(false);
   await expect(page.locator('.workHubDockBackdrop')).toBeVisible();
-  await page.getByRole('menuitem', { name: '重命名', exact: true }).click();
   await expect(page.getByRole('textbox', { name: '重命名任务' })).toBeVisible();
   await page.keyboard.press('Escape');
   await expect(page.getByRole('textbox', { name: '重命名任务' })).toBeHidden();
-  // Dialog focus restoration can open the action tooltip over the dock.
-  // Exercise that keyboard focus explicitly and dismiss the remaining overlay.
-  await actions.press('Tab');
-  await page.keyboard.press('Shift+Tab');
+  await expect(task).toBeFocused();
+  // Exercise action focus explicitly and dismiss its tooltip overlay.
+  await actions.focus();
   const actionTooltip = page.getByRole('tooltip', { name: 'Drag task 0 任务操作', exact: true });
   await expect(actionTooltip).toBeVisible();
   await expect.poll(nativeWorkHubVisible).toBe(false);

--- a/packages/ui/src/__tests__/session-history-multi-select.test.tsx
+++ b/packages/ui/src/__tests__/session-history-multi-select.test.tsx
@@ -615,7 +615,7 @@ test('the menu is about the one row when only that row is picked', async () => {
   const harness = await mount({ selectedIds: ['b'] });
   try {
     await harness.openRowMenu('b');
-    assert.deepEqual(harness.menuLabels(), ['Pin', 'Rename', 'Archive']);
+    assert.deepEqual(harness.menuLabels(), ['Pin', 'Archive']);
   } finally {
     await harness.dispose();
   }
@@ -727,7 +727,7 @@ test('a menu sweeps only the picked rows still on screen', async () => {
     // so it leaves the set here, and stays out of it.
     assert.deepEqual(harness.retains.at(-1), ['a1', 'a2']);
     // And the menu says so: one row, with the single-row wording.
-    assert.deepEqual(harness.menuLabels(), ['Pin', 'Rename', 'Archive']);
+    assert.deepEqual(harness.menuLabels(), ['Pin', 'Archive']);
   } finally {
     await harness.dispose();
   }

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -72,7 +72,7 @@ import { getConversationCopy } from './conversation-copy.js';
 import { getSessionHoverCardCopy } from './session-hover-card-copy.js';
 import { deriveTitlebarProjectName } from './titlebar-session-identity.js';
 
-type SessionRowActionId = 'flag' | 'archive' | 'rename';
+type SessionRowActionId = 'flag' | 'archive';
 type ProjectRowActionId = 'new' | 'relink' | 'rename' | 'archive' | 'restore';
 type SessionHistoryGroupVariant = 'conversation' | 'project';
 
@@ -834,6 +834,18 @@ const SessionNavRow = memo(function SessionNavRow(props: {
           }
           props.onSelectSession(props.session.id);
         }}
+        onKeyDown={(event) => {
+          if (event.key !== 'F2' || !props.actions) return;
+          event.preventDefault();
+          props.onStartRename(
+            {
+              kind: 'session',
+              id: props.session.id,
+              name: props.session.name,
+            },
+            event.currentTarget,
+          );
+        }}
         endContent={
           // Slot 2. The timestamp is what the row shows at rest; the ⋯ menu
           // below is absolutely positioned over this box and sidebar.css swaps
@@ -887,7 +899,6 @@ const SessionNavRow = memo(function SessionNavRow(props: {
           bulkCount={props.bulkCount}
           bulkAllPinned={props.bulkAllPinned}
           selectionCommands={props.selectionCommands}
-          onStartRename={props.onStartRename}
         />
       )}
     </div>
@@ -1246,9 +1257,7 @@ function SessionItemActions(props: {
   bulkCount: number;
   bulkAllPinned: boolean;
   selectionCommands?: SessionRailSelectionCommands;
-  onStartRename(target: SessionRenameTarget, opener: HTMLElement | null): void;
 }) {
-  const trailingRef = useRef<HTMLSpanElement>(null);
   const locale = useUiLocale();
   const copy = getConversationCopy(locale).sessions;
   const actionContext = [
@@ -1292,7 +1301,6 @@ function SessionItemActions(props: {
     <span
       className="maka-session-row-action"
       data-menu-open={menuOpen ? 'true' : undefined}
-      ref={trailingRef}
       onKeyDown={(event) => event.stopPropagation()}
     >
       <MoreMenu
@@ -1328,22 +1336,6 @@ function SessionItemActions(props: {
                     runRowAction('flag', () =>
                       actions.onToggleFlag(props.session.id, !props.session.isFlagged),
                     ),
-                },
-                {
-                  label: copy.rename,
-                  icon: Pencil,
-                  onClick: () => {
-                    const opener =
-                      trailingRef.current?.querySelector<HTMLElement>('button') ?? null;
-                    props.onStartRename(
-                      {
-                        kind: 'session',
-                        id: props.session.id,
-                        name: props.session.name,
-                      },
-                      opener,
-                    );
-                  },
                 },
                 // Archive is where the rail stops. Deleting is the one row
                 // action that cannot be undone, and the rail is where a

--- a/packages/ui/stories/accessibility-dialogs.stories.tsx
+++ b/packages/ui/stories/accessibility-dialogs.stories.tsx
@@ -55,7 +55,7 @@ function RenameConversationStory() {
   );
 }
 
-// Real path: conversation sidebar → row actions → rename.
+// Real path: conversation sidebar task rename opened by double-click.
 export const RenameConversation: Story = {
   render: () => <RenameConversationStory />,
   play: async ({ canvasElement }) => {

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -443,8 +443,9 @@ export const ActiveTaskActionsOpen: Story = {
   play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
     await waitFor(() => expect(page.getByRole('menu')).toBeVisible());
-    expect(page.getByRole('menuitem', { name: '重命名' })).toBeVisible();
-    expect(page.getByRole('menuitem', { name: /^归档$/ })).toBeVisible();
+    expect(page.getByRole('menuitem', { name: '置顶' })).toBeVisible();
+    expect(page.getByRole('menuitem', { name: '归档' })).toBeVisible();
+    expect(page.queryByRole('menuitem', { name: '重命名' })).not.toBeInTheDocument();
     expect(page.queryByRole('menuitem', { name: /删除/ })).toBeNull();
   },
 };
@@ -707,17 +708,21 @@ export const ProjectGroups: Story = {
     const taskActionButton = within(taskRow).getByRole('button', { name: /任务操作$/ });
     taskActionButton.focus();
     await userEvent.keyboard('{Enter}');
-    const renameTask = page.getByRole('menuitem', { name: '重命名' });
-    await expect(renameTask).toBeVisible();
+    const pinTask = page.getByRole('menuitem', { name: '置顶' });
+    await expect(pinTask).toBeVisible();
+    await expect(page.queryByRole('menuitem', { name: '重命名' })).toBeNull();
     const taskAction = taskRow.querySelector<HTMLElement>('.maka-session-row-action');
     if (!taskAction) throw new Error('task action is missing');
     await expect(taskAction).toHaveAttribute(
       'data-menu-open',
       'true',
     );
-    await userEvent.hover(renameTask);
+    await userEvent.hover(pinTask);
     await expect(timestamp).toHaveStyle({ visibility: 'hidden' });
-    await userEvent.click(renameTask);
+    await userEvent.keyboard('{Escape}');
+    await expect(taskActionButton).toHaveFocus();
+    taskControl.focus();
+    await userEvent.keyboard('{F2}');
     await expect(await page.findByRole('dialog', { name: '重命名任务' }, {
       timeout: 5_000,
     })).toBeVisible();


### PR DESCRIPTION
## Summary

<!-- The problem this solves and the outcome it produces. If the approach
is not the obvious one, say why. -->

Task rows already support rename on double-click. Removing the duplicate menu action keeps one sidebar interaction while preserving project rename.

Fixes #4362

<!-- Delete the line above if this PR closes no issue. Use "Refs #N" instead
when an issue is context only. -->

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck --workspace packages/ui`
- `npm --workspace @maka/ui run build`
- `node --test packages/ui/dist/__tests__/session-history-multi-select.test.js`
  (22 tests passed)

The targeted Desktop E2E was attempted locally, but its
`projectSidebarWindow` fixture timed out before reaching the assertions.
The hosted CI run covers the updated keyboard scenarios.

<!--
Add a section only when it changes how this PR should be reviewed,
released, or operated, and name it after the real risk: e.g.
Breaking change, Migration, Rollout, Root cause, Security, Review focus.
If work intentionally remains, open as a draft and track it with a
task list under its own section.
-->

<img width="411" height="462" alt="image" src="https://github.com/user-attachments/assets/e7340e1c-ed7b-4570-94c7-0aa04e00f2f6" />


## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

<!-- If the second option applies, name the tool(s) and briefly describe their
scope. If AI authored material contribution content, add Generated-by trailers
to the affected commits and ensure the final squash commit retains the trailer. -->

Tool(s) and scope: OpenAI Codex GPT 5.6 sol

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
