### PR TITLE
ci: manage inactive issues and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
       - name: Test PR effort classification
         run: node --test --test-concurrency=1 scripts/pr-effort.test.mjs
 
+      # The scheduled lifecycle workflow imports this pure policy module. Keep
+      # its time boundaries and exemptions deterministic before it can write.
+      - name: Test issue and PR lifecycle policy
+        run: node --test --test-concurrency=1 scripts/issue-pr-lifecycle.test.mjs
+
       # Same shape and the same needs: a regenerate-and-diff contract that runs
       # on Node alone, so it belongs beside the planner test rather than behind
       # an install.

--- a/.github/workflows/issue-pr-lifecycle.yml
+++ b/.github/workflows/issue-pr-lifecycle.yml
@@ -29,7 +29,9 @@ on:
         type: boolean
   issues:
     types: [reopened]
-  pull_request:
+  # Reopen handling mutates labels/comments. Use the trusted base workflow so
+  # fork PRs cannot force writes through a read-only pull_request token.
+  pull_request_target:
     types: [reopened]
 
 permissions:

--- a/.github/workflows/issue-pr-lifecycle.yml
+++ b/.github/workflows/issue-pr-lifecycle.yml
@@ -1,0 +1,261 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Issue and PR lifecycle
+
+on:
+  schedule:
+    - cron: "41 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report planned lifecycle changes without writing to GitHub.
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: issue-pr-lifecycle
+  cancel-in-progress: false
+
+jobs:
+  lifecycle:
+    if: github.repository == 'apache/maka'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+        with:
+          script: |
+            const path = require("node:path")
+            const { pathToFileURL } = require("node:url")
+
+            const {
+              LIFECYCLE_LABELS,
+              STALE_CLOSE_MARKER,
+              planLifecycle,
+            } = await import(
+              pathToFileURL(
+                path.join(process.env.GITHUB_WORKSPACE, "scripts/issue-pr-lifecycle.mjs"),
+              ).href
+            )
+
+            const { owner, repo } = context.repo
+            const dryRun = process.env.DRY_RUN === "true"
+
+            const fragments = `
+              fragment IssueFields on Issue {
+                number
+                createdAt
+                labels(first: 100) { nodes { name } }
+                assignees(first: 1) { totalCount }
+                comments(last: 100) {
+                  nodes { createdAt body author { __typename login } }
+                }
+              }
+
+              fragment PullRequestFields on PullRequest {
+                number
+                createdAt
+                labels(first: 100) { nodes { name } }
+                comments(last: 100) {
+                  nodes { createdAt body author { __typename login } }
+                }
+                commits(last: 1) { nodes { commit { committedDate } } }
+              }
+            `
+
+            const normalize = (node) => ({
+              number: node.number,
+              kind: node.__typename === "Issue" ? "issue" : "pull_request",
+              createdAt: node.createdAt,
+              lastCommitAt: node.commits?.nodes?.[0]?.commit?.committedDate,
+              labels: (node.labels?.nodes ?? []).map((label) => label.name),
+              assigneeCount: node.assignees?.totalCount ?? 0,
+              comments: node.comments?.nodes ?? [],
+            })
+
+            async function listOpenItems() {
+              const query = `
+                query LifecycleItems($searchQuery: String!, $cursor: String) {
+                  search(query: $searchQuery, type: ISSUE, first: 100, after: $cursor) {
+                    nodes {
+                      __typename
+                      ...IssueFields
+                      ...PullRequestFields
+                    }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+                ${fragments}
+              `
+              const items = []
+              let cursor
+
+              do {
+                const result = await github.graphql(query, {
+                  searchQuery: `repo:${owner}/${repo} is:open`,
+                  cursor,
+                })
+                items.push(...result.search.nodes.map(normalize))
+                cursor = result.search.pageInfo.hasNextPage
+                  ? result.search.pageInfo.endCursor
+                  : undefined
+              } while (cursor)
+
+              return items
+            }
+
+            async function refresh(number) {
+              const query = `
+                query LifecycleItem($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issueOrPullRequest(number: $number) {
+                      __typename
+                      ...IssueFields
+                      ...PullRequestFields
+                    }
+                  }
+                }
+                ${fragments}
+              `
+              const result = await github.graphql(query, { owner, repo, number })
+              const node = result.repository.issueOrPullRequest
+              return node ? normalize(node) : undefined
+            }
+
+            async function ensureLabels() {
+              for (const label of LIFECYCLE_LABELS) {
+                try {
+                  await github.rest.issues.getLabel({ owner, repo, name: label.name })
+                } catch (error) {
+                  if (error.status !== 404) throw error
+                  if (dryRun) {
+                    core.info(`[dry-run] create label ${label.name}`)
+                    continue
+                  }
+                  await github.rest.issues.createLabel({ owner, repo, ...label })
+                  core.info(`created label ${label.name}`)
+                }
+              }
+            }
+
+            async function removeStale(number) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  name: "stale",
+                })
+              } catch (error) {
+                if (error.status !== 404) throw error
+              }
+            }
+
+            async function apply(item, plan, revalidateClose = true) {
+              const prefix = `${item.kind === "issue" ? "issue" : "PR"} #${item.number}`
+              core.info(`${dryRun ? "[dry-run] " : ""}${prefix}: ${plan.action} (${plan.reason ?? "policy threshold"})`)
+              if (dryRun || plan.action === "none") return
+
+              if (plan.action === "warn") {
+                if (!item.labels.includes("stale")) {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: item.number,
+                    labels: ["stale"],
+                  })
+                }
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: item.number,
+                  body: plan.message,
+                })
+                return
+              }
+
+              if (plan.action === "unstale") {
+                await removeStale(item.number)
+                return
+              }
+
+              if (plan.action === "close" && revalidateClose) {
+                const current = await refresh(item.number)
+                if (!current) {
+                  core.info(`${prefix}: close cancelled because the item is no longer open`)
+                  return
+                }
+                const currentPlan = planLifecycle(current)
+                if (currentPlan.action !== "close") {
+                  core.info(`${prefix}: close cancelled after revalidation`)
+                  await apply(current, currentPlan, false)
+                  return
+                }
+                item = current
+                plan = currentPlan
+              }
+
+              const alreadyExplained = item.comments.some(
+                (comment) =>
+                  comment.author?.__typename === "Bot" &&
+                  comment.body.includes(STALE_CLOSE_MARKER),
+              )
+              if (!alreadyExplained) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: item.number,
+                  body: plan.message,
+                })
+              }
+
+              if (item.kind === "issue") {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: item.number,
+                  state: "closed",
+                })
+              } else {
+                await github.rest.pulls.update({
+                  owner,
+                  repo,
+                  pull_number: item.number,
+                  state: "closed",
+                })
+              }
+            }
+
+            await ensureLabels()
+            const items = await listOpenItems()
+            core.info(`evaluating ${items.length} open issues and pull requests`)
+            for (const item of items) await apply(item, planLifecycle(item))

--- a/.github/workflows/issue-pr-lifecycle.yml
+++ b/.github/workflows/issue-pr-lifecycle.yml
@@ -27,6 +27,10 @@ on:
         required: false
         default: true
         type: boolean
+  issues:
+    types: [reopened]
+  pull_request:
+    types: [reopened]
 
 permissions:
   contents: read
@@ -73,19 +77,23 @@ jobs:
             const fragments = `
               fragment IssueFields on Issue {
                 number
+                state
                 createdAt
                 labels(first: 100) { nodes { name } }
                 assignees(first: 1) { totalCount }
                 comments(last: 100) {
+                  totalCount
                   nodes { createdAt body author { __typename login } }
                 }
               }
 
               fragment PullRequestFields on PullRequest {
                 number
+                state
                 createdAt
                 labels(first: 100) { nodes { name } }
                 comments(last: 100) {
+                  totalCount
                   nodes { createdAt body author { __typename login } }
                 }
                 commits(last: 1) { nodes { commit { committedDate } } }
@@ -94,13 +102,37 @@ jobs:
 
             const normalize = (node) => ({
               number: node.number,
+              state: node.state,
               kind: node.__typename === "Issue" ? "issue" : "pull_request",
               createdAt: node.createdAt,
               lastCommitAt: node.commits?.nodes?.[0]?.commit?.committedDate,
               labels: (node.labels?.nodes ?? []).map((label) => label.name),
               assigneeCount: node.assignees?.totalCount ?? 0,
               comments: node.comments?.nodes ?? [],
+              commentCount: node.comments?.totalCount ?? node.comments?.nodes?.length ?? 0,
             })
+
+            async function hydrateComments(item) {
+              if (item.commentCount <= item.comments.length) return item
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: item.number,
+                per_page: 100,
+              })
+              return {
+                ...item,
+                comments: comments.map((comment) => ({
+                  createdAt: comment.created_at,
+                  body: comment.body,
+                  author: {
+                    __typename: comment.user?.type === "Bot" ? "Bot" : "User",
+                    login: comment.user?.login,
+                  },
+                })),
+                commentCount: comments.length,
+              }
+            }
 
             async function listOpenItems() {
               const query = `
@@ -209,11 +241,12 @@ jobs:
               }
 
               if (plan.action === "close" && revalidateClose) {
-                const current = await refresh(item.number)
-                if (!current) {
+                let current = await refresh(item.number)
+                if (!current || current.state !== "OPEN") {
                   core.info(`${prefix}: close cancelled because the item is no longer open`)
                   return
                 }
+                current = await hydrateComments(current)
                 const currentPlan = planLifecycle(current)
                 if (currentPlan.action !== "close") {
                   core.info(`${prefix}: close cancelled after revalidation`)
@@ -256,6 +289,27 @@ jobs:
             }
 
             await ensureLabels()
+
+            if (context.payload.action === "reopened") {
+              const number = context.payload.issue?.number ?? context.payload.pull_request?.number
+              if (number !== undefined) {
+                core.info(`${dryRun ? "[dry-run] " : ""}reopened #${number}: remove stale and reset lifecycle clock`)
+                if (!dryRun) {
+                  await removeStale(number)
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: number,
+                    body: "<!-- maka-lifecycle:reopened -->",
+                  })
+                }
+                return
+              }
+            }
+
             const items = await listOpenItems()
             core.info(`evaluating ${items.length} open issues and pull requests`)
-            for (const item of items) await apply(item, planLifecycle(item))
+            for (const item of items) {
+              const hydrated = await hydrateComments(item)
+              await apply(hydrated, planLifecycle(hydrated))
+            }

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -808,7 +808,7 @@ function hasPullRequestTrigger(name) {
   // Event-only maintenance workflows may listen for a lifecycle action without
   // becoming a normal pull-request validation lane. They do not belong in the
   // scarce-runner allowlist or its timeout tier.
-  return !/pull_request:\s*\n\s+types:\s*\[\s*reopened\s*\]/u.test(block);
+  return !/pull_request(?:_target)?:\s*\n\s+types:\s*\[\s*reopened\s*\]/u.test(block);
 }
 
 function hasPullRequestGate(name) {

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -428,9 +428,7 @@ test('every pull request lane holds a scarce runner for the same bounded time', 
   // Granularity is the file, not the job: a job inside a gating workflow that
   // opts out of pull requests still carries the tier, because reading a job's
   // `if:` would need the YAML parser this file cannot install.
-  const gates = readdirSync(WORKFLOW_DIR).filter((name) =>
-    /\bpull_request\b/u.test(triggerBlock(name)),
-  );
+  const gates = readdirSync(WORKFLOW_DIR).filter(hasPullRequestGate);
   assert.ok(gates.length > 0, 'no pull request lane found');
 
   for (const name of gates) {
@@ -804,7 +802,18 @@ function triggerBlock(name) {
 }
 
 function hasPullRequestTrigger(name) {
-  return /\bpull_request(_target)?\b/u.test(triggerBlock(name));
+  const block = triggerBlock(name);
+  if (!/\bpull_request(_target)?\b/u.test(block)) return false;
+
+  // Event-only maintenance workflows may listen for a lifecycle action without
+  // becoming a normal pull-request validation lane. They do not belong in the
+  // scarce-runner allowlist or its timeout tier.
+  return !/pull_request:\s*\n\s+types:\s*\[\s*reopened\s*\]/u.test(block);
+}
+
+function hasPullRequestGate(name) {
+  const block = triggerBlock(name);
+  return /^\s*pull_request:\s*$/mu.test(block) && hasPullRequestTrigger(name);
 }
 
 /**

--- a/scripts/issue-pr-lifecycle.mjs
+++ b/scripts/issue-pr-lifecycle.mjs
@@ -89,17 +89,7 @@ function issueActivityAt(item) {
 }
 
 function pullRequestActivityAt(item) {
-  const lastCommitAt = time(item.lastCommitAt ?? item.createdAt, 'lastCommitAt');
-  const reopenAt = latestTimestamp(
-    (item.comments ?? [])
-      .filter(
-        (comment) => isBot(comment) && String(comment.body ?? '').includes(STALE_REOPEN_MARKER),
-      )
-      .map((comment) => comment.createdAt),
-    Number.NEGATIVE_INFINITY,
-    'comment.createdAt',
-  );
-  return Math.max(lastCommitAt, reopenAt);
+  return time(item.lastCommitAt ?? item.createdAt, 'lastCommitAt');
 }
 
 function latestWarningAt(item) {

--- a/scripts/issue-pr-lifecycle.mjs
+++ b/scripts/issue-pr-lifecycle.mjs
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const STALE_WARNING_MARKER = '<!-- maka-lifecycle:stale-warning -->';
+export const STALE_CLOSE_MARKER = '<!-- maka-lifecycle:stale-close -->';
+
+export const LIFECYCLE_LABELS = [
+  {
+    name: 'stale',
+    color: 'ededed',
+    description: 'No qualifying activity within the lifecycle policy window',
+  },
+  {
+    name: 'pinned',
+    color: '0e8a16',
+    description: 'Exempt from automated lifecycle management',
+  },
+];
+
+const POLICY = {
+  issue: { inactiveDays: 30, graceDays: 30 },
+  pull_request: { inactiveDays: 30, graceDays: 7 },
+};
+
+const ISSUE_WARNING = `${STALE_WARNING_MARKER}
+This issue has had no human activity for 30 days and has been marked stale. It will be closed in 30 days unless someone comments.
+
+If the issue is still current, please confirm it against the latest \`main\` and add any information that would help move it forward. Assigned issues and issues labelled \`pinned\` are exempt from this policy.`;
+
+const ISSUE_CLOSE = `${STALE_CLOSE_MARKER}
+This issue has been closed because it received no human response during the 30-day grace period. This is not a judgement on the value of the report.
+
+If the issue still applies to the latest \`main\`, please comment with updated evidence so a maintainer can reopen it, or open a follow-up issue with the missing information.`;
+
+const PR_WARNING = `${STALE_WARNING_MARKER}
+This pull request has had no new commits for 30 days and has been marked stale. It will be closed in 7 days unless a new commit is pushed.
+
+Comments do not reset this timer: only a new commit does. If the pull request is intentionally long-lived, a maintainer can apply the \`pinned\` label.`;
+
+const PR_CLOSE = `${STALE_CLOSE_MARKER}
+This pull request has been closed because it received no new commits during the 7-day grace period. This is not a judgement on the merit of the change; it only keeps the review queue aligned with work that is actively in flight.
+
+The branch and review history are preserved. Push a new commit and reopen the pull request whenever the work is ready to continue.`;
+
+function time(value, field) {
+  const result = Date.parse(value);
+  if (!Number.isFinite(result)) throw new TypeError(`${field} must be an ISO timestamp`);
+  return result;
+}
+
+function isBot(comment) {
+  return (
+    comment.author?.__typename === 'Bot' ||
+    String(comment.author?.login ?? '') === 'github-actions[bot]'
+  );
+}
+
+function latestTimestamp(values, fallback, field) {
+  return values.reduce((latest, value) => Math.max(latest, time(value, field)), fallback);
+}
+
+function issueActivityAt(item) {
+  const createdAt = time(item.createdAt, 'createdAt');
+  const humanComments = (item.comments ?? [])
+    .filter((comment) => !isBot(comment))
+    .map((comment) => comment.createdAt);
+  return latestTimestamp(humanComments, createdAt, 'comment.createdAt');
+}
+
+function pullRequestActivityAt(item) {
+  return time(item.lastCommitAt ?? item.createdAt, 'lastCommitAt');
+}
+
+function latestWarningAt(item) {
+  const warnings = (item.comments ?? [])
+    .filter(
+      (comment) => isBot(comment) && String(comment.body ?? '').includes(STALE_WARNING_MARKER),
+    )
+    .map((comment) => comment.createdAt);
+  return warnings.length === 0
+    ? undefined
+    : latestTimestamp(warnings, Number.NEGATIVE_INFINITY, 'comment.createdAt');
+}
+
+function atLeastDaysBetween(later, earlier, days) {
+  return later - earlier >= days * DAY_MS;
+}
+
+/**
+ * Decide one lifecycle transition without performing GitHub API writes.
+ *
+ * Issues use their creation or latest non-bot comment as activity and are
+ * exempt while assigned. Pull requests use only their latest commit. Both are
+ * exempt when pinned, and grace starts at this workflow's latest warning.
+ *
+ * @param {{
+ *   kind: 'issue' | 'pull_request',
+ *   createdAt: string,
+ *   lastCommitAt?: string,
+ *   labels?: string[],
+ *   assigneeCount?: number,
+ *   comments?: Array<{createdAt: string, body?: string, author?: {__typename?: string, login?: string}}>,
+ * }} item
+ * @param {string | Date} [now]
+ */
+export function planLifecycle(item, now = new Date()) {
+  const policy = POLICY[item.kind];
+  if (!policy) throw new TypeError(`unsupported lifecycle item kind: ${item.kind}`);
+
+  const nowAt = now instanceof Date ? now.getTime() : time(now, 'now');
+  if (!Number.isFinite(nowAt)) throw new TypeError('now must be a valid date');
+
+  const labels = new Set(item.labels ?? []);
+  const isStale = labels.has('stale');
+  const exempt = labels.has('pinned') || (item.kind === 'issue' && (item.assigneeCount ?? 0) > 0);
+
+  if (exempt) {
+    return {
+      action: isStale ? 'unstale' : 'none',
+      reason: labels.has('pinned') ? 'pinned' : 'assigned',
+    };
+  }
+
+  const activityAt = item.kind === 'issue' ? issueActivityAt(item) : pullRequestActivityAt(item);
+  const warningAt = latestWarningAt(item);
+
+  if (isStale) {
+    if (warningAt === undefined) {
+      return { action: 'warn', message: item.kind === 'issue' ? ISSUE_WARNING : PR_WARNING };
+    }
+
+    if (activityAt > warningAt) {
+      return { action: 'unstale', reason: 'qualifying activity after warning' };
+    }
+
+    if (atLeastDaysBetween(nowAt, warningAt, policy.graceDays)) {
+      return { action: 'close', message: item.kind === 'issue' ? ISSUE_CLOSE : PR_CLOSE };
+    }
+
+    return { action: 'none', reason: 'within grace period' };
+  }
+
+  if (atLeastDaysBetween(nowAt, activityAt, policy.inactiveDays)) {
+    return { action: 'warn', message: item.kind === 'issue' ? ISSUE_WARNING : PR_WARNING };
+  }
+
+  return { action: 'none', reason: 'recent qualifying activity' };
+}

--- a/scripts/issue-pr-lifecycle.mjs
+++ b/scripts/issue-pr-lifecycle.mjs
@@ -21,6 +21,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 export const STALE_WARNING_MARKER = '<!-- maka-lifecycle:stale-warning -->';
 export const STALE_CLOSE_MARKER = '<!-- maka-lifecycle:stale-close -->';
+export const STALE_REOPEN_MARKER = '<!-- maka-lifecycle:reopened -->';
 
 export const LIFECYCLE_LABELS = [
   {
@@ -79,14 +80,26 @@ function latestTimestamp(values, fallback, field) {
 
 function issueActivityAt(item) {
   const createdAt = time(item.createdAt, 'createdAt');
-  const humanComments = (item.comments ?? [])
-    .filter((comment) => !isBot(comment))
+  const qualifyingComments = (item.comments ?? [])
+    .filter(
+      (comment) => !isBot(comment) || String(comment.body ?? '').includes(STALE_REOPEN_MARKER),
+    )
     .map((comment) => comment.createdAt);
-  return latestTimestamp(humanComments, createdAt, 'comment.createdAt');
+  return latestTimestamp(qualifyingComments, createdAt, 'comment.createdAt');
 }
 
 function pullRequestActivityAt(item) {
-  return time(item.lastCommitAt ?? item.createdAt, 'lastCommitAt');
+  const lastCommitAt = time(item.lastCommitAt ?? item.createdAt, 'lastCommitAt');
+  const reopenAt = latestTimestamp(
+    (item.comments ?? [])
+      .filter(
+        (comment) => isBot(comment) && String(comment.body ?? '').includes(STALE_REOPEN_MARKER),
+      )
+      .map((comment) => comment.createdAt),
+    Number.NEGATIVE_INFINITY,
+    'comment.createdAt',
+  );
+  return Math.max(lastCommitAt, reopenAt);
 }
 
 function latestWarningAt(item) {

--- a/scripts/issue-pr-lifecycle.test.mjs
+++ b/scripts/issue-pr-lifecycle.test.mjs
@@ -154,12 +154,12 @@ describe('pull request lifecycle', () => {
     });
   });
 
-  it('treats a lifecycle reopen marker as a fresh PR activity timestamp', () => {
+  it('ignores a lifecycle reopen marker for PR activity timing', () => {
     const plan = planLifecycle(
       pullRequest({ comments: [botComment(2, STALE_REOPEN_MARKER)] }),
       NOW,
     );
-    assert.deepEqual(plan, { action: 'none', reason: 'recent qualifying activity' });
+    assert.equal(plan.action, 'warn');
   });
 
   it('still finds human activity when more than 100 comments are present', () => {

--- a/scripts/issue-pr-lifecycle.test.mjs
+++ b/scripts/issue-pr-lifecycle.test.mjs
@@ -20,7 +20,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { planLifecycle, STALE_WARNING_MARKER } from './issue-pr-lifecycle.mjs';
+import { planLifecycle, STALE_REOPEN_MARKER, STALE_WARNING_MARKER } from './issue-pr-lifecycle.mjs';
 
 const NOW = '2026-09-01T12:00:00.000Z';
 
@@ -86,6 +86,11 @@ describe('issue lifecycle', () => {
     assert.equal(plan.action, 'warn');
   });
 
+  it('treats a lifecycle reopen marker as a fresh activity timestamp', () => {
+    const plan = planLifecycle(issue({ comments: [botComment(2, STALE_REOPEN_MARKER)] }), NOW);
+    assert.deepEqual(plan, { action: 'none', reason: 'recent qualifying activity' });
+  });
+
   it('closes only after the full 30-day grace period', () => {
     const pending = issue({ labels: ['stale'], comments: [warning(29)] });
     const expired = issue({ labels: ['stale'], comments: [warning(30)] });
@@ -146,6 +151,25 @@ describe('pull request lifecycle', () => {
     assert.deepEqual(plan, {
       action: 'unstale',
       reason: 'qualifying activity after warning',
+    });
+  });
+
+  it('treats a lifecycle reopen marker as a fresh PR activity timestamp', () => {
+    const plan = planLifecycle(
+      pullRequest({ comments: [botComment(2, STALE_REOPEN_MARKER)] }),
+      NOW,
+    );
+    assert.deepEqual(plan, { action: 'none', reason: 'recent qualifying activity' });
+  });
+
+  it('still finds human activity when more than 100 comments are present', () => {
+    const comments = [
+      humanComment(1),
+      ...Array.from({ length: 100 }, (_, index) => botComment(index + 2)),
+    ];
+    assert.deepEqual(planLifecycle(issue({ comments }), NOW), {
+      action: 'none',
+      reason: 'recent qualifying activity',
     });
   });
 });

--- a/scripts/issue-pr-lifecycle.test.mjs
+++ b/scripts/issue-pr-lifecycle.test.mjs
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { planLifecycle, STALE_WARNING_MARKER } from './issue-pr-lifecycle.mjs';
+
+const NOW = '2026-09-01T12:00:00.000Z';
+
+function daysAgo(days) {
+  return new Date(Date.parse(NOW) - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function humanComment(days, body = 'Still relevant') {
+  return {
+    createdAt: daysAgo(days),
+    body,
+    author: { __typename: 'User', login: 'contributor' },
+  };
+}
+
+function botComment(days, body = 'Automated note') {
+  return {
+    createdAt: daysAgo(days),
+    body,
+    author: { __typename: 'Bot', login: 'github-actions[bot]' },
+  };
+}
+
+function warning(days) {
+  return botComment(days, STALE_WARNING_MARKER);
+}
+
+function issue(overrides = {}) {
+  return {
+    kind: 'issue',
+    createdAt: daysAgo(60),
+    labels: [],
+    assigneeCount: 0,
+    comments: [],
+    ...overrides,
+  };
+}
+
+function pullRequest(overrides = {}) {
+  return {
+    kind: 'pull_request',
+    createdAt: daysAgo(60),
+    lastCommitAt: daysAgo(60),
+    labels: [],
+    comments: [],
+    ...overrides,
+  };
+}
+
+describe('issue lifecycle', () => {
+  it('warns at the 30-day inactivity boundary', () => {
+    assert.equal(planLifecycle(issue({ createdAt: daysAgo(30) }), NOW).action, 'warn');
+    assert.equal(planLifecycle(issue({ createdAt: daysAgo(29) }), NOW).action, 'none');
+  });
+
+  it('uses the latest human comment as activity', () => {
+    const plan = planLifecycle(issue({ comments: [humanComment(10)] }), NOW);
+    assert.deepEqual(plan, { action: 'none', reason: 'recent qualifying activity' });
+  });
+
+  it('ignores bot comments when measuring activity', () => {
+    const plan = planLifecycle(issue({ comments: [botComment(1)] }), NOW);
+    assert.equal(plan.action, 'warn');
+  });
+
+  it('closes only after the full 30-day grace period', () => {
+    const pending = issue({ labels: ['stale'], comments: [warning(29)] });
+    const expired = issue({ labels: ['stale'], comments: [warning(30)] });
+    assert.deepEqual(planLifecycle(pending, NOW), {
+      action: 'none',
+      reason: 'within grace period',
+    });
+    assert.equal(planLifecycle(expired, NOW).action, 'close');
+  });
+
+  it('removes stale after a human response to the warning', () => {
+    const plan = planLifecycle(
+      issue({ labels: ['stale'], comments: [warning(20), humanComment(2)] }),
+      NOW,
+    );
+    assert.deepEqual(plan, {
+      action: 'unstale',
+      reason: 'qualifying activity after warning',
+    });
+  });
+
+  it('exempts assigned issues and removes an existing stale label', () => {
+    assert.deepEqual(planLifecycle(issue({ assigneeCount: 1 }), NOW), {
+      action: 'none',
+      reason: 'assigned',
+    });
+    assert.deepEqual(planLifecycle(issue({ assigneeCount: 1, labels: ['stale'] }), NOW), {
+      action: 'unstale',
+      reason: 'assigned',
+    });
+  });
+});
+
+describe('pull request lifecycle', () => {
+  it('warns based on the latest commit instead of creation or comments', () => {
+    const active = pullRequest({ lastCommitAt: daysAgo(5) });
+    const inactive = pullRequest({
+      lastCommitAt: daysAgo(30),
+      comments: [humanComment(1)],
+    });
+    assert.equal(planLifecycle(active, NOW).action, 'none');
+    assert.equal(planLifecycle(inactive, NOW).action, 'warn');
+  });
+
+  it('closes after seven days without a new commit', () => {
+    const plan = planLifecycle(
+      pullRequest({ labels: ['stale'], comments: [warning(7), humanComment(1)] }),
+      NOW,
+    );
+    assert.equal(plan.action, 'close');
+  });
+
+  it('removes stale after a commit newer than the warning', () => {
+    const plan = planLifecycle(
+      pullRequest({ labels: ['stale'], comments: [warning(7)], lastCommitAt: daysAgo(1) }),
+      NOW,
+    );
+    assert.deepEqual(plan, {
+      action: 'unstale',
+      reason: 'qualifying activity after warning',
+    });
+  });
+});
+
+describe('state repair and exemptions', () => {
+  it('starts a fresh grace period when stale has no workflow warning', () => {
+    const plan = planLifecycle(issue({ labels: ['stale'] }), NOW);
+    assert.equal(plan.action, 'warn');
+    assert.match(plan.message, new RegExp(STALE_WARNING_MARKER));
+  });
+
+  it('does not trust a human-authored warning marker', () => {
+    const plan = planLifecycle(
+      issue({ labels: ['stale'], comments: [humanComment(40, STALE_WARNING_MARKER)] }),
+      NOW,
+    );
+    assert.equal(plan.action, 'warn');
+  });
+
+  it('exempts pinned issues and pull requests', () => {
+    assert.deepEqual(planLifecycle(issue({ labels: ['pinned', 'stale'] }), NOW), {
+      action: 'unstale',
+      reason: 'pinned',
+    });
+    assert.deepEqual(planLifecycle(pullRequest({ labels: ['pinned'] }), NOW), {
+      action: 'none',
+      reason: 'pinned',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a daily Issue/PR lifecycle workflow for the policy agreed in [discussion #4070](https://github.com/apache/maka/discussions/4070), folding in [discussion #3839](https://github.com/apache/maka/discussions/3839)
- compute Issue activity from the latest human comment and PR activity from the latest commit, avoiding `updated_at` changes from labels, triage, and bot comments
- warn/close Issues after 30 + 30 days and PRs after 30 + 7 days; exempt assigned Issues and anything labelled `pinned`
- create the `stale` and `pinned` labels when absent, support manual dry runs, and revalidate immediately before closing
- cover thresholds, exemptions, bot filtering, state repair, and grace-period cancellation with install-free Node tests in CI

## Validation

- `node --test --test-concurrency=1 scripts/issue-pr-lifecycle.test.mjs scripts/pr-effort.test.mjs` (25 tests passed)
- Biome 2.5.9 check on both new scripts
- `node scripts/asf-license-headers.mjs check`
- parsed the workflow with the repository's locked YAML package
- executed the exact embedded `github-script` against the live tracker with all write APIs mocked to fail: 373 open items scanned, 5 unassigned Issues and 1 PR planned for warning, 0 close actions
- executed the close-time `issueOrPullRequest` GraphQL query against the live repository

## Rollout note

The current dry run includes #544. Discussion #4070 identifies it as an example of a long-lived item, so maintainers should create/apply `pinned` to #544 before the first mutating scheduled run if it should remain exempt.

AI assistance disclosure: Codex helped implement and test this change. I reviewed the policy mapping, live dry-run output, and final diff.