### PR TITLE
refactor(runtime-host): derive dispatcher operation groups from spec objects

### DIFF
--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -178,6 +178,7 @@ import { HostSkillCatalogCoordinator } from './skill-catalog-coordinator.js';
 import { SkillCatalogRepository } from './skill-catalog-repository.js';
 import { HostSessionTodoCoordinator } from './session-todo-coordinator.js';
 import { HostTurnControlCoordinator } from './turn-control-coordinator.js';
+import type { TurnOperationHandlerMap } from './operation-dispatcher.js';
 import { HostUsagePricingCoordinator } from './usage-pricing-coordinator.js';
 import { HostWebSearchCoordinator } from './web-search-coordinator.js';
 import { HostWorkHubCoordinationCoordinator } from './workhub-coordination-coordinator.js';
@@ -1181,6 +1182,16 @@ export async function createExecutionRuntimeHostComposition(
       turns: stores.agentRunStore,
       runtime: manager,
     });
+    // Compile-time guarantee that the three Turn coordinators together cover
+    // every key in TURN_OPERATION_SPECS. Domain composition seeds all domain
+    // operations with the operation_unavailable fallback, so a Turn operation
+    // that no coordinator claims would otherwise be swept into that fallback
+    // silently; `satisfies` turns such an omission into a typecheck error here.
+    ({
+      ...turnControl.handlers,
+      ...interactiveTurns.handlers,
+      ...coordinator.handlers,
+    }) satisfies TurnOperationHandlerMap;
     const turnAccessRequests = context.sessionAccessAuthority
       ? new SessionTurnAccessRequestCoordinator({
           authority: context.sessionAccessAuthority,

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -36,6 +36,42 @@ import { HOST_BOOTSTRAP_OPERATION_SPECS } from '../protocol/host-status.js';
 import { ACCESS_AUTHORITY_OPERATION_SPECS } from '../protocol/access-authority.js';
 import { SESSION_COLLABORATION_OPERATION_SPECS } from '../protocol/session-collaboration.js';
 import { PEER_MESH_OPERATION_SPECS } from '../protocol/peer-mesh.js';
+import { AGENT_GRAPH_OPERATION_SPECS } from '../protocol/agent-graph.js';
+import { ARTIFACT_OPERATION_SPECS } from '../protocol/artifact.js';
+import { CLIENT_CAPABILITY_OPERATION_SPECS } from '../protocol/client-capability.js';
+import { CONFIGURATION_OPERATION_SPECS } from '../protocol/configuration.js';
+import { CONNECTION_EFFECT_OPERATION_SPECS } from '../protocol/connection-effects.js';
+import { CONTEXT_OPERATION_SPECS } from '../protocol/context.js';
+import { DAILY_REVIEW_OPERATION_SPECS } from '../protocol/daily-review.js';
+import { DEEP_RESEARCH_OPERATION_SPECS } from '../protocol/deep-research.js';
+import { EXECUTION_INSPECT_OPERATION_SPECS } from '../protocol/execution-inspect.js';
+import { EXTERNAL_SESSION_OPERATION_SPECS } from '../protocol/external-session.js';
+import { GOAL_OPERATION_SPECS } from '../protocol/goal.js';
+import { HOSTED_EXECUTION_OPERATION_SPECS } from '../protocol/hosted-execution.js';
+import { INTERACTION_OPERATION_SPECS } from '../protocol/interaction.js';
+import { MEMORY_OPERATION_SPECS } from '../protocol/memory.js';
+import { MESSAGE_OPERATION_SPECS } from '../protocol/message.js';
+import { NETWORK_PROXY_OPERATION_SPECS } from '../protocol/network-proxy.js';
+import { OAUTH_OPERATION_SPECS } from '../protocol/oauth.js';
+import { PLAN_OPERATION_SPECS } from '../protocol/plan.js';
+import { PROJECT_CATALOG_OPERATION_SPECS } from '../protocol/project-catalog.js';
+import { RUNTIME_POLICY_OPERATION_SPECS } from '../protocol/runtime-policy.js';
+import { RUNTIME_RESOURCE_OPERATION_SPECS } from '../protocol/runtime-resource.js';
+import { SCHEDULED_TASK_OPERATION_SPECS } from '../protocol/scheduled-task.js';
+import { SESSION_CATALOG_OPERATION_SPECS } from '../protocol/session-catalog.js';
+import { SESSION_CONTINUITY_OPERATION_SPECS } from '../protocol/session-continuity.js';
+import { SESSION_EFFECT_OPERATION_SPECS } from '../protocol/session-effects.js';
+import { SESSION_RETIREMENT_OPERATION_SPECS } from '../protocol/session-retirement.js';
+import { SESSION_REVISION_OPERATION_SPECS } from '../protocol/session-revision.js';
+import { SESSION_TODO_OPERATION_SPECS } from '../protocol/session-todo.js';
+import { SESSION_TRANSCRIPT_OPERATION_SPECS } from '../protocol/session-transcript.js';
+import { SESSION_TURNS_OPERATION_SPECS } from '../protocol/session-turns.js';
+import { SKILL_CATALOG_OPERATION_SPECS } from '../protocol/skill-catalog.js';
+import { TURN_OPERATION_SPECS } from '../protocol/turn.js';
+import { USAGE_PRICING_OPERATION_SPECS } from '../protocol/usage-pricing.js';
+import { WEB_SEARCH_OPERATION_SPECS } from '../protocol/web-search.js';
+import { WORKHUB_COORDINATION_OPERATION_SPECS } from '../protocol/workhub-coordination.js';
+import { PLUGIN_PLATFORM_OPERATION_SPECS } from '../protocol/plugin-platform.js';
 import { createPeerMeshOperationHandlers } from './peer-mesh-authority.js';
 import type { RuntimeHostConnectionAuthority } from './connection-authority.js';
 
@@ -64,96 +100,61 @@ export type OperationHandlerMap = {
   [K in OperationKey]: OperationHandler<K>;
 };
 
-export type HostCoreOperationKey =
-  | keyof typeof HOST_BOOTSTRAP_OPERATION_SPECS
-  | keyof typeof ACCESS_AUTHORITY_OPERATION_SPECS
-  | keyof typeof SESSION_COLLABORATION_OPERATION_SPECS
-  | keyof typeof PEER_MESH_OPERATION_SPECS;
+/**
+ * The spec objects a Runtime Host serves from its own core — operations that
+ * never route to a domain coordinator. Declared once here so both the type
+ * (`HostCoreOperationKey`) and the runtime partition in
+ * `createUnavailableDomainOperationHandlers` stay in agreement; adding a fifth
+ * host-core spec object is a single edit.
+ */
+const HOST_CORE_SPEC_OBJECTS = [
+  HOST_BOOTSTRAP_OPERATION_SPECS,
+  ACCESS_AUTHORITY_OPERATION_SPECS,
+  SESSION_COLLABORATION_OPERATION_SPECS,
+  PEER_MESH_OPERATION_SPECS,
+] as const;
+
+type KeysOfUnion<T> = T extends unknown ? keyof T : never;
+export type HostCoreOperationKey = KeysOfUnion<(typeof HOST_CORE_SPEC_OBJECTS)[number]>;
 export type DomainOperationKey = Exclude<OperationKey, HostCoreOperationKey>;
-export type TurnOperationKey = Extract<
-  OperationKey,
-  | 'turn.start'
-  | 'turn.query'
-  | 'turn.stop'
-  | 'turn.regenerate'
-  | 'turn.resume.query'
-  | 'turn.resume.start'
->;
-export type ContextOperationKey = Extract<OperationKey, `context.${string}`>;
-export type RuntimePolicyOperationKey = Extract<
-  OperationKey,
-  | `runtime.policy.${string}`
-  | `connection.catalog.${string}`
-  | `connection.request-headers.${string}`
-  | `credential.vault.${string}`
->;
-export type ConnectionEffectOperationKey = Extract<
-  OperationKey,
-  | 'connection.models.fetch'
-  | 'connection.test.run'
-  | 'connection.onboarding.verify'
-  | 'connection.onboarding.save'
->;
-export type MessageOperationKey = Extract<
-  OperationKey,
-  | 'turn.message.query'
-  | 'turn.message.execution.query'
-  | 'turn.message.submit'
-  | 'queue.retract'
-  | 'queue.entry.retract'
-  | 'queue.entry.promote'
-  | 'queue.entry.update'
-  | 'queue.entries.reorder'
-  | 'turn.interrupt'
->;
-export type InteractionOperationKey = Extract<OperationKey, `interaction.${string}`>;
-export type GoalOperationKey = Extract<OperationKey, `goal.${string}`>;
-export type ExecutionInspectOperationKey = Extract<OperationKey, `execution.inspect.${string}`>;
-export type HostedExecutionOperationKey = Extract<OperationKey, `hosted.execution.${string}`>;
-export type ExternalSessionOperationKey = Extract<OperationKey, `external-session.${string}`>;
-export type AgentGraphOperationKey = Extract<OperationKey, `agent.graph.${string}`>;
-export type SessionContinuityOperationKey = Extract<
-  OperationKey,
-  | 'subscription.open'
-  | 'subscription.close'
-  | 'session.transcript.page'
-  | 'session.transcript.overlay.release'
->;
-export type SessionRevisionOperationKey = Extract<
-  OperationKey,
-  'session.branch.create' | 'session.revision.create' | 'session.revision.abandon'
->;
-export type SessionRetirementOperationKey = Extract<
-  OperationKey,
-  'session.lifecycle.set' | 'session.remove' | 'session.remove.preview'
->;
-export type SessionEffectOperationKey = Extract<OperationKey, 'session.recap.generate'>;
-export type SessionTodoOperationKey = Extract<OperationKey, 'session.todo.query'>;
-export type SessionCatalogOperationKey = Exclude<
-  Extract<OperationKey, `session.${string}`>,
-  | SessionContinuityOperationKey
-  | SessionRevisionOperationKey
-  | SessionRetirementOperationKey
-  | SessionEffectOperationKey
-  | SessionTodoOperationKey
->;
-export type ArtifactOperationKey = Extract<OperationKey, `artifact.${string}`>;
-export type SkillCatalogOperationKey = Extract<OperationKey, `skill.catalog.${string}`>;
-export type UsagePricingOperationKey = Extract<OperationKey, 'usage.query' | `pricing.${string}`>;
-export type MemoryOperationKey = Extract<OperationKey, `memory.${string}`>;
-export type OAuthOperationKey = Extract<OperationKey, `oauth.${string}`>;
-export type RuntimeResourceOperationKey = Extract<OperationKey, `runtime.resource.${string}`>;
-export type ClientCapabilityOperationKey = Extract<OperationKey, `client.capability.${string}`>;
-export type ScheduledTaskOperationKey = Extract<OperationKey, `scheduled-task.${string}`>;
-export type PlanOperationKey = Extract<OperationKey, `plan.${string}`>;
-export type ProjectCatalogOperationKey = Extract<OperationKey, `project.catalog.${string}`>;
-export type DeepResearchOperationKey = Extract<OperationKey, `deep-research.${string}`>;
-export type DailyReviewOperationKey = Extract<OperationKey, `daily-review.${string}`>;
-export type WebSearchOperationKey = Extract<OperationKey, `web-search.${string}`>;
-export type NetworkProxyOperationKey = Extract<OperationKey, `network-proxy.${string}`>;
-export type ConfigurationOperationKey = Extract<OperationKey, `configuration.${string}`>;
-export type WorkHubCoordinationOperationKey = Extract<OperationKey, `workhub.${string}`>;
-export type PluginPlatformOperationKey = Extract<OperationKey, `plugin.${string}`>;
+export type TurnOperationKey = keyof typeof TURN_OPERATION_SPECS;
+export type ContextOperationKey = keyof typeof CONTEXT_OPERATION_SPECS;
+export type RuntimePolicyOperationKey = keyof typeof RUNTIME_POLICY_OPERATION_SPECS;
+export type ConnectionEffectOperationKey = keyof typeof CONNECTION_EFFECT_OPERATION_SPECS;
+export type MessageOperationKey = keyof typeof MESSAGE_OPERATION_SPECS;
+export type InteractionOperationKey = keyof typeof INTERACTION_OPERATION_SPECS;
+export type GoalOperationKey = keyof typeof GOAL_OPERATION_SPECS;
+export type ExecutionInspectOperationKey = keyof typeof EXECUTION_INSPECT_OPERATION_SPECS;
+export type HostedExecutionOperationKey = keyof typeof HOSTED_EXECUTION_OPERATION_SPECS;
+export type ExternalSessionOperationKey = keyof typeof EXTERNAL_SESSION_OPERATION_SPECS;
+export type AgentGraphOperationKey = keyof typeof AGENT_GRAPH_OPERATION_SPECS;
+export type SessionContinuityOperationKey =
+  | keyof typeof SESSION_CONTINUITY_OPERATION_SPECS
+  | keyof typeof SESSION_TRANSCRIPT_OPERATION_SPECS;
+export type SessionRevisionOperationKey = keyof typeof SESSION_REVISION_OPERATION_SPECS;
+export type SessionRetirementOperationKey = keyof typeof SESSION_RETIREMENT_OPERATION_SPECS;
+export type SessionEffectOperationKey = keyof typeof SESSION_EFFECT_OPERATION_SPECS;
+export type SessionTodoOperationKey = keyof typeof SESSION_TODO_OPERATION_SPECS;
+export type SessionCatalogOperationKey =
+  | keyof typeof SESSION_CATALOG_OPERATION_SPECS
+  | keyof typeof SESSION_TURNS_OPERATION_SPECS;
+export type ArtifactOperationKey = keyof typeof ARTIFACT_OPERATION_SPECS;
+export type SkillCatalogOperationKey = keyof typeof SKILL_CATALOG_OPERATION_SPECS;
+export type UsagePricingOperationKey = keyof typeof USAGE_PRICING_OPERATION_SPECS;
+export type MemoryOperationKey = keyof typeof MEMORY_OPERATION_SPECS;
+export type OAuthOperationKey = keyof typeof OAUTH_OPERATION_SPECS;
+export type RuntimeResourceOperationKey = keyof typeof RUNTIME_RESOURCE_OPERATION_SPECS;
+export type ClientCapabilityOperationKey = keyof typeof CLIENT_CAPABILITY_OPERATION_SPECS;
+export type ScheduledTaskOperationKey = keyof typeof SCHEDULED_TASK_OPERATION_SPECS;
+export type PlanOperationKey = keyof typeof PLAN_OPERATION_SPECS;
+export type ProjectCatalogOperationKey = keyof typeof PROJECT_CATALOG_OPERATION_SPECS;
+export type DeepResearchOperationKey = keyof typeof DEEP_RESEARCH_OPERATION_SPECS;
+export type DailyReviewOperationKey = keyof typeof DAILY_REVIEW_OPERATION_SPECS;
+export type WebSearchOperationKey = keyof typeof WEB_SEARCH_OPERATION_SPECS;
+export type NetworkProxyOperationKey = keyof typeof NETWORK_PROXY_OPERATION_SPECS;
+export type ConfigurationOperationKey = keyof typeof CONFIGURATION_OPERATION_SPECS;
+export type WorkHubCoordinationOperationKey = keyof typeof WORKHUB_COORDINATION_OPERATION_SPECS;
+export type PluginPlatformOperationKey = keyof typeof PLUGIN_PLATFORM_OPERATION_SPECS;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
 export type ContextOperationHandlerMap = Pick<OperationHandlerMap, ContextOperationKey>;
@@ -264,12 +265,7 @@ export function composeOperationHandlers(
 export function createUnavailableDomainOperationHandlers(): DomainOperationHandlerMap {
   const handlers: Partial<DomainOperationHandlerMap> = {};
   for (const operation of Object.keys(HOST_OPERATION_SPECS) as OperationKey[]) {
-    if (
-      Object.hasOwn(HOST_BOOTSTRAP_OPERATION_SPECS, operation) ||
-      Object.hasOwn(ACCESS_AUTHORITY_OPERATION_SPECS, operation) ||
-      Object.hasOwn(SESSION_COLLABORATION_OPERATION_SPECS, operation) ||
-      Object.hasOwn(PEER_MESH_OPERATION_SPECS, operation)
-    ) {
+    if (HOST_CORE_SPEC_OBJECTS.some((specs) => Object.hasOwn(specs, operation))) {
       continue;
     }
     const errors = HOST_OPERATION_SPECS[operation].errors as readonly HostOperationErrorCode[];
@@ -290,120 +286,35 @@ export function createUnavailableDomainOperationHandlers(): DomainOperationHandl
 }
 
 export function createUnavailableAccessAuthorityOperationHandlers(): AccessAuthorityOperationHandlerMap {
-  return {
-    'access.credential.issue': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host access credentials are unavailable',
-      },
-    }),
-    'access.credential.replace': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host access credentials are unavailable',
-      },
-    }),
-    'access.credential.prepare': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host access credentials are unavailable',
-      },
-    }),
-    'access.credential.revoke': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host access credentials are unavailable',
-      },
-    }),
-    'access.principal.revoke': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host access credentials are unavailable',
-      },
-    }),
-    'access.credential.rotation.prepare': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host access credentials are unavailable',
-      },
-    }),
-    'access.credential.rotation.revoke': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host access credentials are unavailable',
-      },
-    }),
-    'access.credential.finalize': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host access credentials are unavailable',
-      },
-    }),
-    'collaboration.invitation.prepare': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host collaboration authority is unavailable',
-      },
-    }),
-    'collaboration.access.query': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host collaboration authority is unavailable',
-      },
-    }),
-    'collaboration.grant.revoke': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host collaboration authority is unavailable',
-      },
-    }),
-    'collaboration.principal.revoke': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host collaboration authority is unavailable',
-      },
-    }),
-    'collaboration.turn-request.create': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host collaboration authority is unavailable',
-      },
-    }),
-    'collaboration.turn-request.acknowledge': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host collaboration authority is unavailable',
-      },
-    }),
-    'collaboration.turn-request.query': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host collaboration authority is unavailable',
-      },
-    }),
-    'collaboration.turn-request.decide': async () => ({
-      ok: false,
-      error: {
-        code: 'operation_unavailable',
-        message: 'Runtime Host collaboration authority is unavailable',
-      },
-    }),
-  };
+  const handlers: Partial<AccessAuthorityOperationHandlerMap> = {};
+  const groups = [
+    {
+      specs: ACCESS_AUTHORITY_OPERATION_SPECS,
+      message: 'Runtime Host access credentials are unavailable',
+    },
+    {
+      specs: SESSION_COLLABORATION_OPERATION_SPECS,
+      message: 'Runtime Host collaboration authority is unavailable',
+    },
+  ] as const;
+  for (const { specs, message } of groups) {
+    for (const operation of Object.keys(specs) as OperationKey[]) {
+      const errors = HOST_OPERATION_SPECS[operation].errors as readonly HostOperationErrorCode[];
+      if (!errors.includes('operation_unavailable')) {
+        throw new Error(`${operation} does not declare operation_unavailable`);
+      }
+      Object.assign(handlers, {
+        [operation]: async () => ({
+          ok: false,
+          error: {
+            code: 'operation_unavailable',
+            message,
+          },
+        }),
+      });
+    }
+  }
+  return handlers as AccessAuthorityOperationHandlerMap;
 }
 
 export function createUnavailableHostCoreOperationHandlers(): HostCoreUnavailableOperationHandlerMap {


### PR DESCRIPTION
## Summary

`HOST_OPERATION_SPECS` is assembled by merging per-domain spec objects, so the domain of every operation is already established by which object declares it. `operation-dispatcher.ts` then declared that same grouping a second time by hand, as literal `Extract`/`Exclude` lists — while three host-core groups already derived their keys with `keyof typeof …_OPERATION_SPECS`. This converges every group on that existing form.

- Each group key type is now `keyof typeof <DOMAIN>_OPERATION_SPECS`.
- The two groupings that had already drifted are named explicitly: `SessionContinuityOperationKey` = continuity + transcript spec objects; `SessionCatalogOperationKey` = catalog + turns (session-turns previously reached its coordinator only because the `Exclude` subtraction swept it there — it had no group of its own).
- The `Exclude` subtraction is deleted, so a spec object that no coordinator claims is now a compile error instead of a silent reassignment into Catalog.
- The hand-written 16-handler unavailable access/collaboration map is replaced by a loop over its two spec objects, parameterised by message (mirroring `createUnavailableDomainOperationHandlers`, including its `operation_unavailable` assertion).
- Both `HostCoreOperationKey` (type) and the runtime host-core partition are driven from a single `HOST_CORE_SPEC_OBJECTS` declaration.

Protocol domain and coordinator ownership remain free to differ permanently; the difference is now declared once, on the server side, by naming the spec objects each coordinator serves — never the reverse.

### Split-group exhaustiveness (second commit)

For the ~33 groups served by a single coordinator, the derived group type is a total `OperationHandlerMap`, so omitting a handler is already a compile error. `Turn` is the one group split across three coordinators (`turn-control`, `interactive-turn`, `root-turn`), each `Pick`-ing a fixed subset. Because `composeRuntimeHostDomainHandlers` seeds every domain operation with the `operation_unavailable` fallback, a Turn operation that none of the three claimed compiled and silently kept the fallback — the exact "coordinator serves only part of a spec object" case the issue's step 3 flags.

The second commit closes that gap with a `satisfies TurnOperationHandlerMap` completeness assertion where the three coordinators are already merged (`execution-composition.ts`). An unclaimed Turn operation is now a typecheck error at the composition site, so the issue's step‑5 guarantee ("removing its handler is a compile error") holds for the split group too.

Fixes #4395

## Verification

All run locally in `packages/runtime-host`:

- `npm run typecheck` — pass (exit 0)
- `npm run build` — pass (exit 0)
- `npx biome lint` / `biome format` on the changed files — clean
- `npm run test:dist` — **1467 pass, 12 skipped, 0 fail** (1479 tests)

Followed the issue's suggested method: added temporary per-group `AssertEqual<oldForm, derivedForm>` instantiations and typechecked to confirm each derived form is exactly equal to the hand-written one, then removed them. For the split-group fix I ran the reviewer's own probe — temporarily adding `turn.review-probe` to `TURN_OPERATION_SPECS` — and confirmed the Runtime Host typecheck now **fails** with `TS2741` (`"turn.review-probe"` missing but required in `TurnOperationHandlerMap`) at the composition site, then reverted the probe.

## Review response

Addresses the P2 finding on the first revision (split Turn coordinators could omit a newly declared operation without a type error). The compile-time assertion is added in the second commit; the earlier over-claim in this description is corrected above.

## Rebase & CI note

Rebased onto latest `main`. The only code conflict was in `operation-dispatcher.ts`: `main` had added a new `plugin.*` operation group in the region this PR rewrites — resolved by converging that group to the same derived form (`keyof typeof PLUGIN_PLATFORM_OPERATION_SPECS`). The two changed files are `operation-dispatcher.ts` and `execution-composition.ts`; no other files are touched.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — implemented the refactor (deriving the group types, removing the subtraction, the two loop/single-source collapses) and the split-group exhaustiveness assertion, and ran the verification above. Reviewed by me before submitting. Both commits carry a `Generated-by: Claude Code` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

<!-- This is a behavior-preserving refactor, so no automated test fails when it
is reverted. Correctness is guarded at compile time: the derived groups by the
compiler plus the existing dispatcher composition tests (exact total handler
coverage), and the split-group case by the `satisfies` assertion — demonstrated
to fail via the TURN_OPERATION_SPECS probe above. -->

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
