### PR TITLE
fix(runtime): give sandbox boundary wait a time budget

### DIFF
--- a/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { deferred, nextId } from '@maka/core/test-only/async-primitives';
+import { deferred, nextId, waitFor } from '@maka/core/test-only/async-primitives';
 import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -1077,10 +1077,22 @@ function header(cwd = process.cwd()): SessionHeader {
 async function waitForBoundaryRequest(
   events: SessionEvent[],
 ): Promise<Extract<SessionEvent, { type: 'sandbox_boundary_request' }>> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    const event = events.find((candidate) => candidate.type === 'sandbox_boundary_request');
-    if (event?.type === 'sandbox_boundary_request') return event;
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-  throw new Error('Sandbox boundary request was not emitted');
+  let event: Extract<SessionEvent, { type: 'sandbox_boundary_request' }> | undefined;
+  await waitFor(
+    () => {
+      const candidate = events.find((entry) => entry.type === 'sandbox_boundary_request');
+      if (candidate?.type === 'sandbox_boundary_request') {
+        event = candidate;
+        return true;
+      }
+      return false;
+    },
+    {
+      timeoutMs: 5_000,
+      pollMs: 10,
+      message: 'Sandbox boundary request was not emitted',
+    },
+  );
+  assert.ok(event);
+  return event;
 }


### PR DESCRIPTION
Fixes #4383. Test-only: waitForBoundaryRequest now polls until a 5s wall-clock deadline instead of 100 macrotask ticks. Production runtime is unchanged. 15/15 sandbox-boundary tests passed locally. No behavior change.