### PR TITLE
test(runtime): wait for sandbox boundary requests by deadline

### DIFF
--- a/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
@@ -1077,10 +1077,13 @@ function header(cwd = process.cwd()): SessionHeader {
 async function waitForBoundaryRequest(
   events: SessionEvent[],
 ): Promise<Extract<SessionEvent, { type: 'sandbox_boundary_request' }>> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  const deadline = Date.now() + 5_000;
+  while (true) {
     const event = events.find((candidate) => candidate.type === 'sandbox_boundary_request');
     if (event?.type === 'sandbox_boundary_request') return event;
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(10, remaining)));
   }
-  throw new Error('Sandbox boundary request was not emitted');
+  throw new Error('Sandbox boundary request was not emitted before the 5s deadline');
 }


### PR DESCRIPTION
## Summary

Fixes #4383

The sandbox-boundary test helper now waits until a bounded 5-second deadline instead of polling a fixed 100 macrotask ticks. It still polls without changing production behavior, but filesystem setup that takes longer than the old tick budget no longer flakes solely because of scheduler timing.

## Verification

- `npm run build:test`
- `node --test packages/runtime/dist/__tests__/tool-runtime-sandbox-boundary.test.js` (15 passed)
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `npm test` was run; the full matrix reports Windows-only Rive/remote-access/SQLite failures and workspace timeouts in unrelated suites. The changed sandbox-boundary test passes independently.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex authored the focused test-helper change and validation commands. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No