### PR TITLE
fix(desktop): resolve packaged license and electron paths without assuming hoisted node_modules

### DIFF
--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -18,7 +18,8 @@
  */
 
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import {
   resolveDesktopBuildVersion,
   resolveRuntimeHostSetupPackage,
@@ -28,6 +29,20 @@ import { resolveProductManifestIdentity } from '../../scripts/product-release-id
 
 function readManifest(relativePath) {
   return JSON.parse(readFileSync(new URL(relativePath, import.meta.url), 'utf8'));
+}
+
+// Some license files below ship inside third-party packages that apps/desktop
+// depends on (electron, @fontsource-variable/geist*). Locate each package by
+// resolving its manifest rather than assuming its node_modules location:
+// `../../node_modules/<pkg>` only resolves when the installer hoists these
+// packages to the workspace root, but they are declared in apps/desktop, not
+// the root. electron-builder logs a warning and still exits 0 when a `from`
+// path is missing, so a non-hoisting layout would silently drop the notices
+// (verify-packaged-app.mjs then fails far from the cause). resolve() finds the
+// package wherever the installer placed it — hoisted or nested.
+const require = createRequire(import.meta.url);
+function resolvePackageFile(packageName, relativePath) {
+  return join(dirname(require.resolve(`${packageName}/package.json`)), relativePath);
 }
 
 async function stageReleaseManifests({ packager }) {
@@ -150,11 +165,11 @@ const baseDesktopBuilderConfig = {
       to: 'licenses/maka/DISCLAIMER-WIP',
     },
     {
-      from: '../../node_modules/electron/dist/LICENSE',
+      from: resolvePackageFile('electron', 'dist/LICENSE'),
       to: 'licenses/electron/LICENSE',
     },
     {
-      from: '../../node_modules/electron/dist/LICENSES.chromium.html',
+      from: resolvePackageFile('electron', 'dist/LICENSES.chromium.html'),
       to: 'licenses/electron/LICENSES.chromium.html',
     },
     {
@@ -166,11 +181,11 @@ const baseDesktopBuilderConfig = {
       to: 'licenses/renderer/THIRD_PARTY_LICENSES.txt',
     },
     {
-      from: '../../node_modules/@fontsource-variable/geist/LICENSE',
+      from: resolvePackageFile('@fontsource-variable/geist', 'LICENSE'),
       to: 'licenses/renderer/GEIST_LICENSE.txt',
     },
     {
-      from: '../../node_modules/@fontsource-variable/geist-mono/LICENSE',
+      from: resolvePackageFile('@fontsource-variable/geist-mono', 'LICENSE'),
       to: 'licenses/renderer/GEIST_MONO_LICENSE.txt',
     },
     {

--- a/scripts/install-electron-with-retry.mjs
+++ b/scripts/install-electron-with-retry.mjs
@@ -95,7 +95,11 @@ export function electronInstallerSpawnOptions(repositoryRoot) {
 }
 
 async function main() {
-  const require = createRequire(import.meta.url);
+  // electron is declared by apps/desktop, not the workspace root, so anchor
+  // resolution at that package. Resolving from this script (under scripts/)
+  // only reaches electron when the installer hoists it to the root
+  // node_modules; anchoring at apps/desktop works under any layout.
+  const require = createRequire(new URL('../apps/desktop/package.json', import.meta.url));
   const installer = require.resolve('electron/install.js');
   const launcher = fileURLToPath(new URL('./run-electron-installer.cjs', import.meta.url));
   const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));

--- a/scripts/package-macos-arm64.mjs
+++ b/scripts/package-macos-arm64.mjs
@@ -19,6 +19,7 @@
 
 import { spawn } from 'node:child_process';
 import { access, readFile, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { resolveDesktopBuildVersion } from './desktop-nightly.mjs';
@@ -26,7 +27,16 @@ import { resolveDesktopBuildVersion } from './desktop-nightly.mjs';
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const desktopRoot = join(repoRoot, 'apps', 'desktop');
 const releaseDirectory = join(desktopRoot, 'release');
-const electronDistributionDirectory = join(repoRoot, 'node_modules', 'electron', 'dist');
+// electron is declared by apps/desktop, so resolve its install directory from
+// there rather than assuming node_modules hoisted it to the repo root. This
+// pre-flight guard exists to catch a missing electron dist before packaging;
+// pinning it to the hoisted path would make it fail at the wrong location the
+// moment an installer nests electron under apps/desktop.
+const require = createRequire(join(desktopRoot, 'package.json'));
+const electronDistributionDirectory = join(
+  dirname(require.resolve('electron/package.json')),
+  'dist',
+);
 const requiredElectronLicensePaths = [
   join(electronDistributionDirectory, 'LICENSE'),
   join(electronDistributionDirectory, 'LICENSES.chromium.html'),

--- a/scripts/package-windows-x64.mjs
+++ b/scripts/package-windows-x64.mjs
@@ -19,6 +19,7 @@
 
 import { spawn } from 'node:child_process';
 import { access, copyFile, mkdir, readFile, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { resolveDesktopBuildVersion } from './desktop-nightly.mjs';
@@ -27,7 +28,16 @@ import { npmSpawnOptions } from './npm-spawn.mjs';
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const desktopRoot = join(repoRoot, 'apps', 'desktop');
 const releaseDirectory = join(desktopRoot, 'release');
-const electronDistributionDirectory = join(repoRoot, 'node_modules', 'electron', 'dist');
+// electron is declared by apps/desktop, so resolve its install directory from
+// there rather than assuming node_modules hoisted it to the repo root. This
+// pre-flight guard exists to catch a missing electron dist before packaging;
+// pinning it to the hoisted path would make it fail at the wrong location the
+// moment an installer nests electron under apps/desktop.
+const require = createRequire(join(desktopRoot, 'package.json'));
+const electronDistributionDirectory = join(
+  dirname(require.resolve('electron/package.json')),
+  'dist',
+);
 const sandboxManifestPath = join(
   repoRoot,
   'experiments',

--- a/scripts/product-release.test.mjs
+++ b/scripts/product-release.test.mjs
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import test from 'node:test';
 import { promisify } from 'node:util';
 import { parse as parseYaml } from 'yaml';
@@ -219,6 +219,37 @@ test('Desktop packaging does not distribute the retired bundled Git runtime', ()
     resources.some(({ to }) => to.startsWith('licenses/dugite')),
     false,
   );
+});
+
+test('packaged third-party license sources are resolved, not assumed hoisted', () => {
+  // electron and @fontsource-variable/geist* are declared by apps/desktop, so
+  // `../../node_modules/<pkg>` only resolves when the installer hoists them to
+  // the workspace root. electron-builder logs a warning and still exits 0 on a
+  // missing `extraResources` source, so a non-hoisting layout would silently
+  // drop these notices. The config resolves each package instead; assert the
+  // sources are absolute paths that end at the intended in-package file.
+  const expectedSuffixes = new Map([
+    ['licenses/electron/LICENSE', join('electron', 'dist', 'LICENSE')],
+    [
+      'licenses/electron/LICENSES.chromium.html',
+      join('electron', 'dist', 'LICENSES.chromium.html'),
+    ],
+    ['licenses/renderer/GEIST_LICENSE.txt', join('@fontsource-variable', 'geist', 'LICENSE')],
+    [
+      'licenses/renderer/GEIST_MONO_LICENSE.txt',
+      join('@fontsource-variable', 'geist-mono', 'LICENSE'),
+    ],
+  ]);
+  const byTarget = new Map(desktopBuilderConfig.extraResources.map(({ from, to }) => [to, from]));
+  for (const [to, suffix] of expectedSuffixes) {
+    const from = byTarget.get(to);
+    assert.ok(from, `missing extraResources entry for ${to}`);
+    assert.ok(
+      isAbsolute(from),
+      `${to} source must be a resolved absolute path, not a '../../node_modules' hoisting assumption`,
+    );
+    assert.ok(from.endsWith(suffix), `${to} source must resolve to ${suffix}, got ${from}`);
+  }
 });
 
 test('macOS DMG ships correctly sized background assets', async () => {


### PR DESCRIPTION
## Summary

Packaging and install scripts located third-party packages by walking to the workspace root (`../../node_modules/<pkg>`), which only resolves because npm hoists everything up. `electron` and `@fontsource-variable/geist*` are declared in `apps/desktop`, not the root, so under any layout that does not hoist (e.g. pnpm `nodeLinker: isolated`) the four `extraResources` license entries silently miss — electron-builder logs `file source doesn't exist` and still exits 0, dropping Electron's `LICENSE`/`LICENSES.chromium.html` from the packaged app — and the electron installer throws `Cannot find module 'electron/install.js'`.

This resolves each package by its manifest (`createRequire(...).resolve('<pkg>/package.json')`) instead of assuming its `node_modules` location — correct under npm today and under any non-hoisting layout.

Fixes #4367

### Changes
- `apps/desktop/electron-builder.config.mjs` — resolve the electron + geist license `extraResources` sources through a `resolvePackageFile` helper.
- `scripts/install-electron-with-retry.mjs` — anchor `createRequire` at `apps/desktop/package.json` (electron is *its* dependency, not the root's), so `electron/install.js` resolves under any layout.
- `scripts/package-macos-arm64.mjs`, `scripts/package-windows-x64.mjs` — the release pre-flight guards asserted the same hoisted `node_modules/electron/dist` path; resolve it the same way so the guard checks the real location instead of failing at the wrong one under a nested layout.
- `scripts/product-release.test.mjs` — regression test asserting the packaged electron/geist license sources are resolved absolute paths, not `../../node_modules` hoisting assumptions.

The two release-script guards share the defect but were not named in the issue; fixing them keeps the assumption from resurfacing in the release path once the config is robust.

### Review focus / out of scope
`apps/desktop/scripts/dev-app-runtime.mjs` and `scripts/desktop-real-window-smoke.mjs` carry similar root-`node_modules` assumptions, but they are dev-only launchers/smoke harnesses (not the packaging or install path) that run under the committed npm layout. Left untouched to keep this focused on the filed defect. (`dev-app-runtime.mjs`'s `resolveElectronBinary` already walks up directories, so it is layout-robust already.)

## Verification

- `biome lint` and `biome format` (v2.5.9, the pinned version) — clean, no fixes, on all changed files.
- `node --check` — passes on all changed files.
- **Non-hoisting reproduction:** built a temporary workspace with `electron` and `@fontsource-variable/geist*` present *only* under `apps/desktop/node_modules` and no root `node_modules`. The new resolution finds all four license files and `electron/install.js` at the nested location; the previous `../../node_modules/...` paths point at a non-existent root path (the silent-miss the issue describes).
- **Regression test:** ran the new test's assertions against both the fixed (resolved absolute) and previous (`../../node_modules/...` relative) `extraResources` shapes — passes on the fix, fails on the previous config.
- **Not run locally** (no signing/build environment or installed dependencies here): `tsc` typecheck, the full `product-release.test.mjs` suite, and an end-to-end `electron-builder` packaged build under pnpm `nodeLinker: isolated`. `ci-test-plan.mjs` already maps the changed config and package scripts into the release-contract suite, so CI exercises them.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — investigated the issue, wrote the fix across the four files plus the regression test, and verified it with the non-hoisting reproduction described above. Reviewed by me.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

<!-- Lint and format pass locally; typecheck and the full suite were not run here
(no installed dependencies / build environment) — see Verification. -->

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

<!-- Under the committed npm install the packaged artifacts are byte-identical
(the same files are resolved). The fix only changes behavior under non-hoisting
layouts, which the repo does not currently use. -->
