### PR TITLE
fix(cli): preserve unresolved sandbox failures across unrelated tools

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -286,6 +286,33 @@ describe('Runtime Host maka run adapter', () => {
     );
   });
 
+  test('keeps a sandbox failure unresolved after an unrelated tool succeeds', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const fixture = runFixture({
+      turnEvents: sandboxBoundaryEvents(
+        'turn-1',
+        'step-1',
+        'step-2',
+        'Boundary was not widened',
+        'tool_search',
+      ),
+    });
+    const exitCode = await runFixtureCommand(
+      fixture,
+      ['request inaccessible work'],
+      (text) => stdout.push(text),
+      (text) => stderr.push(text),
+    );
+
+    assert.equal(exitCode, 1);
+    assert.equal(stdout.join(''), '');
+    assert.equal(
+      stderr.join(''),
+      'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
+    );
+  });
+
   test('returns exit code 1 when reconnect restores a missed sandbox failure', async () => {
     let publishReplacement = () => {};
     const fixture = runFixture({

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -588,7 +588,10 @@ class TurnOutcomeClassifier {
   >();
   readonly #unresolvedSandboxFailures = new Map<
     string,
-    { readonly failedStepId: string | undefined }
+    {
+      readonly failedStepId: string | undefined;
+      readonly failedToolName: string | undefined;
+    }
   >();
   #finalOutput: string | undefined;
   #terminal: TerminalOutcomeObservation | undefined;
@@ -621,6 +624,7 @@ class TurnOutcomeClassifier {
         if (observation.outcome === 'sandbox_failure') {
           this.#unresolvedSandboxFailures.set(observation.toolUseId, {
             failedStepId: call?.stepId,
+            failedToolName: call?.toolName,
           });
           return;
         }
@@ -633,7 +637,8 @@ class TurnOutcomeClassifier {
           unresolved.length === 1 &&
           call?.stepId !== undefined &&
           unresolved[0]?.failedStepId !== undefined &&
-          call.stepId !== unresolved[0].failedStepId
+          call.stepId !== unresolved[0].failedStepId &&
+          call.toolName === unresolved[0].failedToolName
         ) {
           this.#unresolvedSandboxFailures.clear();
           this.#sandboxBoundaryRecovered = true;


### PR DESCRIPTION

## Summary

Track the failed tool name with each unresolved sandbox failure. A later success now proves recovery only when it comes from the same tool in a different Step. An unrelated `tool_search` leaves a failed `Read` unresolved, so non-interactive boundary denial returns exit code `1` with empty stdout.

Fixes #4388

## Verification

```text
mise exec node@24.19.0 -- npx -y npm@11.19.0 --workspace maka-agent run build
mise exec node@24.19.0 -- node --test --test-name-pattern "keeps a sandbox failure unresolved" packages/cli/dist/__tests__/runtime-host-run-command.test.js
Before fix: 0 pass, 1 fail, exit 1
```

Before the fix, the failing assertion received exit code `0`; it expected `1`.

```text
mise exec node@24.19.0 -- node --test --test-name-pattern "sandbox failure|sandbox boundary|boundary request" packages/cli/dist/__tests__/runtime-host-run-command.test.js
After fix: 11 pass, 0 fail, exit 0

mise exec node@24.19.0 -- node --test packages/cli/dist/__tests__/runtime-host-run-command.test.js
36 pass, 0 fail, exit 0
```

A live CLI run against the patched build returned `1` after 21 seconds, kept stdout empty, and retained the non-interactive sandbox boundary diagnostic on stderr.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (gpt-5.6-sol), human-reviewed

## Checklist

- [x] Tests cover the change, with a red test recorded before the fix
- [x] The CLI build and affected test file pass locally

Does this PR entail a change in behavior?

- [x] Yes, described under Summary above
- [ ] No
