### PR TITLE
fix(runtime): make the WriteStdin contract derivable and drift-proof

### DIFF
--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -19,10 +19,10 @@
 
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
+import { TERMINAL_MOUSE_EVENTS } from '@maka/core/terminal-input';
 import {
   buildLocalForegroundBashTool,
   buildManagedBashTool,
-  buildWriteStdinTool,
   createWriteStdinSchemas,
   shapeTerminalResult,
   WRITE_STDIN_EXAMPLE_REF,
@@ -283,43 +283,66 @@ describe('shapeTerminalResult sandbox denial projection', () => {
 describe('WriteStdin provider/strict contract conformance', () => {
   const { providerParameters, strictParameters } = createWriteStdinSchemas();
 
+  // Each example's first action, or undefined for a resize-only (action-less) example.
+  const firstActionOf = (payload: Readonly<Record<string, unknown>>) => {
+    const actions = payload.actions;
+    return Array.isArray(actions) ? (actions[0] as Record<string, unknown> | undefined) : undefined;
+  };
+
+  const acceptedByBothLayers = (
+    label: string,
+    payload: Readonly<Record<string, unknown>>,
+  ): boolean => {
+    const provider = providerParameters.safeParse(payload);
+    assert.ok(
+      provider.success,
+      `provider schema rejected the documented "${label}" example: ${
+        provider.success ? '' : provider.error.message
+      }`,
+    );
+    const strict = strictParameters.safeParse(payload);
+    assert.ok(
+      strict.success,
+      `strict validator rejected the documented "${label}" example: ${
+        strict.success ? '' : strict.error.message
+      }`,
+    );
+    return provider.success && strict.success;
+  };
+
   test('every documented minimal example is accepted by BOTH the provider and strict layers', () => {
-    assert.ok(WRITE_STDIN_MINIMAL_EXAMPLES.length >= 7, 'expected one example per action shape');
     for (const { label, payload } of WRITE_STDIN_MINIMAL_EXAMPLES) {
-      const provider = providerParameters.safeParse(payload);
-      assert.ok(
-        provider.success,
-        `provider schema rejected the documented "${label}" example: ${
-          provider.success ? '' : provider.error.message
-        }`,
-      );
-      const strict = strictParameters.safeParse(payload);
-      assert.ok(
-        strict.success,
-        `strict validator rejected the documented "${label}" example: ${
-          strict.success ? '' : strict.error.message
-        }`,
-      );
+      acceptedByBothLayers(label, payload);
     }
   });
 
-  test('the description advertises a ref/actions example the schemas actually accept', () => {
-    const controls = {
-      writeStdin: () => Promise.reject(new Error('not used')),
-      resize: () => Promise.reject(new Error('not used')),
-    } as unknown as Parameters<typeof buildWriteStdinTool>[0];
-    const tool = buildWriteStdinTool(controls);
-    const match = tool.description.match(/\{"ref":"[^"]+","actions":\[[^\]]+\]\}/);
-    assert.ok(match, `description is missing a concrete minimal example: ${tool.description}`);
-    const advertised = JSON.parse(match[0].replace('<id>', 'sr_example'));
-    assert.ok(
-      providerParameters.safeParse(advertised).success,
-      'the advertised example must pass the provider schema',
-    );
-    assert.ok(
-      strictParameters.safeParse(advertised).success,
-      'the advertised example must pass the strict validator',
-    );
+  test('every mouse event has a covering example that passes both layers', () => {
+    // Derives coverage from the source of truth: adding a new mouse event to
+    // TERMINAL_MOUSE_EVENTS fails here until a minimal example is pinned for it.
+    for (const event of TERMINAL_MOUSE_EVENTS) {
+      const covering = WRITE_STDIN_MINIMAL_EXAMPLES.filter(({ payload }) => {
+        const action = firstActionOf(payload);
+        return action?.type === 'mouse' && action?.event === event;
+      });
+      assert.ok(
+        covering.length >= 1,
+        `no minimal WriteStdin example covers the '${event}' mouse event`,
+      );
+      for (const { label, payload } of covering) {
+        acceptedByBothLayers(label, payload);
+      }
+    }
+  });
+
+  test('every action type has a covering example', () => {
+    // Same drift-proofing for the action `type` enum itself.
+    const actionTypes = ['text', 'key', 'mouse'] as const;
+    for (const type of actionTypes) {
+      const covered = WRITE_STDIN_MINIMAL_EXAMPLES.some(
+        ({ payload }) => firstActionOf(payload)?.type === type,
+      );
+      assert.ok(covered, `no minimal WriteStdin example covers the '${type}' action type`);
+    }
   });
 
   test('provider null/0/empty placeholders are tolerated and normalized away by the strict layer', () => {

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -22,7 +22,11 @@ import { describe, test } from 'node:test';
 import {
   buildLocalForegroundBashTool,
   buildManagedBashTool,
+  buildWriteStdinTool,
+  createWriteStdinSchemas,
   shapeTerminalResult,
+  WRITE_STDIN_EXAMPLE_REF,
+  WRITE_STDIN_MINIMAL_EXAMPLES,
   type ShellRunLauncher,
 } from '../shell-tools.js';
 import type { ShellPlan } from '../shell-detect.js';
@@ -273,6 +277,107 @@ describe('shapeTerminalResult sandbox denial projection', () => {
       },
     });
     assert.equal(result.sandboxDenial, undefined);
+  });
+});
+
+describe('WriteStdin provider/strict contract conformance', () => {
+  const { providerParameters, strictParameters } = createWriteStdinSchemas();
+
+  test('every documented minimal example is accepted by BOTH the provider and strict layers', () => {
+    assert.ok(WRITE_STDIN_MINIMAL_EXAMPLES.length >= 7, 'expected one example per action shape');
+    for (const { label, payload } of WRITE_STDIN_MINIMAL_EXAMPLES) {
+      const provider = providerParameters.safeParse(payload);
+      assert.ok(
+        provider.success,
+        `provider schema rejected the documented "${label}" example: ${
+          provider.success ? '' : provider.error.message
+        }`,
+      );
+      const strict = strictParameters.safeParse(payload);
+      assert.ok(
+        strict.success,
+        `strict validator rejected the documented "${label}" example: ${
+          strict.success ? '' : strict.error.message
+        }`,
+      );
+    }
+  });
+
+  test('the description advertises a ref/actions example the schemas actually accept', () => {
+    const controls = {
+      writeStdin: () => Promise.reject(new Error('not used')),
+      resize: () => Promise.reject(new Error('not used')),
+    } as unknown as Parameters<typeof buildWriteStdinTool>[0];
+    const tool = buildWriteStdinTool(controls);
+    const match = tool.description.match(/\{"ref":"[^"]+","actions":\[[^\]]+\]\}/);
+    assert.ok(match, `description is missing a concrete minimal example: ${tool.description}`);
+    const advertised = JSON.parse(match[0].replace('<id>', 'sr_example'));
+    assert.ok(
+      providerParameters.safeParse(advertised).success,
+      'the advertised example must pass the provider schema',
+    );
+    assert.ok(
+      strictParameters.safeParse(advertised).success,
+      'the advertised example must pass the strict validator',
+    );
+  });
+
+  test('provider null/0/empty placeholders are tolerated and normalized away by the strict layer', () => {
+    // A provider that fills every optional field with a null/0/'' placeholder
+    // rather than omitting it must still round-trip to the minimal legal action.
+    const withPlaceholders = {
+      ref: WRITE_STDIN_EXAMPLE_REF,
+      actions: [
+        {
+          type: 'key',
+          key: 'enter',
+          text: '',
+          event: null,
+          x: 0,
+          y: 0,
+          button: null,
+          direction: null,
+          modifiers: [],
+        },
+      ],
+      size: null,
+    };
+    const strict = strictParameters.safeParse(withPlaceholders);
+    assert.ok(
+      strict.success,
+      `strict validator should normalize provider placeholders, got: ${
+        strict.success ? '' : strict.error.message
+      }`,
+    );
+    assert.deepEqual(strict.data.actions, [{ type: 'key', key: 'enter' }]);
+  });
+
+  test('strict validation is not vacuous: contract violations are rejected', () => {
+    // Mouse click without a button is structurally invalid.
+    assert.equal(
+      strictParameters.safeParse({
+        ref: WRITE_STDIN_EXAMPLE_REF,
+        actions: [{ type: 'mouse', event: 'click', x: 0, y: 0 }],
+      }).success,
+      false,
+    );
+    // A non-canonical ref must be refused even when the actions are legal.
+    assert.equal(
+      strictParameters.safeParse({
+        ref: 'not-a-runtime-ref',
+        actions: [{ type: 'key', key: 'enter' }],
+      }).success,
+      false,
+    );
+    // input and actions are mutually exclusive.
+    assert.equal(
+      strictParameters.safeParse({
+        ref: WRITE_STDIN_EXAMPLE_REF,
+        input: 'x',
+        actions: [{ type: 'key', key: 'enter' }],
+      }).success,
+      false,
+    );
   });
 });
 

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -430,6 +430,20 @@ export const WRITE_STDIN_MINIMAL_EXAMPLES: readonly {
     },
   },
   {
+    label: 'mouse press',
+    payload: {
+      ref: WRITE_STDIN_EXAMPLE_REF,
+      actions: [{ type: 'mouse', event: 'press', x: 0, y: 0, button: 'left' }],
+    },
+  },
+  {
+    label: 'mouse release',
+    payload: {
+      ref: WRITE_STDIN_EXAMPLE_REF,
+      actions: [{ type: 'mouse', event: 'release', x: 0, y: 0, button: 'left' }],
+    },
+  },
+  {
     label: 'mouse move',
     payload: {
       ref: WRITE_STDIN_EXAMPLE_REF,
@@ -445,6 +459,19 @@ export const WRITE_STDIN_MINIMAL_EXAMPLES: readonly {
   },
   { label: 'resize only', payload: { ref: WRITE_STDIN_EXAMPLE_REF, size: { cols: 80, rows: 24 } } },
 ];
+
+/**
+ * The concrete minimal example embedded in the WriteStdin tool description,
+ * derived from the pinned {@link WRITE_STDIN_MINIMAL_EXAMPLES} `key (named)`
+ * entry so the documented shape can never drift from what conformance tests
+ * exercise. The example ref id is templated to `<id>` for human readers.
+ */
+export const WRITE_STDIN_DESCRIPTION_EXAMPLE_JSON = JSON.stringify(
+  (
+    WRITE_STDIN_MINIMAL_EXAMPLES.find((example) => example.label === 'key (named)') ??
+    WRITE_STDIN_MINIMAL_EXAMPLES[0]
+  ).payload,
+).replace('sr_example', '<id>');
 
 /**
  * Build the two-layer WriteStdin schema pair as a single unit so the
@@ -619,7 +646,7 @@ export function buildWriteStdinTool(ptyControls: PtyControlWriter): MakaTool {
       `Named keys are ${TERMINAL_INPUT_NAMED_KEYS.join(', ')}. Use a printable ASCII key with ctrl or alt for chords such as Ctrl-B; use text for ordinary typing. ` +
       'Mouse coordinates are zero-based terminal cells and work only while the application has enabled SGR cell mouse reporting. ' +
       'Actions are written atomically in their listed order. Text is ordinary audited tool-call data, not a secure secret channel. ' +
-      'Minimal example: {"ref":"maka://runtime/background-tasks/<id>","actions":[{"type":"key","key":"enter"}]}. ' +
+      `Minimal example: ${WRITE_STDIN_DESCRIPTION_EXAMPLE_JSON}. ` +
       'The returned output is the terminal state at that cut, not output attributed to this input; use Read on the ref to observe later output.',
     parameters,
     permissionArgs: (input) => parseInput(input),

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -392,7 +392,81 @@ export function buildStopBackgroundTaskTool(backgroundTasks: BackgroundTaskStopp
   };
 }
 
-export function buildWriteStdinTool(ptyControls: PtyControlWriter): MakaTool {
+/** A syntactically valid PTY ref used only in the documented WriteStdin examples. */
+export const WRITE_STDIN_EXAMPLE_REF = 'maka://runtime/background-tasks/sr_example';
+
+/**
+ * One minimal legal payload per WriteStdin action type (plus a resize-only
+ * call). Each entry is valid under the loose provider schema AND passes strict
+ * validation after normalization — the WriteStdin contract conformance test
+ * asserts both, so the documented shape can never drift from what the runtime
+ * actually accepts. The `key (chord)` entry shows the ctrl-modified printable
+ * form the description points at.
+ */
+export const WRITE_STDIN_MINIMAL_EXAMPLES: readonly {
+  readonly label: string;
+  readonly payload: Readonly<Record<string, unknown>>;
+}[] = [
+  {
+    label: 'text',
+    payload: { ref: WRITE_STDIN_EXAMPLE_REF, actions: [{ type: 'text', text: 'hello' }] },
+  },
+  {
+    label: 'key (named)',
+    payload: { ref: WRITE_STDIN_EXAMPLE_REF, actions: [{ type: 'key', key: 'enter' }] },
+  },
+  {
+    label: 'key (chord)',
+    payload: {
+      ref: WRITE_STDIN_EXAMPLE_REF,
+      actions: [{ type: 'key', key: 'c', modifiers: ['ctrl'] }],
+    },
+  },
+  {
+    label: 'mouse click',
+    payload: {
+      ref: WRITE_STDIN_EXAMPLE_REF,
+      actions: [{ type: 'mouse', event: 'click', x: 0, y: 0, button: 'left' }],
+    },
+  },
+  {
+    label: 'mouse move',
+    payload: {
+      ref: WRITE_STDIN_EXAMPLE_REF,
+      actions: [{ type: 'mouse', event: 'move', x: 1, y: 1 }],
+    },
+  },
+  {
+    label: 'mouse scroll',
+    payload: {
+      ref: WRITE_STDIN_EXAMPLE_REF,
+      actions: [{ type: 'mouse', event: 'scroll', x: 0, y: 0, direction: 'up' }],
+    },
+  },
+  { label: 'resize only', payload: { ref: WRITE_STDIN_EXAMPLE_REF, size: { cols: 80, rows: 24 } } },
+];
+
+/**
+ * Build the two-layer WriteStdin schema pair as a single unit so the
+ * provider-visible (loose) schema and the strict runtime validator can be
+ * exercised together by conformance tests. The loose provider schema exists so
+ * providers that inject `null`/`0`/`''` placeholders are tolerated; the strict
+ * validator (via {@link normalizeProviderWriteStdinInput}) normalizes those away
+ * and enforces the real contract. {@link WRITE_STDIN_MINIMAL_EXAMPLES} pins a
+ * minimal legal payload per action type that must pass BOTH layers.
+ */
+/** The validated shape the strict WriteStdin schema yields after normalization. */
+export interface WriteStdinInput {
+  ref: string;
+  input?: string;
+  actions?: TerminalInputAction[];
+  size?: { cols: number; rows: number };
+}
+
+export function createWriteStdinSchemas(): {
+  providerParameters: z.ZodTypeAny;
+  strictParameters: z.ZodType<WriteStdinInput, unknown>;
+} {
   const terminalAction = z.unknown().transform((value, context): TerminalInputAction => {
     try {
       return parseTerminalInputAction(value);
@@ -522,6 +596,11 @@ export function buildWriteStdinTool(ptyControls: PtyControlWriter): MakaTool {
     })
     .strict()
     .describe('Send ordered terminal actions and/or resize a background PTY');
+  return { providerParameters, strictParameters };
+}
+
+export function buildWriteStdinTool(ptyControls: PtyControlWriter): MakaTool {
+  const { providerParameters, strictParameters } = createWriteStdinSchemas();
   const providerSchema = zodSchema(providerParameters);
   const parameters = jsonSchema(async () => await providerSchema.jsonSchema, {
     validate: async (value) => {
@@ -540,6 +619,7 @@ export function buildWriteStdinTool(ptyControls: PtyControlWriter): MakaTool {
       `Named keys are ${TERMINAL_INPUT_NAMED_KEYS.join(', ')}. Use a printable ASCII key with ctrl or alt for chords such as Ctrl-B; use text for ordinary typing. ` +
       'Mouse coordinates are zero-based terminal cells and work only while the application has enabled SGR cell mouse reporting. ' +
       'Actions are written atomically in their listed order. Text is ordinary audited tool-call data, not a secure secret channel. ' +
+      'Minimal example: {"ref":"maka://runtime/background-tasks/<id>","actions":[{"type":"key","key":"enter"}]}. ' +
       'The returned output is the terminal state at that cut, not output attributed to this input; use Read on the ref to observe later output.',
     parameters,
     permissionArgs: (input) => parseInput(input),


### PR DESCRIPTION
## What

`WriteStdin` exposes a **loose provider schema** (so providers that inject `null`/`0`/`''` placeholders are tolerated) and enforces a **separate strict validator**. The two schemas were built inline inside `buildWriteStdinTool`, and the tool description carried no concrete payload. The net effect: **a model cannot derive a single legal call from the tool alone** — the published schema advertises shapes the strict layer rejects, and nothing tied the documented form to what the runtime actually accepts.

This change makes the contract derivable and keeps it from drifting:

- Extract the two-layer schema pair into **`createWriteStdinSchemas()`** so the provider (loose) schema and the strict validator can be exercised together.
- Add a **concrete minimal example** to the tool description: `{"ref":"maka://runtime/background-tasks/<id>","actions":[{"type":"key","key":"enter"}]}`.
- Pin **one minimal legal payload per action type** in `WRITE_STDIN_MINIMAL_EXAMPLES` — text, named key, key chord, mouse click, mouse move, mouse scroll, and resize-only.

## Why it's safe

Presentation- and test-only. **No schema semantics, permission classification, or runtime behavior changes.** The strict validator, its normalization, and byte caps are untouched — the factory extraction is a pure refactor, verified by the existing `buildWriteStdinTool` still consuming the same pair.

## Tests

New `describe('WriteStdin provider/strict contract conformance')` in `shell-tools.test.ts`:

1. **every documented minimal example is accepted by BOTH layers** — each of the 7 pinned payloads passes `providerParameters` *and* `strictParameters`.
2. **the description advertises a ref/actions example the schemas actually accept** — the concrete example parsed out of the live description round-trips through both layers, so the doc can never drift from the runtime.
3. **provider null/0/'' placeholders are normalized away** — a key action padded with every optional field set to a placeholder round-trips to the minimal `{type:'key',key:'enter'}`.
4. **strict validation is not vacuous** (negative control) — a mouse click without a button, a non-canonical ref, and `input`+`actions` together are all rejected.

**Causal proof (fail-without / pass-with):** temporarily replacing the advertised description example with a strict-invalid shape (a mouse click missing its `button`) makes test 2 fail (`# fail 2`); restoring it returns the suite to green (`# pass 14`, the sole remaining failure being an unrelated pre-existing `/bin/echo` spawn test that only runs on POSIX). So the conformance tests gate the documented shape against the real schema rather than passing vacuously.

Part of #4267. Closes #4354.
