### PR TITLE
feat(runtime-host): race WebRTC direct upgrades

### DIFF
--- a/native/runtime-host-peer/src/bindings.rs
+++ b/native/runtime-host-peer/src/bindings.rs
@@ -29,7 +29,9 @@ use napi::bindgen_prelude::{Buffer, Error, Result, Status};
 use napi_derive::napi;
 use tokio::sync::{Mutex as AsyncMutex, mpsc, oneshot, watch};
 
-use crate::engine::{self, EngineCommand, PeerError, StreamCommand};
+use crate::engine::{
+    self, DirectTransport, EngineCommand, PeerConnectionPath, PeerError, StreamCommand,
+};
 
 type IncomingStreamReceiver = mpsc::Receiver<std::result::Result<Vec<u8>, PeerError>>;
 const IDENTITY_PAYLOAD_MAX_BYTES: usize = 8 * 1024;
@@ -310,9 +312,18 @@ impl Drop for PeerEndpoint {
 #[napi]
 pub struct PeerStream {
     peer_id: String,
+    path: PeerStreamPath,
     incoming: Arc<AsyncMutex<IncomingStreamReceiver>>,
     commands: mpsc::Sender<StreamCommand>,
     abort: watch::Sender<bool>,
+}
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct PeerStreamPath {
+    pub kind: String,
+    pub transport: Option<String>,
+    pub relay_peer_id: Option<String>,
 }
 
 #[napi]
@@ -320,6 +331,11 @@ impl PeerStream {
     #[napi(getter)]
     pub fn peer_id(&self) -> String {
         self.peer_id.clone()
+    }
+
+    #[napi(getter)]
+    pub fn path(&self) -> PeerStreamPath {
+        self.path.clone()
     }
 
     #[napi]
@@ -450,10 +466,34 @@ pub fn verify_peer_identity(
 fn wrap_stream(stream: engine::PeerStream) -> Result<PeerStream> {
     Ok(PeerStream {
         peer_id: stream.peer_id.to_string(),
+        path: peer_stream_path(stream.path),
         incoming: Arc::new(AsyncMutex::new(stream.incoming)),
         commands: stream.commands,
         abort: stream.abort,
     })
+}
+
+fn peer_stream_path(path: PeerConnectionPath) -> PeerStreamPath {
+    match path {
+        PeerConnectionPath::Direct(transport) => PeerStreamPath {
+            kind: "direct".to_owned(),
+            transport: Some(
+                match transport {
+                    DirectTransport::Quic => "quic",
+                    DirectTransport::Tcp => "tcp",
+                    DirectTransport::WebRtc => "webrtc",
+                    DirectTransport::Other => "other",
+                }
+                .to_owned(),
+            ),
+            relay_peer_id: None,
+        },
+        PeerConnectionPath::Transit { relay_peer_id } => PeerStreamPath {
+            kind: "transit".to_owned(),
+            transport: None,
+            relay_peer_id: Some(relay_peer_id.to_string()),
+        },
+    }
 }
 
 fn parse_peer_id(value: &str) -> Result<PeerId> {

--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -44,8 +44,8 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use crate::webrtc_direct::{
-    SIGNALING_PROTOCOL, UpgradeOptions, UpgradeRole, WebRtcTransport, WebRtcTransportControl,
-    upgrade_connection,
+    SIGNALING_PROTOCOL, UpgradeOptions, UpgradeRole, WebRtcConnection, WebRtcTransport,
+    WebRtcTransportControl, upgrade_connection,
 };
 
 mod address;
@@ -226,6 +226,7 @@ struct PendingConnect {
     transit_after: Instant,
     next_route_attempt: Instant,
     retry_coordination: bool,
+    webrtc_attempted: bool,
     cancellation: CancellationToken,
 }
 
@@ -243,6 +244,7 @@ pub(super) enum DialOrigin {
     Direct,
     Coordination,
     Transit,
+    WebRtc,
 }
 
 struct StartedConnect {
@@ -426,6 +428,13 @@ struct OpenedStream {
     result: Result<application_stream::OpenedStream, String>,
 }
 
+struct OutgoingWebRtcUpgrade {
+    request_id: u32,
+    attempt_id: ConnectAttemptId,
+    peer_id: PeerId,
+    result: Result<WebRtcConnection, String>,
+}
+
 pub(super) enum StreamCompletion {
     Application {
         connection_id: ConnectionId,
@@ -580,6 +589,7 @@ async fn run_endpoint_async(
         mut incoming_streams,
         mesh_control,
         mut mesh_incoming,
+        webrtc_signaling_control,
         mut webrtc_signaling_incoming,
         webrtc_transport,
     } = build_swarm(
@@ -689,6 +699,7 @@ async fn run_endpoint_async(
         .then(relay_discovery::spawn);
     let webrtc_cancellation = CancellationToken::new();
     let mut incoming_webrtc_upgrades = JoinSet::new();
+    let mut outgoing_webrtc_upgrades = JoinSet::new();
 
     loop {
         tokio::select! {
@@ -743,6 +754,7 @@ async fn run_endpoint_async(
                         transit_after,
                         next_route_attempt: Instant::now(),
                         retry_coordination,
+                        webrtc_attempted: false,
                         cancellation: CancellationToken::new(),
                     });
                     retry_connect_routes(
@@ -752,6 +764,14 @@ async fn run_endpoint_async(
                         &stream_control,
                         external_candidate_ready,
                         Instant::now(),
+                    );
+                    start_pending_webrtc_upgrades(
+                        &mut direct.pending,
+                        &direct.retiring_connections,
+                        &stream_control,
+                        webrtc_signaling_control.clone(),
+                        webrtc_stun_urls.as_deref(),
+                        &mut outgoing_webrtc_upgrades,
                     );
                     maybe_open_peer_stream(
                         request_id,
@@ -808,6 +828,14 @@ async fn run_endpoint_async(
                         Instant::now(),
                     );
                     let requests = direct.pending.keys().copied().collect::<Vec<_>>();
+                    start_pending_webrtc_upgrades(
+                        &mut direct.pending,
+                        &direct.retiring_connections,
+                        &stream_control,
+                        webrtc_signaling_control.clone(),
+                        webrtc_stun_urls.as_deref(),
+                        &mut outgoing_webrtc_upgrades,
+                    );
                     for request_id in requests {
                         maybe_open_peer_stream(
                             request_id,
@@ -823,12 +851,20 @@ async fn run_endpoint_async(
                 Some(EngineCommand::Stop { result }) => {
                     webrtc_cancellation.cancel();
                     incoming_webrtc_upgrades.abort_all();
+                    for pending in direct.pending.values() {
+                        pending.cancellation.cancel();
+                    }
+                    outgoing_webrtc_upgrades.abort_all();
                     let _ = result.send(());
                     return Ok(());
                 }
                 None => {
                     webrtc_cancellation.cancel();
                     incoming_webrtc_upgrades.abort_all();
+                    for pending in direct.pending.values() {
+                        pending.cancellation.cancel();
+                    }
+                    outgoing_webrtc_upgrades.abort_all();
                     return Ok(());
                 }
             },
@@ -908,6 +944,30 @@ async fn run_endpoint_async(
                         webrtc_debug(format_args!("inbound upgrade task failed: {error}"));
                     }
                 }
+            }
+            Some(upgrade) = outgoing_webrtc_upgrades.join_next(), if !outgoing_webrtc_upgrades.is_empty() => {
+                match upgrade {
+                    Ok(completed) => {
+                        complete_outgoing_webrtc_upgrade(
+                            &mut swarm,
+                            &webrtc_transport,
+                            &mut direct,
+                            completed,
+                        );
+                    }
+                    Err(error) if error.is_cancelled() => {}
+                    Err(error) => {
+                        webrtc_debug(format_args!("outbound upgrade task failed: {error}"));
+                    }
+                }
+                start_pending_webrtc_upgrades(
+                    &mut direct.pending,
+                    &direct.retiring_connections,
+                    &stream_control,
+                    webrtc_signaling_control.clone(),
+                    webrtc_stun_urls.as_deref(),
+                    &mut outgoing_webrtc_upgrades,
+                );
             }
             Some(candidate) = async {
                 match &mut discovered_relays {
@@ -992,6 +1052,14 @@ async fn run_endpoint_async(
                         continue;
                     }
                 };
+                if waiter.webrtc_attempted {
+                    webrtc_debug(format_args!(
+                        "application stream result peer={} request={} success={}",
+                        waiter.peer_id,
+                        request_id,
+                        opened.result.is_ok(),
+                    ));
+                }
                     match opened.result {
                         Ok(opened) => {
                             if waiter.stream_kind == StreamKind::Application
@@ -1125,6 +1193,14 @@ async fn run_endpoint_async(
                     Instant::now(),
                 );
                 let requests = direct.pending.keys().copied().collect::<Vec<_>>();
+                start_pending_webrtc_upgrades(
+                    &mut direct.pending,
+                    &direct.retiring_connections,
+                    &stream_control,
+                    webrtc_signaling_control.clone(),
+                    webrtc_stun_urls.as_deref(),
+                    &mut outgoing_webrtc_upgrades,
+                );
                 for request_id in requests {
                     maybe_open_peer_stream(
                         request_id,
@@ -1162,6 +1238,14 @@ async fn run_endpoint_async(
                     &stream_control,
                     external_candidate_ready,
                     now,
+                );
+                start_pending_webrtc_upgrades(
+                    &mut direct.pending,
+                    &direct.retiring_connections,
+                    &stream_control,
+                    webrtc_signaling_control.clone(),
+                    webrtc_stun_urls.as_deref(),
+                    &mut outgoing_webrtc_upgrades,
                 );
                 let expired = direct.pending.iter()
                     .filter_map(|(request_id, item)| (item.deadline <= now).then_some(*request_id))
@@ -1207,6 +1291,7 @@ struct BuiltSwarm {
     incoming_streams: mpsc::Receiver<application_stream::InboundStream>,
     mesh_control: application_stream::Control,
     mesh_incoming: mpsc::Receiver<application_stream::InboundStream>,
+    webrtc_signaling_control: application_stream::Control,
     webrtc_signaling_incoming: mpsc::Receiver<application_stream::InboundStream>,
     webrtc_transport: WebRtcTransportControl,
 }
@@ -1227,7 +1312,7 @@ fn build_swarm(
         MESH_INCOMING_STREAM_CAPACITY,
         None,
     );
-    let (webrtc_signaling, _webrtc_signaling_control, webrtc_signaling_incoming) =
+    let (webrtc_signaling, webrtc_signaling_control, webrtc_signaling_incoming) =
         application_stream::Behaviour::new(
             StreamProtocol::new(SIGNALING_PROTOCOL),
             WEBRTC_SIGNALING_STREAM_CAPACITY,
@@ -1287,6 +1372,7 @@ fn build_swarm(
         incoming_streams: incoming,
         mesh_control,
         mesh_incoming,
+        webrtc_signaling_control,
         webrtc_signaling_incoming,
         webrtc_transport,
     })
@@ -1429,6 +1515,140 @@ fn release_active_stream(active: &mut HashMap<ConnectionId, usize>, connection_i
     }
 }
 
+fn start_pending_webrtc_upgrades(
+    pending: &mut HashMap<u32, PendingConnect>,
+    retiring_connections: &HashSet<ConnectionId>,
+    application_control: &application_stream::Control,
+    signaling_control: application_stream::Control,
+    stun_urls: Option<&[String]>,
+    upgrades: &mut JoinSet<OutgoingWebRtcUpgrade>,
+) {
+    let Some(stun_urls) = stun_urls else {
+        return;
+    };
+    for request_id in pending.keys().copied().collect::<Vec<_>>() {
+        if upgrades.len() >= MAX_CONCURRENT_WEBRTC_UPGRADES {
+            return;
+        }
+        let Some(waiter) = pending.get_mut(&request_id) else {
+            continue;
+        };
+        if waiter.stream_kind != StreamKind::Application || waiter.webrtc_attempted {
+            continue;
+        }
+        if application_control.has_connection(
+            waiter.peer_id,
+            retiring_connections,
+            &waiter.transit_relay_peers,
+        ) {
+            continue;
+        }
+        let relay_peers = waiter
+            .coordination_relay_peers
+            .iter()
+            .copied()
+            .chain(waiter.transit_relay_peers.iter().copied())
+            .collect::<HashSet<_>>();
+        if !signaling_control.has_relayed_connection_via(
+            waiter.peer_id,
+            retiring_connections,
+            &relay_peers,
+        ) {
+            continue;
+        }
+
+        waiter.webrtc_attempted = true;
+        let attempt_id = waiter.attempt_id;
+        let peer_id = waiter.peer_id;
+        let cancellation = waiter.cancellation.clone();
+        let upgrade_cancellation = cancellation.clone();
+        let excluded_connections = retiring_connections.clone();
+        let stun_urls = stun_urls.to_vec();
+        let mut signaling_control = signaling_control.clone();
+        upgrades.spawn(async move {
+            let operation = async {
+                let signaling = signaling_control
+                    .open_relayed_stream(peer_id, &excluded_connections, &relay_peers)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                upgrade_connection(
+                    signaling.stream,
+                    peer_id,
+                    peer_id,
+                    UpgradeRole::Offerer,
+                    UpgradeOptions {
+                        stun_urls,
+                        udp_bind_addresses: vec!["0.0.0.0:0".to_owned()],
+                        deadline: WEBRTC_UPGRADE_DEADLINE,
+                        cancellation: upgrade_cancellation,
+                    },
+                )
+                .await
+                .map(|(_, connection)| connection)
+                .map_err(|error| error.to_string())
+            };
+            let result = tokio::select! {
+                _ = cancellation.cancelled() => Err("WebRTC direct upgrade was cancelled".to_owned()),
+                result = operation => result,
+            };
+            OutgoingWebRtcUpgrade {
+                request_id,
+                attempt_id,
+                peer_id,
+                result,
+            }
+        });
+    }
+}
+
+fn complete_outgoing_webrtc_upgrade(
+    swarm: &mut Swarm<Behaviour>,
+    transport: &WebRtcTransportControl,
+    direct: &mut DirectConnectState,
+    completed: OutgoingWebRtcUpgrade,
+) {
+    let Some(waiter) = direct.pending.get_mut(&completed.request_id) else {
+        return;
+    };
+    if waiter.attempt_id != completed.attempt_id || waiter.peer_id != completed.peer_id {
+        return;
+    }
+    let connection = match completed.result {
+        Ok(connection) => connection,
+        Err(error) => {
+            webrtc_debug(format_args!(
+                "outbound upgrade to {} failed: {error}",
+                completed.peer_id,
+            ));
+            return;
+        }
+    };
+    let address = match transport.register_outbound(completed.peer_id, connection) {
+        Ok(address) => address,
+        Err(error) => {
+            webrtc_debug(format_args!(
+                "could not register outbound upgrade to {}: {error}",
+                completed.peer_id,
+            ));
+            return;
+        }
+    };
+    let options = DialOpts::peer_id(completed.peer_id)
+        .condition(PeerCondition::Always)
+        .addresses(vec![address])
+        .build();
+    let connection_id = options.connection_id();
+    if swarm.dial(options).is_ok() {
+        waiter.dials.insert(connection_id, DialOrigin::WebRtc);
+        webrtc_debug(format_args!(
+            "direct dial submitted peer={} request={} connection={connection_id}",
+            completed.peer_id, completed.request_id,
+        ));
+    } else {
+        transport.discard_outbound(completed.peer_id);
+    }
+}
+
 fn maybe_open_peer_stream(
     request_id: u32,
     pending: &mut HashMap<u32, PendingConnect>,
@@ -1460,6 +1680,11 @@ fn maybe_open_peer_stream(
     };
     if waiter.opening.is_some() || !available {
         return;
+    }
+    if waiter.stream_kind == StreamKind::Application && waiter.webrtc_attempted {
+        webrtc_debug(format_args!(
+            "opening application stream peer={peer_id} request={request_id}"
+        ));
     }
     let stream_kind = waiter.stream_kind;
     let attempt_id = waiter.attempt_id;
@@ -1501,6 +1726,15 @@ fn handle_swarm_event(
             endpoint,
             ..
         } => {
+            if direct
+                .pending
+                .values()
+                .any(|connect| connect.dials.get(&connection_id) == Some(&DialOrigin::WebRtc))
+            {
+                webrtc_debug(format_args!(
+                    "direct connection established peer={peer_id} connection={connection_id}"
+                ));
+            }
             discovery_debug(format_args!(
                 "connection established peer={peer_id} relayed={}",
                 endpoint.is_relayed()

--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -58,7 +58,7 @@ use address::{address_with_expected_peer, address_with_peer, is_relayed_address}
 pub(crate) use address::{coordination_relay_peer_id, transit_relay_peer_id};
 use identity_store::load_or_create_key;
 use peer_stream::spawn_stream;
-pub use peer_stream::{PeerStream, StreamCommand};
+pub use peer_stream::{DirectTransport, PeerConnectionPath, PeerStream, StreamCommand};
 
 const APPLICATION_PROTOCOL: &str = "/maka/runtime-host/peer/1";
 const MESH_CONTROL_PROTOCOL: &str = "/maka/runtime-host/mesh-control/1";
@@ -872,6 +872,7 @@ async fn run_endpoint_async(
                 *direct.active.entry(stream.connection_id).or_default() += 1;
                 let peer_stream = spawn_stream(
                     stream.peer_id,
+                    stream.path,
                     stream.stream,
                     Some((
                         StreamCompletion::Application {
@@ -888,6 +889,7 @@ async fn run_endpoint_async(
                 *direct.active.entry(stream.connection_id).or_default() += 1;
                 let peer_stream = spawn_stream(
                     stream.peer_id,
+                    stream.path,
                     stream.stream,
                     Some((
                         StreamCompletion::MeshControl {
@@ -1063,7 +1065,7 @@ async fn run_endpoint_async(
                     match opened.result {
                         Ok(opened) => {
                             if waiter.stream_kind == StreamKind::Application
-                                && opened.relay_peer_id.is_some_and(|relay_peer| {
+                                && opened.path.relay_peer_id().is_some_and(|relay_peer| {
                                     !waiter.transit_relay_peers.contains(&relay_peer)
                                 })
                             {
@@ -1111,6 +1113,7 @@ async fn run_endpoint_async(
                                 );
                                 Ok(spawn_stream(
                                     waiter.peer_id,
+                                    opened.path,
                                     opened.stream,
                                     Some((
                                         StreamCompletion::Application { connection_id },
@@ -1129,6 +1132,7 @@ async fn run_endpoint_async(
                                 *direct.active.entry(connection_id).or_default() += 1;
                                 Ok(spawn_stream(
                                     waiter.peer_id,
+                                    opened.path,
                                     opened.stream,
                                     Some((
                                         StreamCompletion::MeshControl {

--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -217,7 +217,8 @@ struct PendingConnect {
     result: oneshot::Sender<Result<PeerStream, PeerError>>,
     stream_kind: StreamKind,
     deadline: Instant,
-    opening: Option<tokio::task::JoinHandle<()>>,
+    opening: Option<PendingStreamOpen>,
+    rejected_connections: HashSet<ConnectionId>,
     dials: HashMap<ConnectionId, DialOrigin>,
     direct_routes: Vec<Multiaddr>,
     coordination_relays: Vec<Multiaddr>,
@@ -228,6 +229,11 @@ struct PendingConnect {
     retry_coordination: bool,
     webrtc_attempted: bool,
     cancellation: CancellationToken,
+}
+
+struct PendingStreamOpen {
+    connection_id: ConnectionId,
+    task: tokio::task::JoinHandle<()>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -425,7 +431,8 @@ impl CoordinationRelay {
 struct OpenedStream {
     request_id: u32,
     attempt_id: ConnectAttemptId,
-    result: Result<application_stream::OpenedStream, String>,
+    connection_id: ConnectionId,
+    result: Result<application_stream::OpenedStream, application_stream::OpenStreamError>,
 }
 
 struct OutgoingWebRtcUpgrade {
@@ -746,6 +753,7 @@ async fn run_endpoint_async(
                         stream_kind,
                         deadline: Instant::now() + options.deadline,
                         opening: None,
+                        rejected_connections: HashSet::new(),
                         dials: HashMap::new(),
                         direct_routes: started.direct_routes,
                         coordination_relays: options.coordination_relays,
@@ -768,7 +776,6 @@ async fn run_endpoint_async(
                     start_pending_webrtc_upgrades(
                         &mut direct.pending,
                         &direct.retiring_connections,
-                        &stream_control,
                         webrtc_signaling_control.clone(),
                         webrtc_stun_urls.as_deref(),
                         &mut outgoing_webrtc_upgrades,
@@ -831,7 +838,6 @@ async fn run_endpoint_async(
                     start_pending_webrtc_upgrades(
                         &mut direct.pending,
                         &direct.retiring_connections,
-                        &stream_control,
                         webrtc_signaling_control.clone(),
                         webrtc_stun_urls.as_deref(),
                         &mut outgoing_webrtc_upgrades,
@@ -965,7 +971,6 @@ async fn run_endpoint_async(
                 start_pending_webrtc_upgrades(
                     &mut direct.pending,
                     &direct.retiring_connections,
-                    &stream_control,
                     webrtc_signaling_control.clone(),
                     webrtc_stun_urls.as_deref(),
                     &mut outgoing_webrtc_upgrades,
@@ -1033,6 +1038,7 @@ async fn run_endpoint_async(
             }
             Some(opened) = opened_rx.recv() => {
                 let request_id = opened.request_id;
+                let connection_id = opened.connection_id;
                 let Some(admission) = direct.take_pending_attempt(
                     opened.request_id,
                     opened.attempt_id,
@@ -1054,6 +1060,15 @@ async fn run_endpoint_async(
                         continue;
                     }
                 };
+                if waiter
+                    .opening
+                    .as_ref()
+                    .is_none_or(|opening| opening.connection_id != connection_id)
+                {
+                    direct.pending.insert(request_id, waiter);
+                    continue;
+                }
+                waiter.opening.take();
                 if waiter.webrtc_attempted {
                     webrtc_debug(format_args!(
                         "application stream result peer={} request={} success={}",
@@ -1062,42 +1077,41 @@ async fn run_endpoint_async(
                         opened.result.is_ok(),
                     ));
                 }
-                    match opened.result {
-                        Ok(opened) => {
-                            if waiter.stream_kind == StreamKind::Application
-                                && opened.path.relay_peer_id().is_some_and(|relay_peer| {
-                                    !waiter.transit_relay_peers.contains(&relay_peer)
-                                })
-                            {
-                                let connection_id = opened.connection_id;
-                                direct.retiring_connections.insert(connection_id);
-                                let _ = swarm.close_connection(connection_id);
-                                waiter.opening.take();
-                                waiter.dials.remove(&connection_id);
-                                waiter.next_route_attempt = Instant::now();
-                                direct.pending.insert(request_id, waiter);
-                                retry_connect_routes(
-                                    &mut swarm,
-                                    &mut direct,
-                                    &coordination_relays,
-                                    &stream_control,
-                                    external_candidate_ready,
-                                    Instant::now(),
-                                );
-                                maybe_open_peer_stream(
-                                    request_id,
-                                    &mut direct.pending,
-                                    &direct.retiring_connections,
-                                    stream_control.clone(),
-                                    mesh_control.clone(),
-                                    opened_tx.clone(),
-                                );
-                                continue;
-                            }
-                            waiter.cancellation.cancel();
-                            let result = match waiter.stream_kind {
+                match opened.result {
+                    Ok(opened) => {
+                        if waiter.stream_kind == StreamKind::Application
+                            && opened.path.relay_peer_id().is_some_and(|relay_peer| {
+                                !waiter.transit_relay_peers.contains(&relay_peer)
+                            })
+                        {
+                            direct.retiring_connections.insert(connection_id);
+                            let _ = swarm.close_connection(connection_id);
+                            waiter.dials.remove(&connection_id);
+                            waiter.rejected_connections.insert(connection_id);
+                            waiter.next_route_attempt = Instant::now();
+                            direct.pending.insert(request_id, waiter);
+                            retry_connect_routes(
+                                &mut swarm,
+                                &mut direct,
+                                &coordination_relays,
+                                &stream_control,
+                                external_candidate_ready,
+                                Instant::now(),
+                            );
+                            maybe_open_peer_stream(
+                                request_id,
+                                &mut direct.pending,
+                                &direct.retiring_connections,
+                                stream_control.clone(),
+                                mesh_control.clone(),
+                                opened_tx.clone(),
+                            );
+                            continue;
+                        }
+                        waiter.cancellation.cancel();
+                        abort_pending_openings(&mut waiter);
+                        let result = match waiter.stream_kind {
                             StreamKind::Application => {
-                                let connection_id = opened.connection_id;
                                 retire_direct_dials(
                                     &mut swarm,
                                     &mut direct.retiring_connections,
@@ -1122,12 +1136,11 @@ async fn run_endpoint_async(
                                 ))
                             }
                             StreamKind::MeshControl => {
-                                let connection_id = opened.connection_id;
                                 retire_direct_dials(
                                     &mut swarm,
                                     &mut direct.retiring_connections,
                                     waiter.dials,
-                                    None,
+                                    Some(connection_id),
                                 );
                                 *direct.active.entry(connection_id).or_default() += 1;
                                 Ok(spawn_stream(
@@ -1144,28 +1157,52 @@ async fn run_endpoint_async(
                                     )),
                                 ))
                             }
-                            };
-                            let _ = waiter.result.send(result);
-                        }
-                        Err(message) => {
-                            let code = match waiter.stream_kind {
-                                StreamKind::Application
-                                    if !waiter.transit_relay_peers.is_empty() =>
-                                {
-                                    "transit_unavailable"
-                                }
-                                StreamKind::Application => "direct_path_unavailable",
-                                StreamKind::MeshControl => "mesh_control_unavailable",
-                            };
-                            fail_pending_connect(
-                                &mut swarm,
-                                &mut direct,
-                                &mut coordination_relays,
-                                waiter,
-                                PeerError::new(code, message),
-                            );
-                        }
+                        };
+                        let _ = waiter.result.send(result);
                     }
+                    Err(application_stream::OpenStreamError::UnsupportedProtocol) => {
+                        fail_pending_connect(
+                            &mut swarm,
+                            &mut direct,
+                            &mut coordination_relays,
+                            waiter,
+                            PeerError::new(
+                                "peer_protocol_unsupported",
+                                "peer does not support the requested stream protocol",
+                            ),
+                        );
+                    }
+                    Err(error) => {
+                        webrtc_debug(format_args!(
+                            "stream candidate failed peer={} request={} connection={connection_id}: {error}",
+                            waiter.peer_id,
+                            request_id,
+                        ));
+                        waiter.rejected_connections.insert(connection_id);
+                        if waiter.dials.remove(&connection_id).is_some() {
+                            direct.retiring_connections.insert(connection_id);
+                            let _ = swarm.close_connection(connection_id);
+                        }
+                        waiter.next_route_attempt = Instant::now();
+                        direct.pending.insert(request_id, waiter);
+                        retry_connect_routes(
+                            &mut swarm,
+                            &mut direct,
+                            &coordination_relays,
+                            &stream_control,
+                            external_candidate_ready,
+                            Instant::now(),
+                        );
+                        maybe_open_peer_stream(
+                            request_id,
+                            &mut direct.pending,
+                            &direct.retiring_connections,
+                            stream_control.clone(),
+                            mesh_control.clone(),
+                            opened_tx.clone(),
+                        );
+                    }
+                }
             }
             event = swarm.select_next_some() => {
                 handle_swarm_event(
@@ -1200,7 +1237,6 @@ async fn run_endpoint_async(
                 start_pending_webrtc_upgrades(
                     &mut direct.pending,
                     &direct.retiring_connections,
-                    &stream_control,
                     webrtc_signaling_control.clone(),
                     webrtc_stun_urls.as_deref(),
                     &mut outgoing_webrtc_upgrades,
@@ -1246,7 +1282,6 @@ async fn run_endpoint_async(
                 start_pending_webrtc_upgrades(
                     &mut direct.pending,
                     &direct.retiring_connections,
-                    &stream_control,
                     webrtc_signaling_control.clone(),
                     webrtc_stun_urls.as_deref(),
                     &mut outgoing_webrtc_upgrades,
@@ -1522,7 +1557,6 @@ fn release_active_stream(active: &mut HashMap<ConnectionId, usize>, connection_i
 fn start_pending_webrtc_upgrades(
     pending: &mut HashMap<u32, PendingConnect>,
     retiring_connections: &HashSet<ConnectionId>,
-    application_control: &application_stream::Control,
     signaling_control: application_stream::Control,
     stun_urls: Option<&[String]>,
     upgrades: &mut JoinSet<OutgoingWebRtcUpgrade>,
@@ -1538,13 +1572,6 @@ fn start_pending_webrtc_upgrades(
             continue;
         };
         if waiter.stream_kind != StreamKind::Application || waiter.webrtc_attempted {
-            continue;
-        }
-        if application_control.has_connection(
-            waiter.peer_id,
-            retiring_connections,
-            &waiter.transit_relay_peers,
-        ) {
             continue;
         }
         let relay_peers = waiter
@@ -1565,17 +1592,27 @@ fn start_pending_webrtc_upgrades(
         let attempt_id = waiter.attempt_id;
         let peer_id = waiter.peer_id;
         let cancellation = waiter.cancellation.clone();
-        let upgrade_cancellation = cancellation.clone();
         let excluded_connections = retiring_connections.clone();
         let stun_urls = stun_urls.to_vec();
         let mut signaling_control = signaling_control.clone();
         upgrades.spawn(async move {
-            let operation = async {
-                let signaling = signaling_control
-                    .open_relayed_stream(peer_id, &excluded_connections, &relay_peers)
-                    .await
-                    .map_err(|error| error.to_string())?;
-                upgrade_connection(
+            let signaling = tokio::select! {
+                _ = cancellation.cancelled() => {
+                    return OutgoingWebRtcUpgrade {
+                        request_id,
+                        attempt_id,
+                        peer_id,
+                        result: Err("WebRTC direct upgrade was cancelled".to_owned()),
+                    };
+                }
+                result = signaling_control.open_relayed_stream(
+                    peer_id,
+                    &excluded_connections,
+                    &relay_peers,
+                ) => result,
+            };
+            let result = match signaling {
+                Ok(signaling) => upgrade_connection(
                     signaling.stream,
                     peer_id,
                     peer_id,
@@ -1584,16 +1621,13 @@ fn start_pending_webrtc_upgrades(
                         stun_urls,
                         udp_bind_addresses: vec!["0.0.0.0:0".to_owned()],
                         deadline: WEBRTC_UPGRADE_DEADLINE,
-                        cancellation: upgrade_cancellation,
+                        cancellation,
                     },
                 )
                 .await
                 .map(|(_, connection)| connection)
-                .map_err(|error| error.to_string())
-            };
-            let result = tokio::select! {
-                _ = cancellation.cancelled() => Err("WebRTC direct upgrade was cancelled".to_owned()),
-                result = operation => result,
+                .map_err(|error| error.to_string()),
+                Err(error) => Err(error.to_string()),
             };
             OutgoingWebRtcUpgrade {
                 request_id,
@@ -1611,45 +1645,59 @@ fn complete_outgoing_webrtc_upgrade(
     direct: &mut DirectConnectState,
     completed: OutgoingWebRtcUpgrade,
 ) {
-    let Some(waiter) = direct.pending.get_mut(&completed.request_id) else {
-        return;
-    };
-    if waiter.attempt_id != completed.attempt_id || waiter.peer_id != completed.peer_id {
+    let OutgoingWebRtcUpgrade {
+        request_id,
+        attempt_id,
+        peer_id,
+        result,
+    } = completed;
+    let current = direct
+        .pending
+        .get(&request_id)
+        .is_some_and(|waiter| waiter.attempt_id == attempt_id && waiter.peer_id == peer_id);
+    if !current {
+        if let Ok(connection) = result {
+            connection.close_in_background();
+        }
         return;
     }
-    let connection = match completed.result {
+    let connection = match result {
         Ok(connection) => connection,
         Err(error) => {
             webrtc_debug(format_args!(
                 "outbound upgrade to {} failed: {error}",
-                completed.peer_id,
+                peer_id,
             ));
             return;
         }
     };
-    let address = match transport.register_outbound(completed.peer_id, connection) {
+    let address = match transport.register_outbound(peer_id, connection) {
         Ok(address) => address,
         Err(error) => {
             webrtc_debug(format_args!(
                 "could not register outbound upgrade to {}: {error}",
-                completed.peer_id,
+                peer_id,
             ));
             return;
         }
     };
-    let options = DialOpts::peer_id(completed.peer_id)
+    let options = DialOpts::peer_id(peer_id)
         .condition(PeerCondition::Always)
         .addresses(vec![address])
         .build();
     let connection_id = options.connection_id();
     if swarm.dial(options).is_ok() {
+        let waiter = direct
+            .pending
+            .get_mut(&request_id)
+            .expect("current WebRTC upgrade has a pending connect");
         waiter.dials.insert(connection_id, DialOrigin::WebRtc);
         webrtc_debug(format_args!(
             "direct dial submitted peer={} request={} connection={connection_id}",
-            completed.peer_id, completed.request_id,
+            peer_id, request_id,
         ));
     } else {
-        transport.discard_outbound(completed.peer_id);
+        transport.discard_outbound(peer_id);
     }
 }
 
@@ -1657,8 +1705,8 @@ fn maybe_open_peer_stream(
     request_id: u32,
     pending: &mut HashMap<u32, PendingConnect>,
     retiring_connections: &HashSet<ConnectionId>,
-    mut application_control: application_stream::Control,
-    mut mesh_control: application_stream::Control,
+    application_control: application_stream::Control,
+    mesh_control: application_stream::Control,
     opened_tx: mpsc::Sender<OpenedStream>,
 ) {
     let Some(waiter) = pending.get_mut(&request_id) else {
@@ -1674,45 +1722,70 @@ fn maybe_open_peer_stream(
             .chain(waiter.transit_relay_peers.iter().copied())
             .collect(),
     };
-    let available = match waiter.stream_kind {
-        StreamKind::Application => {
-            application_control.has_connection(peer_id, retiring_connections, &eligible_relay_peers)
-        }
-        StreamKind::MeshControl => {
-            mesh_control.has_connection(peer_id, retiring_connections, &eligible_relay_peers)
-        }
-    };
-    if waiter.opening.is_some() || !available {
+    let excluded = retiring_connections
+        .union(&waiter.rejected_connections)
+        .copied()
+        .collect::<HashSet<_>>();
+    if waiter.opening.is_some() {
         return;
     }
-    if waiter.stream_kind == StreamKind::Application && waiter.webrtc_attempted {
-        webrtc_debug(format_args!(
-            "opening application stream peer={peer_id} request={request_id}"
-        ));
-    }
     let stream_kind = waiter.stream_kind;
+    let candidates = match stream_kind {
+        StreamKind::Application => {
+            application_control.eligible_connections(peer_id, &excluded, &eligible_relay_peers)
+        }
+        StreamKind::MeshControl => {
+            mesh_control.eligible_connections(peer_id, &excluded, &eligible_relay_peers)
+        }
+    };
+    let Some((connection_id, _)) = candidates
+        .into_iter()
+        .min_by_key(|(_, path)| stream_candidate_priority(path))
+    else {
+        return;
+    };
     let attempt_id = waiter.attempt_id;
     let cancellation = waiter.cancellation.clone();
-    let retiring_connections = retiring_connections.clone();
-    waiter.opening = Some(tokio::spawn(async move {
-        let control = match stream_kind {
-            StreamKind::Application => &mut application_control,
-            StreamKind::MeshControl => &mut mesh_control,
-        };
-        let result = tokio::select! {
-            _ = cancellation.cancelled() => return,
-            result = control.open_stream(peer_id, &retiring_connections, &eligible_relay_peers) => {
-                result.map_err(|error| error.to_string())
-            }
-        };
-        let _ = opened_tx
-            .send(OpenedStream {
-                request_id,
-                attempt_id,
-                result,
-            })
-            .await;
-    }));
+    if stream_kind == StreamKind::Application && waiter.webrtc_attempted {
+        webrtc_debug(format_args!(
+            "opening application stream peer={peer_id} request={request_id} connection={connection_id}"
+        ));
+    }
+    let mut control = match stream_kind {
+        StreamKind::Application => application_control,
+        StreamKind::MeshControl => mesh_control,
+    };
+    waiter.opening = Some(PendingStreamOpen {
+        connection_id,
+        task: tokio::spawn(async move {
+            let result = tokio::select! {
+                _ = cancellation.cancelled() => return,
+                result = control.open_stream_on(
+                    connection_id,
+                    peer_id,
+                    &eligible_relay_peers,
+                ) => result,
+            };
+            let _ = opened_tx
+                .send(OpenedStream {
+                    request_id,
+                    attempt_id,
+                    connection_id,
+                    result,
+                })
+                .await;
+        }),
+    });
+}
+
+fn stream_candidate_priority(path: &PeerConnectionPath) -> u8 {
+    match path {
+        PeerConnectionPath::Direct(DirectTransport::Quic) => 0,
+        PeerConnectionPath::Direct(DirectTransport::Tcp) => 1,
+        PeerConnectionPath::Direct(DirectTransport::WebRtc) => 2,
+        PeerConnectionPath::Direct(DirectTransport::Other) => 3,
+        PeerConnectionPath::Transit { .. } => 4,
+    }
 }
 
 fn handle_swarm_event(
@@ -1768,9 +1841,6 @@ fn handle_swarm_event(
                     }
                 }
             }
-            for connect in direct.pending.values_mut() {
-                connect.dials.remove(&connection_id);
-            }
         }
         SwarmEvent::ConnectionClosed {
             peer_id,
@@ -1780,6 +1850,15 @@ fn handle_swarm_event(
             direct.retiring_connections.remove(&connection_id);
             for connect in direct.pending.values_mut() {
                 connect.dials.remove(&connection_id);
+                connect.rejected_connections.remove(&connection_id);
+                if connect
+                    .opening
+                    .as_ref()
+                    .is_some_and(|opening| opening.connection_id == connection_id)
+                    && let Some(opening) = connect.opening.take()
+                {
+                    opening.task.abort();
+                }
             }
             direct.active.remove(&connection_id);
             if let Some(relay) = coordination_relays.get_mut(&peer_id) {
@@ -1828,6 +1907,15 @@ fn handle_swarm_event(
             direct.retiring_connections.remove(&connection_id);
             for connect in direct.pending.values_mut() {
                 connect.dials.remove(&connection_id);
+                connect.rejected_connections.remove(&connection_id);
+                if connect
+                    .opening
+                    .as_ref()
+                    .is_some_and(|opening| opening.connection_id == connection_id)
+                    && let Some(opening) = connect.opening.take()
+                {
+                    opening.task.abort();
+                }
             }
             let mut failed_automatic = None;
             for (peer_id, relay) in coordination_relays.iter_mut() {
@@ -2142,7 +2230,7 @@ fn reconcile_pending_transit_connects(
             .transit_relay_peers
             .retain(|peer| !revoked_relays.contains(peer));
         if let Some(opening) = waiter.opening.take() {
-            opening.abort();
+            opening.task.abort();
         }
         retire_pending_dials_by_origin(
             swarm,
@@ -2198,10 +2286,11 @@ fn fail_pending_connect(
     swarm: &mut Swarm<Behaviour>,
     direct: &mut DirectConnectState,
     coordination_relays: &mut HashMap<PeerId, CoordinationRelay>,
-    waiter: PendingConnect,
+    mut waiter: PendingConnect,
     error: PeerError,
 ) {
     waiter.cancellation.cancel();
+    abort_pending_openings(&mut waiter);
     retire_direct_dials(swarm, &mut direct.retiring_connections, waiter.dials, None);
     release_coordination_relays(
         swarm,
@@ -2210,6 +2299,12 @@ fn fail_pending_connect(
         &direct.active,
     );
     let _ = waiter.result.send(Err(error));
+}
+
+fn abort_pending_openings(waiter: &mut PendingConnect) {
+    if let Some(opening) = waiter.opening.take() {
+        opening.task.abort();
+    }
 }
 
 fn reconcile_transit_reservations(
@@ -2892,11 +2987,12 @@ fn retry_connect_routes(
         if connect.next_route_attempt > now {
             continue;
         }
-        if stream_control.has_connection(
-            peer_id,
-            &direct.retiring_connections,
-            &connect.transit_relay_peers,
-        ) {
+        let excluded = direct
+            .retiring_connections
+            .union(&connect.rejected_connections)
+            .copied()
+            .collect::<HashSet<_>>();
+        if stream_control.has_connection(peer_id, &excluded, &connect.transit_relay_peers) {
             continue;
         }
         connect.next_route_attempt = now + COORDINATION_RETRY_INTERVAL;
@@ -3013,6 +3109,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn application_streams_commit_on_the_best_established_path() {
+        let relay_peer_id = PeerId::random();
+        assert!(
+            stream_candidate_priority(&PeerConnectionPath::Direct(DirectTransport::Quic))
+                < stream_candidate_priority(&PeerConnectionPath::Direct(DirectTransport::WebRtc))
+        );
+        assert!(
+            stream_candidate_priority(&PeerConnectionPath::Direct(DirectTransport::WebRtc))
+                < stream_candidate_priority(&PeerConnectionPath::Transit { relay_peer_id })
+        );
+    }
+
+    #[test]
     fn completion_at_the_immutable_deadline_cannot_commit() {
         let now = Instant::now();
         let mut direct = DirectConnectState::default();
@@ -3027,6 +3136,7 @@ mod tests {
                 stream_kind: StreamKind::Application,
                 deadline: now,
                 opening: None,
+                rejected_connections: HashSet::new(),
                 dials: HashMap::new(),
                 direct_routes: Vec::new(),
                 coordination_relays: Vec::new(),
@@ -3035,6 +3145,7 @@ mod tests {
                 transit_after: now,
                 next_route_attempt: now,
                 retry_coordination: false,
+                webrtc_attempted: false,
                 cancellation: CancellationToken::new(),
             },
         );

--- a/native/runtime-host-peer/src/engine/application_stream.rs
+++ b/native/runtime-host-peer/src/engine/application_stream.rs
@@ -44,7 +44,10 @@ use libp2p::{
 };
 use tokio::sync::{mpsc, oneshot};
 
-use super::address::relay_peer_id_from_circuit_address;
+use super::{
+    address::relay_peer_id_from_circuit_address,
+    peer_stream::{DirectTransport, PeerConnectionPath},
+};
 
 const OUTBOUND_COMMAND_CAPACITY: usize = 1;
 
@@ -58,6 +61,7 @@ pub(super) struct Behaviour {
 pub(super) struct InboundStream {
     pub(super) peer_id: PeerId,
     pub(super) connection_id: ConnectionId,
+    pub(super) path: PeerConnectionPath,
     pub(super) stream: Stream,
 }
 
@@ -85,9 +89,13 @@ impl Behaviour {
         &mut self,
         connection_id: ConnectionId,
         peer_id: PeerId,
-        relay_peer_id: Option<PeerId>,
+        path: PeerConnectionPath,
         allow_relayed: bool,
     ) -> Handler {
+        let relay_peer_id = match path {
+            PeerConnectionPath::Direct(_) => None,
+            PeerConnectionPath::Transit { relay_peer_id } => Some(relay_peer_id),
+        };
         if relay_peer_id.is_some()
             && !allow_relayed
             && self.trusted_transit_relays.as_ref().is_some_and(|trusted| {
@@ -97,14 +105,15 @@ impl Behaviour {
                     .unwrap_or(false)
             })
         {
-            lock(&self.shared).insert(connection_id, peer_id, relay_peer_id, None);
+            lock(&self.shared).insert(connection_id, peer_id, path, None);
             return Handler::relayed();
         }
         let (sender, receiver) = mpsc::channel(OUTBOUND_COMMAND_CAPACITY);
-        lock(&self.shared).insert(connection_id, peer_id, relay_peer_id, Some(sender));
+        lock(&self.shared).insert(connection_id, peer_id, path.clone(), Some(sender));
         Handler::direct(
             connection_id,
             peer_id,
+            path,
             self.protocol.clone(),
             self.incoming.clone(),
             receiver,
@@ -126,8 +135,7 @@ impl NetworkBehaviour for Behaviour {
         Ok(self.handler(
             connection_id,
             peer_id,
-            relay_peer_id_from_circuit_address(local_addr)
-                .or_else(|| relay_peer_id_from_circuit_address(remote_addr)),
+            connection_path(local_addr, remote_addr),
             false,
         ))
     }
@@ -143,7 +151,7 @@ impl NetworkBehaviour for Behaviour {
         Ok(self.handler(
             connection_id,
             peer_id,
-            relay_peer_id_from_circuit_address(address),
+            connection_path(address, address),
             true,
         ))
     }
@@ -238,7 +246,7 @@ impl Control {
         excluded: &HashSet<ConnectionId>,
         allowed_relays: &HashSet<PeerId>,
     ) -> Result<OpenedStream, OpenStreamError> {
-        let (connection_id, relay_peer_id, sender) = lock(&self.shared)
+        let (connection_id, path, sender) = lock(&self.shared)
             .connection(peer_id, excluded, allowed_relays)
             .ok_or(OpenStreamError::NoEligibleConnection)?;
         let (result, receiver) = oneshot::channel();
@@ -251,7 +259,7 @@ impl Control {
             .map_err(|_| OpenStreamError::ConnectionClosed)??;
         Ok(OpenedStream {
             connection_id,
-            relay_peer_id,
+            path,
             stream,
         })
     }
@@ -275,7 +283,7 @@ impl Control {
             .map_err(|_| OpenStreamError::ConnectionClosed)??;
         Ok(OpenedStream {
             connection_id,
-            relay_peer_id: Some(relay_peer_id),
+            path: PeerConnectionPath::Transit { relay_peer_id },
             stream,
         })
     }
@@ -283,7 +291,7 @@ impl Control {
 
 pub(super) struct OpenedStream {
     pub(super) connection_id: ConnectionId,
-    pub(super) relay_peer_id: Option<PeerId>,
+    pub(super) path: PeerConnectionPath,
     pub(super) stream: Stream,
 }
 
@@ -321,6 +329,7 @@ struct DirectConnections {
 struct DirectConnection {
     peer_id: PeerId,
     relay_peer_id: Option<PeerId>,
+    path: PeerConnectionPath,
     sender: Option<mpsc::Sender<NewStream>>,
 }
 
@@ -329,14 +338,19 @@ impl DirectConnections {
         &mut self,
         connection_id: ConnectionId,
         peer_id: PeerId,
-        relay_peer_id: Option<PeerId>,
+        path: PeerConnectionPath,
         sender: Option<mpsc::Sender<NewStream>>,
     ) {
+        let relay_peer_id = match path {
+            PeerConnectionPath::Direct(_) => None,
+            PeerConnectionPath::Transit { relay_peer_id } => Some(relay_peer_id),
+        };
         self.connections.insert(
             connection_id,
             DirectConnection {
                 peer_id,
                 relay_peer_id,
+                path,
                 sender,
             },
         );
@@ -351,7 +365,7 @@ impl DirectConnections {
         peer_id: PeerId,
         excluded: &HashSet<ConnectionId>,
         allowed_relays: &HashSet<PeerId>,
-    ) -> Option<(ConnectionId, Option<PeerId>, mpsc::Sender<NewStream>)> {
+    ) -> Option<(ConnectionId, PeerConnectionPath, mpsc::Sender<NewStream>)> {
         self.connections
             .iter()
             .find_map(|(connection_id, connection)| {
@@ -362,7 +376,7 @@ impl DirectConnections {
                         .relay_peer_id
                         .is_none_or(|relay| allowed_relays.contains(&relay))
                     && !sender.is_closed())
-                .then(|| (*connection_id, connection.relay_peer_id, sender.clone()))
+                .then(|| (*connection_id, connection.path.clone(), sender.clone()))
             })
     }
 
@@ -392,9 +406,29 @@ fn lock(shared: &Arc<Mutex<DirectConnections>>) -> MutexGuard<'_, DirectConnecti
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+fn connection_path(local_addr: &Multiaddr, remote_addr: &Multiaddr) -> PeerConnectionPath {
+    if let Some(relay_peer_id) = relay_peer_id_from_circuit_address(local_addr)
+        .or_else(|| relay_peer_id_from_circuit_address(remote_addr))
+    {
+        return PeerConnectionPath::Transit { relay_peer_id };
+    }
+    let transport = local_addr
+        .iter()
+        .chain(remote_addr.iter())
+        .find_map(|protocol| match protocol {
+            libp2p::multiaddr::Protocol::WebRTC => Some(DirectTransport::WebRtc),
+            libp2p::multiaddr::Protocol::QuicV1 => Some(DirectTransport::Quic),
+            libp2p::multiaddr::Protocol::Tcp(_) => Some(DirectTransport::Tcp),
+            _ => None,
+        })
+        .unwrap_or(DirectTransport::Other);
+    PeerConnectionPath::Direct(transport)
+}
+
 pub(super) struct Handler {
     connection_id: Option<ConnectionId>,
     peer_id: Option<PeerId>,
+    path: Option<PeerConnectionPath>,
     protocol: Option<StreamProtocol>,
     incoming: Option<mpsc::Sender<InboundStream>>,
     commands: Option<mpsc::Receiver<NewStream>>,
@@ -406,6 +440,7 @@ impl Handler {
     fn direct(
         connection_id: ConnectionId,
         peer_id: PeerId,
+        path: PeerConnectionPath,
         protocol: StreamProtocol,
         incoming: mpsc::Sender<InboundStream>,
         commands: mpsc::Receiver<NewStream>,
@@ -413,6 +448,7 @@ impl Handler {
         Self {
             connection_id: Some(connection_id),
             peer_id: Some(peer_id),
+            path: Some(path),
             protocol: Some(protocol),
             incoming: Some(incoming),
             commands: Some(commands),
@@ -425,6 +461,7 @@ impl Handler {
         Self {
             connection_id: None,
             peer_id: None,
+            path: None,
             protocol: None,
             incoming: None,
             commands: None,
@@ -508,6 +545,7 @@ impl ConnectionHandler for Handler {
                             .connection_id
                             .expect("direct handlers have a connection id"),
                         peer_id: self.peer_id.expect("direct handlers have a peer id"),
+                        path: self.path.clone().expect("direct handlers have a path"),
                         stream,
                     });
                 }
@@ -637,7 +675,10 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![protocol.clone()]
         );
-        assert!(control.has_connection(peer_id, &HashSet::new(), &HashSet::from([relay_peer_id]),));
+        let (_, relay_path, _) = lock(&control.shared)
+            .connection(peer_id, &HashSet::new(), &HashSet::from([relay_peer_id]))
+            .expect("trusted relay connection");
+        assert_eq!(relay_path, PeerConnectionPath::Transit { relay_peer_id });
         let relay_connections = control.connections_via(&HashSet::from([relay_peer_id]));
         assert_eq!(relay_connections.len(), 2);
         assert!(relay_connections.contains(&ConnectionId::new_unchecked(1)));
@@ -666,6 +707,13 @@ mod tests {
             lock(&control.shared)
                 .connection(peer_id, &HashSet::new(), &HashSet::new())
                 .is_some()
+        );
+        let (_, direct_path, _) = lock(&control.shared)
+            .connection(peer_id, &HashSet::new(), &HashSet::new())
+            .expect("direct connection");
+        assert_eq!(
+            direct_path,
+            PeerConnectionPath::Direct(DirectTransport::Quic)
         );
         assert!(control.has_connection(peer_id, &HashSet::new(), &HashSet::new()));
         assert!(!control.has_connection(

--- a/native/runtime-host-peer/src/engine/application_stream.rs
+++ b/native/runtime-host-peer/src/engine/application_stream.rs
@@ -50,6 +50,7 @@ use super::{
 };
 
 const OUTBOUND_COMMAND_CAPACITY: usize = 1;
+const OUTBOUND_STREAM_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub(super) struct Behaviour {
     protocol: StreamProtocol,
@@ -92,10 +93,7 @@ impl Behaviour {
         path: PeerConnectionPath,
         allow_relayed: bool,
     ) -> Handler {
-        let relay_peer_id = match path {
-            PeerConnectionPath::Direct(_) => None,
-            PeerConnectionPath::Transit { relay_peer_id } => Some(relay_peer_id),
-        };
+        let relay_peer_id = path.relay_peer_id();
         if relay_peer_id.is_some()
             && !allow_relayed
             && self.trusted_transit_relays.as_ref().is_some_and(|trusted| {
@@ -192,7 +190,7 @@ impl Control {
             .filter_map(|(connection_id, connection)| {
                 active_streams
                     .contains_key(connection_id)
-                    .then_some(connection.relay_peer_id)
+                    .then_some(connection.path.relay_peer_id())
                     .flatten()
             })
             .collect()
@@ -204,7 +202,8 @@ impl Control {
             .iter()
             .filter_map(|(connection_id, connection)| {
                 connection
-                    .relay_peer_id
+                    .path
+                    .relay_peer_id()
                     .is_some_and(|relay| relays.contains(&relay))
                     .then_some(*connection_id)
             })
@@ -217,16 +216,24 @@ impl Control {
         excluded: &HashSet<ConnectionId>,
         allowed_relays: &HashSet<PeerId>,
     ) -> bool {
-        lock(&self.shared)
-            .connection(peer_id, excluded, allowed_relays)
-            .is_some()
+        !self
+            .eligible_connections(peer_id, excluded, allowed_relays)
+            .is_empty()
+    }
+
+    pub(super) fn eligible_connections(
+        &self,
+        peer_id: PeerId,
+        excluded: &HashSet<ConnectionId>,
+        allowed_relays: &HashSet<PeerId>,
+    ) -> Vec<(ConnectionId, PeerConnectionPath)> {
+        lock(&self.shared).eligible_connections(peer_id, excluded, allowed_relays)
     }
 
     pub(super) fn has_relayed_connection(&self, peer_id: PeerId) -> bool {
-        lock(&self.shared)
-            .connections
-            .values()
-            .any(|connection| connection.peer_id == peer_id && connection.relay_peer_id.is_some())
+        lock(&self.shared).connections.values().any(|connection| {
+            connection.peer_id == peer_id && connection.path.relay_peer_id().is_some()
+        })
     }
 
     pub(super) fn has_relayed_connection_via(
@@ -240,14 +247,14 @@ impl Control {
             .is_some()
     }
 
-    pub(super) async fn open_stream(
+    pub(super) async fn open_stream_on(
         &mut self,
+        connection_id: ConnectionId,
         peer_id: PeerId,
-        excluded: &HashSet<ConnectionId>,
         allowed_relays: &HashSet<PeerId>,
     ) -> Result<OpenedStream, OpenStreamError> {
-        let (connection_id, path, sender) = lock(&self.shared)
-            .connection(peer_id, excluded, allowed_relays)
+        let (path, sender) = lock(&self.shared)
+            .connection_by_id(connection_id, peer_id, allowed_relays)
             .ok_or(OpenStreamError::NoEligibleConnection)?;
         let (result, receiver) = oneshot::channel();
         sender
@@ -257,11 +264,7 @@ impl Control {
         let stream = receiver
             .await
             .map_err(|_| OpenStreamError::ConnectionClosed)??;
-        Ok(OpenedStream {
-            connection_id,
-            path,
-            stream,
-        })
+        Ok(OpenedStream { path, stream })
     }
 
     pub(super) async fn open_relayed_stream(
@@ -270,7 +273,7 @@ impl Control {
         excluded: &HashSet<ConnectionId>,
         allowed_relays: &HashSet<PeerId>,
     ) -> Result<OpenedStream, OpenStreamError> {
-        let (connection_id, relay_peer_id, sender) = lock(&self.shared)
+        let (relay_peer_id, sender) = lock(&self.shared)
             .relayed_connection(peer_id, excluded, allowed_relays)
             .ok_or(OpenStreamError::NoEligibleConnection)?;
         let (result, receiver) = oneshot::channel();
@@ -282,7 +285,6 @@ impl Control {
             .await
             .map_err(|_| OpenStreamError::ConnectionClosed)??;
         Ok(OpenedStream {
-            connection_id,
             path: PeerConnectionPath::Transit { relay_peer_id },
             stream,
         })
@@ -290,7 +292,6 @@ impl Control {
 }
 
 pub(super) struct OpenedStream {
-    pub(super) connection_id: ConnectionId,
     pub(super) path: PeerConnectionPath,
     pub(super) stream: Stream,
 }
@@ -328,7 +329,6 @@ struct DirectConnections {
 
 struct DirectConnection {
     peer_id: PeerId,
-    relay_peer_id: Option<PeerId>,
     path: PeerConnectionPath,
     sender: Option<mpsc::Sender<NewStream>>,
 }
@@ -341,15 +341,10 @@ impl DirectConnections {
         path: PeerConnectionPath,
         sender: Option<mpsc::Sender<NewStream>>,
     ) {
-        let relay_peer_id = match path {
-            PeerConnectionPath::Direct(_) => None,
-            PeerConnectionPath::Transit { relay_peer_id } => Some(relay_peer_id),
-        };
         self.connections.insert(
             connection_id,
             DirectConnection {
                 peer_id,
-                relay_peer_id,
                 path,
                 sender,
             },
@@ -360,24 +355,43 @@ impl DirectConnections {
         self.connections.remove(&connection_id);
     }
 
-    fn connection(
+    fn eligible_connections(
         &self,
         peer_id: PeerId,
         excluded: &HashSet<ConnectionId>,
         allowed_relays: &HashSet<PeerId>,
-    ) -> Option<(ConnectionId, PeerConnectionPath, mpsc::Sender<NewStream>)> {
+    ) -> Vec<(ConnectionId, PeerConnectionPath)> {
         self.connections
             .iter()
-            .find_map(|(connection_id, connection)| {
+            .filter_map(|(connection_id, connection)| {
                 let sender = connection.sender.as_ref()?;
                 (connection.peer_id == peer_id
                     && !excluded.contains(connection_id)
                     && connection
-                        .relay_peer_id
+                        .path
+                        .relay_peer_id()
                         .is_none_or(|relay| allowed_relays.contains(&relay))
                     && !sender.is_closed())
-                .then(|| (*connection_id, connection.path.clone(), sender.clone()))
+                .then(|| (*connection_id, connection.path.clone()))
             })
+            .collect()
+    }
+
+    fn connection_by_id(
+        &self,
+        connection_id: ConnectionId,
+        peer_id: PeerId,
+        allowed_relays: &HashSet<PeerId>,
+    ) -> Option<(PeerConnectionPath, mpsc::Sender<NewStream>)> {
+        let connection = self.connections.get(&connection_id)?;
+        let sender = connection.sender.as_ref()?;
+        (connection.peer_id == peer_id
+            && connection
+                .path
+                .relay_peer_id()
+                .is_none_or(|relay| allowed_relays.contains(&relay))
+            && !sender.is_closed())
+        .then(|| (connection.path.clone(), sender.clone()))
     }
 
     fn relayed_connection(
@@ -385,17 +399,17 @@ impl DirectConnections {
         peer_id: PeerId,
         excluded: &HashSet<ConnectionId>,
         allowed_relays: &HashSet<PeerId>,
-    ) -> Option<(ConnectionId, PeerId, mpsc::Sender<NewStream>)> {
+    ) -> Option<(PeerId, mpsc::Sender<NewStream>)> {
         self.connections
             .iter()
             .find_map(|(connection_id, connection)| {
                 let sender = connection.sender.as_ref()?;
-                let relay = connection.relay_peer_id?;
+                let relay = connection.path.relay_peer_id()?;
                 (connection.peer_id == peer_id
                     && !excluded.contains(connection_id)
                     && allowed_relays.contains(&relay)
                     && !sender.is_closed())
-                .then(|| (*connection_id, relay, sender.clone()))
+                .then(|| (relay, sender.clone()))
             })
     }
 }
@@ -516,7 +530,8 @@ impl ConnectionHandler for Handler {
                             protocol: libp2p::swarm::SubstreamProtocol::new(
                                 ProtocolUpgrade(vec![protocol]),
                                 request_id,
-                            ),
+                            )
+                            .with_timeout(OUTBOUND_STREAM_OPEN_TIMEOUT),
                         },
                     );
                 }
@@ -649,7 +664,7 @@ mod tests {
         );
         assert!(
             lock(&control.shared)
-                .connection(peer_id, &HashSet::new(), &HashSet::new())
+                .connection_by_id(ConnectionId::new_unchecked(1), peer_id, &HashSet::new(),)
                 .is_none()
         );
         assert!(!control.has_connection(peer_id, &HashSet::new(), &HashSet::new()));
@@ -675,8 +690,12 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![protocol.clone()]
         );
-        let (_, relay_path, _) = lock(&control.shared)
-            .connection(peer_id, &HashSet::new(), &HashSet::from([relay_peer_id]))
+        let (relay_path, _) = lock(&control.shared)
+            .connection_by_id(
+                ConnectionId::new_unchecked(2),
+                peer_id,
+                &HashSet::from([relay_peer_id]),
+            )
             .expect("trusted relay connection");
         assert_eq!(relay_path, PeerConnectionPath::Transit { relay_peer_id });
         let relay_connections = control.connections_via(&HashSet::from([relay_peer_id]));
@@ -705,11 +724,11 @@ mod tests {
         );
         assert!(
             lock(&control.shared)
-                .connection(peer_id, &HashSet::new(), &HashSet::new())
+                .connection_by_id(ConnectionId::new_unchecked(3), peer_id, &HashSet::new(),)
                 .is_some()
         );
-        let (_, direct_path, _) = lock(&control.shared)
-            .connection(peer_id, &HashSet::new(), &HashSet::new())
+        let (direct_path, _) = lock(&control.shared)
+            .connection_by_id(ConnectionId::new_unchecked(3), peer_id, &HashSet::new())
             .expect("direct connection");
         assert_eq!(
             direct_path,

--- a/native/runtime-host-peer/src/engine/application_stream.rs
+++ b/native/runtime-host-peer/src/engine/application_stream.rs
@@ -221,6 +221,17 @@ impl Control {
             .any(|connection| connection.peer_id == peer_id && connection.relay_peer_id.is_some())
     }
 
+    pub(super) fn has_relayed_connection_via(
+        &self,
+        peer_id: PeerId,
+        excluded: &HashSet<ConnectionId>,
+        allowed_relays: &HashSet<PeerId>,
+    ) -> bool {
+        lock(&self.shared)
+            .relayed_connection(peer_id, excluded, allowed_relays)
+            .is_some()
+    }
+
     pub(super) async fn open_stream(
         &mut self,
         peer_id: PeerId,
@@ -241,6 +252,30 @@ impl Control {
         Ok(OpenedStream {
             connection_id,
             relay_peer_id,
+            stream,
+        })
+    }
+
+    pub(super) async fn open_relayed_stream(
+        &mut self,
+        peer_id: PeerId,
+        excluded: &HashSet<ConnectionId>,
+        allowed_relays: &HashSet<PeerId>,
+    ) -> Result<OpenedStream, OpenStreamError> {
+        let (connection_id, relay_peer_id, sender) = lock(&self.shared)
+            .relayed_connection(peer_id, excluded, allowed_relays)
+            .ok_or(OpenStreamError::NoEligibleConnection)?;
+        let (result, receiver) = oneshot::channel();
+        sender
+            .send(NewStream { result })
+            .await
+            .map_err(|_| OpenStreamError::ConnectionClosed)?;
+        let stream = receiver
+            .await
+            .map_err(|_| OpenStreamError::ConnectionClosed)??;
+        Ok(OpenedStream {
+            connection_id,
+            relay_peer_id: Some(relay_peer_id),
             stream,
         })
     }
@@ -328,6 +363,25 @@ impl DirectConnections {
                         .is_none_or(|relay| allowed_relays.contains(&relay))
                     && !sender.is_closed())
                 .then(|| (*connection_id, connection.relay_peer_id, sender.clone()))
+            })
+    }
+
+    fn relayed_connection(
+        &self,
+        peer_id: PeerId,
+        excluded: &HashSet<ConnectionId>,
+        allowed_relays: &HashSet<PeerId>,
+    ) -> Option<(ConnectionId, PeerId, mpsc::Sender<NewStream>)> {
+        self.connections
+            .iter()
+            .find_map(|(connection_id, connection)| {
+                let sender = connection.sender.as_ref()?;
+                let relay = connection.relay_peer_id?;
+                (connection.peer_id == peer_id
+                    && !excluded.contains(connection_id)
+                    && allowed_relays.contains(&relay)
+                    && !sender.is_closed())
+                .then(|| (*connection_id, relay, sender.clone()))
             })
     }
 }

--- a/native/runtime-host-peer/src/engine/peer_stream.rs
+++ b/native/runtime-host-peer/src/engine/peer_stream.rs
@@ -74,7 +74,11 @@ pub(super) fn spawn_stream(
                                 "peer_stream_aborted",
                                 "peer stream was aborted",
                             )),
-                            outcome = writer.write_all(&bytes) => outcome.map_err(|error| {
+                            outcome = async {
+                                writer.write_all(&bytes).await?;
+                                // Framed transports may buffer a complete write until flush.
+                                writer.flush().await
+                            } => outcome.map_err(|error| {
                                 PeerError::new("peer_native_failed", error.to_string())
                             }),
                         };

--- a/native/runtime-host-peer/src/engine/peer_stream.rs
+++ b/native/runtime-host-peer/src/engine/peer_stream.rs
@@ -28,9 +28,33 @@ const CHUNK_BYTES: usize = 64 * 1024;
 
 pub struct PeerStream {
     pub peer_id: PeerId,
+    pub path: PeerConnectionPath,
     pub incoming: mpsc::Receiver<Result<Vec<u8>, PeerError>>,
     pub commands: mpsc::Sender<StreamCommand>,
     pub abort: watch::Sender<bool>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DirectTransport {
+    Quic,
+    Tcp,
+    WebRtc,
+    Other,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PeerConnectionPath {
+    Direct(DirectTransport),
+    Transit { relay_peer_id: PeerId },
+}
+
+impl PeerConnectionPath {
+    pub(super) fn relay_peer_id(&self) -> Option<PeerId> {
+        match self {
+            Self::Direct(_) => None,
+            Self::Transit { relay_peer_id } => Some(*relay_peer_id),
+        }
+    }
 }
 
 pub enum StreamCommand {
@@ -45,6 +69,7 @@ pub enum StreamCommand {
 
 pub(super) fn spawn_stream(
     peer_id: PeerId,
+    path: PeerConnectionPath,
     stream: libp2p::swarm::Stream,
     completion: Option<(StreamCompletion, mpsc::Sender<CompletedStream>)>,
 ) -> PeerStream {
@@ -141,6 +166,7 @@ pub(super) fn spawn_stream(
     });
     PeerStream {
         peer_id,
+        path,
         incoming: incoming_rx,
         commands: command_tx,
         abort: abort_tx,

--- a/native/runtime-host-peer/src/webrtc_direct/tests.rs
+++ b/native/runtime-host-peer/src/webrtc_direct/tests.rs
@@ -20,10 +20,20 @@
 use std::{pin::Pin, time::Duration};
 
 use futures::{AsyncReadExt as _, AsyncWriteExt as _, future::poll_fn};
-use libp2p::{PeerId, core::muxing::StreamMuxer};
+use libp2p::{
+    PeerId,
+    core::{
+        Endpoint,
+        muxing::StreamMuxer,
+        transport::{DialOpts, PortUse, Transport},
+    },
+};
 use tokio_util::compat::TokioAsyncReadCompatExt as _;
 
-use super::{UpgradeOptions, UpgradeRole, upgrade::MAX_INBOUND_SUBSTREAMS, upgrade_connection};
+use super::{
+    UpgradeOptions, UpgradeRole, WebRtcTransport, upgrade::MAX_INBOUND_SUBSTREAMS,
+    upgrade_connection,
+};
 
 #[tokio::test]
 async fn authenticated_signaling_yields_a_libp2p_stream() {
@@ -51,8 +61,23 @@ async fn authenticated_signaling_yields_a_libp2p_stream() {
             options,
         )
     );
-    let (_, mut connection_a) = offer.expect("offerer upgrade");
+    let (_, connection_a) = offer.expect("offerer upgrade");
     let (_, mut connection_b) = answer.expect("answerer upgrade");
+    let (mut transport, control) = WebRtcTransport::new();
+    let address = control
+        .register_outbound(peer_b, connection_a)
+        .expect("register outbound connection");
+    let (_, mut connection_a) = transport
+        .dial(
+            address,
+            DialOpts {
+                role: Endpoint::Dialer,
+                port_use: PortUse::Reuse,
+            },
+        )
+        .expect("dial prepared WebRTC connection")
+        .await
+        .expect("prepared WebRTC connection");
 
     let (outbound, inbound) = tokio::join!(
         poll_fn(|cx| Pin::new(&mut connection_a).poll_outbound(cx)),

--- a/native/runtime-host-peer/src/webrtc_direct/transport.rs
+++ b/native/runtime-host-peer/src/webrtc_direct/transport.rs
@@ -107,12 +107,14 @@ impl WebRtcTransportControl {
     ) -> Result<Multiaddr, io::Error> {
         let mut outgoing = lock(&self.outgoing);
         if outgoing.contains_key(&peer) {
+            connection.close_in_background();
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 "WebRTC transport already has a pending connection for this peer",
             ));
         }
         if outgoing.len() >= OUTGOING_CONNECTION_CAPACITY {
+            connection.close_in_background();
             return Err(io::Error::new(
                 io::ErrorKind::WouldBlock,
                 "WebRTC transport outbound queue is full",
@@ -123,7 +125,9 @@ impl WebRtcTransportControl {
     }
 
     pub fn discard_outbound(&self, peer: PeerId) {
-        lock(&self.outgoing).remove(&peer);
+        if let Some(connection) = lock(&self.outgoing).remove(&peer) {
+            connection.close_in_background();
+        }
     }
 }
 

--- a/native/runtime-host-peer/src/webrtc_direct/transport.rs
+++ b/native/runtime-host-peer/src/webrtc_direct/transport.rs
@@ -21,6 +21,7 @@ use std::{
     collections::{HashMap, VecDeque},
     io,
     pin::Pin,
+    sync::{Arc, Mutex, MutexGuard},
     task::{Context, Poll},
 };
 
@@ -34,6 +35,7 @@ use libp2p::{
 use super::muxer::WebRtcConnection;
 
 const INCOMING_CONNECTION_CAPACITY: usize = 4;
+const OUTGOING_CONNECTION_CAPACITY: usize = 32;
 
 type TransportOutput = (PeerId, WebRtcConnection);
 
@@ -43,25 +45,30 @@ pub struct WebRtcTransport {
     pending_events:
         VecDeque<TransportEvent<future::Ready<Result<TransportOutput, io::Error>>, io::Error>>,
     pending_incoming: VecDeque<TransportOutput>,
+    outgoing: Arc<Mutex<HashMap<PeerId, WebRtcConnection>>>,
 }
 
 #[derive(Clone)]
 pub struct WebRtcTransportControl {
     incoming: mpsc::Sender<TransportOutput>,
+    outgoing: Arc<Mutex<HashMap<PeerId, WebRtcConnection>>>,
 }
 
 impl WebRtcTransport {
     pub fn new() -> (Self, WebRtcTransportControl) {
         let (incoming_sender, incoming) = mpsc::channel(INCOMING_CONNECTION_CAPACITY);
+        let outgoing = Arc::new(Mutex::new(HashMap::new()));
         (
             Self {
                 incoming,
                 listeners: HashMap::new(),
                 pending_events: VecDeque::new(),
                 pending_incoming: VecDeque::new(),
+                outgoing: Arc::clone(&outgoing),
             },
             WebRtcTransportControl {
                 incoming: incoming_sender,
+                outgoing,
             },
         )
     }
@@ -91,6 +98,32 @@ impl WebRtcTransportControl {
                 },
             )
         })
+    }
+
+    pub fn register_outbound(
+        &self,
+        peer: PeerId,
+        connection: WebRtcConnection,
+    ) -> Result<Multiaddr, io::Error> {
+        let mut outgoing = lock(&self.outgoing);
+        if outgoing.contains_key(&peer) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "WebRTC transport already has a pending connection for this peer",
+            ));
+        }
+        if outgoing.len() >= OUTGOING_CONNECTION_CAPACITY {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "WebRTC transport outbound queue is full",
+            ));
+        }
+        outgoing.insert(peer, connection);
+        Ok(webrtc_peer_address(peer))
+    }
+
+    pub fn discard_outbound(&self, peer: PeerId) {
+        lock(&self.outgoing).remove(&peer);
     }
 }
 
@@ -138,7 +171,16 @@ impl Transport for WebRtcTransport {
         address: Multiaddr,
         _options: DialOpts,
     ) -> Result<Self::Dial, TransportError<Self::Error>> {
-        Err(TransportError::MultiaddrNotSupported(address))
+        let Some(peer) = webrtc_peer_id(&address) else {
+            return Err(TransportError::MultiaddrNotSupported(address));
+        };
+        let Some(connection) = lock(&self.outgoing).remove(&peer) else {
+            return Err(TransportError::Other(io::Error::new(
+                io::ErrorKind::NotFound,
+                "WebRTC transport has no prepared connection for this peer",
+            )));
+        };
+        Ok(future::ready(Ok((peer, connection))))
     }
 
     fn poll(
@@ -177,9 +219,25 @@ pub fn webrtc_peer_address(peer: PeerId) -> Multiaddr {
         .with(Protocol::P2p(peer))
 }
 
+fn webrtc_peer_id(address: &Multiaddr) -> Option<PeerId> {
+    let mut protocols = address.iter();
+    match (protocols.next(), protocols.next(), protocols.next()) {
+        (Some(Protocol::WebRTC), Some(Protocol::P2p(peer)), None) => Some(peer),
+        _ => None,
+    }
+}
+
 fn is_webrtc_listener_address(address: &Multiaddr) -> bool {
     let mut protocols = address.iter();
     matches!(protocols.next(), Some(Protocol::WebRTC)) && protocols.next().is_none()
+}
+
+fn lock(
+    shared: &Arc<Mutex<HashMap<PeerId, WebRtcConnection>>>,
+) -> MutexGuard<'_, HashMap<PeerId, WebRtcConnection>> {
+    shared
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 #[cfg(test)]

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -68,6 +68,8 @@ import {
 } from '../protocol/index.js';
 import { FramedTransport, RuntimeHostTransportError } from '../transport/framed-transport.js';
 import type { RuntimeHostMessageTransport } from '../transport/message-transport.js';
+import type { RuntimeHostPeerConnectionPath } from '../transport/peer-native.js';
+export type { RuntimeHostPeerConnectionPath } from '../transport/peer-native.js';
 import { WebSocketTransport } from '../transport/websocket-transport.js';
 import type { OperationMode, OperationSpec } from '../protocol/operation-spec.js';
 import {
@@ -174,6 +176,7 @@ export interface ConnectRuntimeHostMessageTransportInput {
   readonly livenessIntervalMs?: number;
   readonly onLivenessProbe?: () => void;
   readonly connectionResource?: RuntimeHostConnectionResource;
+  readonly peerPath?: RuntimeHostPeerConnectionPath;
 }
 
 export interface RuntimeHostConnectionResource {
@@ -230,6 +233,7 @@ export interface RuntimeHostConnection {
   readonly selectedProtocol: number;
   readonly compositionId: string;
   readonly compositionRevision: string;
+  readonly peerPath?: RuntimeHostPeerConnectionPath;
   readonly closed: Promise<void>;
   request<K extends DirectRequestOperationKey>(
     operation: K,
@@ -328,6 +332,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   readonly selectedProtocol: number;
   readonly compositionId: string;
   readonly compositionRevision: string;
+  readonly peerPath: RuntimeHostPeerConnectionPath | undefined;
   readonly closed: Promise<void>;
   readonly #transport: RuntimeHostMessageTransport;
   readonly #pendingRequests = new Map<string, PendingRequest>();
@@ -363,6 +368,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       livenessIntervalMs?: number;
       onLivenessProbe?: () => void;
       connectionResource?: RuntimeHostConnectionResource;
+      peerPath?: RuntimeHostPeerConnectionPath;
     },
   ) {
     this.#livenessIntervalMs = options?.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS;
@@ -374,6 +380,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.selectedProtocol = accepted.selectedProtocol;
     this.compositionId = accepted.compositionId;
     this.compositionRevision = accepted.compositionRevision;
+    this.peerPath = options?.peerPath;
     const connectionResource = options?.connectionResource;
     if (connectionResource) {
       const abortForResourceClosure = (cause: Error) =>
@@ -1044,6 +1051,7 @@ export async function connectRuntimeHostMessageTransport(
       livenessIntervalMs: normalized.livenessIntervalMs,
       onLivenessProbe: input.onLivenessProbe,
       connectionResource: input.connectionResource,
+      ...(input.peerPath ? { peerPath: input.peerPath } : {}),
     });
     if (result.kind === 'connected') {
       resourceTransferred = true;
@@ -1348,6 +1356,7 @@ interface ExchangeRuntimeHostHandshakeInput {
   readonly livenessIntervalMs?: number;
   readonly onLivenessProbe?: () => void;
   readonly connectionResource?: RuntimeHostConnectionResource;
+  readonly peerPath?: RuntimeHostPeerConnectionPath;
 }
 
 interface LegacySurfaceClientHello extends ClientHello {
@@ -1427,6 +1436,7 @@ async function exchangeRuntimeHostHandshake(
       livenessIntervalMs: input.livenessIntervalMs,
       onLivenessProbe: input.onLivenessProbe,
       connectionResource: input.connectionResource,
+      ...(input.peerPath ? { peerPath: input.peerPath } : {}),
     }),
   };
 }

--- a/packages/runtime-host/src/client/host-profile.ts
+++ b/packages/runtime-host/src/client/host-profile.ts
@@ -631,6 +631,7 @@ export async function connectPeerRuntimeHost(input: {
       ...(input.handshakeTimeoutMs === undefined
         ? {}
         : { handshakeTimeoutMs: input.handshakeTimeoutMs }),
+      ...(stream.path ? { peerPath: stream.path } : {}),
     });
     input.signal?.throwIfAborted();
     if (result.kind === 'incompatible') {

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -31,6 +31,7 @@ export {
   RuntimeHostOperationError,
   RuntimeHostRequestInterruptedError,
   type RuntimeHostConnection,
+  type RuntimeHostPeerConnectionPath,
   type DirectRequestOperationKey,
 } from './connection.js';
 export {

--- a/packages/runtime-host/src/transport/peer-native.ts
+++ b/packages/runtime-host/src/transport/peer-native.ts
@@ -49,11 +49,22 @@ export class RuntimeHostPeerError extends Error {
 
 export interface RuntimeHostPeerNativeStream {
   readonly peerId: string;
+  readonly path?: RuntimeHostPeerConnectionPath;
   read(): Promise<Buffer | null>;
   write(bytes: Buffer): Promise<void>;
   close(): Promise<void>;
   abort(): void;
 }
+
+export type RuntimeHostPeerConnectionPath =
+  | {
+      readonly kind: 'direct';
+      readonly transport: 'quic' | 'tcp' | 'webrtc' | 'other';
+    }
+  | {
+      readonly kind: 'transit';
+      readonly relayPeerId: string;
+    };
 
 export interface RuntimeHostPeerIdentityProof {
   readonly publicKey: Buffer;


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Outcome

Make WebRTC a second direct attempt under the same connection authority instead of a serial fallback or parallel networking product. QUIC/DCUtR and WebRTC can progress concurrently; the best authenticated direct connection commits once and closes the losing direct work, while approved member transit keeps its existing timing and admission rules.

## Scope

- Start the bounded WebRTC upgrade from eligible authenticated coordination connections.
- Race direct paths without stacking their timeouts.
- Keep application-stream admission on direct or explicitly trusted transit connections only.
- Rank established direct candidates deterministically (QUIC, TCP, WebRTC, then other) before the single application-stream commit.
- Classify the winning peer path as direct QUIC/WebRTC/TCP/other or approved member transit.
- Project path metadata through the existing Runtime Host connection; do not add live migration or mutation replay.

This is stack 3/4 for #4382. STUN product policy and Desktop presentation are isolated in the next layer.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked` (20 focused native tests across the stack)
- Runtime Host build and full Runtime Host test suite

</details>

<details>
<summary>中文</summary>

## 结果

WebRTC 成为同一 connection authority 下的第二条 direct attempt，而不是串行 fallback 或平行网络产品。QUIC/DCUtR 与 WebRTC 可以并行推进；最优的已认证 direct connection 只提交一次并关闭其余 direct work，获批成员转发的时机与准入规则保持不变。

## 范围

- 从合格且已认证的 coordination connection 启动有界 WebRTC upgrade。
- 竞速 direct path，不串行叠加 timeout。
- Application stream 仍只允许 direct 或明确受信的 transit connection。
- 在唯一 application-stream commit 前，按 QUIC、TCP、WebRTC、其他路径确定性选择已建立的 direct candidate。
- 将 winning path 分类为 direct QUIC/WebRTC/TCP/other 或获批成员转发。
- 通过既有 Runtime Host connection 投影 path metadata；不加入 live migration 或 mutation replay。

这是 #4382 的第 3/4 层。STUN 产品策略与 Desktop 呈现留在下一层。

## 验证

- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`（整个 stack 共 20 个聚焦 native tests）
- Runtime Host build 与完整 Runtime Host test suite

</details>

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented and verified adaptive direct-path selection under human direction. The human contributor owns review and merge decisions.

## Checklist

- [x] Tests cover the decision-relevant behavior
- [x] Formatting, lint, and affected tests pass locally
