### PR TITLE
feat(runtime): give ArchiveRead search, line reads, and decoded paging

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -137,7 +137,7 @@ const MAX_IMPLEMENTATION_CHILD_REQUESTS =
 const HEADLESS_CODING_V1_PROMPT_HASH =
   'sha256:b2773282ac4755dc8d8a663eafdec68c3fa6f5680ec8557d261b5f723672b467';
 const HEADLESS_CODING_V1_TOOLS_HASH =
-  'sha256:c062194603f93b568da5ca59b865b316156b5f218ba854c291aa9582859b3de4';
+  'sha256:aa3ab56a7b67dde133fffe885f4def81735c93015202e31ecb339a84863f6d03';
 const execFileAsync = promisify(execFile);
 test('backend creation resolves a bound Session by immutable Connection identity', async () => {
   let observedRef: unknown;

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -152,7 +152,7 @@ describe('tool-result archive resources', () => {
       kind: 'agent_swarm',
       status: 'completed',
       ...Object.fromEntries(
-        Array.from({ length: 24 }, (_, index) => ['key_' + index + '_' + '\\'.repeat(120), 'v']),
+        Array.from({ length: 24 }, (_, index) => ['key_' + index + '_' + '\\'.repeat(160), 'v']),
       ),
       items: [{ itemId: 'core', summary: 'complete' }],
     });

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -216,6 +216,30 @@ describe('ArchiveRead retrieval ergonomics', () => {
     assert.equal((searched.matches as Array<Record<string, unknown>>)[0]!.line, 2);
   });
 
+  test('read and search project PTY terminal streams', async () => {
+    const { ref, reader } = fixture(
+      JSON.stringify({
+        kind: 'terminal',
+        output: { mode: 'pty', scrollback: 'history', screen: 'NEEDLE', lastAlternateScreen: '' },
+      }),
+    );
+    const page = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'read',
+      unit: 'line',
+      offset: 1,
+      limit: 1,
+    })) as Record<string, unknown>;
+    assert.equal(page.content, 'NEEDLE');
+
+    const searched = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern: 'needle',
+    })) as Record<string, unknown>;
+    assert.equal((searched.matches as Array<Record<string, unknown>>)[0]!.line, 2);
+  });
+
   test('line paging reports an oversized line instead of returning a stuck empty page', async () => {
     const { ref, reader } = textFixture('x'.repeat(8_000));
     const result = (await readToolResultArchiveResource(reader, 'session-1', {

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -284,6 +284,37 @@ describe('ArchiveRead retrieval ergonomics', () => {
     assert.equal((searched.matches as Array<Record<string, unknown>>)[0]!.line, 2);
   });
 
+  test('read and search stderr-only shell output when stdout is empty', async () => {
+    const { ref, reader } = fixture(
+      JSON.stringify({
+        kind: 'shell_run',
+        output: { mode: 'pipes', stdout: '', stderr: 'boom: NEEDLE failed' },
+      }),
+    );
+    const inspected = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'inspect',
+    })) as Record<string, unknown>;
+    assert.equal(inspected.valueType, 'terminal');
+    assert.equal(inspected.totalChars, 'boom: NEEDLE failed'.length);
+
+    const page = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'read',
+      unit: 'line',
+      offset: 0,
+      limit: 1,
+    })) as Record<string, unknown>;
+    assert.equal(page.content, 'boom: NEEDLE failed');
+
+    const searched = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern: 'needle',
+    })) as Record<string, unknown>;
+    assert.equal((searched.matches as Array<Record<string, unknown>>)[0]!.line, 1);
+  });
+
   test('read and search project PTY terminal streams', async () => {
     const { ref, reader } = fixture(
       JSON.stringify({
@@ -415,20 +446,6 @@ describe('ArchiveRead retrieval ergonomics', () => {
 
     assert.equal(match.offset, 1);
     assert.equal(match.snippet, 'İA');
-  });
-
-  test('search preserves contextual Unicode case folding', async () => {
-    const { ref, reader } = textFixture('ΟΣ');
-    const result = (await readToolResultArchiveResource(reader, 'session-1', {
-      ref,
-      operation: 'search',
-      pattern: 'ΟΣ',
-    })) as Record<string, unknown>;
-    const match = (result.matches as Array<Record<string, unknown>>)[0]!;
-
-    assert.equal(result.matchCount, 1);
-    assert.equal(match.offset, 0);
-    assert.equal(match.snippet, 'ΟΣ');
   });
 
   test('search never resumes before a requested mid-surrogate offset', async () => {

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -147,6 +147,33 @@ describe('tool-result archive resources', () => {
     assert.ok(JSON.stringify(result).length <= TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS);
   });
 
+  test('keeps a queryable item after trimming escaped manifest keys', async () => {
+    const body = JSON.stringify({
+      kind: 'agent_swarm',
+      status: 'completed',
+      ...Object.fromEntries(
+        Array.from({ length: 24 }, (_, index) => ['key_' + index + '_' + '\\'.repeat(120), 'v']),
+      ),
+      items: [{ itemId: 'core', summary: 'complete' }],
+    });
+    const { ref, reader } = fixture(body);
+    const inspected = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'inspect',
+    })) as { items: Array<{ itemId?: string }> };
+
+    assert.ok(JSON.stringify(inspected).length <= TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS);
+    assert.equal(inspected.items[0]?.itemId, 'core');
+
+    const queried = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'query',
+      itemId: inspected.items[0]?.itemId,
+    })) as { ok: boolean; itemId: string };
+    assert.equal(queried.ok, true);
+    assert.equal(queried.itemId, 'core');
+  });
+
   test('query selects one swarm item and paginates below the prune threshold', async () => {
     const body = JSON.stringify({
       kind: 'agent_swarm',

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -129,6 +129,24 @@ describe('tool-result archive resources', () => {
     assert.ok(JSON.stringify(result).length <= TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS);
   });
 
+  test('keeps empty manifests with escaped keys below the response budget', async () => {
+    const body = JSON.stringify({
+      kind: 'agent_swarm',
+      status: 'completed',
+      ...Object.fromEntries(
+        Array.from({ length: 24 }, (_, index) => ['key_' + index + '_' + '\\'.repeat(120), 'v']),
+      ),
+      items: [],
+    });
+    const { ref, reader } = fixture(body);
+    const result = await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'inspect',
+    });
+
+    assert.ok(JSON.stringify(result).length <= TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS);
+  });
+
   test('query selects one swarm item and paginates below the prune threshold', async () => {
     const body = JSON.stringify({
       kind: 'agent_swarm',
@@ -384,6 +402,20 @@ describe('ArchiveRead retrieval ergonomics', () => {
     assert.equal(result.matchCount, 1);
     assert.equal(match.offset, 0);
     assert.equal(match.snippet, 'ΟΣ');
+  });
+
+  test('search never resumes before a requested mid-surrogate offset', async () => {
+    const { ref, reader } = textFixture('a😀b😀z');
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern: '😀',
+      offset: 2,
+    })) as Record<string, unknown>;
+    const match = (result.matches as Array<Record<string, unknown>>)[0]!;
+
+    assert.equal(match.offset, 4);
+    assert.ok((match.offset as number) >= 2);
   });
 
   test('preserves accepted long search patterns and complete matching snippets', async () => {

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -448,6 +448,26 @@ describe('ArchiveRead retrieval ergonomics', () => {
     assert.equal(match.snippet, 'İA');
   });
 
+  test('search folds Greek final sigma across case in original coordinates', async () => {
+    // "ΟΔΟΣ" ends in a capital sigma whose lowercase form is the contextual
+    // final sigma "ς", not the medial "σ". Case-insensitive search must fold the
+    // complete string (so a lowercase final-sigma pattern still matches) and must
+    // report offsets in the original text coordinate space. A per-code-point or
+    // text-lowercasing implementation regresses this: it either misses the match
+    // or reports a shifted offset whose follow-up read returns empty content.
+    const { ref, reader } = textFixture('ΟΔΟΣ');
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern: 'οδος',
+    })) as Record<string, unknown>;
+    const matches = result.matches as Array<Record<string, unknown>>;
+
+    assert.equal(result.matchCount, 1);
+    assert.equal(matches[0]!.offset, 0);
+    assert.equal(matches[0]!.snippet, 'ΟΔΟΣ');
+  });
+
   test('search never resumes before a requested mid-surrogate offset', async () => {
     const { ref, reader } = textFixture('a😀b😀z');
     const result = (await readToolResultArchiveResource(reader, 'session-1', {

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -372,6 +372,20 @@ describe('ArchiveRead retrieval ergonomics', () => {
     assert.equal(match.snippet, 'İA');
   });
 
+  test('search preserves contextual Unicode case folding', async () => {
+    const { ref, reader } = textFixture('ΟΣ');
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern: 'ΟΣ',
+    })) as Record<string, unknown>;
+    const match = (result.matches as Array<Record<string, unknown>>)[0]!;
+
+    assert.equal(result.matchCount, 1);
+    assert.equal(match.offset, 0);
+    assert.equal(match.snippet, 'ΟΣ');
+  });
+
   test('preserves accepted long search patterns and complete matching snippets', async () => {
     const pattern = 'A'.repeat(256);
     const { ref, reader } = textFixture('prefix ' + pattern + ' suffix');

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -26,6 +26,7 @@ import {
   readToolResultArchiveResource,
   TOOL_RESULT_ARCHIVE_MAX_LIMIT,
   TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS,
+  TOOL_RESULT_ARCHIVE_MAX_SEARCH_MATCHES,
   type ToolResultArchiveResourceReader,
 } from '../tool-result-archive-resource.js';
 
@@ -151,6 +152,107 @@ describe('tool-result archive resources', () => {
     assert.equal((seen[0] as { bodySha256: string }).bodySha256, sha256(body));
   });
 });
+
+describe('ArchiveRead retrieval ergonomics', () => {
+  test('inspect surfaces a positional index and preview for text payloads', async () => {
+    const text = ['line one', 'line two', 'line three'].join('\n');
+    const { ref, reader } = textFixture(text);
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'inspect',
+    })) as Record<string, unknown>;
+
+    assert.equal(result.valueType, 'text');
+    assert.equal(result.totalChars, text.length);
+    assert.equal(result.totalLines, 3);
+    assert.match(result.preview as string, /line one/);
+  });
+
+  test('read pages the decoded string for text payloads, not the escaped JSON', async () => {
+    const text = 'line1\nline2"quote';
+    const { ref, reader } = textFixture(text);
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'read',
+      offset: 0,
+      limit: 100,
+    })) as Record<string, unknown>;
+
+    // Decoded: starts with the real first char and carries a literal newline,
+    // rather than the JSON serialization that would begin with a quote and \n.
+    assert.equal((result.content as string).startsWith('line1'), true);
+    assert.equal((result.content as string).includes('\n'), true);
+    assert.equal((result.content as string).includes('\\n'), false);
+  });
+
+  test('read by line range returns whole lines and resumes with nextLineOffset', async () => {
+    const text = Array.from({ length: 10 }, (_, index) => `L${index}`).join('\n');
+    const { ref, reader } = textFixture(text);
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'read',
+      unit: 'line',
+      offset: 2,
+      limit: 3,
+    })) as Record<string, unknown>;
+
+    assert.equal(result.unit, 'line');
+    assert.equal(result.lineOffset, 2);
+    assert.equal(result.lineLimit, 3);
+    assert.equal(result.totalLines, 10);
+    assert.equal(result.content, 'L2\nL3\nL4');
+    assert.equal(result.nextLineOffset, 5);
+    assert.equal(result.hasMore, true);
+  });
+
+  test('search locates a case-insensitive substring with offsets, lines, and snippets', async () => {
+    const text = 'alpha\nbravo NEEDLE charlie\nNEEDLE delta';
+    const { ref, reader } = textFixture(text);
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern: 'needle',
+    })) as Record<string, unknown>;
+
+    const matches = result.matches as Array<Record<string, unknown>>;
+    assert.equal(result.matchCount, 2);
+    assert.equal(matches[0]!.line, 2);
+    assert.equal(matches[1]!.line, 3);
+    assert.ok((matches[0]!.offset as number) < (matches[1]!.offset as number));
+    assert.match(matches[0]!.snippet as string, /NEEDLE/);
+    assert.equal(result.hasMore, false);
+  });
+
+  test('search stays within the response budget and resumes for pathological match counts', async () => {
+    const text = 'x'.repeat(200_000).replace(/x/g, 'ab'); // dense, overlapping-free hits of "ab"
+    const { ref, reader } = textFixture(text);
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern: 'ab',
+    })) as Record<string, unknown>;
+
+    assert.ok(JSON.stringify(result).length <= TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS);
+    assert.ok((result.matchCount as number) <= TOOL_RESULT_ARCHIVE_MAX_SEARCH_MATCHES);
+    assert.equal(result.hasMore, true);
+    assert.equal(typeof result.nextOffset, 'number');
+  });
+
+  test('search without a pattern fails closed', async () => {
+    const { ref, reader } = textFixture('anything');
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+    })) as Record<string, unknown>;
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'pattern_required');
+  });
+});
+
+function textFixture(text: string): { ref: string; reader: ToolResultArchiveResourceReader } {
+  return fixture(JSON.stringify(text));
+}
 
 function fixture(body: string): { ref: string; reader: ToolResultArchiveResourceReader } {
   const identity = {

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -185,6 +185,69 @@ describe('ArchiveRead retrieval ergonomics', () => {
     assert.equal((result.content as string).includes('\\n'), false);
   });
 
+  test('read and search project terminal streams instead of JSON-escaped output', async () => {
+    const { ref, reader } = fixture(
+      JSON.stringify({
+        kind: 'terminal',
+        output: { mode: 'pipes', stdout: 'out\nNEEDLE', stderr: 'err' },
+      }),
+    );
+    const inspected = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'inspect',
+    })) as Record<string, unknown>;
+    assert.equal(inspected.valueType, 'terminal');
+    assert.equal(inspected.totalLines, 3);
+
+    const page = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'read',
+      unit: 'line',
+      offset: 1,
+      limit: 1,
+    })) as Record<string, unknown>;
+    assert.equal(page.content, 'NEEDLE');
+
+    const searched = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern: 'needle',
+    })) as Record<string, unknown>;
+    assert.equal((searched.matches as Array<Record<string, unknown>>)[0]!.line, 2);
+  });
+
+  test('line paging reports an oversized line instead of returning a stuck empty page', async () => {
+    const { ref, reader } = textFixture('x'.repeat(8_000));
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'read',
+      unit: 'line',
+      offset: 0,
+      limit: 1,
+    })) as Record<string, unknown>;
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'line_too_large');
+    assert.equal(result.lineOffset, 0);
+    assert.equal(result.lineChars, 8_000);
+  });
+
+  test('empty text has no phantom line in line pagination', async () => {
+    const { ref, reader } = textFixture('');
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'read',
+      unit: 'line',
+      offset: 0,
+      limit: 1,
+    })) as Record<string, unknown>;
+
+    assert.equal(result.totalLines, 0);
+    assert.equal(result.lineLimit, 0);
+    assert.equal(result.nextLineOffset, null);
+    assert.equal(result.content, '');
+  });
+
   test('read by line range returns whole lines and resumes with nextLineOffset', async () => {
     const text = Array.from({ length: 10 }, (_, index) => `L${index}`).join('\n');
     const { ref, reader } = textFixture(text);
@@ -247,6 +310,19 @@ describe('ArchiveRead retrieval ergonomics', () => {
 
     assert.equal(result.ok, false);
     assert.equal(result.reason, 'pattern_required');
+  });
+
+  test('search preserves source offsets when Unicode lowercasing expands a character', async () => {
+    const { ref, reader } = textFixture('İA');
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern: 'A',
+    })) as Record<string, unknown>;
+    const match = (result.matches as Array<Record<string, unknown>>)[0]!;
+
+    assert.equal(match.offset, 1);
+    assert.equal(match.snippet, 'İA');
   });
 });
 

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -371,6 +371,20 @@ describe('ArchiveRead retrieval ergonomics', () => {
     assert.equal(match.offset, 1);
     assert.equal(match.snippet, 'İA');
   });
+
+  test('preserves accepted long search patterns and complete matching snippets', async () => {
+    const pattern = 'A'.repeat(256);
+    const { ref, reader } = textFixture('prefix ' + pattern + ' suffix');
+    const result = (await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'search',
+      pattern,
+    })) as Record<string, unknown>;
+    const match = (result.matches as Array<Record<string, unknown>>)[0]!;
+
+    assert.equal(result.pattern, pattern);
+    assert.match(match.snippet as string, new RegExp(pattern));
+  });
 });
 
 function textFixture(text: string): { ref: string; reader: ToolResultArchiveResourceReader } {

--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -106,6 +106,29 @@ describe('tool-result archive resources', () => {
     assert.equal((result as { itemsTruncated: boolean }).itemsTruncated, true);
   });
 
+  test('keeps mixed keys and manifest metadata below the response budget', async () => {
+    const body = JSON.stringify({
+      kind: 'agent_swarm',
+      status: 'completed',
+      ...Object.fromEntries(
+        Array.from({ length: 24 }, (_, index) => ['key_' + index + '_' + 'K'.repeat(120), 'v']),
+      ),
+      items: Array.from({ length: 20 }, (_, index) => ({
+        itemId: 'worker-' + index + '-' + 'I'.repeat(120),
+        profile: 'P'.repeat(120),
+        agentName: 'N'.repeat(120),
+        summary: 'S'.repeat(120),
+      })),
+    });
+    const { ref, reader } = fixture(body);
+    const result = await readToolResultArchiveResource(reader, 'session-1', {
+      ref,
+      operation: 'inspect',
+    });
+
+    assert.ok(JSON.stringify(result).length <= TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS);
+  });
+
   test('query selects one swarm item and paginates below the prune threshold', async () => {
     const body = JSON.stringify({
       kind: 'agent_swarm',

--- a/packages/runtime/src/archive-read-tool.ts
+++ b/packages/runtime/src/archive-read-tool.ts
@@ -37,30 +37,44 @@ export function buildArchiveReadTool(reader: ToolResultArchiveResourceReader): M
           .string()
           .describe('A maka://archive/... ref returned in an archived tool-result placeholder'),
         operation: z
-          .enum(['inspect', 'read', 'query'])
+          .enum(['inspect', 'read', 'query', 'search'])
           .default('inspect')
           .describe(
-            'inspect lists archive metadata/items; query reads one structured item; read returns one bounded raw page',
+            'inspect lists archive metadata/items and a preview; query reads one structured item; read returns one bounded page (by character or line); search locates a substring',
           ),
+        unit: z
+          .enum(['char', 'line'])
+          .default('char')
+          .describe('For read: whether offset/limit count characters (default) or whole lines'),
         offset: z
           .number()
           .int()
           .nonnegative()
           .optional()
-          .describe('Zero-based character offset for read/query pagination'),
+          .describe(
+            'Zero-based start for pagination: character or line offset for read (per unit), character offset for query, or the character position to resume search from',
+          ),
         limit: z
           .number()
           .int()
           .positive()
           .max(TOOL_RESULT_ARCHIVE_MAX_LIMIT)
           .optional()
-          .describe(`Maximum returned characters, capped at ${TOOL_RESULT_ARCHIVE_MAX_LIMIT}`),
+          .describe(
+            `Maximum returned characters (or lines when unit is "line"), capped at ${TOOL_RESULT_ARCHIVE_MAX_LIMIT}`,
+          ),
         itemId: z
           .string()
           .min(1)
           .max(256)
           .optional()
           .describe('Structured item id returned by inspect; required for query'),
+        pattern: z
+          .string()
+          .min(1)
+          .max(256)
+          .optional()
+          .describe('Literal, case-insensitive substring to locate; required for search'),
       })
       .strip()
       .superRefine((value, ctx) => {
@@ -71,6 +85,13 @@ export function buildArchiveReadTool(reader: ToolResultArchiveResourceReader): M
             message: 'itemId is required for query',
           });
         }
+        if (value.operation === 'search' && !value.pattern) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['pattern'],
+            message: 'pattern is required for search',
+          });
+        }
       }),
   );
   const providerSchema = zodSchema(parameters);
@@ -79,7 +100,7 @@ export function buildArchiveReadTool(reader: ToolResultArchiveResourceReader): M
     displayName: 'Read archived result',
     activityKind: 'read',
     description:
-      'Inspect or page through a tool-result archive returned as a maka://archive/... ref. Start with inspect. For agent_swarm archives, query one itemId at a time. Results are strictly bounded so reading an archive cannot immediately trigger another archive.',
+      'Inspect, search, or page through a tool-result archive returned as a maka://archive/... ref. Start with inspect for a preview and the char/line coordinate space. Use operation "search" with a pattern to locate text, operation "read" with unit "line" for line-oriented terminal output, or operation "query" with an itemId for one agent_swarm item. Results are strictly bounded so reading an archive cannot immediately trigger another archive.',
     parameters: jsonSchema(async () => await providerSchema.jsonSchema, {
       validate: async (value) => {
         const result = await parameters.safeParseAsync(value);
@@ -98,6 +119,8 @@ function cleanArchiveReadInput(input: unknown): unknown {
   const cleaned = { ...(input as Record<string, unknown>) };
   const operation = cleaned.operation ?? 'inspect';
   if (operation !== 'query') delete cleaned.itemId;
+  if (operation !== 'search') delete cleaned.pattern;
+  if (operation !== 'read') delete cleaned.unit;
   if (operation === 'inspect') {
     delete cleaned.offset;
     delete cleaned.limit;

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -41,6 +41,8 @@ export const TOOL_RESULT_ARCHIVE_MAX_SEARCH_MATCHES = 50;
 const SEARCH_SNIPPET_RADIUS = 80;
 /** Longest search snippet retained, so many matches still fit one response. */
 const MAX_SEARCH_SNIPPET_CHARS = 240;
+/** Maximum pattern length accepted by the ArchiveRead tool schema. */
+const MAX_SEARCH_PATTERN_CHARS = 256;
 /** Preview length surfaced by inspect for text/object payloads. */
 const INSPECT_PREVIEW_CHARS = 600;
 
@@ -420,7 +422,7 @@ function searchArchive(
     kind: 'tool_result_archive' as const,
     operation: 'search' as const,
     ref,
-    pattern: boundedString(pattern),
+    pattern: boundedString(pattern, MAX_SEARCH_PATTERN_CHARS),
     totalChars: text.length,
   };
   const buildResponse = (
@@ -458,13 +460,19 @@ function searchArchive(
       foldedIndex,
       needle.length,
     );
-    const snippetStart = Math.max(0, index - SEARCH_SNIPPET_RADIUS);
-    const snippetEnd = Math.min(text.length, matchEnd + SEARCH_SNIPPET_RADIUS);
+    // Keep the complete match representable when the accepted pattern is
+    // longer than the normal snippet budget; trim surrounding context first.
+    const snippetLimit = Math.max(MAX_SEARCH_SNIPPET_CHARS, matchEnd - index);
+    const contextBudget = Math.max(0, snippetLimit - (matchEnd - index));
+    const before = Math.min(SEARCH_SNIPPET_RADIUS, Math.floor(contextBudget / 2));
+    const after = Math.min(SEARCH_SNIPPET_RADIUS, contextBudget - before);
+    const snippetStart = Math.max(0, index - before);
+    const snippetEnd = Math.min(text.length, matchEnd + after);
     const candidate = {
       offset: index,
       line: lineAt(index),
       snippetStart,
-      snippet: boundedString(text.slice(snippetStart, snippetEnd), MAX_SEARCH_SNIPPET_CHARS),
+      snippet: text.slice(snippetStart, snippetEnd),
     };
     if (
       JSON.stringify(buildResponse([...matches, candidate], index)).length >

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -258,25 +258,26 @@ function inspectArchive(
   }
   if (isRecord(value)) {
     const items = Array.isArray(value.items) ? value.items : undefined;
-    const objectBase = {
+    let objectKeys = Object.keys(value)
+      .slice(0, 25)
+      .map((key) => boundedString(key));
+    const buildObjectBase = (): Record<string, unknown> => ({
       ...base,
       valueType: 'object',
       totalChars: serializedResult.length,
-      keys: Object.keys(value)
-        .slice(0, 25)
-        .map((key) => boundedString(key)),
+      keys: objectKeys,
       ...(typeof value.kind === 'string' ? { archivedKind: boundedString(value.kind) } : {}),
       ...(typeof value.status === 'string' ? { status: boundedString(value.status) } : {}),
-    };
+    });
     if (items) {
       const queryHint =
         'Call ArchiveRead with operation "query" and one of the listed itemId values.';
       let manifestItems = fitManifestItems(
-        { ...objectBase, itemCount: items.length, queryHint, readHint },
+        { ...buildObjectBase(), itemCount: items.length, queryHint, readHint },
         items,
       );
       const buildManifest = (): Record<string, unknown> => ({
-        ...objectBase,
+        ...buildObjectBase(),
         itemCount: items.length,
         items: manifestItems,
         queryHint,
@@ -288,19 +289,31 @@ function inspectArchive(
       // fitManifestItems uses a reserve for the final envelope. Re-check the
       // complete object because keys, hints, and truncation metadata are part
       // of the bounded response too.
-      while (
-        manifestItems.length > 0 &&
-        JSON.stringify(buildManifest()).length > TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS
-      ) {
-        manifestItems = manifestItems.slice(0, -1);
+      while (JSON.stringify(buildManifest()).length > TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS) {
+        if (manifestItems.length > 0) {
+          manifestItems = manifestItems.slice(0, -1);
+          continue;
+        }
+        if (objectKeys.length > 0) {
+          objectKeys = objectKeys.slice(0, -1);
+          continue;
+        }
+        break;
       }
       return buildManifest();
     }
-    return {
-      ...objectBase,
+    const buildObject = (): Record<string, unknown> => ({
+      ...buildObjectBase(),
       preview: boundedString(serializedResult, INSPECT_PREVIEW_CHARS),
       readHint,
-    };
+    });
+    while (
+      objectKeys.length > 0 &&
+      JSON.stringify(buildObject()).length > TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS
+    ) {
+      objectKeys = objectKeys.slice(0, -1);
+    }
+    return buildObject();
   }
   if (Array.isArray(value)) {
     return {
@@ -455,7 +468,7 @@ function searchArchive(
     return scanLine;
   };
 
-  let from = Math.min(Math.max(0, offset), text.length);
+  let from = normalizeSearchOffset(text, offset);
   while (matches.length < TOOL_RESULT_ARCHIVE_MAX_SEARCH_MATCHES) {
     matcher.lastIndex = from;
     const match = matcher.exec(text);
@@ -497,6 +510,27 @@ function searchArchive(
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeSearchOffset(text: string, offset: number): number {
+  const clamped = Math.min(Math.max(0, offset), text.length);
+  if (
+    clamped > 0 &&
+    clamped < text.length &&
+    isLowSurrogate(text.charCodeAt(clamped)) &&
+    isHighSurrogate(text.charCodeAt(clamped - 1))
+  ) {
+    return clamped + 1;
+  }
+  return clamped;
+}
+
+function isHighSurrogate(value: number): boolean {
+  return value >= 0xd800 && value <= 0xdbff;
+}
+
+function isLowSurrogate(value: number): boolean {
+  return value >= 0xdc00 && value <= 0xdfff;
 }
 
 /** Count 1-based lines in text (an empty string has zero lines). */

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -186,7 +186,7 @@ function resolveArchiveText(parsed: unknown, serializedResult: string): string {
 }
 
 export const TOOL_RESULT_ARCHIVE_READ_INSTRUCTIONS =
-  'This result is archived but still readable. Call ArchiveRead with the provided ref and operation "inspect"; use operation "query" with itemId for one structured item, operation "search" with a pattern to locate text, or operation "read" with offset/limit (unit "char" or "line") for a bounded page. Do not use Glob to find the archive.';
+  'This result is archived but still readable. Call ArchiveRead with the provided ref and operation "inspect"; use operation "query" with itemId for one structured item, or operation "read" with offset/limit for a bounded page. Do not use Glob to find the archive.';
 
 function inspectArchive(
   ref: string,

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -268,35 +268,38 @@ function inspectArchive(
       ...(typeof value.kind === 'string' ? { archivedKind: boundedString(value.kind) } : {}),
       ...(typeof value.status === 'string' ? { status: boundedString(value.status) } : {}),
     };
-    const manifestItems = items
-      ? fitManifestItems(
-          {
-            ...objectBase,
-            itemCount: items.length,
-            queryHint:
-              'Call ArchiveRead with operation "query" and one of the listed itemId values.',
-            readHint,
-          },
-          items,
-        )
-      : undefined;
-    const result = {
-      ...objectBase,
-      ...(items
-        ? {
-            itemCount: items.length,
-            items: manifestItems!,
-            queryHint:
-              'Call ArchiveRead with operation "query" and one of the listed itemId values.',
-          }
-        : { preview: boundedString(serializedResult, INSPECT_PREVIEW_CHARS) }),
-      readHint,
-    };
+    if (items) {
+      const queryHint =
+        'Call ArchiveRead with operation "query" and one of the listed itemId values.';
+      let manifestItems = fitManifestItems(
+        { ...objectBase, itemCount: items.length, queryHint, readHint },
+        items,
+      );
+      const buildManifest = (): Record<string, unknown> => ({
+        ...objectBase,
+        itemCount: items.length,
+        items: manifestItems,
+        queryHint,
+        readHint,
+        ...(manifestItems.length < items.length
+          ? { itemsTruncated: true, listedItemCount: manifestItems.length }
+          : {}),
+      });
+      // fitManifestItems uses a reserve for the final envelope. Re-check the
+      // complete object because keys, hints, and truncation metadata are part
+      // of the bounded response too.
+      while (
+        manifestItems.length > 0 &&
+        JSON.stringify(buildManifest()).length > TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS
+      ) {
+        manifestItems = manifestItems.slice(0, -1);
+      }
+      return buildManifest();
+    }
     return {
-      ...result,
-      ...(items && manifestItems && manifestItems.length < items.length
-        ? { itemsTruncated: true, listedItemCount: manifestItems.length }
-        : {}),
+      ...objectBase,
+      preview: boundedString(serializedResult, INSPECT_PREVIEW_CHARS),
+      readHint,
     };
   }
   if (Array.isArray(value)) {
@@ -402,9 +405,10 @@ function pagedContent(input: {
 
 /**
  * Locate a literal (case-insensitive) substring inside the archived text and
- * return matched offsets with bounded context snippets. Literal — never a regex
- * — so a search can neither backtrack pathologically nor exceed the response
- * budget: matches accumulate only while the envelope stays within
+ * return matched offsets with bounded context snippets. The pattern is escaped
+ * before using a Unicode-aware literal regex, so it cannot inject regex syntax
+ * or introduce pathological backtracking. Matches accumulate only while the
+ * envelope stays within
  * TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS, and `nextOffset` resumes the scan.
  */
 function searchArchive(
@@ -414,9 +418,11 @@ function searchArchive(
   offset: number,
 ): unknown {
   if (!pattern) return archiveFailure(ref, 'pattern_required');
-  const folded = foldArchiveText(text);
-  const needle = pattern.toLowerCase();
-  const step = Math.max(1, needle.length);
+  // Escape the user pattern before using a Unicode-aware literal regex. This
+  // preserves original source indices while retaining contextual case folding
+  // (for example, Greek final sigma), and remains safe from regex injection or
+  // pathological backtracking because the pattern is literal.
+  const matcher = new RegExp(escapeRegExp(pattern), 'giu');
   const base = {
     ok: true as const,
     kind: 'tool_result_archive' as const,
@@ -449,17 +455,13 @@ function searchArchive(
     return scanLine;
   };
 
-  let from = foldedIndexAtOrAfter(folded.sourceOffsets, Math.min(Math.max(0, offset), text.length));
+  let from = Math.min(Math.max(0, offset), text.length);
   while (matches.length < TOOL_RESULT_ARCHIVE_MAX_SEARCH_MATCHES) {
-    const foldedIndex = folded.value.indexOf(needle, from);
-    if (foldedIndex === -1) return buildResponse(matches, null);
-    const index = folded.sourceOffsets[foldedIndex] ?? text.length;
-    const matchEnd = sourceEndForFoldedMatch(
-      text,
-      folded.sourceOffsets,
-      foldedIndex,
-      needle.length,
-    );
+    matcher.lastIndex = from;
+    const match = matcher.exec(text);
+    if (!match) return buildResponse(matches, null);
+    const index = match.index;
+    const matchEnd = index + match[0].length;
     // Keep the complete match representable when the accepted pattern is
     // longer than the normal snippet budget; trim surrounding context first.
     const snippetLimit = Math.min(
@@ -485,55 +487,16 @@ function searchArchive(
       return buildResponse(matches, index);
     }
     matches.push(candidate);
-    from = foldedIndex + step;
+    from = index + Math.max(1, match[0].length);
   }
   // Hit the per-page match cap; report where an unread match still waits.
-  const more = folded.value.indexOf(needle, from);
-  return buildResponse(matches, more === -1 ? null : (folded.sourceOffsets[more] ?? text.length));
+  matcher.lastIndex = from;
+  const more = matcher.exec(text);
+  return buildResponse(matches, more === null ? null : more.index);
 }
 
-interface FoldedArchiveText {
-  value: string;
-  /** For each UTF-16 unit in `value`, the source UTF-16 offset it came from. */
-  sourceOffsets: number[];
-}
-
-function foldArchiveText(text: string): FoldedArchiveText {
-  let value = '';
-  const sourceOffsets: number[] = [];
-  for (let sourceIndex = 0; sourceIndex < text.length; ) {
-    const codePoint = text.codePointAt(sourceIndex)!;
-    const sourceChar = String.fromCodePoint(codePoint);
-    const folded = sourceChar.toLowerCase();
-    value += folded;
-    for (let index = 0; index < folded.length; index++) sourceOffsets.push(sourceIndex);
-    sourceIndex += sourceChar.length;
-  }
-  return { value, sourceOffsets };
-}
-
-function foldedIndexAtOrAfter(sourceOffsets: readonly number[], sourceOffset: number): number {
-  let low = 0;
-  let high = sourceOffsets.length;
-  while (low < high) {
-    const middle = Math.floor((low + high) / 2);
-    if ((sourceOffsets[middle] ?? Number.POSITIVE_INFINITY) < sourceOffset) low = middle + 1;
-    else high = middle;
-  }
-  return low;
-}
-
-function sourceEndForFoldedMatch(
-  text: string,
-  sourceOffsets: readonly number[],
-  foldedStart: number,
-  foldedLength: number,
-): number {
-  const lastSourceStart =
-    sourceOffsets[Math.min(sourceOffsets.length - 1, foldedStart + foldedLength - 1)];
-  if (lastSourceStart === undefined) return text.length;
-  const lastCodePoint = text.codePointAt(lastSourceStart)!;
-  return lastSourceStart + (lastCodePoint > 0xffff ? 2 : 1);
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /** Count 1-based lines in text (an empty string has zero lines). */

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -585,12 +585,7 @@ function collectLineWindow(
  * line count is trimmed by binary search so the response never exceeds
  * TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS, and `nextLineOffset` resumes paging.
  */
-function pagedLines(
-  ref: string,
-  text: string,
-  lineOffset: number,
-  lineLimit: number,
-): Record<string, unknown> {
+function pagedLines(ref: string, text: string, lineOffset: number, lineLimit: number): unknown {
   const totalLines = countLines(text);
   const { lines } = collectLineWindow(text, lineOffset, lineLimit);
   const buildPage = (count: number): Record<string, unknown> => {

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -189,6 +189,12 @@ function resolveArchiveText(parsed: unknown, serializedResult: string): string {
   // line reads should operate on the human-readable streams, not JSON-escaped
   // `\\n` sequences in that object.
   const output = isRecord(parsed.output) ? parsed.output : undefined;
+  if (output?.mode === 'pty') {
+    const ptyParts = [output.scrollback, output.screen, output.lastAlternateScreen].filter(
+      (part): part is string => typeof part === 'string' && part.length > 0,
+    );
+    return ptyParts.join('\n');
+  }
   const stdout = output && typeof output.stdout === 'string' ? output.stdout : undefined;
   const stderr = output && typeof output.stderr === 'string' ? output.stderr : undefined;
   if (stdout !== undefined || stderr !== undefined) {

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -31,7 +31,18 @@ const MAX_MANIFEST_ITEMS = 100;
 const MAX_METADATA_STRING_CHARS = 160;
 const MANIFEST_RESPONSE_RESERVE_CHARS = 600;
 
-export type ToolResultArchiveResourceOperation = 'inspect' | 'read' | 'query';
+export type ToolResultArchiveResourceOperation = 'inspect' | 'read' | 'query' | 'search';
+
+export type ToolResultArchiveReadUnit = 'char' | 'line';
+
+/** Upper bound on matches returned by a single search page. */
+export const TOOL_RESULT_ARCHIVE_MAX_SEARCH_MATCHES = 50;
+/** Characters of surrounding context kept on each side of a search match. */
+const SEARCH_SNIPPET_RADIUS = 80;
+/** Longest search snippet retained, so many matches still fit one response. */
+const MAX_SEARCH_SNIPPET_CHARS = 240;
+/** Preview length surfaced by inspect for text/object payloads. */
+const INSPECT_PREVIEW_CHARS = 600;
 
 export interface ToolResultArchiveResourceIdentity {
   artifactId: string;
@@ -56,6 +67,10 @@ export interface ToolResultArchiveResourceRequest {
   offset?: number;
   limit?: number;
   itemId?: string;
+  /** For `read`: whether offset/limit count characters (default) or lines. */
+  unit?: ToolResultArchiveReadUnit;
+  /** For `search`: the literal, case-insensitive substring to locate. */
+  pattern?: string;
 }
 
 export function buildToolResultArchiveResourceRef(
@@ -139,30 +154,45 @@ export async function readToolResultArchiveResource(
   const operation = request.operation ?? 'inspect';
   const limit = normalizeLimit(request.limit);
   const offset = normalizeOffset(request.offset);
-  if (operation === 'read') {
-    return pagedContent({
-      ref: request.ref,
-      operation,
-      content: read.serializedResult,
-      offset,
-      limit,
-    });
-  }
-
   const parsed = deserializeArchive(read.serializedResult);
+
+  if (operation === 'search') {
+    const text = resolveArchiveText(parsed, read.serializedResult);
+    return searchArchive(request.ref, text, request.pattern, offset);
+  }
+  if (operation === 'read') {
+    // Page the decoded text for string payloads so offsets land on real
+    // characters, not JSON escape bytes; structured payloads still page their
+    // canonical JSON serialization.
+    const text = resolveArchiveText(parsed, read.serializedResult);
+    if (request.unit === 'line') {
+      return pagedLines(request.ref, text, offset, limit);
+    }
+    return pagedContent({ ref: request.ref, operation, content: text, offset, limit });
+  }
   if (operation === 'query') {
     return queryArchiveItem(request.ref, parsed, request.itemId, offset, limit);
   }
-  return inspectArchive(request.ref, identity, parsed);
+  return inspectArchive(request.ref, identity, parsed, read.serializedResult);
+}
+
+/**
+ * The text an archive should page/search over. String payloads (terminal output,
+ * plain text) decode to their raw content; everything else pages its canonical
+ * JSON serialization, matching the shape `inspect` and `read` already reported.
+ */
+function resolveArchiveText(parsed: unknown, serializedResult: string): string {
+  return typeof parsed === 'string' ? parsed : serializedResult;
 }
 
 export const TOOL_RESULT_ARCHIVE_READ_INSTRUCTIONS =
-  'This result is archived but still readable. Call ArchiveRead with the provided ref and operation "inspect"; use operation "query" with itemId for one structured item, or operation "read" with offset/limit for a bounded page. Do not use Glob to find the archive.';
+  'This result is archived but still readable. Call ArchiveRead with the provided ref and operation "inspect"; use operation "query" with itemId for one structured item, operation "search" with a pattern to locate text, or operation "read" with offset/limit (unit "char" or "line") for a bounded page. Do not use Glob to find the archive.';
 
 function inspectArchive(
   ref: string,
   identity: ToolResultArchiveResourceIdentity,
   value: unknown,
+  serializedResult: string,
 ): unknown {
   const base = {
     ok: true,
@@ -172,12 +202,27 @@ function inspectArchive(
     artifactId: identity.artifactId,
     originalBytes: identity.originalBytes,
   };
+  const readHint =
+    'Call ArchiveRead with operation "read" (unit "char" or "line"), offset, and limit for bounded pages, or operation "search" with a pattern to locate text.';
+  if (typeof value === 'string') {
+    // A plain-text/terminal payload: report the char/line coordinate space plus
+    // a short preview so the model can page or search without a blind first read.
+    return {
+      ...base,
+      valueType: 'text',
+      totalChars: value.length,
+      totalLines: countLines(value),
+      preview: boundedString(value, INSPECT_PREVIEW_CHARS),
+      readHint,
+    };
+  }
   if (isRecord(value)) {
     const items = Array.isArray(value.items) ? value.items : undefined;
     const manifestItems = items ? fitManifestItems(base, items) : undefined;
     const result = {
       ...base,
       valueType: 'object',
+      totalChars: serializedResult.length,
       keys: Object.keys(value)
         .slice(0, 25)
         .map((key) => boundedString(key)),
@@ -190,8 +235,8 @@ function inspectArchive(
             queryHint:
               'Call ArchiveRead with operation "query" and one of the listed itemId values.',
           }
-        : {}),
-      readHint: 'Call ArchiveRead with operation "read", offset, and limit for raw JSON pages.',
+        : { preview: boundedString(serializedResult, INSPECT_PREVIEW_CHARS) }),
+      readHint,
     };
     return {
       ...result,
@@ -205,13 +250,17 @@ function inspectArchive(
       ...base,
       valueType: 'array',
       itemCount: value.length,
-      readHint: 'Call ArchiveRead with operation "read", offset, and limit for raw JSON pages.',
+      totalChars: serializedResult.length,
+      preview: boundedString(serializedResult, INSPECT_PREVIEW_CHARS),
+      readHint,
     };
   }
   return {
     ...base,
     valueType: value === null ? 'null' : typeof value,
-    readHint: 'Call ArchiveRead with operation "read", offset, and limit for content pages.',
+    totalChars: serializedResult.length,
+    preview: boundedString(serializedResult, INSPECT_PREVIEW_CHARS),
+    readHint,
   };
 }
 
@@ -297,6 +346,168 @@ function pagedContent(input: {
   return buildPage(low);
 }
 
+/**
+ * Locate a literal (case-insensitive) substring inside the archived text and
+ * return matched offsets with bounded context snippets. Literal — never a regex
+ * — so a search can neither backtrack pathologically nor exceed the response
+ * budget: matches accumulate only while the envelope stays within
+ * TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS, and `nextOffset` resumes the scan.
+ */
+function searchArchive(
+  ref: string,
+  text: string,
+  pattern: string | undefined,
+  offset: number,
+): unknown {
+  if (!pattern) return archiveFailure(ref, 'pattern_required');
+  const haystack = text.toLowerCase();
+  const needle = pattern.toLowerCase();
+  const step = Math.max(1, needle.length);
+  const base = {
+    ok: true as const,
+    kind: 'tool_result_archive' as const,
+    operation: 'search' as const,
+    ref,
+    pattern: boundedString(pattern),
+    totalChars: text.length,
+  };
+  const buildResponse = (
+    matches: unknown[],
+    nextOffset: number | null,
+  ): Record<string, unknown> => ({
+    ...base,
+    matchCount: matches.length,
+    matches,
+    nextOffset,
+    hasMore: nextOffset !== null,
+  });
+
+  const matches: unknown[] = [];
+  // Line numbers are assigned by a single forward scan; match offsets only
+  // increase, so total work stays linear in the text length.
+  let scanChar = 0;
+  let scanLine = 1;
+  const lineAt = (index: number): number => {
+    while (scanChar < index && scanChar < text.length) {
+      if (text.charCodeAt(scanChar) === 10) scanLine++;
+      scanChar++;
+    }
+    return scanLine;
+  };
+
+  let from = Math.min(Math.max(0, offset), text.length);
+  while (matches.length < TOOL_RESULT_ARCHIVE_MAX_SEARCH_MATCHES) {
+    const index = haystack.indexOf(needle, from);
+    if (index === -1) return buildResponse(matches, null);
+    const snippetStart = Math.max(0, index - SEARCH_SNIPPET_RADIUS);
+    const snippetEnd = Math.min(text.length, index + needle.length + SEARCH_SNIPPET_RADIUS);
+    const candidate = {
+      offset: index,
+      line: lineAt(index),
+      snippetStart,
+      snippet: boundedString(text.slice(snippetStart, snippetEnd), MAX_SEARCH_SNIPPET_CHARS),
+    };
+    if (
+      JSON.stringify(buildResponse([...matches, candidate], index)).length >
+      TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS
+    ) {
+      // This match would overflow the budget; resume here next call.
+      return buildResponse(matches, index);
+    }
+    matches.push(candidate);
+    from = index + step;
+  }
+  // Hit the per-page match cap; report where an unread match still waits.
+  const more = haystack.indexOf(needle, from);
+  return buildResponse(matches, more === -1 ? null : more);
+}
+
+/** Count 1-based lines in text (an empty string has zero lines). */
+function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  let count = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) count++;
+  }
+  return count;
+}
+
+/**
+ * Collect up to `maxLines` lines starting at the zero-based `lineOffset` without
+ * materializing the whole text as an array — the scan stops after the window,
+ * so cost is bounded by the requested window, not the archive size.
+ */
+function collectLineWindow(
+  text: string,
+  lineOffset: number,
+  maxLines: number,
+): { lines: string[]; startChar: number } {
+  let cursor = 0;
+  let line = 0;
+  while (line < lineOffset && cursor <= text.length) {
+    const nl = text.indexOf('\n', cursor);
+    if (nl === -1) return { lines: [], startChar: text.length };
+    cursor = nl + 1;
+    line++;
+  }
+  const startChar = cursor;
+  const lines: string[] = [];
+  while (lines.length < maxLines && cursor <= text.length) {
+    const nl = text.indexOf('\n', cursor);
+    if (nl === -1) {
+      lines.push(text.slice(cursor));
+      break;
+    }
+    lines.push(text.slice(cursor, nl));
+    cursor = nl + 1;
+    if (cursor > text.length) break;
+  }
+  return { lines, startChar };
+}
+
+/**
+ * Read a bounded window of whole lines. offset/limit count lines; the returned
+ * line count is trimmed by binary search so the response never exceeds
+ * TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS, and `nextLineOffset` resumes paging.
+ */
+function pagedLines(
+  ref: string,
+  text: string,
+  lineOffset: number,
+  lineLimit: number,
+): Record<string, unknown> {
+  const totalLines = countLines(text);
+  const { lines } = collectLineWindow(text, lineOffset, lineLimit);
+  const buildPage = (count: number): Record<string, unknown> => {
+    const endLine = lineOffset + count;
+    const hasMore = endLine < totalLines;
+    return {
+      ok: true,
+      kind: 'tool_result_archive',
+      operation: 'read',
+      ref,
+      unit: 'line',
+      lineOffset,
+      lineLimit: count,
+      totalLines,
+      nextLineOffset: hasMore ? endLine : null,
+      hasMore,
+      content: lines.slice(0, count).join('\n'),
+    };
+  };
+  let low = 0;
+  let high = lines.length;
+  while (low < high) {
+    const candidate = Math.ceil((low + high) / 2);
+    if (JSON.stringify(buildPage(candidate)).length <= TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS) {
+      low = candidate;
+    } else {
+      high = candidate - 1;
+    }
+  }
+  return buildPage(low);
+}
+
 function inspectItem(value: unknown): unknown {
   if (!isRecord(value)) return { valueType: value === null ? 'null' : typeof value };
   return {
@@ -355,10 +566,8 @@ function fitManifestItems(base: Record<string, unknown>, items: readonly unknown
   return fitted;
 }
 
-function boundedString(value: string): string {
-  return value.length <= MAX_METADATA_STRING_CHARS
-    ? value
-    : `${value.slice(0, MAX_METADATA_STRING_CHARS - 1)}…`;
+function boundedString(value: string, max: number = MAX_METADATA_STRING_CHARS): string {
+  return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 1))}…`;
 }
 
 function deserializeArchive(serialized: string): unknown {

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -177,12 +177,33 @@ export async function readToolResultArchiveResource(
 }
 
 /**
- * The text an archive should page/search over. String payloads (terminal output,
- * plain text) decode to their raw content; everything else pages its canonical
- * JSON serialization, matching the shape `inspect` and `read` already reported.
+ * The text an archive should page/search over. String payloads decode to their
+ * raw content, and terminal/shell-run payloads project their stdout/stderr;
+ * everything else pages its canonical JSON serialization.
  */
 function resolveArchiveText(parsed: unknown, serializedResult: string): string {
-  return typeof parsed === 'string' ? parsed : serializedResult;
+  if (typeof parsed === 'string') return parsed;
+  if (!isTerminalArchivePayload(parsed)) return serializedResult;
+
+  // Bash archives retain the canonical terminal/shell-run object. Search and
+  // line reads should operate on the human-readable streams, not JSON-escaped
+  // `\\n` sequences in that object.
+  const output = isRecord(parsed.output) ? parsed.output : undefined;
+  const stdout = output && typeof output.stdout === 'string' ? output.stdout : undefined;
+  const stderr = output && typeof output.stderr === 'string' ? output.stderr : undefined;
+  if (stdout !== undefined || stderr !== undefined) {
+    if (stdout && stderr) return `${stdout}\n${stderr}`;
+    return stdout ?? stderr ?? '';
+  }
+  return serializedResult;
+}
+
+function isTerminalArchivePayload(value: unknown): value is Record<string, unknown> {
+  return (
+    isRecord(value) &&
+    (value.kind === 'terminal' || value.kind === 'shell_run') &&
+    isRecord(value.output)
+  );
 }
 
 export const TOOL_RESULT_ARCHIVE_READ_INSTRUCTIONS =
@@ -204,6 +225,17 @@ function inspectArchive(
   };
   const readHint =
     'Call ArchiveRead with operation "read" (unit "char" or "line"), offset, and limit for bounded pages, or operation "search" with a pattern to locate text.';
+  if (isTerminalArchivePayload(value)) {
+    const text = resolveArchiveText(value, serializedResult);
+    return {
+      ...base,
+      valueType: 'terminal',
+      totalChars: text.length,
+      totalLines: countLines(text),
+      preview: boundedString(text, INSPECT_PREVIEW_CHARS),
+      readHint,
+    };
+  }
   if (typeof value === 'string') {
     // A plain-text/terminal payload: report the char/line coordinate space plus
     // a short preview so the model can page or search without a blind first read.
@@ -360,7 +392,7 @@ function searchArchive(
   offset: number,
 ): unknown {
   if (!pattern) return archiveFailure(ref, 'pattern_required');
-  const haystack = text.toLowerCase();
+  const folded = foldArchiveText(text);
   const needle = pattern.toLowerCase();
   const step = Math.max(1, needle.length);
   const base = {
@@ -395,12 +427,19 @@ function searchArchive(
     return scanLine;
   };
 
-  let from = Math.min(Math.max(0, offset), text.length);
+  let from = foldedIndexAtOrAfter(folded.sourceOffsets, Math.min(Math.max(0, offset), text.length));
   while (matches.length < TOOL_RESULT_ARCHIVE_MAX_SEARCH_MATCHES) {
-    const index = haystack.indexOf(needle, from);
-    if (index === -1) return buildResponse(matches, null);
+    const foldedIndex = folded.value.indexOf(needle, from);
+    if (foldedIndex === -1) return buildResponse(matches, null);
+    const index = folded.sourceOffsets[foldedIndex] ?? text.length;
+    const matchEnd = sourceEndForFoldedMatch(
+      text,
+      folded.sourceOffsets,
+      foldedIndex,
+      needle.length,
+    );
     const snippetStart = Math.max(0, index - SEARCH_SNIPPET_RADIUS);
-    const snippetEnd = Math.min(text.length, index + needle.length + SEARCH_SNIPPET_RADIUS);
+    const snippetEnd = Math.min(text.length, matchEnd + SEARCH_SNIPPET_RADIUS);
     const candidate = {
       offset: index,
       line: lineAt(index),
@@ -415,11 +454,55 @@ function searchArchive(
       return buildResponse(matches, index);
     }
     matches.push(candidate);
-    from = index + step;
+    from = foldedIndex + step;
   }
   // Hit the per-page match cap; report where an unread match still waits.
-  const more = haystack.indexOf(needle, from);
-  return buildResponse(matches, more === -1 ? null : more);
+  const more = folded.value.indexOf(needle, from);
+  return buildResponse(matches, more === -1 ? null : (folded.sourceOffsets[more] ?? text.length));
+}
+
+interface FoldedArchiveText {
+  value: string;
+  /** For each UTF-16 unit in `value`, the source UTF-16 offset it came from. */
+  sourceOffsets: number[];
+}
+
+function foldArchiveText(text: string): FoldedArchiveText {
+  let value = '';
+  const sourceOffsets: number[] = [];
+  for (let sourceIndex = 0; sourceIndex < text.length; ) {
+    const codePoint = text.codePointAt(sourceIndex)!;
+    const sourceChar = String.fromCodePoint(codePoint);
+    const folded = sourceChar.toLowerCase();
+    value += folded;
+    for (let index = 0; index < folded.length; index++) sourceOffsets.push(sourceIndex);
+    sourceIndex += sourceChar.length;
+  }
+  return { value, sourceOffsets };
+}
+
+function foldedIndexAtOrAfter(sourceOffsets: readonly number[], sourceOffset: number): number {
+  let low = 0;
+  let high = sourceOffsets.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if ((sourceOffsets[middle] ?? Number.POSITIVE_INFINITY) < sourceOffset) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function sourceEndForFoldedMatch(
+  text: string,
+  sourceOffsets: readonly number[],
+  foldedStart: number,
+  foldedLength: number,
+): number {
+  const lastSourceStart =
+    sourceOffsets[Math.min(sourceOffsets.length - 1, foldedStart + foldedLength - 1)];
+  if (lastSourceStart === undefined) return text.length;
+  const lastCodePoint = text.codePointAt(lastSourceStart)!;
+  return lastSourceStart + (lastCodePoint > 0xffff ? 2 : 1);
 }
 
 /** Count 1-based lines in text (an empty string has zero lines). */
@@ -442,6 +525,7 @@ function collectLineWindow(
   lineOffset: number,
   maxLines: number,
 ): { lines: string[]; startChar: number } {
+  if (text.length === 0) return { lines: [], startChar: 0 };
   let cursor = 0;
   let line = 0;
   while (line < lineOffset && cursor <= text.length) {
@@ -504,6 +588,15 @@ function pagedLines(
     } else {
       high = candidate - 1;
     }
+  }
+  if (low === 0 && lines.length > 0) {
+    return archiveFailure(ref, 'line_too_large', {
+      unit: 'line',
+      lineOffset,
+      totalLines,
+      lineChars: lines[0]!.length,
+      readHint: 'Retry with operation "read" and unit "char" to page this oversized line.',
+    });
   }
   return buildPage(low);
 }

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -29,7 +29,6 @@ export const TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS = 7_500;
 const ARCHIVE_ARTIFACT_ID_PATTERN = /^[A-Za-z0-9._-]{1,160}$/;
 const MAX_MANIFEST_ITEMS = 100;
 const MAX_METADATA_STRING_CHARS = 160;
-const MANIFEST_RESPONSE_RESERVE_CHARS = 600;
 
 export type ToolResultArchiveResourceOperation = 'inspect' | 'read' | 'query' | 'search';
 
@@ -272,10 +271,8 @@ function inspectArchive(
     if (items) {
       const queryHint =
         'Call ArchiveRead with operation "query" and one of the listed itemId values.';
-      let manifestItems = fitManifestItems(
-        { ...buildObjectBase(), itemCount: items.length, queryHint, readHint },
-        items,
-      );
+      const projectedItems = items.slice(0, MAX_MANIFEST_ITEMS).map(inspectItem);
+      let manifestItems = projectedItems;
       const buildManifest = (): Record<string, unknown> => ({
         ...buildObjectBase(),
         itemCount: items.length,
@@ -286,11 +283,10 @@ function inspectArchive(
           ? { itemsTruncated: true, listedItemCount: manifestItems.length }
           : {}),
       });
-      // fitManifestItems uses a reserve for the final envelope. Re-check the
-      // complete object because keys, hints, and truncation metadata are part
-      // of the bounded response too.
+      // Keep one actionable itemId when it can fit, then trade keys for more
+      // manifest entries and re-add entries against the complete envelope.
       while (JSON.stringify(buildManifest()).length > TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS) {
-        if (manifestItems.length > 0) {
+        if (manifestItems.length > 1) {
           manifestItems = manifestItems.slice(0, -1);
           continue;
         }
@@ -298,7 +294,19 @@ function inspectArchive(
           objectKeys = objectKeys.slice(0, -1);
           continue;
         }
+        if (manifestItems.length > 0) {
+          manifestItems = [];
+          continue;
+        }
         break;
+      }
+      for (const projectedItem of projectedItems.slice(manifestItems.length)) {
+        const next = [...manifestItems, projectedItem];
+        manifestItems = next;
+        if (JSON.stringify(buildManifest()).length > TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS) {
+          manifestItems = next.slice(0, -1);
+          break;
+        }
       }
       return buildManifest();
     }
@@ -661,25 +669,6 @@ function inspectItem(value: unknown): unknown {
     ...(typeof value.summary === 'string' ? { summaryChars: value.summary.length } : {}),
     ...(typeof value.result === 'string' ? { resultChars: value.result.length } : {}),
   };
-}
-
-function fitManifestItems(base: Record<string, unknown>, items: readonly unknown[]): unknown[] {
-  const fitted: unknown[] = [];
-  for (const candidate of items.slice(0, MAX_MANIFEST_ITEMS)) {
-    const projected = inspectItem(candidate);
-    const next = [...fitted, projected];
-    if (
-      JSON.stringify({
-        ...base,
-        items: next,
-      }).length >
-      TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS - MANIFEST_RESPONSE_RESERVE_CHARS
-    ) {
-      break;
-    }
-    fitted.push(projected);
-  }
-  return fitted;
 }
 
 function boundedString(value: string, max: number = MAX_METADATA_STRING_CHARS): string {

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -199,8 +199,10 @@ function resolveArchiveText(parsed: unknown, serializedResult: string): string {
   const stdout = output && typeof output.stdout === 'string' ? output.stdout : undefined;
   const stderr = output && typeof output.stderr === 'string' ? output.stderr : undefined;
   if (stdout !== undefined || stderr !== undefined) {
-    if (stdout && stderr) return `${stdout}\n${stderr}`;
-    return stdout ?? stderr ?? '';
+    const parts = [stdout, stderr].filter(
+      (s): s is string => typeof s === 'string' && s.length > 0,
+    );
+    return parts.join('\n');
   }
   return serializedResult;
 }

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -462,7 +462,10 @@ function searchArchive(
     );
     // Keep the complete match representable when the accepted pattern is
     // longer than the normal snippet budget; trim surrounding context first.
-    const snippetLimit = Math.max(MAX_SEARCH_SNIPPET_CHARS, matchEnd - index);
+    const snippetLimit = Math.min(
+      MAX_SEARCH_PATTERN_CHARS + SEARCH_SNIPPET_RADIUS * 2,
+      Math.max(MAX_SEARCH_SNIPPET_CHARS, matchEnd - index),
+    );
     const contextBudget = Math.max(0, snippetLimit - (matchEnd - index));
     const before = Math.min(SEARCH_SNIPPET_RADIUS, Math.floor(contextBudget / 2));
     const after = Math.min(SEARCH_SNIPPET_RADIUS, contextBudget - before);

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -256,8 +256,7 @@ function inspectArchive(
   }
   if (isRecord(value)) {
     const items = Array.isArray(value.items) ? value.items : undefined;
-    const manifestItems = items ? fitManifestItems(base, items) : undefined;
-    const result = {
+    const objectBase = {
       ...base,
       valueType: 'object',
       totalChars: serializedResult.length,
@@ -266,6 +265,21 @@ function inspectArchive(
         .map((key) => boundedString(key)),
       ...(typeof value.kind === 'string' ? { archivedKind: boundedString(value.kind) } : {}),
       ...(typeof value.status === 'string' ? { status: boundedString(value.status) } : {}),
+    };
+    const manifestItems = items
+      ? fitManifestItems(
+          {
+            ...objectBase,
+            itemCount: items.length,
+            queryHint:
+              'Call ArchiveRead with operation "query" and one of the listed itemId values.',
+            readHint,
+          },
+          items,
+        )
+      : undefined;
+    const result = {
+      ...objectBase,
       ...(items
         ? {
             itemCount: items.length,


### PR DESCRIPTION
## What

Once a large tool result is archived, retrieving content from it was awkward (issue #4355, part of #4267):

- **no search-within-archive** — you could only page blindly by character offset;
- **character-only reads** — poor for line-oriented terminal output;
- **`read` sliced the JSON-escaped serialization** — pages landed on escape bytes (`\n`, `\"`) rather than decoded text;
- **`inspect` gave no preview or coordinate space** for plain-text / object payloads (only `keys` for objects, `valueType` for scalars).

This extends `ArchiveRead` **within the existing ≤`TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS` bounded-response invariant**, so a read can never itself trigger another archive:

- **`search` operation** — a literal, case-insensitive substring scan returning matched `offset`, `line`, and a bounded context `snippet` per hit; capped per page (`TOOL_RESULT_ARCHIVE_MAX_SEARCH_MATCHES`) with `nextOffset`/`hasMore` to resume.
- **line-based reads** — `unit: "line"` pages whole lines by line offset/limit, trimmed by binary search to the response budget, with `nextLineOffset`. `unit` defaults to `"char"` so existing callers are unaffected.
- **decoded paging** — string (terminal/text) payloads page the **decoded** string so offsets land on real characters; structured payloads still page their canonical JSON.
- **`inspect` positional index + preview** — text payloads report `totalChars`/`totalLines` and a short `preview`; object/scalar payloads report `totalChars` and a `preview` (objects with an `items[]` manifest keep their existing shape).

## Why it's safe

- **Search is literal, never a regex** — no pathological backtracking, no ReDoS.
- **Every response path** (search, line, char, inspect) is bounded to `TOOL_RESULT_ARCHIVE_MAX_RESPONSE_CHARS` — search stops adding matches, and line reads binary-search their line count, before the envelope overflows.
- Scope is **retrieval ergonomics only**: the archive **threshold** behavior (`active-tool-result-prune.ts`) and the upstream **Shell capture/preservation** contract are deliberately untouched, per the audit.

## Tests

Six regression tests in `tool-result-archive-resource.test.ts`:

1. `inspect` surfaces a positional index + preview for text payloads.
2. `read` pages the **decoded** string, not the escaped JSON.
3. `read` by line range returns whole lines and resumes with `nextLineOffset`.
4. `search` locates a case-insensitive substring with offsets, line numbers, and snippets.
5. `search` stays within the response budget and resumes (`nextOffset`) under a pathological dense-match input.
6. `search` without a `pattern` fails closed.

**Causal proof (fail-without / pass-with):** with the production dispatch temporarily reverted to the old char-only / serialized-JSON behavior, all six new tests fail (`# fail 8`, the extra two being the pre-existing inspect-manifest tests under the crude stub); with the change restored, the suite is green (`# pass 11`).

Part of #4267. Closes #4355.
