### PR TITLE
fix(ci): guard stale npm script approvals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
       - name: Verify ASF npm preflight policy
         run: npm run check:asf-npm
 
+      - name: Check npm install script allowlist
+        run: npm run check:allow-scripts
+
+      - name: Test npm install script allowlist
+        run: node --test --test-concurrency=1 scripts/check-allow-scripts.test.mjs
+
       # The source-header gate has to see every file that lands, not only the
       # files an affected surface selects, so it runs unconditionally beside
       # the other install-free checks.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "clean": "node scripts/clean-build.mjs",
     "rebuild": "npm run clean && npm run build",
     "check:stale": "node scripts/check-stale-dist.mjs",
+    "check:allow-scripts": "node scripts/check-allow-scripts.mjs",
     "generate:third-party-notices": "node scripts/generate-third-party-notices.mjs",
     "check:third-party-notices": "node scripts/generate-third-party-notices.mjs --check",
     "generate:cli-third-party-notices": "node scripts/generate-third-party-notices.mjs --target cli",
@@ -113,8 +114,8 @@
     "yaml": "2.9.0"
   },
   "allowScripts": {
-    "esbuild@0.27.7": true,
-    "@jackwener/opencli@1.8.4": true,
+    "esbuild@0.28.2": true,
+    "@jackwener/opencli@1.8.6": true,
     "node-pty@1.2.0-beta.15": true
   },
   "overrides": {

--- a/scripts/check-allow-scripts.mjs
+++ b/scripts/check-allow-scripts.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(fileURLToPath(new URL('..', import.meta.url)));
+
+/**
+ * Return allowScripts entries that no longer match an exact package in the
+ * lockfile. npm treats these keys as exact name@version specifiers, so a
+ * dependency bump can otherwise leave a silently ineffective approval behind.
+ */
+export function findStaleAllowScripts(allowScripts = {}, lockPackages = {}) {
+  return Object.keys(allowScripts).filter((specifier) => {
+    const separator = specifier.lastIndexOf('@');
+    if (separator <= 0 || separator === specifier.length - 1) return true;
+
+    const packageName = specifier.slice(0, separator);
+    const version = specifier.slice(separator + 1);
+    return !Object.entries(lockPackages).some(
+      ([path, packageInfo]) =>
+        (path === `node_modules/${packageName}` || path.endsWith(`/node_modules/${packageName}`)) &&
+        packageInfo?.version === version,
+    );
+  });
+}
+
+function main() {
+  const manifest = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  const lockfile = JSON.parse(readFileSync(join(root, 'package-lock.json'), 'utf8'));
+  const stale = findStaleAllowScripts(manifest.allowScripts, lockfile.packages);
+
+  if (stale.length > 0) {
+    throw new Error(
+      `allowScripts contains entries not present at the locked version: ${stale.join(', ')}`,
+    );
+  }
+
+  console.log(
+    `allowScripts entries match package-lock.json (${Object.keys(manifest.allowScripts ?? {}).length})`,
+  );
+}
+
+if (import.meta.main) main();

--- a/scripts/check-allow-scripts.test.mjs
+++ b/scripts/check-allow-scripts.test.mjs
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { findStaleAllowScripts } from './check-allow-scripts.mjs';
+
+test('accepts exact allowScripts entries at top-level and nested lockfile paths', () => {
+  assert.deepEqual(
+    findStaleAllowScripts(
+      {
+        'esbuild@0.28.2': true,
+        '@scope/tool@1.2.3': true,
+      },
+      {
+        'node_modules/esbuild': { version: '0.28.2' },
+        'node_modules/parent/node_modules/@scope/tool': { version: '1.2.3' },
+      },
+    ),
+    [],
+  );
+});
+
+test('reports removed, malformed, and version-bumped allowScripts entries', () => {
+  assert.deepEqual(
+    findStaleAllowScripts(
+      {
+        'esbuild@0.27.7': true,
+        'removed-package@1.0.0': true,
+        malformed: true,
+      },
+      { 'node_modules/esbuild': { version: '0.28.2' } },
+    ),
+    ['esbuild@0.27.7', 'removed-package@1.0.0', 'malformed'],
+  );
+});


### PR DESCRIPTION
## Summary

The root `allowScripts` policy uses exact `name@version` keys, so dependency bumps can silently turn reviewed approvals into entries that match nothing. This leaves `npm ci` successful while skipping install scripts without a repository check identifying the stale policy.

This change:

- updates the two stale approvals to the versions present in `package-lock.json`;
- adds an install-free `check:allow-scripts` gate that validates every approval against the lockfile, including nested packages;
- runs the gate and its regression tests in CI.

The deny-by-default policy remains unchanged; packages without an explicit approval remain denied.

## Validation

- `npm ci --no-audit --no-fund`
- `npm run check:allow-scripts`
- `node --test --test-concurrency=1 scripts/check-allow-scripts.test.mjs`
- `npm run build`
- `npm run format:check`
- `npm run lint`
- `npm run check:asf-headers`
- `npm run check:asf-npm`
- `git diff --check`

The repository-wide `typecheck` and `npm test` commands were also run. They report existing failures in untouched desktop, storage, CLI, evaluation, and Windows-specific PTY paths; the changed files pass their focused checks and the full build succeeds.
