### PR TITLE
fix(model-metadata): refresh stale snapshot and add scheduled upkeep

### DIFF
--- a/.github/workflows/model-metadata-refresh.yml
+++ b/.github/workflows/model-metadata-refresh.yml
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Model metadata refresh
+
+# Nightly drift check: pull the current models.dev catalog, and if it differs from the
+# committed snapshot (scripts/model-metadata/models-dev-api.snapshot.json), open a PR so
+# a human reviews the diff. Running the refresh itself *is* the drift check — there is no
+# separate comparison step, because refresh-then-diff already tells us exactly what
+# upstream changed. check:model-metadata (run in CI) only ever verified the generated
+# output against the committed snapshot, never the snapshot against upstream; this job is
+# what keeps the snapshot itself from going stale between manual refreshes.
+on:
+  schedule:
+    # Offset from the hour to reduce peak-time scheduling delays.
+    - cron: '41 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: model-metadata-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Refresh the models.dev snapshot
+        run: npm run refresh:model-metadata
+
+      - name: Enforce the sanity floor
+        # Runs after the refresh so a degraded upstream response never reaches the diff
+        # or PR steps below, even though sync-model-metadata.mjs already refuses a
+        # refresh that would remove any previously committed projection path.
+        run: node scripts/check-model-metadata-floor.mjs
+
+      - name: Check for a diff
+        id: diff
+        run: |
+          if git diff --quiet -- scripts/model-metadata packages/core/src/model-metadata.generated.ts packages/runtime/src/telemetry/model-pricing.generated.ts; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open a pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          branch="automation/model-metadata-refresh-$(date -u +%Y%m%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add scripts/model-metadata packages/core/src/model-metadata.generated.ts packages/runtime/src/telemetry/model-pricing.generated.ts
+          git commit -m "chore(model-metadata): refresh models.dev snapshot"
+          git push origin "$branch"
+          existing="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number' || true)"
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already open for $branch"
+            exit 0
+          fi
+          gh pr create \
+            --title "chore(model-metadata): refresh models.dev snapshot" \
+            --body "Automated nightly refresh of the models.dev catalog snapshot. Review the diff under scripts/model-metadata and the two generated files before merging; sync:model-metadata's shrink guard already blocks any refresh that would silently drop a previously committed model or capability." \
+            --base main \
+            --head "$branch"

--- a/scripts/check-model-metadata-floor.mjs
+++ b/scripts/check-model-metadata-floor.mjs
@@ -45,8 +45,7 @@ export async function main(argv = process.argv) {
 
   const requiredProviders = Object.keys(PROVIDERS);
   const missingProviders = requiredProviders.filter(
-    (providerType) =>
-      !metadata[providerType] || Object.keys(metadata[providerType]).length === 0,
+    (providerType) => !metadata[providerType] || Object.keys(metadata[providerType]).length === 0,
   );
   if (missingProviders.length > 0) {
     throw new Error(

--- a/scripts/check-model-metadata-floor.mjs
+++ b/scripts/check-model-metadata-floor.mjs
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Sanity floor for a freshly refreshed model-metadata snapshot. sync-model-metadata.mjs
+// already refuses a refresh that would remove any previously committed projection path
+// (see assertProjectionDoesNotShrink), which enforces a per-provider, per-model floor.
+// This check adds the one thing that misses: a models.dev response that is well-formed
+// per-provider but truncated or empty overall (e.g. an outage returning a near-empty but
+// schema-valid payload) would still pass that check if it happened to contain no removals
+// relative to an already-small snapshot. A floor on the total model count catches that.
+
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { PROVIDERS } from './sync-model-metadata.mjs';
+
+const DEFAULT_SNAPSHOT = 'scripts/model-metadata/models-dev-api.snapshot.json';
+// Set comfortably below the committed count at the time this floor was introduced
+// (1871 models across 47 providers) so ordinary upstream churn never trips it, while
+// a mostly-empty response still does.
+const MIN_TOTAL_MODELS = 1500;
+
+export async function main(argv = process.argv) {
+  const snapshotPath = option('--snapshot', argv) ?? DEFAULT_SNAPSHOT;
+  const snapshot = JSON.parse(await readFile(snapshotPath, 'utf8'));
+  const metadata = snapshot?.projection?.metadata;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new Error(`${snapshotPath} has no projection.metadata object`);
+  }
+
+  const requiredProviders = Object.keys(PROVIDERS);
+  const missingProviders = requiredProviders.filter(
+    (providerType) =>
+      !metadata[providerType] || Object.keys(metadata[providerType]).length === 0,
+  );
+  if (missingProviders.length > 0) {
+    throw new Error(
+      `model-metadata snapshot is missing models for required provider(s): ${missingProviders.join(', ')}`,
+    );
+  }
+
+  const totalModels = Object.values(metadata).reduce(
+    (sum, models) => sum + Object.keys(models).length,
+    0,
+  );
+  if (totalModels < MIN_TOTAL_MODELS) {
+    throw new Error(
+      `model-metadata snapshot has ${totalModels} total models, below the floor of ${MIN_TOTAL_MODELS}; ` +
+        'this likely means the models.dev response was truncated or degraded',
+    );
+  }
+
+  console.log(
+    `model-metadata sanity floor passed: ${totalModels} models across ${requiredProviders.length} providers`,
+  );
+}
+
+function option(name, argv) {
+  const index = argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`);
+  return value;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/model-metadata/models-dev-api.snapshot.json
+++ b/scripts/model-metadata/models-dev-api.snapshot.json
@@ -2,10 +2,12 @@
   "formatVersion": 1,
   "sourceUrl": "https://models.dev/api.json",
   "origin": {
-    "kind": "generated-output-migration",
-    "commit": "729839ed8ada3e5498b0ad27e64fb42dfd283ae7"
+    "kind": "models-dev-response",
+    "retrievedAt": "2026-09-01T00:47:09.000Z",
+    "etag": "W/\"2d4b48020d170517e16482364f5bb859\"",
+    "responseSha256": "2d4b48020d170517e16482364f5bb859065a5de55208b91b03404361f70328ae"
   },
-  "projectionSha256": "6957e4d11c649fa77dc33474bd67390a28d290c994f34dabac23f539b5f59149",
+  "projectionSha256": "21eedd7164b1d9dc2f877a10b0107038a0496688afc4ba4c553b5ed31f589b3a",
   "projection": {
     "metadata": {
       "anthropic": {
@@ -24,11 +26,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-haiku-4-5": {
@@ -47,8 +61,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-haiku-4-5-20251001": {
@@ -67,8 +87,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-5": {
@@ -87,11 +113,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-5-20251101": {
@@ -110,11 +146,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-6": {
@@ -133,11 +179,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-7": {
@@ -156,11 +213,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-8": {
@@ -179,11 +248,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-5": {
@@ -202,11 +283,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-5": {
@@ -225,8 +318,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-5-20250929": {
@@ -245,8 +344,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-6": {
@@ -265,11 +370,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-5": {
@@ -288,12 +404,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -314,12 +442,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -337,11 +472,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qvq-max": {
@@ -359,8 +506,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-flash": {
@@ -381,8 +533,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-max": {
@@ -400,8 +556,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-mt-plus": {
@@ -419,8 +579,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-mt-turbo": {
@@ -438,8 +602,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-omni-turbo": {
@@ -457,8 +625,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen-omni-turbo-realtime": {
@@ -476,8 +651,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen-plus": {
@@ -498,8 +680,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-plus-character-ja": {
@@ -517,8 +703,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-turbo": {
@@ -539,8 +729,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-max": {
@@ -558,8 +752,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-ocr": {
@@ -577,8 +776,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-plus": {
@@ -596,8 +800,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-14b-instruct": {
@@ -615,8 +824,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-32b-instruct": {
@@ -634,8 +847,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-72b-instruct": {
@@ -653,8 +870,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-7b-instruct": {
@@ -672,8 +893,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-omni-7b": {
@@ -691,8 +916,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen2-5-vl-72b-instruct": {
@@ -710,8 +942,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-vl-7b-instruct": {
@@ -729,8 +966,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-14b": {
@@ -751,8 +993,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-235b-a22b": {
@@ -773,8 +1019,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-32b": {
@@ -795,8 +1045,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-8b": {
@@ -817,8 +1071,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-asr-flash": {
@@ -836,8 +1094,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-30b-a3b-instruct": {
@@ -855,8 +1117,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-480b-a35b-instruct": {
@@ -874,8 +1140,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-flash": {
@@ -893,8 +1163,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-plus": {
@@ -912,8 +1186,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-livetranslate-flash-realtime": {
@@ -931,8 +1209,15 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-max": {
@@ -950,8 +1235,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-next-80b-a3b-instruct": {
@@ -969,8 +1258,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-next-80b-a3b-thinking": {
@@ -988,8 +1281,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-omni-flash": {
@@ -1010,8 +1307,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-omni-flash-realtime": {
@@ -1029,8 +1333,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-vl-235b-a22b": {
@@ -1048,8 +1359,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-vl-30b-a3b": {
@@ -1067,8 +1383,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-vl-plus": {
@@ -1089,8 +1410,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-122b-a10b": {
@@ -1111,8 +1437,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-27b": {
@@ -1133,8 +1465,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-35b-a3b": {
@@ -1155,8 +1493,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-397b-a17b": {
@@ -1177,8 +1521,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -1199,8 +1549,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-27b": {
@@ -1221,8 +1576,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-35b-a3b": {
@@ -1243,8 +1604,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -1265,8 +1632,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-max-preview": {
@@ -1287,8 +1659,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -1309,8 +1685,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -1330,8 +1711,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -1352,8 +1737,45 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen3.8-flash": {
+          "displayName": "Qwen3.8 Flash",
+          "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://www.alibabacloud.com/help/en/model-studio/models",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -1371,12 +1793,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwq-plus": {
@@ -1394,8 +1826,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -1414,8 +1850,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-0528": {
@@ -1432,8 +1872,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-llama-70b": {
@@ -1450,8 +1894,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-llama-8b": {
@@ -1462,14 +1910,19 @@
           "contextWindow": 32768,
           "maxOutputTokens": 16384,
           "lastUpdated": "2025-01-01",
+          "isFree": true,
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-qwen-1-5b": {
@@ -1480,14 +1933,19 @@
           "contextWindow": 32768,
           "maxOutputTokens": 16384,
           "lastUpdated": "2025-01-01",
+          "isFree": true,
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-qwen-14b": {
@@ -1504,8 +1962,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-qwen-32b": {
@@ -1522,8 +1984,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-qwen-7b": {
@@ -1540,8 +2006,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v3": {
@@ -1558,8 +2028,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v3-1": {
@@ -1576,8 +2050,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v3-2-exp": {
@@ -1594,8 +2072,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash": {
@@ -1614,12 +2096,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -1638,12 +2127,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -1663,8 +2159,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -1685,8 +2185,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -1704,8 +2208,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2-thinking": {
@@ -1723,8 +2231,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -1746,8 +2258,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -1769,8 +2286,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi/kimi-k2.5": {
@@ -1792,8 +2314,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -1810,8 +2337,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax/MiniMax-M2.7": {
@@ -1828,8 +2359,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshot-kimi-k2-instruct": {
@@ -1847,8 +2382,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qvq-max": {
@@ -1866,8 +2405,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-deep-research": {
@@ -1885,8 +2429,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-doc-turbo": {
@@ -1904,8 +2452,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-flash": {
@@ -1926,8 +2478,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-long": {
@@ -1945,8 +2501,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-math-plus": {
@@ -1964,8 +2524,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-math-turbo": {
@@ -1983,8 +2547,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-max": {
@@ -2002,8 +2570,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-mt-plus": {
@@ -2021,8 +2593,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-mt-turbo": {
@@ -2040,8 +2616,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-omni-turbo": {
@@ -2059,8 +2639,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen-omni-turbo-realtime": {
@@ -2078,8 +2665,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen-plus": {
@@ -2100,8 +2694,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-plus-character": {
@@ -2119,8 +2717,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-turbo": {
@@ -2141,8 +2743,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-max": {
@@ -2160,8 +2766,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-ocr": {
@@ -2179,8 +2790,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-plus": {
@@ -2198,8 +2814,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-14b-instruct": {
@@ -2217,8 +2838,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-32b-instruct": {
@@ -2236,8 +2861,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-72b-instruct": {
@@ -2255,8 +2884,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-7b-instruct": {
@@ -2274,8 +2907,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-coder-32b-instruct": {
@@ -2293,8 +2930,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-coder-7b-instruct": {
@@ -2312,8 +2953,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-math-72b-instruct": {
@@ -2331,8 +2976,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-math-7b-instruct": {
@@ -2350,8 +2999,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-omni-7b": {
@@ -2369,8 +3022,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen2-5-vl-72b-instruct": {
@@ -2388,8 +3048,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-vl-7b-instruct": {
@@ -2407,8 +3072,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-14b": {
@@ -2429,8 +3099,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-235b-a22b": {
@@ -2451,8 +3125,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-32b": {
@@ -2473,8 +3151,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-8b": {
@@ -2495,8 +3177,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-asr-flash": {
@@ -2514,8 +3200,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-30b-a3b-instruct": {
@@ -2533,8 +3223,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-480b-a35b-instruct": {
@@ -2552,8 +3246,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-flash": {
@@ -2571,8 +3269,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-plus": {
@@ -2590,8 +3292,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-max": {
@@ -2609,8 +3315,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-next-80b-a3b-instruct": {
@@ -2628,8 +3338,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-next-80b-a3b-thinking": {
@@ -2647,8 +3361,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-omni-flash": {
@@ -2669,8 +3387,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-omni-flash-realtime": {
@@ -2688,8 +3413,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-vl-235b-a22b": {
@@ -2707,8 +3439,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-vl-30b-a3b": {
@@ -2726,8 +3463,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-vl-plus": {
@@ -2748,8 +3490,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-397b-a17b": {
@@ -2770,8 +3517,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-flash": {
@@ -2793,8 +3545,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -2815,8 +3572,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -2837,8 +3599,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-max-preview": {
@@ -2859,8 +3626,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -2881,8 +3652,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-flash": {
@@ -2904,8 +3680,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -2925,8 +3706,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -2947,8 +3732,45 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen3.8-flash": {
+          "displayName": "Qwen3.8 Flash",
+          "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://www.alibabacloud.com/help/en/model-studio/models",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -2966,12 +3788,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwq-32b": {
@@ -2989,8 +3821,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwq-plus": {
@@ -3008,8 +3844,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "siliconflow/deepseek-r1-0528": {
@@ -3027,8 +3867,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "siliconflow/deepseek-v3-0324": {
@@ -3046,8 +3890,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "siliconflow/deepseek-v3.1-terminus": {
@@ -3068,8 +3916,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "siliconflow/deepseek-v3.2": {
@@ -3090,8 +3942,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tongyi-intent-detect-v3": {
@@ -3109,8 +3965,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -3134,8 +3994,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -3156,8 +4020,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -3179,8 +4047,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -3198,8 +4071,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-next": {
@@ -3218,8 +4095,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-plus": {
@@ -3238,8 +4119,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-max-2026-01-23": {
@@ -3258,8 +4143,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -3281,8 +4170,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -3303,8 +4197,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -3326,8 +4225,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -3347,8 +4251,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -3370,8 +4278,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -3395,8 +4308,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -3417,8 +4334,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -3440,8 +4361,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -3460,8 +4386,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-next": {
@@ -3480,8 +4410,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-plus": {
@@ -3500,8 +4434,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-max-2026-01-23": {
@@ -3520,8 +4458,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -3543,8 +4485,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -3565,8 +4512,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -3588,8 +4540,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -3609,8 +4566,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -3632,8 +4593,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -3658,8 +4624,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash": {
@@ -3679,12 +4649,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash-0731": {
@@ -3704,12 +4681,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -3729,12 +4713,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro-0813": {
@@ -3745,7 +4736,7 @@
           "contextWindow": 1000000,
           "maxOutputTokens": 384000,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "isFree": true,
           "capabilities": {
             "vision": false,
@@ -3753,12 +4744,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -3780,8 +4778,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -3803,8 +4805,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -3823,11 +4829,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "happyhorse-1.1-i2v": {
@@ -3845,7 +4858,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
+            "input": [
+              "image",
+              "text"
+            ],
             "output": []
           }
         },
@@ -3864,7 +4880,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
+            "input": [
+              "image",
+              "text"
+            ],
             "output": []
           }
         },
@@ -3883,7 +4902,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -3907,8 +4928,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -3931,8 +4957,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -3955,8 +4986,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -3975,8 +5011,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-image-2.0": {
@@ -3994,8 +5034,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen-image-2.0-pro": {
@@ -4013,8 +5057,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -4036,8 +5084,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -4060,8 +5113,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -4083,8 +5141,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -4107,8 +5169,46 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen3.8-flash": {
+          "displayName": "Qwen3.8 Flash",
+          "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://www.alibabacloud.com/help/zh/model-studio/token-plan-overview",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -4127,12 +5227,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max-preview": {
@@ -4151,11 +5261,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "wan2.7-image": {
@@ -4173,8 +5292,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "wan2.7-image-pro": {
@@ -4192,8 +5315,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         }
       },
@@ -4218,8 +5345,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash": {
@@ -4239,12 +5370,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash-0731": {
@@ -4264,12 +5402,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -4289,12 +5434,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro-0813": {
@@ -4305,7 +5457,7 @@
           "contextWindow": 1000000,
           "maxOutputTokens": 384000,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "isFree": true,
           "capabilities": {
             "vision": false,
@@ -4313,12 +5465,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -4340,8 +5499,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -4363,8 +5526,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -4383,11 +5550,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "happyhorse-1.1-i2v": {
@@ -4405,7 +5579,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
+            "input": [
+              "image",
+              "text"
+            ],
             "output": []
           }
         },
@@ -4424,7 +5601,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
+            "input": [
+              "image",
+              "text"
+            ],
             "output": []
           }
         },
@@ -4443,7 +5623,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -4467,8 +5649,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -4491,8 +5678,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -4515,8 +5707,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -4535,8 +5732,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-image-2.0": {
@@ -4554,8 +5755,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen-image-2.0-pro": {
@@ -4573,8 +5778,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -4596,8 +5805,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -4620,8 +5834,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -4643,8 +5862,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -4667,8 +5890,46 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen3.8-flash": {
+          "displayName": "Qwen3.8 Flash",
+          "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://www.alibabacloud.com/help/en/model-studio/token-plan-overview",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -4687,12 +5948,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max-preview": {
@@ -4711,11 +5982,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "wan2.7-image": {
@@ -4733,8 +6013,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "wan2.7-image-pro": {
@@ -4752,8 +6036,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         }
       },
@@ -4773,11 +6061,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-oss-120b": {
@@ -4795,11 +6093,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -4818,8 +6124,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "c4ai-aya-expanse-8b": {
@@ -4836,8 +6146,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "c4ai-aya-vision-32b": {
@@ -4854,8 +6168,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "c4ai-aya-vision-8b": {
@@ -4872,8 +6191,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-03-2025": {
@@ -4891,8 +6215,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-plus-05-2026": {
@@ -4914,8 +6242,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-reasoning-08-2025": {
@@ -4936,8 +6269,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-translate-08-2025": {
@@ -4955,8 +6292,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-vision-07-2025": {
@@ -4974,8 +6315,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-r-08-2024": {
@@ -4993,8 +6339,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-r-plus-08-2024": {
@@ -5012,8 +6362,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-r7b-12-2024": {
@@ -5031,8 +6385,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-r7b-arabic-02-2025": {
@@ -5050,8 +6408,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "north-mini-code-1-0": {
@@ -5071,11 +6433,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -5095,8 +6464,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
@@ -5115,8 +6488,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/deepseek-ai/deepseek-v4-flash-0731": {
@@ -5135,12 +6512,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/deepseek-ai/deepseek-v4-pro-0813": {
@@ -5151,19 +6535,26 @@
           "contextWindow": 1048576,
           "maxOutputTokens": 1048576,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/google/gemma-4-26b-a4b-it": {
@@ -5181,12 +6572,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/ibm-granite/granite-4.0-h-micro": {
@@ -5204,8 +6604,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.1-8b-instruct-fp8": {
@@ -5224,8 +6628,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.2-11b-vision-instruct": {
@@ -5244,8 +6652,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.2-1b-instruct": {
@@ -5264,8 +6677,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.2-3b-instruct": {
@@ -5284,8 +6701,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
@@ -5304,8 +6725,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-4-scout-17b-16e-instruct": {
@@ -5324,8 +6749,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-guard-3-8b": {
@@ -5344,8 +6774,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/mistralai/mistral-small-3.1-24b-instruct": {
@@ -5363,8 +6797,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/moonshotai/kimi-k2.6": {
@@ -5383,12 +6821,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/moonshotai/kimi-k2.7-code": {
@@ -5407,12 +6854,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/nvidia/nemotron-3-120b-a12b": {
@@ -5430,12 +6886,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/openai/gpt-oss-120b": {
@@ -5453,11 +6917,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/openai/gpt-oss-20b": {
@@ -5475,8 +6947,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/qwen/qwen2.5-coder-32b-instruct": {
@@ -5494,8 +6970,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/qwen/qwen3-30b-a3b-fp8": {
@@ -5513,8 +6993,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/qwen/qwen3.8-27b": {
@@ -5532,12 +7016,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/qwen/qwq-32b": {
@@ -5556,8 +7049,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/zai-org/glm-4.7-flash": {
@@ -5576,12 +7073,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/zai-org/glm-5.2": {
@@ -5599,12 +7104,75 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "@cf/zai-org/glm-5.3": {
+          "displayName": "Glm 5.3",
+          "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+          "lifecycle": "active",
+          "docsUrl": "https://developers.cloudflare.com/workers-ai/models/",
+          "contextWindow": 1310720,
+          "maxOutputTokens": 1310720,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "@cf/zai-org/glm-5.3-flash": {
+          "displayName": "Glm 5.3 Flash",
+          "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+          "lifecycle": "active",
+          "docsUrl": "https://developers.cloudflare.com/workers-ai/models/",
+          "contextWindow": 1310720,
+          "maxOutputTokens": 1048576,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -5624,11 +7192,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ByteDance/Seed-2.0-mini": {
@@ -5646,8 +7224,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ByteDance/Seed-2.0-pro": {
@@ -5665,8 +7248,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-R1-0528": {
@@ -5685,8 +7273,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -5704,8 +7296,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3-0324": {
@@ -5723,8 +7319,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -5745,8 +7345,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -5768,8 +7372,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -5788,12 +7396,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -5815,8 +7432,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -5835,12 +7456,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -5851,19 +7481,26 @@
           "contextWindow": 1048576,
           "maxOutputTokens": 384000,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -5884,8 +7521,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31B-it": {
@@ -5906,8 +7548,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-E4B-it": {
@@ -5928,8 +7575,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -5947,8 +7600,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
@@ -5966,8 +7623,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
@@ -5985,8 +7647,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -6004,8 +7671,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -6022,8 +7693,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -6032,7 +7707,7 @@
           "lifecycle": "active",
           "docsUrl": "https://deepinfra.com/models",
           "contextWindow": 524288,
-          "maxOutputTokens": 128000,
+          "maxOutputTokens": 512000,
           "structuredOutput": true,
           "lastUpdated": "2026-06-01",
           "capabilities": {
@@ -6041,8 +7716,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -6064,8 +7744,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -6087,8 +7772,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -6110,8 +7800,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -6129,11 +7824,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/Llama-3.3-Nemotron-Super-49B-v1.5": {
@@ -6151,8 +7855,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/Nemotron-3-Nano-30B-A3B": {
@@ -6172,8 +7880,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning": {
@@ -6191,8 +7903,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -6210,11 +7928,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -6232,11 +7958,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507": {
@@ -6254,8 +7988,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-30B-A3B": {
@@ -6273,8 +8011,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -6293,8 +8035,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo": {
@@ -6313,8 +8059,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Max": {
@@ -6333,8 +8083,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Instruct": {
@@ -6353,8 +8107,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -6373,8 +8131,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -6392,8 +8155,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -6411,8 +8180,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -6431,8 +8206,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -6451,8 +8231,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -6470,8 +8255,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -6489,8 +8279,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -6508,8 +8304,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.7-Max": {
@@ -6527,8 +8328,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.8-2.4T-A95B": {
@@ -6546,11 +8351,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.8-27B": {
@@ -6568,12 +8381,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.8-Max": {
@@ -6591,8 +8413,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/Step-3.7-Flash": {
@@ -6610,8 +8438,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/Hy3": {
@@ -6629,8 +8462,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling": {
@@ -6647,8 +8484,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling-Small": {
@@ -6666,8 +8509,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2.5": {
@@ -6689,8 +8538,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2.5-Pro": {
@@ -6712,8 +8567,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.6": {
@@ -6735,8 +8595,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.7": {
@@ -6758,8 +8622,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.7-Flash": {
@@ -6778,8 +8646,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5": {
@@ -6801,8 +8673,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.1": {
@@ -6824,8 +8700,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.2": {
@@ -6843,54 +8723,87 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        }
-      },
-      "deepseek": {
-        "deepseek-chat": {
-          "displayName": "DeepSeek Chat",
-          "description": "DeepSeek chat model for instruction following, coding, and analysis",
-          "lifecycle": "active",
-          "docsUrl": "https://api-docs.deepseek.com/quick_start/pricing",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 384000,
-          "knowledgeCutoff": "2025-09",
-          "lastUpdated": "2026-02-28",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
-        "deepseek-reasoner": {
-          "displayName": "DeepSeek Reasoner",
-          "description": "DeepSeek reasoning model for multi-step analysis, math, coding, and tools",
+        "zai-org/GLM-5.3": {
+          "displayName": "GLM-5.3",
+          "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
           "lifecycle": "active",
-          "docsUrl": "https://api-docs.deepseek.com/quick_start/pricing",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 384000,
-          "knowledgeCutoff": "2025-09",
-          "lastUpdated": "2026-02-28",
+          "docsUrl": "https://deepinfra.com/models",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
+        "zai-org/GLM-5.3-Flash": {
+          "displayName": "GLM-5.3-Flash",
+          "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://deepinfra.com/models",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        }
+      },
+      "deepseek": {
         "deepseek-v4-flash": {
           "displayName": "DeepSeek V4 Flash",
           "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
@@ -6907,12 +8820,52 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-v4-flash-vision-exp": {
+          "displayName": "DeepSeek V4 Flash Vision Exp",
+          "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+          "lifecycle": "beta",
+          "docsUrl": "https://api-docs.deepseek.com/quick_start/pricing",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-21",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -6923,47 +8876,30 @@
           "contextWindow": 1000000,
           "maxOutputTokens": 384000,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
       "fireworks-ai": {
-        "accounts/fireworks/models/deepseek-v4-flash": {
-          "displayName": "DeepSeek V4 Flash",
-          "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
-          "lifecycle": "active",
-          "docsUrl": "https://fireworks.ai/docs/",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 384000,
-          "knowledgeCutoff": "2025-05",
-          "structuredOutput": true,
-          "lastUpdated": "2026-06-16",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["high", "max"],
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
         "accounts/fireworks/models/deepseek-v4-flash-0731": {
           "displayName": "DeepSeek V4 Flash 0731",
           "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
@@ -6980,36 +8916,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "accounts/fireworks/models/deepseek-v4-pro": {
-          "displayName": "DeepSeek V4 Pro",
-          "description": "Open MoE flagship with million-token context for coding and long agent runs",
-          "lifecycle": "active",
-          "docsUrl": "https://fireworks.ai/docs/",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 384000,
-          "knowledgeCutoff": "2025-05",
-          "structuredOutput": true,
-          "lastUpdated": "2026-04-24",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["high", "max"],
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/deepseek-v4-pro-0813": {
@@ -7020,19 +8940,26 @@
           "contextWindow": 1000000,
           "maxOutputTokens": 384000,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/glm-5p2": {
@@ -7049,12 +8976,79 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "accounts/fireworks/models/glm-5p3": {
+          "displayName": "GLM 5.3",
+          "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+          "lifecycle": "active",
+          "docsUrl": "https://fireworks.ai/docs/",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-28",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "accounts/fireworks/models/glm-5p3-flash": {
+          "displayName": "GLM 5.3 Flash",
+          "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://fireworks.ai/docs/",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/gpt-oss-120b": {
@@ -7071,32 +9065,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "accounts/fireworks/models/gpt-oss-20b": {
-          "displayName": "GPT OSS 20B",
-          "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
-          "lifecycle": "active",
-          "docsUrl": "https://fireworks.ai/docs/",
-          "contextWindow": 131072,
-          "maxOutputTokens": 32768,
-          "lastUpdated": "2025-08-05",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/inkling": {
@@ -7113,8 +9094,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/kimi-k2p6": {
@@ -7134,8 +9121,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/kimi-k2p7-code": {
@@ -7155,8 +9147,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/kimi-k3": {
@@ -7174,33 +9171,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "accounts/fireworks/models/minimax-m2p7": {
-          "displayName": "MiniMax-M2.7",
-          "description": "MiniMax model for chat, coding, office work, and agentic tasks",
-          "lifecycle": "active",
-          "docsUrl": "https://fireworks.ai/docs/",
-          "contextWindow": 196608,
-          "maxOutputTokens": 196608,
-          "lastUpdated": "2026-04-12",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/minimax-m3": {
@@ -7217,11 +9203,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/muse-glimmer-30b": {
@@ -7240,11 +9235,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
@@ -7264,8 +9269,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
@@ -7286,8 +9295,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/qwen3p7-plus": {
@@ -7304,12 +9317,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/qwen3p8-max": {
@@ -7329,8 +9351,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/routers/glm-5p2-fast": {
@@ -7347,75 +9373,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "accounts/fireworks/routers/kimi-k2p6-fast": {
-          "displayName": "Kimi K2.6 Fast",
-          "description": "Kimi reasoning model for long-horizon research, planning, and tool use",
-          "lifecycle": "active",
-          "docsUrl": "https://fireworks.ai/docs/",
-          "contextWindow": 262000,
-          "maxOutputTokens": 262000,
-          "lastUpdated": "2026-06-05",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "accounts/fireworks/routers/kimi-k2p6-turbo": {
-          "displayName": "Kimi K2.6 Turbo",
-          "description": "Kimi reasoning model for long-horizon research, planning, and tool use",
-          "lifecycle": "active",
-          "docsUrl": "https://fireworks.ai/docs/",
-          "contextWindow": 262000,
-          "maxOutputTokens": 262000,
-          "lastUpdated": "2026-04-17",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "accounts/fireworks/routers/kimi-k2p7-code-fast": {
-          "displayName": "Kimi K2.7 Code Fast",
-          "description": "Kimi coding model for software agents, refactors, and repository reasoning",
-          "lifecycle": "active",
-          "docsUrl": "https://fireworks.ai/docs/",
-          "contextWindow": 262000,
-          "maxOutputTokens": 262000,
-          "lastUpdated": "2026-06-16",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/routers/kimi-k3-fast": {
@@ -7433,12 +9403,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -7458,11 +9438,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-haiku-4.5": {
@@ -7481,8 +9473,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4.5": {
@@ -7501,8 +9499,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4.6": {
@@ -7521,11 +9525,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4.7": {
@@ -7544,11 +9559,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4.8": {
@@ -7567,11 +9594,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-5": {
@@ -7591,11 +9630,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4": {
@@ -7614,8 +9665,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4.5": {
@@ -7634,8 +9691,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4.6": {
@@ -7654,11 +9717,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-5": {
@@ -7676,11 +9750,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.1-pro-preview": {
@@ -7700,11 +9786,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash": {
@@ -7724,11 +9821,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.6-flash": {
@@ -7748,11 +9857,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.7-flash": {
@@ -7772,11 +9892,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4.1": {
@@ -7796,8 +9925,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-mini": {
@@ -7817,11 +9952,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2": {
@@ -7841,8 +9985,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2-codex": {
@@ -7862,8 +10011,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex": {
@@ -7883,11 +10038,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4": {
@@ -7907,11 +10073,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-mini": {
@@ -7931,11 +10109,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-nano": {
@@ -7955,8 +10144,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5": {
@@ -7976,11 +10170,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-luna": {
@@ -8000,11 +10206,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-sol": {
@@ -8024,11 +10243,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-terra": {
@@ -8048,11 +10280,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.5": {
@@ -8071,11 +10316,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.6": {
@@ -8095,11 +10349,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -8119,8 +10383,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -8138,11 +10407,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mai-code-1-flash-picker": {
@@ -8162,11 +10440,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mai-code-1.1-flash": {
@@ -8185,11 +10471,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -8209,8 +10505,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "deep-research-preview-04-2026": {
@@ -8228,8 +10532,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-2.5-computer-use-preview-10-2025": {
@@ -8247,8 +10559,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-2.5-flash": {
@@ -8270,8 +10587,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-2.5-flash-image": {
@@ -8289,8 +10613,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-2.5-flash-lite": {
@@ -8312,8 +10642,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-2.5-flash-preview-tts": {
@@ -8331,8 +10668,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "gemini-2.5-pro": {
@@ -8351,8 +10692,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-2.5-pro-preview-tts": {
@@ -8370,8 +10718,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "gemini-3-flash-preview": {
@@ -8390,11 +10742,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3-pro-image": {
@@ -8412,11 +10776,20 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3-pro-image-preview": {
@@ -8434,8 +10807,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3.1-flash-image": {
@@ -8453,11 +10832,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3.1-flash-image-preview": {
@@ -8475,11 +10864,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3.1-flash-lite": {
@@ -8498,11 +10897,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.1-flash-lite-image": {
@@ -8521,11 +10932,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3.1-flash-lite-preview": {
@@ -8544,11 +10964,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.1-flash-live-preview": {
@@ -8567,11 +10999,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "gemini-3.1-flash-tts-preview": {
@@ -8589,8 +11033,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "gemini-3.1-pro-preview": {
@@ -8609,11 +11057,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.1-pro-preview-customtools": {
@@ -8632,11 +11091,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash": {
@@ -8655,11 +11125,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash-lite": {
@@ -8678,11 +11160,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-live-translate-preview": {
@@ -8700,8 +11194,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["audio", "text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "audio",
+              "text"
+            ]
           }
         },
         "gemini-3.6-flash": {
@@ -8720,11 +11219,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.7-flash": {
@@ -8743,11 +11254,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-embedding-001": {
@@ -8765,8 +11287,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-embedding-2": {
@@ -8784,8 +11310,15 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-flash-latest": {
@@ -8804,11 +11337,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-flash-lite-latest": {
@@ -8827,11 +11371,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-omni-flash-preview": {
@@ -8848,31 +11404,11 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
-          }
-        },
-        "gemini-robotics-er-1.6-preview": {
-          "displayName": "Gemini Robotics-ER 1.6 Preview",
-          "description": "Vision-language model for embodied reasoning: spatial understanding, task planning, and physical-world agentic robotics",
-          "lifecycle": "active",
-          "docsUrl": "https://ai.google.dev/gemini-api/docs/models",
-          "contextWindow": 131072,
-          "maxOutputTokens": 65536,
-          "knowledgeCutoff": "2025-01",
-          "structuredOutput": true,
-          "lastUpdated": "2026-04-14",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
           }
         },
         "gemma-4-26b-a4b-it": {
@@ -8893,8 +11429,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemma-4-31b-it": {
@@ -8915,8 +11456,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "lyria-3-clip-preview": {
@@ -8935,8 +11481,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "lyria-3-pro-preview": {
@@ -8955,8 +11507,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "veo-3.1-fast-generate-preview": {
@@ -8973,7 +11531,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         },
@@ -8991,7 +11552,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         },
@@ -9009,7 +11573,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         }
@@ -9030,8 +11597,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "canopylabs/orpheus-arabic-saudi": {
@@ -9048,8 +11619,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "canopylabs/orpheus-v1-english": {
@@ -9066,8 +11641,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "groq/compound": {
@@ -9084,8 +11663,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "groq/compound-mini": {
@@ -9102,8 +11685,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "llama-3.1-8b-instant": {
@@ -9121,8 +11708,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "llama-3.3-70b-versatile": {
@@ -9140,8 +11731,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-prompt-guard-2-22m": {
@@ -9158,8 +11753,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-prompt-guard-2-86m": {
@@ -9176,8 +11775,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -9195,11 +11798,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -9217,11 +11828,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -9239,11 +11858,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-27b": {
@@ -9261,11 +11888,52 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "default"]
+            "efforts": [
+              "none",
+              "default"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen/qwen3.8-27b": {
+          "displayName": "Qwen3.8 27B",
+          "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+          "lifecycle": "active",
+          "docsUrl": "https://console.groq.com/docs/models",
+          "contextWindow": 131042,
+          "maxOutputTokens": 16384,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "default",
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "whisper-large-v3": {
@@ -9282,8 +11950,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "whisper-large-v3-turbo": {
@@ -9300,8 +11972,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -9322,8 +11998,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-R1-0528": {
@@ -9341,8 +12021,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -9360,8 +12044,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3-0324": {
@@ -9379,8 +12067,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -9398,8 +12090,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -9417,8 +12113,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -9437,8 +12137,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -9457,11 +12161,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -9480,11 +12191,17 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -9495,18 +12212,26 @@
           "contextWindow": 1000000,
           "maxOutputTokens": 384000,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -9524,8 +12249,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31B-it": {
@@ -9543,8 +12273,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-3.1-8B-Instruct": {
@@ -9563,8 +12298,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct": {
@@ -9583,8 +12322,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2": {
@@ -9593,7 +12336,7 @@
           "lifecycle": "active",
           "docsUrl": "https://huggingface.co/docs/inference-providers",
           "contextWindow": 204800,
-          "maxOutputTokens": 128000,
+          "maxOutputTokens": 131072,
           "lastUpdated": "2025-10-27",
           "capabilities": {
             "vision": false,
@@ -9601,8 +12344,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.1": {
@@ -9620,8 +12367,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -9638,8 +12389,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -9657,8 +12412,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -9667,7 +12426,7 @@
           "lifecycle": "active",
           "docsUrl": "https://huggingface.co/docs/inference-providers",
           "contextWindow": 524288,
-          "maxOutputTokens": 128000,
+          "maxOutputTokens": 512000,
           "structuredOutput": true,
           "lastUpdated": "2026-06-01",
           "capabilities": {
@@ -9676,8 +12435,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2-Instruct": {
@@ -9695,8 +12459,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2-Instruct-0905": {
@@ -9714,8 +12482,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2-Thinking": {
@@ -9733,8 +12505,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -9752,8 +12528,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -9771,8 +12552,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -9791,8 +12577,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -9810,11 +12601,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -9832,11 +12632,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -9854,11 +12662,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen2.5-Coder-32B-Instruct": {
@@ -9876,8 +12692,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B": {
@@ -9896,8 +12716,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507": {
@@ -9915,8 +12739,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -9934,8 +12762,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-30B-A3B": {
@@ -9953,8 +12785,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -9973,8 +12809,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
@@ -9993,8 +12833,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
@@ -10012,8 +12856,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-Next": {
@@ -10031,8 +12879,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Embedding-4B": {
@@ -10050,8 +12902,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Embedding-8B": {
@@ -10069,8 +12925,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Instruct": {
@@ -10088,8 +12948,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Thinking": {
@@ -10107,8 +12971,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -10127,8 +12995,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Thinking": {
@@ -10147,11 +13020,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -10169,8 +13051,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -10188,8 +13075,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -10207,8 +13099,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -10226,11 +13123,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -10248,8 +13155,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -10267,8 +13179,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -10286,8 +13203,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.8-2.4T-A95B": {
@@ -10305,11 +13227,50 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "Qwen/Qwen3.8-27B": {
+          "displayName": "Qwen3.8 27B",
+          "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://huggingface.co/docs/inference-providers",
+          "contextWindow": 262144,
+          "maxOutputTokens": 32768,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/Step-3.5-Flash": {
@@ -10327,8 +13288,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/Step-3.7-Flash": {
@@ -10346,11 +13311,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/Hy3": {
@@ -10368,11 +13342,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling": {
@@ -10390,11 +13372,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling-Small": {
@@ -10411,8 +13402,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2-Flash": {
@@ -10430,8 +13426,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2.5": {
@@ -10450,12 +13450,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"],
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2.5-Pro": {
@@ -10474,12 +13484,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"],
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.5": {
@@ -10497,8 +13517,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.5-Air": {
@@ -10516,8 +13540,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.5V": {
@@ -10535,8 +13563,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.6": {
@@ -10554,8 +13587,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.6V-Flash": {
@@ -10575,8 +13612,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.7": {
@@ -10594,8 +13636,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.7-Flash": {
@@ -10614,8 +13660,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5": {
@@ -10632,8 +13682,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.1": {
@@ -10650,8 +13704,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.2": {
@@ -10669,8 +13727,73 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "zai-org/GLM-5.3": {
+          "displayName": "GLM-5.3",
+          "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+          "lifecycle": "active",
+          "docsUrl": "https://huggingface.co/docs/inference-providers",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "zai-org/GLM-5.3-Flash": {
+          "displayName": "GLM-5.3-Flash",
+          "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://huggingface.co/docs/inference-providers",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -10691,12 +13814,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "k3-256k": {
@@ -10715,11 +13847,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-for-coding": {
@@ -10739,8 +13880,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-for-coding-highspeed": {
@@ -10760,8 +13906,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -10771,8 +13922,8 @@
           "description": "Efficient open MiniMax model built for coding agents and tool-heavy workflows",
           "lifecycle": "active",
           "docsUrl": "https://platform.minimax.io/docs/guides/quickstart",
-          "contextWindow": 196608,
-          "maxOutputTokens": 128000,
+          "contextWindow": 204800,
+          "maxOutputTokens": 131072,
           "lastUpdated": "2025-10-27",
           "capabilities": {
             "vision": false,
@@ -10780,8 +13931,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.1": {
@@ -10798,8 +13953,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -10816,8 +13975,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -10834,8 +13997,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7": {
@@ -10852,8 +14019,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -10870,8 +14041,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M3": {
@@ -10879,8 +14054,8 @@
           "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
           "lifecycle": "active",
           "docsUrl": "https://platform.minimax.io/docs/guides/quickstart",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 128000,
+          "contextWindow": 1048576,
+          "maxOutputTokens": 512000,
           "lastUpdated": "2026-06-25",
           "capabilities": {
             "vision": true,
@@ -10891,8 +14066,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -10902,8 +14082,8 @@
           "description": "MiniMax model for chat, coding, office work, and agentic tasks",
           "lifecycle": "active",
           "docsUrl": "https://platform.minimaxi.com/docs/guides/quickstart",
-          "contextWindow": 196608,
-          "maxOutputTokens": 128000,
+          "contextWindow": 204800,
+          "maxOutputTokens": 131072,
           "lastUpdated": "2025-10-27",
           "capabilities": {
             "vision": false,
@@ -10911,8 +14091,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.1": {
@@ -10929,8 +14113,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -10947,8 +14135,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -10965,8 +14157,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7": {
@@ -10983,8 +14179,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -11001,8 +14201,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M3": {
@@ -11010,8 +14214,8 @@
           "description": "MiniMax multimodal coding model for long-context reasoning and agent tasks",
           "lifecycle": "active",
           "docsUrl": "https://platform.minimaxi.com/docs/guides/quickstart",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 128000,
+          "contextWindow": 1048576,
+          "maxOutputTokens": 512000,
           "lastUpdated": "2026-06-25",
           "capabilities": {
             "vision": true,
@@ -11022,8 +14226,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -11033,8 +14242,8 @@
           "description": "MiniMax model for chat, coding, office work, and agentic tasks",
           "lifecycle": "active",
           "docsUrl": "https://platform.minimax.io/docs/token-plan/intro",
-          "contextWindow": 196608,
-          "maxOutputTokens": 128000,
+          "contextWindow": 204800,
+          "maxOutputTokens": 131072,
           "lastUpdated": "2025-10-27",
           "isFree": true,
           "capabilities": {
@@ -11043,8 +14252,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.1": {
@@ -11062,8 +14275,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -11081,8 +14298,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -11100,8 +14321,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7": {
@@ -11119,8 +14344,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -11138,8 +14367,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M3": {
@@ -11147,8 +14380,8 @@
           "description": "MiniMax multimodal coding model for long-context reasoning and agent tasks",
           "lifecycle": "active",
           "docsUrl": "https://platform.minimax.io/docs/token-plan/intro",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 128000,
+          "contextWindow": 1048576,
+          "maxOutputTokens": 512000,
           "lastUpdated": "2026-06-25",
           "isFree": true,
           "capabilities": {
@@ -11160,8 +14393,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -11181,8 +14419,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-2512": {
@@ -11200,8 +14442,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-latest": {
@@ -11219,8 +14465,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-medium-2507": {
@@ -11238,8 +14488,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-medium-latest": {
@@ -11257,8 +14511,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-small-2505": {
@@ -11276,8 +14534,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-small-2507": {
@@ -11295,8 +14557,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "labs-devstral-small-2512": {
@@ -11315,8 +14581,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "magistral-medium-latest": {
@@ -11334,8 +14605,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "magistral-small": {
@@ -11353,8 +14628,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ministral-3b-latest": {
@@ -11372,8 +14651,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ministral-8b-latest": {
@@ -11391,8 +14674,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-embed": {
@@ -11409,8 +14696,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-large-2411": {
@@ -11428,8 +14719,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-large-2512": {
@@ -11447,8 +14742,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-large-latest": {
@@ -11466,8 +14766,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-medium-2505": {
@@ -11485,8 +14790,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-medium-2508": {
@@ -11504,8 +14814,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-medium-2604": {
@@ -11523,11 +14838,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-medium-latest": {
@@ -11545,11 +14868,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-nemo": {
@@ -11567,8 +14898,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-small-2506": {
@@ -11586,8 +14921,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-small-2603": {
@@ -11605,11 +14945,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-small-latest": {
@@ -11627,11 +14975,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "open-mistral-7b": {
@@ -11649,8 +15005,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "open-mistral-nemo": {
@@ -11668,8 +15028,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "open-mixtral-8x22b": {
@@ -11687,8 +15051,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "open-mixtral-8x7b": {
@@ -11706,8 +15074,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "pixtral-12b": {
@@ -11725,8 +15097,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "pixtral-large-latest": {
@@ -11744,8 +15121,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voxtral-mini-latest": {
@@ -11762,8 +15144,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voxtral-mini-tts-latest": {
@@ -11780,8 +15166,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "voxtral-small-latest": {
@@ -11798,8 +15188,42 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "zai-glm-5-2": {
+          "displayName": "GLM-5.2",
+          "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+          "lifecycle": "beta",
+          "docsUrl": "https://docs.mistral.ai/getting-started/models/",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-06-13",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -11819,8 +15243,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2-0905-preview": {
@@ -11838,8 +15266,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2-thinking": {
@@ -11857,8 +15289,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2-thinking-turbo": {
@@ -11876,8 +15312,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2-turbo-preview": {
@@ -11895,8 +15335,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -11918,8 +15362,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -11941,8 +15390,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -11961,8 +15415,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code-highspeed": {
@@ -11981,8 +15440,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -12000,12 +15464,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -12025,8 +15498,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "baai/bge-m3": {
@@ -12044,8 +15521,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "black-forest-labs/flux_1-kontext-dev": {
@@ -12063,8 +15544,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "black-forest-labs/flux_1-schnell": {
@@ -12085,8 +15571,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "black-forest-labs/flux_2-klein-4b": {
@@ -12105,8 +15595,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["image"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "black-forest-labs/flux.1-dev": {
@@ -12125,8 +15620,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seed-oss-36b-instruct": {
@@ -12145,8 +15644,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/deepseek-v4-flash": {
@@ -12165,11 +15668,51 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high", "max"]
+            "efforts": [
+              "none",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-ai/deepseek-v4-flash-0731": {
+          "displayName": "DeepSeek V4 Flash 0731",
+          "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.api.nvidia.com/nim/",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-07-31",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/deepseek-v4-pro": {
@@ -12188,11 +15731,50 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high", "max"]
+            "efforts": [
+              "none",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-ai/deepseek-v4-pro-0813": {
+          "displayName": "DeepSeek V4 Pro 0813",
+          "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.api.nvidia.com/nim/",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-22",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-2-2b-it": {
@@ -12211,8 +15793,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3-12b-it": {
@@ -12230,8 +15816,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3-4b-it": {
@@ -12249,8 +15840,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3n-e2b-it": {
@@ -12270,8 +15866,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3n-e4b-it": {
@@ -12291,8 +15892,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31b-it": {
@@ -12314,8 +15920,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/google-paligemma": {
@@ -12333,8 +15944,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/esm2-650m": {
@@ -12352,8 +15968,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/esmfold": {
@@ -12371,8 +15991,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.1-70b-instruct": {
@@ -12391,8 +16015,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.1-8b-instruct": {
@@ -12411,8 +16039,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.2-11b-vision-instruct": {
@@ -12432,8 +16064,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.2-1b-instruct": {
@@ -12453,8 +16090,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.2-3b-instruct": {
@@ -12473,8 +16114,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.2-90b-vision-instruct": {
@@ -12493,8 +16138,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.3-70b-instruct": {
@@ -12513,8 +16163,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-4-maverick-17b-128e-instruct": {
@@ -12534,8 +16188,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-guard-4-12b": {
@@ -12553,8 +16212,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -12574,11 +16238,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "microsoft/phi-4-mini-instruct": {
@@ -12597,8 +16273,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "microsoft/phi-4-multimodal-instruct": {
@@ -12618,8 +16298,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimaxai/minimax-m2.7": {
@@ -12637,8 +16321,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimaxai/minimax-m3": {
@@ -12659,8 +16347,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/magistral-small-2506": {
@@ -12680,8 +16373,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/ministral-14b-instruct-2512": {
@@ -12699,8 +16396,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-7b-instruct-v0.3": {
@@ -12719,8 +16421,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-large-3-675b-instruct-2512": {
@@ -12740,8 +16446,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3-instruct": {
@@ -12761,8 +16472,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3.5-128b": {
@@ -12781,11 +16497,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-nemotron": {
@@ -12803,8 +16527,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-4-119b-2603": {
@@ -12823,11 +16551,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mixtral-8x22b-instruct": {
@@ -12845,8 +16581,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mixtral-8x7b-instruct": {
@@ -12864,8 +16604,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-instruct-0905": {
@@ -12884,8 +16628,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -12905,11 +16653,57 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "moonshotai/kimi-k3": {
+          "displayName": "Kimi K3",
+          "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.api.nvidia.com/nim/",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-07-16",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/active-speaker-detection": {
@@ -12928,7 +16722,9 @@
           },
           "modalities": {
             "input": [],
-            "output": ["text"]
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/bevformer": {
@@ -12947,7 +16743,9 @@
           },
           "modalities": {
             "input": [],
-            "output": ["text"]
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/cosmos-predict1-5b": {
@@ -12965,7 +16763,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         },
@@ -12984,8 +16785,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/cosmos-transfer1-7b": {
@@ -13003,7 +16809,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         },
@@ -13022,7 +16831,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         },
@@ -13041,8 +16853,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3_2-nemoretriever-300m-embed-v1": {
@@ -13060,8 +16876,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-70b-instruct": {
@@ -13079,8 +16899,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-nano-8b-v1": {
@@ -13101,8 +16925,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-nano-vl-8b-v1": {
@@ -13120,8 +16948,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-safety-guard-8b-v3": {
@@ -13139,8 +16972,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-ultra-253b-v1": {
@@ -13161,8 +16998,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.3-nemotron-super-49b-v1": {
@@ -13183,8 +17024,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.3-nemotron-super-49b-v1.5": {
@@ -13205,8 +17050,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-nemotron-embed-vl-1b-v2": {
@@ -13224,8 +17073,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-nemotron-rerank-vl-1b-v2": {
@@ -13243,8 +17097,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/magpie-tts-zeroshot": {
@@ -13262,8 +17121,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "nvidia/nemotron-3-content-safety": {
@@ -13281,8 +17145,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -13304,8 +17172,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
@@ -13327,8 +17199,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -13349,8 +17227,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -13371,8 +17253,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-lightning-30b-a3b": {
@@ -13394,8 +17280,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-content-safety-reasoning-4b": {
@@ -13413,8 +17303,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-mini-4b-instruct": {
@@ -13432,8 +17326,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-nano-12b-v2-vl": {
@@ -13451,8 +17349,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-voicechat": {
@@ -13470,8 +17373,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nv-embed-v1": {
@@ -13489,8 +17397,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nv-embedcode-7b-v1": {
@@ -13508,8 +17420,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nvidia-nemotron-nano-9b-v2": {
@@ -13531,8 +17447,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/rerank-qa-mistral-4b": {
@@ -13550,8 +17470,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/riva-translate-4b-instruct-v1.1": {
@@ -13569,8 +17493,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/sparsedrive": {
@@ -13589,7 +17517,9 @@
           },
           "modalities": {
             "input": [],
-            "output": ["text"]
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/streampetr": {
@@ -13608,7 +17538,9 @@
           },
           "modalities": {
             "input": [],
-            "output": ["text"]
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/studiovoice": {
@@ -13626,8 +17558,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/synthetic-video-detector": {
@@ -13646,7 +17582,9 @@
           },
           "modalities": {
             "input": [],
-            "output": ["text"]
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/usdcode": {
@@ -13664,8 +17602,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/usdvalidate": {
@@ -13683,8 +17625,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -13704,11 +17650,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -13727,11 +17681,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/whisper-large-v3": {
@@ -13750,8 +17712,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-xs-2.1": {
@@ -13770,8 +17736,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-image": {
@@ -13790,8 +17760,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen/qwen-image-edit": {
@@ -13810,8 +17785,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen/qwen2.5-coder-32b-instruct": {
@@ -13830,8 +17810,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-480b-a35b-instruct": {
@@ -13850,8 +17834,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-next-80b-a3b-instruct": {
@@ -13870,8 +17858,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-122b-a10b": {
@@ -13893,8 +17885,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-397b-a17b": {
@@ -13917,8 +17915,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sarvamai/sarvam-m": {
@@ -13936,8 +17939,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/step-3.5-flash": {
@@ -13955,11 +17962,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/step-3.7-flash": {
@@ -13977,11 +17992,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling": {
@@ -13999,8 +18026,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "upstage/solar-10.7b-instruct": {
@@ -14018,8 +18051,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.2": {
@@ -14041,8 +18078,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -14061,12 +18102,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash:0731": {
@@ -14085,12 +18133,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -14107,12 +18162,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemma4:31b": {
@@ -14133,8 +18195,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -14154,8 +18221,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -14173,11 +18244,80 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "glm-5.3": {
+          "displayName": "GLM-5.3",
+          "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.ollama.com/cloud",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "glm-5.3-flash": {
+          "displayName": "GLM-5.3-Flash",
+          "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.ollama.com/cloud",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-oss:120b": {
@@ -14194,11 +18334,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-oss:20b": {
@@ -14215,11 +18363,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -14239,8 +18395,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -14260,8 +18421,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -14283,8 +18449,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -14302,12 +18473,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5": {
@@ -14325,8 +18505,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.7": {
@@ -14346,8 +18530,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m3": {
@@ -14365,12 +18553,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-large-3:675b": {
@@ -14387,8 +18585,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-nano:30b": {
@@ -14408,8 +18611,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-super": {
@@ -14429,8 +18636,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-ultra": {
@@ -14450,8 +18661,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5:397b": {
@@ -14471,8 +18686,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -14492,8 +18712,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gpt-3.5-turbo": {
@@ -14512,8 +18738,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4": {
@@ -14532,8 +18762,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4-turbo": {
@@ -14552,8 +18786,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4.1": {
@@ -14572,8 +18811,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4.1-mini": {
@@ -14592,8 +18837,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4.1-nano": {
@@ -14612,8 +18863,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o": {
@@ -14632,8 +18888,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o-2024-05-13": {
@@ -14652,8 +18914,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o-2024-08-06": {
@@ -14672,8 +18939,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o-2024-11-20": {
@@ -14692,8 +18964,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o-mini": {
@@ -14712,8 +18989,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5": {
@@ -14733,11 +19016,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-mini": {
@@ -14757,11 +19050,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-nano": {
@@ -14781,11 +19084,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-pro": {
@@ -14805,11 +19118,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1": {
@@ -14829,11 +19149,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2": {
@@ -14853,11 +19183,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2-chat-latest": {
@@ -14876,11 +19217,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium"]
+            "efforts": [
+              "medium"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2-pro": {
@@ -14900,11 +19248,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-chat-latest": {
@@ -14923,8 +19280,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex": {
@@ -14944,11 +19306,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex-spark": {
@@ -14968,11 +19342,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4": {
@@ -14992,11 +19378,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-mini": {
@@ -15016,11 +19414,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-nano": {
@@ -15040,11 +19449,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-pro": {
@@ -15064,11 +19484,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5": {
@@ -15088,11 +19517,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5-pro": {
@@ -15112,11 +19553,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6": {
@@ -15136,11 +19587,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-luna": {
@@ -15160,11 +19624,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-sol": {
@@ -15184,11 +19661,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-terra": {
@@ -15208,11 +19698,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-image-1": {
@@ -15230,8 +19733,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "gpt-image-1-mini": {
@@ -15249,8 +19757,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gpt-image-1.5": {
@@ -15268,8 +19782,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gpt-image-2": {
@@ -15287,8 +19807,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "gpt-realtime-2.1": {
@@ -15308,11 +19833,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "audio", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "o1": {
@@ -15331,11 +19869,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o1-pro": {
@@ -15354,11 +19902,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o3": {
@@ -15377,11 +19934,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o3-mini": {
@@ -15400,11 +19967,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o3-pro": {
@@ -15423,11 +19998,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o4-mini": {
@@ -15446,11 +20030,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "text-embedding-3-large": {
@@ -15468,8 +20061,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "text-embedding-3-small": {
@@ -15487,8 +20084,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "text-embedding-ada-002": {
@@ -15506,8 +20107,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -15530,8 +20135,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-3-5-haiku": {
@@ -15549,8 +20158,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-fable-5": {
@@ -15568,11 +20183,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-haiku-4-5": {
@@ -15590,8 +20217,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-1": {
@@ -15609,8 +20242,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-5": {
@@ -15628,11 +20267,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-6": {
@@ -15650,11 +20299,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-7": {
@@ -15672,11 +20332,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-8": {
@@ -15694,11 +20366,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-5": {
@@ -15716,11 +20400,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4": {
@@ -15738,8 +20434,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-5": {
@@ -15757,8 +20459,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-6": {
@@ -15776,11 +20484,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-5": {
@@ -15798,11 +20517,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash": {
@@ -15821,12 +20552,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash-free": {
@@ -15846,11 +20585,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -15869,12 +20616,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3-flash": {
@@ -15893,11 +20647,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3-pro": {
@@ -15916,11 +20682,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.1-pro": {
@@ -15939,11 +20715,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash": {
@@ -15962,11 +20749,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash-lite": {
@@ -15985,11 +20784,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.6-flash": {
@@ -16008,11 +20819,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.7-flash": {
@@ -16031,11 +20854,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.6": {
@@ -16056,8 +20890,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7": {
@@ -16078,8 +20916,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7-free": {
@@ -16101,8 +20943,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -16123,8 +20969,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5-free": {
@@ -16146,8 +20996,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -16168,8 +21022,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -16187,11 +21045,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5": {
@@ -16211,11 +21076,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-codex": {
@@ -16235,11 +21110,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-nano": {
@@ -16259,11 +21143,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1": {
@@ -16283,11 +21177,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1-codex": {
@@ -16307,11 +21211,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1-codex-max": {
@@ -16331,11 +21244,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1-codex-mini": {
@@ -16355,11 +21278,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2": {
@@ -16379,11 +21311,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2-codex": {
@@ -16403,11 +21346,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex": {
@@ -16427,11 +21381,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex-spark": {
@@ -16451,11 +21417,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4": {
@@ -16475,11 +21450,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-mini": {
@@ -16499,11 +21486,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-nano": {
@@ -16523,11 +21522,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-pro": {
@@ -16547,11 +21558,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5": {
@@ -16571,11 +21592,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5-pro": {
@@ -16595,11 +21628,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-luna": {
@@ -16619,11 +21662,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-sol": {
@@ -16643,11 +21699,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-terra": {
@@ -16667,11 +21736,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.5": {
@@ -16689,11 +21771,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.6": {
@@ -16712,11 +21803,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-build-0.1": {
@@ -16734,8 +21835,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-code": {
@@ -16753,14 +21860,18 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy3-free": {
           "displayName": "Hy3 Free",
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "docsUrl": "https://opencode.ai/docs/zen",
           "contextWindow": 190000,
           "maxOutputTokens": 64000,
@@ -16773,12 +21884,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy3-preview-free": {
@@ -16797,8 +21916,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2": {
@@ -16816,8 +21939,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2-thinking": {
@@ -16835,8 +21962,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -16857,8 +21988,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5-free": {
@@ -16880,8 +22016,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -16902,8 +22043,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -16922,8 +22068,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -16941,11 +22092,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max"]
+            "efforts": [
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "laguna-s-2.1-free": {
@@ -16964,11 +22122,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ling-2.6-flash-free": {
@@ -16987,8 +22153,39 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "ling-3.0-flash-fin-free": {
+          "displayName": "Ling 3.0 Flash Fin Free",
+          "description": "Finance-enhanced model for financial research, multi-step investment workflows, and long-horizon planning and execution",
+          "lifecycle": "active",
+          "docsUrl": "https://opencode.ai/docs/zen",
+          "contextWindow": 262144,
+          "maxOutputTokens": 32768,
+          "structuredOutput": false,
+          "lastUpdated": "2026-08-27",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ling-3.0-flash-free": {
@@ -17007,11 +22204,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ling-3.0-tiny-free": {
@@ -17030,8 +22235,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "longcat-2.0-free": {
@@ -17052,8 +22261,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-flash-free": {
@@ -17072,8 +22285,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-omni-free": {
@@ -17092,8 +22309,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-pro-free": {
@@ -17112,8 +22336,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-free": {
@@ -17132,8 +22360,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.1": {
@@ -17151,8 +22385,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.1-free": {
@@ -17171,8 +22409,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5": {
@@ -17190,8 +22432,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5-free": {
@@ -17210,8 +22456,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.7": {
@@ -17229,8 +22479,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m3": {
@@ -17247,8 +22501,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m3-free": {
@@ -17270,8 +22529,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "muse-spark-1.2": {
@@ -17289,11 +22553,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "muse-spark-1.2-contributor-free": {
@@ -17312,11 +22589,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-super-free": {
@@ -17335,8 +22625,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-ultra-free": {
@@ -17355,8 +22649,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3.5-lightning-free": {
@@ -17375,8 +22673,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "north-mini-code-free": {
@@ -17396,11 +22698,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder": {
@@ -17418,8 +22727,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -17440,8 +22753,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -17462,8 +22780,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus-free": {
@@ -17485,8 +22808,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ring-2.6-1t-free": {
@@ -17505,8 +22833,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "trinity-large-preview-free": {
@@ -17525,14 +22857,18 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-preview-f-free": {
           "displayName": "Ox Alpha Free (Unlimited)",
           "description": "Stealth reasoning model for coding, agentic tasks, and tool use",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "docsUrl": "https://opencode.ai/docs/zen",
           "contextWindow": 1000000,
           "maxOutputTokens": 131072,
@@ -17545,11 +22881,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -17570,11 +22915,51 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-v4-flash-vision-exp": {
+          "displayName": "DeepSeek V4 Flash Vision Exp",
+          "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+          "lifecycle": "active",
+          "docsUrl": "https://opencode.ai/docs/zen",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-21",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -17593,11 +22978,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -17615,8 +23007,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -17634,8 +23030,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -17653,11 +23053,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3": {
@@ -17675,11 +23082,51 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "glm-5.3-flash": {
+          "displayName": "GLM-5.3-Flash (2x usage)",
+          "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://opencode.ai/docs/zen",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-luna": {
@@ -17699,17 +23146,30 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.5": {
           "displayName": "Grok 4.5",
           "description": "xAI's Grok model for chat, coding, agentic tools, and lower hallucination risk",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "docsUrl": "https://opencode.ai/docs/zen",
           "contextWindow": 500000,
           "maxOutputTokens": 500000,
@@ -17721,15 +23181,57 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "grok-4.6": {
+          "displayName": "Grok 4.6",
+          "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+          "lifecycle": "active",
+          "docsUrl": "https://opencode.ai/docs/zen",
+          "contextWindow": 500000,
+          "maxOutputTokens": 500000,
+          "knowledgeCutoff": "2026-02-01",
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-12",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy3": {
-          "displayName": "Hy3 (8x usage)",
+          "displayName": "Hy3",
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
           "lifecycle": "active",
           "docsUrl": "https://opencode.ai/docs/zen",
@@ -17742,11 +23244,47 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "hy4-preview": {
+          "displayName": "Hy4 preview",
+          "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+          "lifecycle": "active",
+          "docsUrl": "https://opencode.ai/docs/zen",
+          "contextWindow": 1024000,
+          "maxOutputTokens": 64000,
+          "lastUpdated": "2026-08-28",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -17764,8 +23302,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -17783,8 +23326,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -17803,8 +23351,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -17822,11 +23375,43 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max"]
+            "efforts": [
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "longcat-2.0": {
+          "displayName": "LongCat-2.0",
+          "description": "Meituan LongCat-2.0, a reasoning model with tool calling and a 1M-token context window",
+          "lifecycle": "active",
+          "docsUrl": "https://opencode.ai/docs/zen",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "lastUpdated": "2026-06-30",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-omni": {
@@ -17844,8 +23429,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-pro": {
@@ -17863,8 +23455,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -17882,8 +23478,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -17901,8 +23503,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5": {
@@ -17920,8 +23526,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.7": {
@@ -17939,8 +23549,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m3": {
@@ -17961,8 +23575,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "muse-spark-1.2-contributor": {
@@ -17980,17 +23599,30 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ox-alpha-free": {
           "displayName": "Ox Alpha Free (Unlimited)",
           "description": "Stealth reasoning model for coding, agentic tasks, and tool use",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "docsUrl": "https://opencode.ai/docs/zen",
           "contextWindow": 1000000,
           "maxOutputTokens": 131072,
@@ -18003,11 +23635,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -18028,8 +23669,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -18050,8 +23696,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -18071,8 +23722,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -18092,8 +23747,45 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen3.8-flash": {
+          "displayName": "Qwen3.8 Flash",
+          "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://opencode.ai/docs/zen",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -18111,11 +23803,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -18135,11 +23837,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~anthropic/claude-haiku-latest": {
@@ -18160,8 +23874,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~anthropic/claude-opus-latest": {
@@ -18179,12 +23899,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~anthropic/claude-sonnet-latest": {
@@ -18203,12 +23935,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~deepseek/deepseek-v4-flash-latest": {
@@ -18217,7 +23961,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1310720,
-          "maxOutputTokens": 1048576,
+          "maxOutputTokens": 393216,
           "structuredOutput": true,
           "lastUpdated": "2026-08-01",
           "capabilities": {
@@ -18226,12 +23970,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~google/gemini-flash-latest": {
@@ -18250,11 +24002,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~google/gemini-pro-latest": {
@@ -18273,11 +24036,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["audio", "pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "audio",
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~moonshotai/kimi-latest": {
@@ -18286,7 +24060,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1048576,
-          "maxOutputTokens": 974842,
+          "maxOutputTokens": 943718,
           "structuredOutput": true,
           "lastUpdated": "2026-04-27",
           "capabilities": {
@@ -18295,12 +24069,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~openai/gpt-latest": {
@@ -18319,11 +24102,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~openai/gpt-mini-latest": {
@@ -18342,11 +24138,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~x-ai/grok-latest": {
@@ -18355,7 +24163,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 500000,
-          "maxOutputTokens": 1000000,
+          "maxOutputTokens": 450000,
           "structuredOutput": true,
           "lastUpdated": "2026-07-08",
           "capabilities": {
@@ -18364,11 +24172,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~z-ai/glm-latest": {
@@ -18376,9 +24195,9 @@
           "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 1048576,
-          "maxOutputTokens": 131072,
-          "structuredOutput": false,
+          "contextWindow": 1310720,
+          "maxOutputTokens": 943718,
+          "structuredOutput": true,
           "lastUpdated": "2026-08-19",
           "capabilities": {
             "vision": false,
@@ -18386,11 +24205,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "aion-labs/aion-2.0": {
@@ -18408,8 +24235,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "aion-labs/aion-3.0": {
@@ -18427,8 +24258,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "aion-labs/aion-3.0-mini": {
@@ -18446,8 +24281,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "aion-labs/aion-rp-llama-3.1-8b": {
@@ -18456,7 +24295,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 32768,
-          "maxOutputTokens": 32768,
+          "maxOutputTokens": 29491,
           "knowledgeCutoff": "2023-12-31",
           "structuredOutput": false,
           "lastUpdated": "2025-02-04",
@@ -18466,27 +24305,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "allenai/olmo-3-32b-think": {
-          "displayName": "Olmo 3 32B Think",
-          "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 65536,
-          "maxOutputTokens": 65536,
-          "structuredOutput": true,
-          "lastUpdated": "2025-11-21",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": false
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-2-lite-v1": {
@@ -18503,9 +24327,18 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-lite-v1": {
@@ -18524,8 +24357,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-micro-v1": {
@@ -18544,8 +24382,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-premier-v1": {
@@ -18563,8 +24405,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-pro-v1": {
@@ -18583,8 +24430,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthracite-org/magnum-v4-72b": {
@@ -18603,8 +24455,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-3-haiku": {
@@ -18623,8 +24479,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-fable-5": {
@@ -18643,11 +24504,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -18669,8 +24542,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4": {
@@ -18692,8 +24571,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.1": {
@@ -18715,8 +24600,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -18735,12 +24626,17 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -18759,12 +24655,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -18783,12 +24690,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.7-fast": {
@@ -18807,12 +24726,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -18831,12 +24762,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.8-fast": {
@@ -18855,12 +24798,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-5": {
@@ -18879,12 +24834,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-5-fast": {
@@ -18903,12 +24870,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -18930,8 +24909,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -18953,8 +24938,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -18973,12 +24964,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -18997,12 +24999,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "arcee-ai/trinity-large-thinking": {
@@ -19011,8 +25025,8 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
-          "structuredOutput": true,
+          "maxOutputTokens": 80000,
+          "structuredOutput": false,
           "lastUpdated": "2026-05-28",
           "capabilities": {
             "vision": false,
@@ -19020,28 +25034,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "arcee-ai/virtuoso-large": {
-          "displayName": "Virtuoso Large",
-          "description": "Flagship model for demanding analysis, coding, and production agent workflows",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 131072,
-          "maxOutputTokens": 64000,
-          "knowledgeCutoff": "2025-03-31",
-          "structuredOutput": false,
-          "lastUpdated": "2025-05-05",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "baidu/ernie-4.5-vl-424b-a47b": {
@@ -19059,9 +25057,17 @@
             "reasoning": true,
             "functionCalling": false
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-1.6": {
@@ -19078,9 +25084,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-1.6-flash": {
@@ -19097,9 +25111,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-2-1-turbo": {
@@ -19108,7 +25130,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2026-08-12",
           "capabilities": {
@@ -19116,9 +25138,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-2.0-code": {
@@ -19136,12 +25166,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-2.0-lite": {
@@ -19159,12 +25198,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-2.0-mini": {
@@ -19182,12 +25231,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance/ui-tars-1.5-7b": {
@@ -19206,8 +25265,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
@@ -19226,8 +25290,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/command-a": {
@@ -19246,8 +25314,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/command-r-08-2024": {
@@ -19266,8 +25338,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/command-r-plus-08-2024": {
@@ -19286,8 +25362,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/command-r7b-12-2024": {
@@ -19306,8 +25386,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/north-mini-code:free": {
@@ -19325,28 +25409,16 @@
             "reasoning": true,
             "functionCalling": true
           },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "deepcogito/cogito-v2.1-671b": {
-          "displayName": "Cogito v2.1 671B",
-          "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 128000,
-          "maxOutputTokens": 128000,
-          "structuredOutput": true,
-          "lastUpdated": "2025-11-13",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": false
+          "thinkingOptions": {
+            "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-chat": {
@@ -19365,8 +25437,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-chat-v3-0324": {
@@ -19375,7 +25451,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 163840,
-          "maxOutputTokens": 163840,
+          "maxOutputTokens": 147456,
           "knowledgeCutoff": "2024-07-31",
           "structuredOutput": true,
           "lastUpdated": "2025-03-24",
@@ -19385,8 +25461,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-chat-v3.1": {
@@ -19395,7 +25475,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 163840,
-          "maxOutputTokens": 32768,
+          "maxOutputTokens": 144900,
           "knowledgeCutoff": "2025-03-31",
           "structuredOutput": true,
           "lastUpdated": "2025-08-21",
@@ -19408,8 +25488,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-r1": {
@@ -19428,8 +25512,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-r1-0528": {
@@ -19448,8 +25536,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-r1-distill-llama-70b": {
@@ -19458,7 +25550,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 8192,
-          "maxOutputTokens": 8192,
+          "maxOutputTokens": 7372,
           "knowledgeCutoff": "2024-07-31",
           "structuredOutput": false,
           "lastUpdated": "2025-01-23",
@@ -19467,9 +25559,16 @@
             "reasoning": true,
             "functionCalling": false
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.1-terminus": {
@@ -19491,8 +25590,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -19514,8 +25617,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2-exp": {
@@ -19537,8 +25644,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -19557,12 +25668,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -19571,7 +25689,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1310720,
-          "maxOutputTokens": 384000,
+          "maxOutputTokens": 943718,
           "knowledgeCutoff": "2025-05",
           "structuredOutput": true,
           "lastUpdated": "2026-07-31",
@@ -19581,12 +25699,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash-vision-exp": {
@@ -19604,12 +25730,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -19618,7 +25753,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1048576,
-          "maxOutputTokens": 393216,
+          "maxOutputTokens": 384000,
           "knowledgeCutoff": "2025-05",
           "structuredOutput": true,
           "lastUpdated": "2026-04-24",
@@ -19628,12 +25763,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
@@ -19644,19 +25786,27 @@
           "contextWindow": 1048576,
           "maxOutputTokens": 384000,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "dots-studio/dots-3-note-preview:free": {
@@ -19665,7 +25815,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 512000,
-          "maxOutputTokens": 512000,
+          "maxOutputTokens": 460800,
           "structuredOutput": true,
           "lastUpdated": "2026-08-14",
           "isFree": true,
@@ -19674,9 +25824,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash": {
@@ -19698,8 +25856,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash-image": {
@@ -19718,8 +25883,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -19741,8 +25912,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro": {
@@ -19761,8 +25939,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro-preview": {
@@ -19781,8 +25966,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["pdf", "image", "text", "audio"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro-preview-05-06": {
@@ -19801,8 +25993,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-flash-preview": {
@@ -19821,12 +26020,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-pro-image": {
@@ -19845,8 +26056,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3-pro-image-preview": {
@@ -19865,8 +26082,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-image": {
@@ -19885,12 +26108,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"],
+            "efforts": [
+              "minimal",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text", "image"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-image-preview": {
@@ -19899,7 +26131,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 65536,
-          "maxOutputTokens": 65536,
+          "maxOutputTokens": 58982,
           "knowledgeCutoff": "2025-01",
           "structuredOutput": true,
           "lastUpdated": "2026-02-26",
@@ -19909,12 +26141,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"],
+            "efforts": [
+              "minimal",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text", "image"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -19933,12 +26174,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite-image": {
@@ -19947,7 +26200,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 65536,
-          "maxOutputTokens": 65536,
+          "maxOutputTokens": 58982,
           "knowledgeCutoff": "2025-01",
           "structuredOutput": false,
           "lastUpdated": "2026-06-30",
@@ -19957,12 +26210,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"],
+            "efforts": [
+              "minimal",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite-preview": {
@@ -19981,12 +26243,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -20005,11 +26279,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-pro-preview-customtools": {
@@ -20028,11 +26313,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash": {
@@ -20051,11 +26347,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash-lite": {
@@ -20074,11 +26382,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.6-flash": {
@@ -20097,11 +26417,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.7-flash": {
@@ -20120,11 +26452,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-2-27b-it": {
@@ -20143,8 +26486,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3-12b-it": {
@@ -20163,8 +26510,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3-27b-it": {
@@ -20172,8 +26524,8 @@
           "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 262144,
-          "maxOutputTokens": 131072,
+          "contextWindow": 131072,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2024-08-31",
           "structuredOutput": true,
           "lastUpdated": "2025-03-12",
@@ -20183,8 +26535,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3-4b-it": {
@@ -20203,28 +26560,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "google/gemma-3n-e4b-it": {
-          "displayName": "Gemma 3n 4B",
-          "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 32768,
-          "maxOutputTokens": 32768,
-          "knowledgeCutoff": "2024-08-31",
-          "structuredOutput": true,
-          "lastUpdated": "2025-05-20",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": false
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26b-a4b-it": {
@@ -20245,8 +26587,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26b-a4b-it:free": {
@@ -20268,8 +26615,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31b-it": {
@@ -20278,7 +26630,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 16384,
           "structuredOutput": true,
           "lastUpdated": "2026-04-02",
           "capabilities": {
@@ -20290,8 +26642,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31b-it:free": {
@@ -20313,8 +26670,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/lyria-3-clip-preview": {
@@ -20333,8 +26695,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "google/lyria-3-pro-preview": {
@@ -20353,8 +26721,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "gryphe/mythomax-l2-13b": {
@@ -20363,7 +26737,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 8192,
-          "maxOutputTokens": 4096,
+          "maxOutputTokens": 3686,
           "knowledgeCutoff": "2023-06-30",
           "structuredOutput": true,
           "lastUpdated": "2023-07-02",
@@ -20373,8 +26747,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ibm-granite/granite-4.0-h-micro": {
@@ -20383,7 +26761,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131000,
-          "maxOutputTokens": 131000,
+          "maxOutputTokens": 117900,
           "structuredOutput": false,
           "lastUpdated": "2025-10-20",
           "capabilities": {
@@ -20392,8 +26770,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ibm-granite/granite-4.1-8b": {
@@ -20402,7 +26784,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "structuredOutput": true,
           "lastUpdated": "2026-04-30",
           "capabilities": {
@@ -20411,8 +26793,42 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "ibm-granite/granite-4.2-8b": {
+          "displayName": "Granite 4.2 8B",
+          "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 131072,
+          "maxOutputTokens": 117964,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-31",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inception/mercury-2": {
@@ -20430,49 +26846,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "inclusionai/ling-2.6-1t": {
-          "displayName": "Ling-2.6-1T",
-          "description": "Tool-capable chat model for instruction following and agentic application workflows",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 262144,
-          "maxOutputTokens": 32768,
-          "structuredOutput": true,
-          "lastUpdated": "2026-04-23",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "inclusionai/ling-2.6-flash": {
-          "displayName": "Ling-2.6-flash",
-          "description": "Efficient model for low-latency assistance, extraction, and routine automation",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 262144,
-          "maxOutputTokens": 32768,
-          "structuredOutput": true,
-          "lastUpdated": "2026-04-21",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ling-3.0-flash": {
@@ -20489,50 +26876,43 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
-        "inclusionai/ring-2.6-1t": {
-          "displayName": "Ring-2.6-1T",
-          "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+        "inclusionai/ling-3.0-flash-fin:free": {
+          "displayName": "Ling 3.0 Flash Fin (free)",
+          "description": "Efficient model for low-latency assistance, extraction, and routine automation",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 65536,
+          "maxOutputTokens": 32768,
           "structuredOutput": false,
-          "lastUpdated": "2026-05-08",
+          "lastUpdated": "2026-08-27",
+          "isFree": true,
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"]
+            "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "kwaipilot/kat-coder-air-v2.5": {
-          "displayName": "KAT-Coder-Air V2.5",
-          "description": "Coding model for repository understanding, refactors, and agentic engineering tasks",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 256000,
-          "maxOutputTokens": 80000,
-          "structuredOutput": true,
-          "lastUpdated": "2026-07-10",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v2": {
@@ -20541,7 +26921,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 80000,
+          "maxOutputTokens": 144000,
           "structuredOutput": true,
           "lastUpdated": "2026-03-27",
           "capabilities": {
@@ -20550,8 +26930,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v2.5": {
@@ -20559,8 +26943,8 @@
           "description": "Coding model for repository understanding, refactors, and agentic engineering tasks",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 256000,
-          "maxOutputTokens": 80000,
+          "contextWindow": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2026-07-10",
           "capabilities": {
@@ -20569,8 +26953,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "liquid/lfm-2.5-2.6b:free": {
@@ -20589,8 +26977,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mancer/weaver": {
@@ -20609,8 +27001,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meituan/longcat-2.0": {
@@ -20627,9 +27023,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.1-70b-instruct": {
@@ -20648,8 +27051,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.1-8b-instruct": {
@@ -20658,7 +27065,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2023-12",
           "structuredOutput": true,
           "lastUpdated": "2024-07-23",
@@ -20668,8 +27075,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.2-1b-instruct": {
@@ -20678,7 +27089,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 60000,
-          "maxOutputTokens": 60000,
+          "maxOutputTokens": 54000,
           "knowledgeCutoff": "2023-12-31",
           "structuredOutput": false,
           "lastUpdated": "2024-09-25",
@@ -20688,8 +27099,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.2-3b-instruct": {
@@ -20698,7 +27113,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2023-12-31",
           "structuredOutput": true,
           "lastUpdated": "2024-09-25",
@@ -20708,8 +27123,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.3-70b-instruct": {
@@ -20718,7 +27137,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 115200,
           "knowledgeCutoff": "2023-12",
           "structuredOutput": true,
           "lastUpdated": "2024-12-06",
@@ -20728,8 +27147,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-4-maverick": {
@@ -20738,7 +27161,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1048576,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 115200,
           "knowledgeCutoff": "2024-08-31",
           "structuredOutput": true,
           "lastUpdated": "2025-04-05",
@@ -20748,8 +27171,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-4-scout": {
@@ -20758,7 +27186,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1310720,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 8192,
           "knowledgeCutoff": "2024-08-31",
           "structuredOutput": true,
           "lastUpdated": "2025-04-05",
@@ -20768,8 +27196,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-guard-4-12b": {
@@ -20777,7 +27210,7 @@
           "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 1048576,
+          "contextWindow": 163840,
           "maxOutputTokens": 16384,
           "knowledgeCutoff": "2024-08-31",
           "structuredOutput": false,
@@ -20788,8 +27221,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -20798,7 +27236,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 16384,
           "knowledgeCutoff": "2026-01-04",
           "structuredOutput": true,
           "lastUpdated": "2026-08-10",
@@ -20808,11 +27246,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-spark-1.1": {
@@ -20821,7 +27269,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1048576,
-          "maxOutputTokens": 1048576,
+          "maxOutputTokens": 943718,
           "structuredOutput": true,
           "lastUpdated": "2026-07-09",
           "capabilities": {
@@ -20830,11 +27278,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-spark-1.2": {
@@ -20843,7 +27304,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1048576,
-          "maxOutputTokens": 1048576,
+          "maxOutputTokens": 943718,
           "structuredOutput": true,
           "lastUpdated": "2026-08-05",
           "capabilities": {
@@ -20852,11 +27313,59 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "meta/muse-spark-1.2-contributor": {
+          "displayName": "Muse Spark 1.2 Contributor",
+          "description": "Open Llama multimodal model for image understanding and text reasoning",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 943718,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-21",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "microsoft/phi-4": {
@@ -20865,7 +27374,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 16384,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 14745,
           "knowledgeCutoff": "2024-06-30",
           "structuredOutput": true,
           "lastUpdated": "2025-01-10",
@@ -20875,8 +27384,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "microsoft/wizardlm-2-8x22b": {
@@ -20895,8 +27408,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-01": {
@@ -20905,7 +27422,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1000192,
-          "maxOutputTokens": 1000192,
+          "maxOutputTokens": 900172,
           "knowledgeCutoff": "2024-03-31",
           "structuredOutput": false,
           "lastUpdated": "2025-01-15",
@@ -20915,8 +27432,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m1": {
@@ -20934,9 +27456,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2": {
@@ -20954,8 +27483,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2-her": {
@@ -20973,8 +27506,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.1": {
@@ -20992,8 +27529,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5": {
@@ -21002,7 +27543,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 204800,
-          "maxOutputTokens": 32768,
+          "maxOutputTokens": 128000,
           "structuredOutput": true,
           "lastUpdated": "2026-02-12",
           "capabilities": {
@@ -21011,8 +27552,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7": {
@@ -21030,8 +27575,36 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "minimax/minimax-m2.7:free": {
+          "displayName": "MiniMax M2.7 (free)",
+          "description": "MiniMax model for chat, coding, office work, and agentic tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 196608,
+          "maxOutputTokens": 176947,
+          "structuredOutput": false,
+          "lastUpdated": "2026-03-18",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m3": {
@@ -21048,9 +27621,45 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "minimax/minimax-m3:free": {
+          "displayName": "MiniMax M3 (free)",
+          "description": "MiniMax multimodal coding model for long-context reasoning and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 943718,
+          "structuredOutput": false,
+          "lastUpdated": "2026-06-01",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/codestral-2508": {
@@ -21059,7 +27668,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 256000,
-          "maxOutputTokens": 256000,
+          "maxOutputTokens": 204800,
           "knowledgeCutoff": "2025-03-31",
           "structuredOutput": true,
           "lastUpdated": "2025-08-01",
@@ -21069,8 +27678,38 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "mistralai/devstral-2512": {
+          "displayName": "Devstral 2",
+          "description": "Mistral coding agent model for repository tasks and software engineering workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 262144,
+          "maxOutputTokens": 209715,
+          "knowledgeCutoff": "2025-12",
+          "structuredOutput": true,
+          "lastUpdated": "2025-12-09",
+          "capabilities": {
+            "vision": false,
+            "reasoning": false,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/ministral-14b-2512": {
@@ -21079,7 +27718,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 209715,
           "structuredOutput": true,
           "lastUpdated": "2025-12-02",
           "capabilities": {
@@ -21088,8 +27727,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/ministral-3b-2512": {
@@ -21098,7 +27742,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 104857,
           "structuredOutput": true,
           "lastUpdated": "2025-12-02",
           "capabilities": {
@@ -21107,28 +27751,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "mistralai/ministral-8b": {
-          "displayName": "Ministral 8B",
-          "description": "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 128000,
-          "maxOutputTokens": 128000,
-          "knowledgeCutoff": "2024-09-30",
-          "structuredOutput": true,
-          "lastUpdated": "2024-10-17",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": false
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/ministral-8b-2512": {
@@ -21137,7 +27766,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 209715,
           "structuredOutput": true,
           "lastUpdated": "2025-12-02",
           "capabilities": {
@@ -21146,8 +27775,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-large": {
@@ -21156,7 +27790,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 128000,
-          "maxOutputTokens": 128000,
+          "maxOutputTokens": 102400,
           "knowledgeCutoff": "2024-11-30",
           "structuredOutput": true,
           "lastUpdated": "2024-02-26",
@@ -21166,8 +27800,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-large-2407": {
@@ -21176,7 +27815,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 104857,
           "knowledgeCutoff": "2024-03-31",
           "structuredOutput": true,
           "lastUpdated": "2024-11-19",
@@ -21186,8 +27825,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-large-2512": {
@@ -21196,7 +27840,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 209715,
           "knowledgeCutoff": "2024-11",
           "structuredOutput": true,
           "lastUpdated": "2025-12-02",
@@ -21206,8 +27850,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3": {
@@ -21216,7 +27866,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 104857,
           "knowledgeCutoff": "2025-03-31",
           "structuredOutput": true,
           "lastUpdated": "2025-05-07",
@@ -21226,8 +27876,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3-5": {
@@ -21236,7 +27892,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 209715,
           "structuredOutput": true,
           "lastUpdated": "2026-04-30",
           "capabilities": {
@@ -21245,11 +27901,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3.1": {
@@ -21258,7 +27923,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 104857,
           "knowledgeCutoff": "2025-06-30",
           "structuredOutput": true,
           "lastUpdated": "2025-08-13",
@@ -21268,8 +27933,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-nemo": {
@@ -21288,8 +27959,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-saba": {
@@ -21298,7 +27973,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 32768,
-          "maxOutputTokens": 32768,
+          "maxOutputTokens": 26214,
           "knowledgeCutoff": "2024-09-30",
           "structuredOutput": true,
           "lastUpdated": "2025-02-17",
@@ -21308,8 +27983,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-24b-instruct-2501": {
@@ -21328,8 +28008,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-2603": {
@@ -21338,7 +28022,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 209715,
           "knowledgeCutoff": "2025-06",
           "structuredOutput": true,
           "lastUpdated": "2026-03-16",
@@ -21348,11 +28032,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-3.1-24b-instruct": {
@@ -21361,7 +28053,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 128000,
-          "maxOutputTokens": 128000,
+          "maxOutputTokens": 102400,
           "knowledgeCutoff": "2023-10-31",
           "structuredOutput": false,
           "lastUpdated": "2025-03-17",
@@ -21371,8 +28063,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-3.2-24b-instruct": {
@@ -21380,7 +28077,7 @@
           "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 256000,
+          "contextWindow": 131072,
           "maxOutputTokens": 16384,
           "knowledgeCutoff": "2023-10-31",
           "structuredOutput": true,
@@ -21391,8 +28088,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mixtral-8x22b-instruct": {
@@ -21401,7 +28103,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 65536,
-          "maxOutputTokens": 65536,
+          "maxOutputTokens": 52428,
           "knowledgeCutoff": "2024-01-31",
           "structuredOutput": true,
           "lastUpdated": "2024-04-17",
@@ -21411,8 +28113,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/voxtral-small-24b-2507": {
@@ -21420,8 +28127,8 @@
           "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 32000,
-          "maxOutputTokens": 32000,
+          "contextWindow": 32768,
+          "maxOutputTokens": 26214,
           "structuredOutput": true,
           "lastUpdated": "2025-10-30",
           "capabilities": {
@@ -21430,8 +28137,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2": {
@@ -21450,8 +28163,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-0905": {
@@ -21470,8 +28187,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -21490,8 +28211,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -21500,7 +28225,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2025-01",
           "structuredOutput": true,
           "lastUpdated": "2026-01",
@@ -21509,9 +28234,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -21520,7 +28253,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2025-01",
           "structuredOutput": true,
           "lastUpdated": "2026-04-21",
@@ -21529,9 +28262,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -21540,7 +28281,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2025-01",
           "structuredOutput": true,
           "lastUpdated": "2026-06-12",
@@ -21550,8 +28291,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3": {
@@ -21560,7 +28306,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1048576,
-          "maxOutputTokens": 1048576,
+          "maxOutputTokens": 943718,
           "structuredOutput": true,
           "lastUpdated": "2026-07-16",
           "capabilities": {
@@ -21569,12 +28315,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "morph/morph-v3-fast": {
@@ -21592,8 +28347,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "morph/morph-v3-large": {
@@ -21611,8 +28370,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nex-agi/nex-n2-mini": {
@@ -21621,7 +28384,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2026-06-24",
           "capabilities": {
@@ -21629,9 +28392,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nex-agi/nex-n2-pro": {
@@ -21640,7 +28411,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": false,
           "lastUpdated": "2026-06-08",
           "capabilities": {
@@ -21648,9 +28419,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nousresearch/hermes-3-llama-3.1-405b": {
@@ -21669,8 +28448,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nousresearch/hermes-3-llama-3.1-70b": {
@@ -21689,8 +28472,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nousresearch/hermes-4-405b": {
@@ -21699,7 +28486,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2024-08-31",
           "structuredOutput": false,
           "lastUpdated": "2025-08-26",
@@ -21712,8 +28499,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nousresearch/hermes-4-70b": {
@@ -21722,7 +28513,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2024-08-31",
           "structuredOutput": false,
           "lastUpdated": "2025-08-26",
@@ -21735,8 +28526,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -21745,7 +28540,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 228000,
           "structuredOutput": true,
           "lastUpdated": "2025-12-15",
           "capabilities": {
@@ -21753,29 +28548,16 @@
             "reasoning": true,
             "functionCalling": true
           },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "nvidia/nemotron-3-nano-30b-a3b:free": {
-          "displayName": "Nemotron 3 Nano 30B A3B (free)",
-          "description": "Small Nemotron 3 MoE for efficient coding, math, and long-context agents",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 256000,
-          "maxOutputTokens": 256000,
-          "structuredOutput": false,
-          "lastUpdated": "2025-12-15",
-          "isFree": true,
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
+          "thinkingOptions": {
+            "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
@@ -21793,9 +28575,18 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -21813,12 +28604,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium"],
+            "efforts": [
+              "low",
+              "medium"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b:free": {
@@ -21827,7 +28625,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2026-03-11",
           "isFree": true,
@@ -21837,12 +28635,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium"],
+            "efforts": [
+              "low",
+              "medium"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -21850,7 +28655,7 @@
           "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 512288,
+          "contextWindow": 262144,
           "maxOutputTokens": 16384,
           "structuredOutput": true,
           "lastUpdated": "2026-06-04",
@@ -21860,12 +28665,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high"],
+            "efforts": [
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b:free": {
@@ -21884,12 +28696,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high"],
+            "efforts": [
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-content-safety:free": {
@@ -21907,9 +28726,17 @@
             "reasoning": true,
             "functionCalling": false
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-lightning": {
@@ -21930,8 +28757,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-lightning:free": {
@@ -21953,48 +28784,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "nvidia/nemotron-nano-12b-v2-vl:free": {
-          "displayName": "Nemotron Nano 12B 2 VL (free)",
-          "description": "Nemotron multimodal model for visual reasoning and agentic AI workflows",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 128000,
-          "maxOutputTokens": 128000,
-          "structuredOutput": false,
-          "lastUpdated": "2025-10-28",
-          "isFree": true,
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "nvidia/nemotron-nano-9b-v2:free": {
-          "displayName": "Nemotron Nano 9B V2 (free)",
-          "description": "Compact Nemotron model for efficient reasoning and deployable AI agents",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 128000,
-          "maxOutputTokens": 128000,
-          "structuredOutput": true,
-          "lastUpdated": "2025-08-18",
-          "isFree": true,
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo": {
@@ -22013,8 +28808,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo-0613": {
@@ -22023,7 +28822,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 4095,
-          "maxOutputTokens": 4096,
+          "maxOutputTokens": 3685,
           "knowledgeCutoff": "2021-09-30",
           "structuredOutput": true,
           "lastUpdated": "2024-01-25",
@@ -22033,8 +28832,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo-16k": {
@@ -22053,8 +28856,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo-instruct": {
@@ -22063,7 +28870,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 4095,
-          "maxOutputTokens": 4096,
+          "maxOutputTokens": 3685,
           "knowledgeCutoff": "2021-09-30",
           "structuredOutput": true,
           "lastUpdated": "2023-09-28",
@@ -22073,8 +28880,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4": {
@@ -22093,8 +28904,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4-turbo": {
@@ -22113,8 +28928,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4-turbo-preview": {
@@ -22133,8 +28953,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1": {
@@ -22153,8 +28977,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-mini": {
@@ -22173,8 +29003,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-nano": {
@@ -22193,8 +29029,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o": {
@@ -22213,8 +29055,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-2024-05-13": {
@@ -22233,8 +29081,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-2024-08-06": {
@@ -22253,8 +29107,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-2024-11-20": {
@@ -22273,8 +29133,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini": {
@@ -22293,8 +29159,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini-2024-07-18": {
@@ -22313,8 +29185,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5": {
@@ -22334,11 +29212,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-image": {
@@ -22357,8 +29246,15 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["image", "text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "image",
+              "text"
+            ]
           }
         },
         "openai/gpt-5-image-mini": {
@@ -22376,8 +29272,15 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["image", "text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "image",
+              "text"
+            ]
           }
         },
         "openai/gpt-5-mini": {
@@ -22397,11 +29300,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-nano": {
@@ -22421,11 +29335,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-pro": {
@@ -22445,11 +29370,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1": {
@@ -22469,11 +29402,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -22493,11 +29437,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-max": {
@@ -22517,11 +29470,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -22541,12 +29504,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2": {
@@ -22566,11 +29538,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-chat": {
@@ -22589,8 +29573,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -22610,11 +29600,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -22634,11 +29634,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -22658,11 +29668,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4": {
@@ -22682,11 +29704,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-image-2": {
@@ -22704,11 +29738,24 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["image", "text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "image",
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -22728,11 +29775,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -22752,11 +29811,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -22776,11 +29847,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5": {
@@ -22800,11 +29881,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -22824,11 +29917,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -22848,11 +29951,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna-pro": {
@@ -22872,11 +29988,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -22896,11 +30025,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol-pro": {
@@ -22920,11 +30062,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -22944,11 +30099,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra-pro": {
@@ -22968,11 +30136,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-audio": {
@@ -22990,8 +30171,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-audio-mini": {
@@ -23009,8 +30196,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-chat-latest": {
@@ -23028,8 +30221,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -23038,7 +30237,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "structuredOutput": true,
           "lastUpdated": "2025-08-05",
           "capabilities": {
@@ -23047,11 +30246,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -23060,7 +30267,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "structuredOutput": true,
           "lastUpdated": "2025-08-05",
           "capabilities": {
@@ -23069,34 +30276,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "openai/gpt-oss-20b:free": {
-          "displayName": "gpt-oss-20b (free)",
-          "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 131072,
-          "maxOutputTokens": 32768,
-          "structuredOutput": true,
-          "lastUpdated": "2025-08-05",
-          "isFree": true,
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -23114,11 +30306,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o1": {
@@ -23137,11 +30337,17 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o1-pro": {
@@ -23159,9 +30365,18 @@
             "reasoning": true,
             "functionCalling": false
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3": {
@@ -23180,11 +30395,17 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-mini": {
@@ -23203,11 +30424,16 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "toggle": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-mini-high": {
@@ -23226,11 +30452,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-pro": {
@@ -23249,11 +30482,17 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "toggle": true
           },
           "modalities": {
-            "input": ["text", "pdf", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o4-mini": {
@@ -23272,11 +30511,17 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o4-mini-high": {
@@ -23295,11 +30540,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openrouter/auto": {
@@ -23317,8 +30570,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "openrouter/bodybuilder": {
@@ -23336,8 +30597,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openrouter/free": {
@@ -23357,8 +30622,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openrouter/fusion": {
@@ -23376,8 +30646,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openrouter/pareto-code": {
@@ -23395,8 +30669,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perceptron/perceptron-mk1": {
@@ -23413,9 +30691,17 @@
             "reasoning": true,
             "functionCalling": false
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar": {
@@ -23424,7 +30710,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 127072,
-          "maxOutputTokens": 127072,
+          "maxOutputTokens": 114364,
           "structuredOutput": false,
           "lastUpdated": "2025-01-27",
           "capabilities": {
@@ -23433,8 +30719,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-deep-research": {
@@ -23443,7 +30734,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 128000,
-          "maxOutputTokens": 128000,
+          "maxOutputTokens": 115200,
           "structuredOutput": false,
           "lastUpdated": "2025-03-07",
           "capabilities": {
@@ -23451,9 +30742,16 @@
             "reasoning": true,
             "functionCalling": false
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-pro": {
@@ -23471,8 +30769,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-pro-search": {
@@ -23490,8 +30793,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-reasoning-pro": {
@@ -23500,7 +30808,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 128000,
-          "maxOutputTokens": 128000,
+          "maxOutputTokens": 115200,
           "structuredOutput": false,
           "lastUpdated": "2025-03-07",
           "capabilities": {
@@ -23508,9 +30816,17 @@
             "reasoning": true,
             "functionCalling": false
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-s-2.1": {
@@ -23527,9 +30843,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-s-2.1:free": {
@@ -23547,9 +30870,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-xs-2.1": {
@@ -23566,9 +30896,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-xs-2.1:free": {
@@ -23586,9 +30923,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-2.5-72b-instruct": {
@@ -23607,8 +30951,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-2.5-7b-instruct": {
@@ -23617,7 +30965,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 32768,
-          "maxOutputTokens": 32768,
+          "maxOutputTokens": 29491,
           "knowledgeCutoff": "2024-06-30",
           "structuredOutput": true,
           "lastUpdated": "2024-10-16",
@@ -23627,8 +30975,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-2.5-coder-32b-instruct": {
@@ -23637,7 +30989,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 32768,
-          "maxOutputTokens": 32768,
+          "maxOutputTokens": 29491,
           "knowledgeCutoff": "2024-06-30",
           "structuredOutput": false,
           "lastUpdated": "2024-11-11",
@@ -23647,8 +30999,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-plus": {
@@ -23667,8 +31023,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-plus-2025-07-28": {
@@ -23687,28 +31047,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "qwen/qwen-plus-2025-07-28:thinking": {
-          "displayName": "Qwen Plus 0728 (thinking)",
-          "description": "Qwen reasoning model for deliberate problem solving, math, and coding",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 32768,
-          "knowledgeCutoff": "2025-03-31",
-          "structuredOutput": true,
-          "lastUpdated": "2025-09-08",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen2.5-vl-72b-instruct": {
@@ -23717,7 +31061,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 128000,
-          "maxOutputTokens": 128000,
+          "maxOutputTokens": 28800,
           "knowledgeCutoff": "2024-06-30",
           "structuredOutput": true,
           "lastUpdated": "2025-02-01",
@@ -23727,8 +31071,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-14b": {
@@ -23750,8 +31099,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-235b-a22b": {
@@ -23773,8 +31126,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-235b-a22b-2507": {
@@ -23783,7 +31140,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2025-06-30",
           "structuredOutput": true,
           "lastUpdated": "2025-07-21",
@@ -23793,8 +31150,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-235b-a22b-thinking-2507": {
@@ -23802,8 +31163,8 @@
           "description": "Qwen reasoning model for deliberate problem solving, math, and coding",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 262144,
-          "maxOutputTokens": 32768,
+          "contextWindow": 131072,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2025-06-30",
           "structuredOutput": false,
           "lastUpdated": "2025-07-25",
@@ -23813,8 +31174,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-30b-a3b": {
@@ -23823,7 +31188,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 8192,
+          "maxOutputTokens": 16384,
           "structuredOutput": false,
           "lastUpdated": "2025-04-28",
           "capabilities": {
@@ -23835,8 +31200,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-30b-a3b-instruct-2507": {
@@ -23855,8 +31224,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-30b-a3b-thinking-2507": {
@@ -23875,8 +31248,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-32b": {
@@ -23898,8 +31275,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-8b": {
@@ -23921,8 +31302,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder": {
@@ -23941,8 +31326,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-30b-a3b-instruct": {
@@ -23951,7 +31340,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2025-04",
           "structuredOutput": true,
           "lastUpdated": "2025-04",
@@ -23961,8 +31350,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-flash": {
@@ -23981,8 +31374,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-next": {
@@ -23991,7 +31388,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2025-09",
           "structuredOutput": true,
           "lastUpdated": "2026-02-03",
@@ -24001,8 +31398,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-plus": {
@@ -24021,8 +31422,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-max": {
@@ -24041,8 +31446,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-max-thinking": {
@@ -24059,9 +31468,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-next-80b-a3b-instruct": {
@@ -24070,7 +31486,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2025-04",
           "structuredOutput": true,
           "lastUpdated": "2025-09",
@@ -24080,8 +31496,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-next-80b-a3b-thinking": {
@@ -24100,8 +31520,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-235b-a22b-instruct": {
@@ -24120,8 +31544,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-235b-a22b-thinking": {
@@ -24140,8 +31569,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-30b-a3b-instruct": {
@@ -24150,7 +31584,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 32768,
+          "maxOutputTokens": 16384,
           "knowledgeCutoff": "2025-03-31",
           "structuredOutput": true,
           "lastUpdated": "2025-10-06",
@@ -24160,8 +31594,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-30b-a3b-thinking": {
@@ -24180,8 +31619,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-32b-instruct": {
@@ -24199,8 +31643,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-8b-instruct": {
@@ -24218,8 +31667,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-8b-thinking": {
@@ -24237,8 +31691,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-122b-a10b": {
@@ -24247,7 +31706,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 65536,
+          "maxOutputTokens": 81920,
           "structuredOutput": true,
           "lastUpdated": "2026-02-23",
           "capabilities": {
@@ -24259,8 +31718,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-27b": {
@@ -24281,8 +31745,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-35b-a3b": {
@@ -24291,7 +31760,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2026-02-23",
           "capabilities": {
@@ -24303,8 +31772,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-397b-a17b": {
@@ -24325,8 +31799,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-9b": {
@@ -24335,7 +31814,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2026-02-23",
           "capabilities": {
@@ -24347,8 +31826,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-flash-02-23": {
@@ -24369,8 +31853,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-plus-02-15": {
@@ -24392,8 +31881,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-plus-20260420": {
@@ -24414,8 +31908,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-27b": {
@@ -24424,7 +31923,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2026-04-22",
           "capabilities": {
@@ -24436,8 +31935,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-35b-a3b": {
@@ -24446,7 +31950,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2026-04-17",
           "capabilities": {
@@ -24458,8 +31962,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-flash": {
@@ -24480,8 +31989,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-max-preview": {
@@ -24503,8 +32017,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-plus": {
@@ -24526,8 +32044,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-flash": {
@@ -24545,9 +32068,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-max": {
@@ -24568,8 +32099,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-plus": {
@@ -24591,8 +32126,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.8-2.4t-a95b": {
@@ -24610,11 +32150,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.8-27b": {
@@ -24632,12 +32180,48 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen/qwen3.8-flash": {
+          "displayName": "Qwen3.8 Flash",
+          "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.8-max": {
@@ -24655,11 +32239,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "rekaai/reka-edge": {
@@ -24668,7 +32263,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 16384,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 14745,
           "structuredOutput": true,
           "lastUpdated": "2026-03-20",
           "capabilities": {
@@ -24677,8 +32272,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "rekaai/reka-flash-3": {
@@ -24687,7 +32287,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 65536,
-          "maxOutputTokens": 65536,
+          "maxOutputTokens": 58982,
           "knowledgeCutoff": "2025-01-31",
           "structuredOutput": true,
           "lastUpdated": "2025-03-12",
@@ -24697,8 +32297,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "relace/relace-apply-3": {
@@ -24716,8 +32320,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "relace/relace-search": {
@@ -24735,8 +32343,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sakana/fugu-ultra": {
@@ -24754,11 +32366,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh", "max"]
+            "efforts": [
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sakana/sakana-namazu": {
@@ -24776,11 +32397,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sao10k/l3-lunaris-8b": {
@@ -24789,7 +32419,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 8192,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 7372,
           "knowledgeCutoff": "2023-12-31",
           "structuredOutput": true,
           "lastUpdated": "2024-08-13",
@@ -24799,8 +32429,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sao10k/l3.1-euryale-70b": {
@@ -24819,8 +32453,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sao10k/l3.3-euryale-70b": {
@@ -24839,31 +32477,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "stealth/ox-alpha": {
-          "displayName": "Ox Alpha",
-          "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 1048576,
-          "maxOutputTokens": 131072,
-          "structuredOutput": false,
-          "lastUpdated": "2026-08-20",
-          "isFree": true,
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -24882,8 +32501,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -24893,7 +32516,7 @@
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
           "inputLimit": 256000,
-          "maxOutputTokens": 256000,
+          "maxOutputTokens": 230400,
           "knowledgeCutoff": "2026-03-01",
           "structuredOutput": true,
           "lastUpdated": "2026-05-29",
@@ -24903,11 +32526,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hunyuan-a13b-instruct": {
@@ -24916,7 +32548,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2025-03-31",
           "structuredOutput": true,
           "lastUpdated": "2025-07-08",
@@ -24925,9 +32557,16 @@
             "reasoning": true,
             "functionCalling": false
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-1.8b": {
@@ -24945,8 +32584,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-30b-a3b": {
@@ -24964,8 +32607,35 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "tencent/hy-mt2-7b": {
+          "displayName": "Hy-MT2-7B",
+          "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 8192,
+          "maxOutputTokens": 4096,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-19",
+          "capabilities": {
+            "vision": false,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy3": {
@@ -24983,11 +32653,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy3-preview": {
@@ -24996,7 +32674,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 262144,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 235929,
           "structuredOutput": false,
           "lastUpdated": "2026-04-20",
           "capabilities": {
@@ -25005,11 +32683,49 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "tencent/hy4-preview": {
+          "displayName": "Hy4 preview",
+          "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 64000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-28",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thedrummer/cydonia-24b-v4.1": {
@@ -25018,7 +32734,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2024-04-30",
           "structuredOutput": true,
           "lastUpdated": "2025-09-27",
@@ -25028,28 +32744,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "thedrummer/rocinante-12b": {
-          "displayName": "Rocinante 12B",
-          "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
-          "lifecycle": "active",
-          "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 65536,
-          "maxOutputTokens": 65536,
-          "knowledgeCutoff": "2024-04-30",
-          "structuredOutput": true,
-          "lastUpdated": "2024-09-30",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": false
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thedrummer/skyfall-36b-v2": {
@@ -25058,7 +32758,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 32768,
-          "maxOutputTokens": 32768,
+          "maxOutputTokens": 29491,
           "knowledgeCutoff": "2024-06-30",
           "structuredOutput": true,
           "lastUpdated": "2025-03-10",
@@ -25068,8 +32768,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thedrummer/unslopnemo-12b": {
@@ -25078,7 +32782,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1024000,
-          "maxOutputTokens": 1024000,
+          "maxOutputTokens": 26214,
           "knowledgeCutoff": "2024-04-30",
           "structuredOutput": true,
           "lastUpdated": "2024-11-08",
@@ -25088,8 +32792,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling": {
@@ -25098,7 +32806,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1048576,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 471859,
           "structuredOutput": false,
           "lastUpdated": "2026-07-15",
           "capabilities": {
@@ -25107,11 +32815,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling-small": {
@@ -25121,7 +32842,7 @@
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1048576,
           "maxOutputTokens": 262144,
-          "structuredOutput": true,
+          "structuredOutput": false,
           "lastUpdated": "2026-07-30",
           "capabilities": {
             "vision": true,
@@ -25129,11 +32850,96 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "thinkingmachines/inkling-small:free": {
+          "displayName": "Inkling Small (free)",
+          "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 262144,
+          "structuredOutput": false,
+          "lastUpdated": "2026-07-30",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "thinkingmachines/inkling:free": {
+          "displayName": "Inkling (free)",
+          "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 262144,
+          "structuredOutput": false,
+          "lastUpdated": "2026-07-15",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "undi95/remm-slerp-l2-13b": {
@@ -25142,7 +32948,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 6144,
-          "maxOutputTokens": 6144,
+          "maxOutputTokens": 4096,
           "knowledgeCutoff": "2023-06-30",
           "structuredOutput": true,
           "lastUpdated": "2023-07-22",
@@ -25152,8 +32958,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "upstage/solar-pro-3": {
@@ -25162,7 +32972,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 131072,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 117964,
           "structuredOutput": true,
           "lastUpdated": "2026-01-27",
           "capabilities": {
@@ -25170,9 +32980,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "upstage/solar-pro4": {
@@ -25189,9 +33006,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "writer/palmyra-x5": {
@@ -25209,8 +33033,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.20": {
@@ -25219,7 +33047,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 2000000,
-          "maxOutputTokens": 2000000,
+          "maxOutputTokens": 1800000,
           "knowledgeCutoff": "2025-09-01",
           "structuredOutput": true,
           "lastUpdated": "2026-03-31",
@@ -25228,9 +33056,18 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.20-multi-agent": {
@@ -25239,7 +33076,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 2000000,
-          "maxOutputTokens": 2000000,
+          "maxOutputTokens": 1800000,
           "knowledgeCutoff": "2025-09-01",
           "structuredOutput": true,
           "lastUpdated": "2026-03-31",
@@ -25249,11 +33086,22 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.3": {
@@ -25262,7 +33110,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1000000,
-          "maxOutputTokens": 1000000,
+          "maxOutputTokens": 900000,
           "structuredOutput": true,
           "lastUpdated": "2026-04-17",
           "capabilities": {
@@ -25271,11 +33119,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.5": {
@@ -25284,7 +33143,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 500000,
-          "maxOutputTokens": 500000,
+          "maxOutputTokens": 450000,
           "structuredOutput": true,
           "lastUpdated": "2026-07-08",
           "capabilities": {
@@ -25293,11 +33152,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.6": {
@@ -25306,7 +33175,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 500000,
-          "maxOutputTokens": 500000,
+          "maxOutputTokens": 450000,
           "knowledgeCutoff": "2026-02-01",
           "structuredOutput": true,
           "lastUpdated": "2026-08-12",
@@ -25316,11 +33185,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-build-0.1": {
@@ -25329,7 +33209,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 256000,
-          "maxOutputTokens": 256000,
+          "maxOutputTokens": 230400,
           "structuredOutput": true,
           "lastUpdated": "2026-04-16",
           "capabilities": {
@@ -25338,8 +33218,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -25361,8 +33247,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -25384,8 +33276,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5": {
@@ -25407,8 +33303,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5-air": {
@@ -25430,8 +33330,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5v": {
@@ -25453,8 +33357,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6": {
@@ -25463,7 +33372,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 204800,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 16384,
           "knowledgeCutoff": "2025-04",
           "structuredOutput": true,
           "lastUpdated": "2025-09-30",
@@ -25472,9 +33381,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6v": {
@@ -25492,9 +33408,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7": {
@@ -25512,9 +33436,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7-flash": {
@@ -25532,9 +33463,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5": {
@@ -25551,9 +33489,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5-turbo": {
@@ -25570,9 +33515,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.1": {
@@ -25589,9 +33541,16 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.2": {
@@ -25600,7 +33559,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 1048576,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 262144,
           "structuredOutput": true,
           "lastUpdated": "2026-06-13",
           "capabilities": {
@@ -25609,12 +33568,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.2:free": {
@@ -25623,7 +33589,7 @@
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
           "contextWindow": 256000,
-          "maxOutputTokens": 256000,
+          "maxOutputTokens": 230400,
           "structuredOutput": true,
           "lastUpdated": "2026-06-13",
           "isFree": true,
@@ -25633,12 +33599,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.3": {
@@ -25646,9 +33619,9 @@
           "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
           "lifecycle": "active",
           "docsUrl": "https://openrouter.ai/models",
-          "contextWindow": 1048576,
+          "contextWindow": 1310720,
           "maxOutputTokens": 131072,
-          "structuredOutput": false,
+          "structuredOutput": true,
           "lastUpdated": "2026-08-14",
           "capabilities": {
             "vision": false,
@@ -25656,11 +33629,50 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "z-ai/glm-5.3-flash": {
+          "displayName": "GLM-5.3-Flash",
+          "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+          "lifecycle": "active",
+          "docsUrl": "https://openrouter.ai/models",
+          "contextWindow": 1310720,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5v-turbo": {
@@ -25677,9 +33689,17 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "toggle": true
+          },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -25699,8 +33719,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ByteDance-Seed/Seed-OSS-36B-Instruct": {
@@ -25718,8 +33742,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-R1": {
@@ -25737,8 +33765,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -25756,8 +33788,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -25778,8 +33814,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.1-Terminus": {
@@ -25800,8 +33840,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -25822,8 +33866,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.2-Exp": {
@@ -25844,8 +33892,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -25864,8 +33916,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -25884,8 +33940,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -25903,8 +33963,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31B-it": {
@@ -25922,8 +33986,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionAI/Ling-flash-2.0": {
@@ -25941,8 +34009,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -25960,8 +34032,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -25979,8 +34055,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -25998,8 +34079,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -26017,8 +34103,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -26036,8 +34126,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen2.5-72B-Instruct": {
@@ -26055,8 +34149,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen2.5-7B-Instruct": {
@@ -26074,8 +34172,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-14B": {
@@ -26096,8 +34198,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -26115,8 +34221,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-30B-A3B-Instruct-2507": {
@@ -26134,8 +34244,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -26156,8 +34270,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-8B": {
@@ -26178,8 +34296,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
@@ -26197,8 +34319,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
@@ -26216,8 +34342,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -26235,8 +34365,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Thinking": {
@@ -26254,8 +34389,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-30B-A3B-Instruct": {
@@ -26273,8 +34413,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-30B-A3B-Thinking": {
@@ -26292,8 +34437,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-32B-Instruct": {
@@ -26311,8 +34461,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-32B-Thinking": {
@@ -26330,8 +34485,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-8B-Instruct": {
@@ -26349,8 +34509,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -26368,8 +34533,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -26387,8 +34556,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -26406,8 +34579,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -26425,8 +34602,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -26444,8 +34625,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -26463,8 +34648,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -26482,8 +34671,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/Step-3.5-Flash": {
@@ -26501,8 +34694,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/Hunyuan-A13B-Instruct": {
@@ -26523,8 +34720,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/Hy3-preview": {
@@ -26541,8 +34742,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.5-Air": {
@@ -26560,8 +34765,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5": {
@@ -26579,8 +34788,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.1": {
@@ -26598,8 +34811,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.2": {
@@ -26617,11 +34834,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5V-Turbo": {
@@ -26641,8 +34865,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -26663,8 +34892,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-2-16k": {
@@ -26683,8 +34916,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash": {
@@ -26703,11 +34940,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash-2603": {
@@ -26726,11 +34970,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.7-flash": {
@@ -26749,11 +35000,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-tts-2": {
@@ -26770,8 +35030,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "stepaudio-2.5-asr": {
@@ -26788,8 +35052,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepaudio-2.5-tts": {
@@ -26806,8 +35074,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -26828,8 +35100,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-2-16k": {
@@ -26848,8 +35124,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash": {
@@ -26868,11 +35148,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash-2603": {
@@ -26891,11 +35178,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.7-flash": {
@@ -26914,11 +35208,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-tts-2": {
@@ -26935,8 +35238,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "stepaudio-2.5-asr": {
@@ -26953,8 +35260,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepaudio-2.5-tts": {
@@ -26971,8 +35282,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -26993,11 +35308,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash-2603": {
@@ -27016,11 +35338,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.7-flash": {
@@ -27039,11 +35368,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -27064,11 +35402,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash-2603": {
@@ -27087,11 +35432,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.7-flash": {
@@ -27110,11 +35462,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-router-v1": {
@@ -27133,8 +35494,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -27156,8 +35521,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-R1": {
@@ -27175,8 +35544,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -27194,8 +35567,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3-1": {
@@ -27216,8 +35593,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -27236,12 +35617,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -27259,12 +35647,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -27275,19 +35670,27 @@
           "contextWindow": 1048576,
           "maxOutputTokens": 384000,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "essentialai/Rnj-1-Instruct": {
@@ -27305,8 +35708,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3n-E4B-it": {
@@ -27324,8 +35731,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31B-it": {
@@ -27344,8 +35755,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "LiquidAI/LFM2-24B-A2B": {
@@ -27362,8 +35778,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -27381,8 +35801,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Meta-Llama-3-8B-Instruct-Lite": {
@@ -27399,8 +35823,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -27417,8 +35845,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -27436,8 +35868,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -27455,8 +35891,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -27477,8 +35918,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -27500,8 +35946,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -27519,8 +35970,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -27538,11 +35993,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -27563,8 +36027,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -27582,11 +36050,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -27604,11 +36080,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "pearl-ai/gemma-4-31b-it": {
@@ -27625,8 +36109,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen2.5-7B-Instruct-Turbo": {
@@ -27644,8 +36132,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
@@ -27663,8 +36155,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
@@ -27682,8 +36178,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-Next-FP8": {
@@ -27701,8 +36201,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -27722,8 +36226,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -27744,8 +36253,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-Plus": {
@@ -27765,8 +36279,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.7-Max": {
@@ -27783,8 +36301,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling": {
@@ -27802,11 +36324,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max", "xhigh", "high", "medium", "low", "none"]
+            "efforts": [
+              "max",
+              "xhigh",
+              "high",
+              "medium",
+              "low",
+              "none"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5": {
@@ -27827,8 +36362,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.1": {
@@ -27850,8 +36389,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.2": {
@@ -27869,12 +36412,80 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "zai-org/GLM-5.3": {
+          "displayName": "GLM-5.3",
+          "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.together.ai/docs/serverless-models",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 262144,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "zai-org/GLM-5.3-Flash": {
+          "displayName": "GLM-5.3-Flash",
+          "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.together.ai/docs/serverless-models",
+          "contextWindow": 1048575,
+          "maxOutputTokens": 400000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -27897,8 +36508,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hunyuan-2.0-instruct": {
@@ -27916,8 +36531,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hunyuan-2.0-thinking": {
@@ -27935,8 +36554,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hunyuan-t1": {
@@ -27954,8 +36577,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hunyuan-turbos": {
@@ -27973,8 +36600,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -27996,8 +36627,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5": {
@@ -28015,8 +36651,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tc-code-latest": {
@@ -28034,8 +36674,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -28055,12 +36699,48 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "none",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "hy4-preview": {
+          "displayName": "Hy4 preview",
+          "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+          "lifecycle": "active",
+          "docsUrl": "https://cloud.tencent.com/document/product/1823/130060",
+          "contextWindow": 1024000,
+          "maxOutputTokens": 64000,
+          "lastUpdated": "2026-08-28",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "high"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -28080,12 +36760,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "none",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy3-preview": {
@@ -28103,12 +36790,49 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "hy4-preview": {
+          "displayName": "Hy4 preview",
+          "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+          "lifecycle": "active",
+          "docsUrl": "https://cloud.tencent.com/document/product/1823/130050",
+          "contextWindow": 1024000,
+          "maxOutputTokens": 64000,
+          "lastUpdated": "2026-08-28",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "high"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -28131,8 +36855,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen-3-235b": {
@@ -28150,8 +36878,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen-3-30b": {
@@ -28172,8 +36904,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen-3-32b": {
@@ -28194,8 +36930,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen-3.6-max-preview": {
@@ -28215,8 +36955,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-235b-a22b-thinking": {
@@ -28234,8 +36978,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-coder": {
@@ -28253,8 +37003,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-coder-30b-a3b": {
@@ -28272,8 +37026,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-coder-next": {
@@ -28292,8 +37050,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-coder-plus": {
@@ -28311,8 +37073,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-embedding-0.6b": {
@@ -28329,8 +37095,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-embedding-4b": {
@@ -28347,8 +37117,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-embedding-8b": {
@@ -28365,8 +37139,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-max": {
@@ -28384,8 +37162,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-max-preview": {
@@ -28403,8 +37185,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-max-thinking": {
@@ -28422,8 +37208,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-next-80b-a3b-instruct": {
@@ -28441,8 +37231,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-next-80b-a3b-thinking": {
@@ -28460,8 +37254,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-vl-235b-a22b-instruct": {
@@ -28480,8 +37278,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-vl-instruct": {
@@ -28499,8 +37302,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-vl-thinking": {
@@ -28518,8 +37326,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.5-flash": {
@@ -28540,8 +37354,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.5-plus": {
@@ -28562,8 +37382,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.6-27b": {
@@ -28584,8 +37410,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.6-plus": {
@@ -28606,8 +37438,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.7-flash": {
@@ -28625,8 +37463,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.7-max": {
@@ -28646,8 +37490,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.7-plus": {
@@ -28668,8 +37516,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.8-2.4t-a95b": {
@@ -28678,7 +37532,7 @@
           "lifecycle": "active",
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
           "contextWindow": 262144,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 128000,
           "structuredOutput": true,
           "lastUpdated": "2026-08-12",
           "capabilities": {
@@ -28687,11 +37541,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.8-27b": {
@@ -28709,11 +37572,81 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "alibaba/qwen3.8-flash": {
+          "displayName": "Qwen 3.8 Flash",
+          "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 991000,
+          "maxOutputTokens": 128000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "alibaba/qwen3.8-flash-next": {
+          "displayName": "Qwen 3.8 Flash Next",
+          "description": "Open-weight experimental preview of the Qwen4 architecture: hybrid-attention MoE (125B total, 6B active) with vision encoder for coding, agent tasks, and image and video understanding",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 1048576,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-27",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.8-max": {
@@ -28730,11 +37663,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/wan-v2.5-t2v-preview": {
@@ -28751,7 +37693,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -28769,7 +37713,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -28787,7 +37733,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -28805,7 +37753,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -28823,7 +37773,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -28841,7 +37793,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -28859,7 +37813,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -28877,7 +37833,51 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
+            "output": []
+          }
+        },
+        "alibaba/wan-v3.0-video": {
+          "displayName": "Wan v3.0 Video",
+          "description": "Video model for prompt-guided generation, editing, and motion workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 0,
+          "maxOutputTokens": 0,
+          "lastUpdated": "2026-08-23",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": []
+          }
+        },
+        "alibaba/wan-v3.0-video-prime": {
+          "displayName": "Wan v3.0 Video Prime",
+          "description": "Video model for prompt-guided generation, editing, and motion workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 0,
+          "maxOutputTokens": 0,
+          "lastUpdated": "2026-08-28",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         },
@@ -28896,12 +37896,22 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-lite": {
@@ -28919,8 +37929,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-micro": {
@@ -28938,8 +37953,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-pro": {
@@ -28957,8 +37976,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/titan-embed-text-v2": {
@@ -28975,8 +37999,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-3-haiku": {
@@ -28994,8 +38022,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-fable-5": {
@@ -29013,12 +38046,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -29039,8 +38083,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4": {
@@ -29058,8 +38108,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -29080,8 +38136,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -29099,12 +38161,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -29122,12 +38194,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -29145,12 +38228,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.8-fast": {
@@ -29168,12 +38262,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-5": {
@@ -29191,11 +38296,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-5-fast": {
@@ -29213,11 +38330,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -29235,8 +38364,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -29255,8 +38390,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -29274,12 +38415,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -29297,12 +38448,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "arcee-ai/trinity-large-thinking": {
@@ -29319,27 +38481,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "arcee-ai/trinity-mini": {
-          "displayName": "Trinity Mini",
-          "description": "Reasoning-tuned 26B MoE model with 3B active parameters for agents, tools, and multi-step workloads",
-          "lifecycle": "active",
-          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
-          "contextWindow": 131072,
-          "maxOutputTokens": 131072,
-          "knowledgeCutoff": "2024-10",
-          "lastUpdated": "2025-12",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": false
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bfl/flux-2-flex": {
@@ -29356,8 +38503,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-2-klein-4b": {
@@ -29374,8 +38525,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-2-klein-9b": {
@@ -29392,8 +38547,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-2-max": {
@@ -29410,8 +38569,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-2-pro": {
@@ -29428,8 +38591,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-3-video": {
@@ -29446,7 +38613,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -29464,8 +38633,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-kontext-pro": {
@@ -29482,8 +38655,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-pro-1.0-fill": {
@@ -29500,8 +38677,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-pro-1.1": {
@@ -29518,8 +38699,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-pro-1.1-ultra": {
@@ -29536,8 +38721,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seed-1.6": {
@@ -29558,8 +38747,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance/seed-1.8": {
@@ -29577,12 +38771,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance/seedance-2.0": {
@@ -29599,7 +38803,10 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         },
@@ -29617,7 +38824,31 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": []
+          }
+        },
+        "bytedance/seedance-2.0-mini": {
+          "displayName": "Seedance 2.0 Mini",
+          "description": "Video model for prompt-guided generation, editing, and motion workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 0,
+          "maxOutputTokens": 0,
+          "lastUpdated": "2026-06-22",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         },
@@ -29635,7 +38866,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -29653,7 +38886,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -29671,7 +38906,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -29689,7 +38926,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -29707,8 +38946,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seedream-4.5": {
@@ -29725,8 +38968,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seedream-5.0-lite": {
@@ -29743,8 +38990,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seedream-5.0-pro": {
@@ -29761,8 +39012,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "cohere/command-a": {
@@ -29780,8 +39035,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/embed-v4.0": {
@@ -29798,8 +39057,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/rerank-v3.5": {
@@ -29816,8 +39079,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/rerank-v4-fast": {
@@ -29834,8 +39101,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/rerank-v4-pro": {
@@ -29852,8 +39123,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-r1": {
@@ -29871,8 +39146,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3": {
@@ -29889,8 +39168,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.1": {
@@ -29910,8 +39193,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.1-terminus": {
@@ -29932,8 +39219,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -29952,8 +39243,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2-thinking": {
@@ -29971,8 +39266,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -29991,12 +39290,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -30015,8 +39321,43 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek/deepseek-v4-flash-vision-exp": {
+          "displayName": "DeepSeek V4 Flash Vision Exp",
+          "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-21",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -30024,8 +39365,8 @@
           "description": "Open MoE flagship with million-token context for coding and long agent runs",
           "lifecycle": "active",
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
-          "contextWindow": 1048600,
-          "maxOutputTokens": 1048600,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
           "knowledgeCutoff": "2025-05",
           "structuredOutput": true,
           "lastUpdated": "2026-04-24",
@@ -30035,12 +39376,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
@@ -30051,19 +39399,26 @@
           "contextWindow": 1000000,
           "maxOutputTokens": 384000,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-12",
+          "lastUpdated": "2026-08-22",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "fish-audio/s1": {
@@ -30080,8 +39435,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s1-free": {
@@ -30098,8 +39457,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s2-pro": {
@@ -30116,8 +39479,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s2-pro-free": {
@@ -30134,8 +39501,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s2.1-pro": {
@@ -30152,8 +39523,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s2.1-pro-free": {
@@ -30170,8 +39545,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/transcribe-1": {
@@ -30188,8 +39567,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "fish-audio/transcribe-1-free": {
@@ -30206,8 +39589,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash": {
@@ -30229,8 +39616,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash-image": {
@@ -30248,8 +39642,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -30271,8 +39671,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro": {
@@ -30291,8 +39697,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-flash": {
@@ -30310,11 +39723,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-pro-image": {
@@ -30332,8 +39756,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-image": {
@@ -30351,11 +39781,20 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-image-preview": {
@@ -30373,11 +39812,20 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -30396,11 +39844,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite-image": {
@@ -30419,8 +39878,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -30439,11 +39904,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash": {
@@ -30462,11 +39937,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash-lite": {
@@ -30485,11 +39971,66 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemini-3.5-transcribe": {
+          "displayName": "Gemini 3.5 Transcribe",
+          "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 0,
+          "maxOutputTokens": 0,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": false,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemini-3.5-transcribe-live": {
+          "displayName": "Gemini 3.5 Transcribe Live",
+          "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 0,
+          "maxOutputTokens": 0,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": false,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.6-flash": {
@@ -30508,11 +40049,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.7-flash": {
@@ -30531,11 +40083,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-embedding-001": {
@@ -30553,8 +40115,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-embedding-2": {
@@ -30572,8 +40138,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-omni-flash-preview": {
@@ -30590,8 +40160,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26b-a4b-it": {
@@ -30609,8 +40185,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31b-it": {
@@ -30628,8 +40210,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/text-embedding-005": {
@@ -30646,8 +40234,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/text-multilingual-embedding-002": {
@@ -30664,8 +40256,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/veo-3.0-fast-generate-001": {
@@ -30682,7 +40278,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30700,7 +40298,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30718,7 +40318,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30736,7 +40338,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30754,7 +40358,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30772,11 +40378,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inception/mercury-coder-small": {
@@ -30793,8 +40407,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ling-3.0-flash": {
@@ -30811,8 +40429,64 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inclusionai/ling-3.0-flash-fin": {
+          "displayName": "Ling 3.0 Flash Fin",
+          "description": "Finance-enhanced model for financial research, multi-step investment workflows, and long-horizon planning and execution",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 256000,
+          "maxOutputTokens": 32000,
+          "lastUpdated": "2026-08-27",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inclusionai/ling-3.0-flash-fin-free": {
+          "displayName": "Ling 3.0 Flash Fin (Free)",
+          "description": "Finance-enhanced model for financial research, multi-step investment workflows, and long-horizon planning and execution",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 256000,
+          "maxOutputTokens": 32000,
+          "lastUpdated": "2026-08-27",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "interfaze/interfaze-beta": {
@@ -30829,11 +40503,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "klingai/kling-v2.5-turbo-i2v": {
@@ -30850,7 +40534,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30868,7 +40554,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30886,7 +40574,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30904,7 +40594,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30922,7 +40614,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30940,7 +40634,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30958,7 +40654,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30976,7 +40674,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -30994,8 +40694,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v1": {
@@ -31013,8 +40718,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v2": {
@@ -31031,8 +40740,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v2.5": {
@@ -31049,8 +40762,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.1-70b": {
@@ -31068,8 +40786,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.1-8b": {
@@ -31087,8 +40809,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.3-70b": {
@@ -31107,8 +40833,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-4-maverick": {
@@ -31127,8 +40857,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-4-scout": {
@@ -31147,8 +40882,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -31167,11 +40907,44 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "meta/muse-image-1.0": {
+          "displayName": "Muse Image 1.0",
+          "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 0,
+          "maxOutputTokens": 0,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "meta/muse-spark-1.1": {
@@ -31189,11 +40962,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-spark-1.2": {
@@ -31211,8 +40996,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-spark-1.2-contributor": {
@@ -31229,8 +41020,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-h3": {
@@ -31247,7 +41044,31 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": []
+          }
+        },
+        "minimax/minimax-h3-max": {
+          "displayName": "MiniMax H3 Max",
+          "description": "Video model for prompt-guided generation, editing, and motion workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 0,
+          "maxOutputTokens": 0,
+          "lastUpdated": "2026-08-27",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
             "output": []
           }
         },
@@ -31266,8 +41087,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.1": {
@@ -31284,8 +41109,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.1-lightning": {
@@ -31303,8 +41132,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5": {
@@ -31321,8 +41154,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5-highspeed": {
@@ -31339,8 +41176,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7": {
@@ -31357,8 +41198,35 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "minimax/minimax-m2.7-free": {
+          "displayName": "Minimax M2.7 (Free)",
+          "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 196608,
+          "maxOutputTokens": 196608,
+          "lastUpdated": "2026-03-18",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7-highspeed": {
@@ -31375,8 +41243,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m3": {
@@ -31384,8 +41256,8 @@
           "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
           "lifecycle": "active",
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 1000000,
+          "contextWindow": 512000,
+          "maxOutputTokens": 512000,
           "lastUpdated": "2026-06-01",
           "capabilities": {
             "vision": true,
@@ -31396,8 +41268,41 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "minimax/minimax-m3-free": {
+          "displayName": "MiniMax M3 (Free)",
+          "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 1048576,
+          "lastUpdated": "2026-06-01",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/codestral": {
@@ -31415,8 +41320,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/codestral-embed": {
@@ -31433,8 +41342,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/devstral-2": {
@@ -31452,8 +41365,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/devstral-small-2": {
@@ -31471,46 +41388,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "mistral/magistral-medium": {
-          "displayName": "Magistral Medium (latest)",
-          "description": "Mistral reasoning model for transparent analysis, math, and complex decisions",
-          "lifecycle": "active",
-          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
-          "contextWindow": 128000,
-          "maxOutputTokens": 16384,
-          "knowledgeCutoff": "2025-06",
-          "lastUpdated": "2025-03-20",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "mistral/magistral-small": {
-          "displayName": "Magistral Small",
-          "description": "Mistral reasoning model for transparent analysis, math, and complex decisions",
-          "lifecycle": "active",
-          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
-          "contextWindow": 128000,
-          "maxOutputTokens": 128000,
-          "knowledgeCutoff": "2025-06",
-          "lastUpdated": "2025-03-17",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/ministral-14b": {
@@ -31528,8 +41412,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/ministral-3b": {
@@ -31547,8 +41437,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/ministral-8b": {
@@ -31566,8 +41460,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-embed": {
@@ -31584,8 +41482,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-large-3": {
@@ -31603,8 +41505,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-medium": {
@@ -31622,8 +41529,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-medium-3.5": {
@@ -31640,11 +41552,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-nemo": {
@@ -31662,8 +41582,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-small": {
@@ -31681,8 +41606,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/pixtral-12b": {
@@ -31700,8 +41630,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2": {
@@ -31718,8 +41653,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -31737,8 +41676,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -31760,8 +41703,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -31783,8 +41731,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -31803,8 +41756,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code-highspeed": {
@@ -31823,8 +41782,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3": {
@@ -31842,8 +41807,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3-fast": {
@@ -31861,11 +41832,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "morph/morph-v3-fast": {
@@ -31882,8 +41863,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "morph/morph-v3-large": {
@@ -31900,8 +41885,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -31921,8 +41910,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -31942,8 +41935,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -31963,8 +41960,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-lightning": {
@@ -31985,8 +41986,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-nano-12b-v2-vl": {
@@ -32006,8 +42011,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-nano-9b-v2": {
@@ -32027,8 +42037,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo": {
@@ -32048,8 +42062,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4-turbo": {
@@ -32068,8 +42086,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1": {
@@ -32088,8 +42111,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-fast": {
@@ -32109,8 +42138,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-mini": {
@@ -32129,8 +42164,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-mini-fast": {
@@ -32150,8 +42191,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-nano": {
@@ -32170,8 +42217,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-nano-fast": {
@@ -32191,8 +42243,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o": {
@@ -32211,8 +42269,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-fast": {
@@ -32232,8 +42296,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini": {
@@ -32252,8 +42322,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini-fast": {
@@ -32273,29 +42349,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "openai/gpt-4o-mini-search-preview": {
-          "displayName": "GPT 4o Mini Search Preview",
-          "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-          "lifecycle": "active",
-          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
-          "contextWindow": 128000,
-          "inputLimit": 111616,
-          "maxOutputTokens": 16384,
-          "knowledgeCutoff": "2023-09",
-          "structuredOutput": false,
-          "lastUpdated": "2025-01",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": false
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini-transcribe": {
@@ -32312,8 +42373,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-transcribe": {
@@ -32330,8 +42395,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5": {
@@ -32351,11 +42420,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-codex": {
@@ -32374,9 +42453,22 @@
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-fast": {
@@ -32396,11 +42488,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-mini": {
@@ -32420,11 +42523,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-mini-fast": {
@@ -32444,11 +42557,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-nano": {
@@ -32468,11 +42592,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-pro": {
@@ -32492,11 +42626,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -32516,11 +42658,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-max": {
@@ -32540,11 +42692,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -32564,11 +42727,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-thinking": {
@@ -32587,11 +42760,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "openai/gpt-5.1-thinking-fast": {
@@ -32609,8 +42794,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2": {
@@ -32630,11 +42821,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -32654,11 +42857,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-fast": {
@@ -32678,11 +42892,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -32702,11 +42928,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -32726,11 +42962,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-codex-fast": {
@@ -32750,11 +42997,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4": {
@@ -32774,11 +43032,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-fast": {
@@ -32798,11 +43068,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -32822,11 +43104,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-mini-fast": {
@@ -32846,11 +43140,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -32870,11 +43176,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -32894,11 +43212,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5": {
@@ -32918,11 +43246,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-fast": {
@@ -32942,11 +43282,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -32966,11 +43318,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -32990,11 +43352,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna-fast": {
@@ -33014,11 +43389,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -33038,11 +43426,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol-fast": {
@@ -33062,11 +43463,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -33086,11 +43500,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra-fast": {
@@ -33110,11 +43537,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-image-1": {
@@ -33131,8 +43571,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "openai/gpt-image-1-mini": {
@@ -33149,8 +43593,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "openai/gpt-image-1.5": {
@@ -33167,8 +43615,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "openai/gpt-image-2": {
@@ -33185,8 +43637,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -33205,11 +43661,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -33229,11 +43693,50 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "openai/gpt-oss-safeguard-120b": {
+          "displayName": "GPT OSS Safeguard 120B",
+          "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 128000,
+          "inputLimit": 112000,
+          "maxOutputTokens": 16000,
+          "structuredOutput": true,
+          "lastUpdated": "2025-10-29",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -33241,9 +43744,9 @@
           "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
           "lifecycle": "active",
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
-          "contextWindow": 131072,
-          "inputLimit": 65536,
-          "maxOutputTokens": 65536,
+          "contextWindow": 128000,
+          "inputLimit": 112000,
+          "maxOutputTokens": 16000,
           "knowledgeCutoff": "2024-10",
           "lastUpdated": "2024-12-01",
           "capabilities": {
@@ -33252,11 +43755,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-realtime-1.5": {
@@ -33273,8 +43784,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-realtime-2": {
@@ -33291,8 +43808,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-realtime-2.1": {
@@ -33312,11 +43835,23 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-realtime-mini": {
@@ -33333,8 +43868,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-realtime-whisper": {
@@ -33351,8 +43892,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o1": {
@@ -33371,11 +43916,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3": {
@@ -33394,34 +43949,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "openai/o3-deep-research": {
-          "displayName": "o3-deep-research",
-          "description": "Research model for long-horizon investigation, synthesis, and analytical reports",
-          "lifecycle": "active",
-          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
-          "contextWindow": 200000,
-          "inputLimit": 100000,
-          "maxOutputTokens": 100000,
-          "knowledgeCutoff": "2024-05",
-          "lastUpdated": "2024-06-26",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["medium"]
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-fast": {
@@ -33441,11 +43983,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-mini": {
@@ -33464,11 +44016,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-pro": {
@@ -33488,11 +44048,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o4-mini": {
@@ -33511,11 +44081,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o4-mini-fast": {
@@ -33535,11 +44114,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/text-embedding-3-large": {
@@ -33557,8 +44146,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/text-embedding-3-small": {
@@ -33576,8 +44169,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/text-embedding-ada-002": {
@@ -33595,8 +44192,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/tts-1": {
@@ -33613,8 +44214,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "openai/tts-1-hd": {
@@ -33631,8 +44236,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "openai/whisper-1": {
@@ -33649,8 +44258,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/pplx-embed-v1-0.6b": {
@@ -33667,8 +44280,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/pplx-embed-v1-4b": {
@@ -33685,8 +44302,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar": {
@@ -33704,8 +44325,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-pro": {
@@ -33723,8 +44349,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-reasoning-pro": {
@@ -33742,11 +44373,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-s-2.1": {
@@ -33767,8 +44408,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-s-2.1-free": {
@@ -33790,8 +44435,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "prodia/flux-fast-schnell": {
@@ -33808,8 +44457,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "quiverai/arrow-1.1": {
@@ -33826,8 +44479,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v2": {
@@ -33844,8 +44501,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v3": {
@@ -33862,8 +44523,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4": {
@@ -33880,8 +44545,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4-pro": {
@@ -33898,8 +44567,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4.1": {
@@ -33916,8 +44589,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4.1-pro": {
@@ -33934,8 +44611,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4.1-utility": {
@@ -33952,8 +44633,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4.1-utility-pro": {
@@ -33970,8 +44655,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "sakana/fugu-ultra": {
@@ -33989,8 +44678,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sakana/namazu": {
@@ -34007,8 +44701,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.1-fast-non-reasoning": {
@@ -34025,8 +44725,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.1-fast-reasoning": {
@@ -34043,8 +44749,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-multi-agent": {
@@ -34061,8 +44773,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-multi-agent-beta": {
@@ -34079,8 +44797,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-non-reasoning": {
@@ -34097,8 +44821,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-non-reasoning-beta": {
@@ -34115,8 +44845,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-reasoning": {
@@ -34133,8 +44869,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-reasoning-beta": {
@@ -34151,8 +44893,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.3": {
@@ -34162,15 +44910,29 @@
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
           "contextWindow": 1000000,
           "maxOutputTokens": 1000000,
-          "lastUpdated": "2026-04-30",
+          "structuredOutput": true,
+          "lastUpdated": "2026-04-17",
           "capabilities": {
             "vision": true,
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.5": {
@@ -34180,15 +44942,29 @@
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
           "contextWindow": 500000,
           "maxOutputTokens": 500000,
+          "structuredOutput": true,
           "lastUpdated": "2026-07-08",
           "capabilities": {
             "vision": true,
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.6": {
@@ -34198,15 +44974,29 @@
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
           "contextWindow": 500000,
           "maxOutputTokens": 500000,
+          "knowledgeCutoff": "2026-02-01",
+          "structuredOutput": true,
           "lastUpdated": "2026-08-12",
           "capabilities": {
             "vision": true,
             "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-build-0.1": {
@@ -34216,15 +45006,21 @@
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
           "contextWindow": 256000,
           "maxOutputTokens": 256000,
-          "lastUpdated": "2026-05-20",
+          "structuredOutput": true,
+          "lastUpdated": "2026-04-16",
           "capabilities": {
             "vision": true,
             "reasoning": true,
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-imagine-image": {
@@ -34241,8 +45037,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "spacexai/grok-imagine-image-2.0": {
@@ -34259,8 +45059,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "spacexai/grok-imagine-video": {
@@ -34277,7 +45081,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -34288,14 +45094,16 @@
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
           "contextWindow": 0,
           "maxOutputTokens": 0,
-          "lastUpdated": "2026-06-22",
+          "lastUpdated": "2026-05-30",
           "capabilities": {
             "vision": false,
             "reasoning": false,
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -34313,7 +45121,9 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "output": []
           }
         },
@@ -34331,8 +45141,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-tts": {
@@ -34349,8 +45163,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "spacexai/grok-voice-think-fast-1.0": {
@@ -34367,8 +45185,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "spacexai/grok-voice-think-fast-2.0": {
@@ -34385,8 +45209,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -34404,11 +45234,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -34427,11 +45266,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-lite": {
@@ -34448,8 +45296,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-plus": {
@@ -34466,8 +45318,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-pro": {
@@ -34484,8 +45340,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy3": {
@@ -34493,8 +45353,8 @@
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
           "lifecycle": "active",
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
-          "contextWindow": 256000,
-          "maxOutputTokens": 128000,
+          "contextWindow": 262144,
+          "maxOutputTokens": 262144,
           "lastUpdated": "2026-07-06",
           "capabilities": {
             "vision": false,
@@ -34502,11 +45362,47 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "tencent/hy4-preview": {
+          "displayName": "Tencent Hy4 Preview",
+          "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 1024000,
+          "maxOutputTokens": 64000,
+          "lastUpdated": "2026-08-28",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling": {
@@ -34523,11 +45419,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling-small": {
@@ -34544,11 +45454,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/rerank-2.5": {
@@ -34565,8 +45489,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/rerank-2.5-lite": {
@@ -34583,8 +45511,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-3-large": {
@@ -34601,8 +45533,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-3.5": {
@@ -34619,8 +45555,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-3.5-lite": {
@@ -34637,8 +45577,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-4": {
@@ -34655,8 +45599,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-4-large": {
@@ -34673,8 +45621,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-4-lite": {
@@ -34691,8 +45643,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-code-2": {
@@ -34709,8 +45665,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-code-3": {
@@ -34727,8 +45687,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-finance-2": {
@@ -34745,8 +45709,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-law-2": {
@@ -34763,8 +45731,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -34785,8 +45757,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -34807,8 +45784,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.5": {
@@ -34829,8 +45810,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.5-air": {
@@ -34851,8 +45836,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.5v": {
@@ -34873,8 +45862,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.6": {
@@ -34895,8 +45889,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.7": {
@@ -34917,8 +45915,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.7-flash": {
@@ -34939,8 +45941,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.7-flashx": {
@@ -34961,8 +45967,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5": {
@@ -34982,8 +45992,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5-turbo": {
@@ -35004,8 +46018,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5.1": {
@@ -35026,8 +46044,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5.2": {
@@ -35045,12 +46067,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5.2-fast": {
@@ -35068,12 +46097,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5.3": {
@@ -35082,7 +46118,7 @@
           "lifecycle": "active",
           "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
           "contextWindow": 1000000,
-          "maxOutputTokens": 12800,
+          "maxOutputTokens": 1000000,
           "structuredOutput": true,
           "lastUpdated": "2026-08-14",
           "capabilities": {
@@ -35091,11 +46127,50 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "zai/glm-5.3-flash": {
+          "displayName": "GLM 5.3 Flash",
+          "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5v-turbo": {
@@ -35115,8 +46190,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -35136,8 +46217,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.20-0309-reasoning": {
@@ -35155,8 +46242,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.20-multi-agent-0309": {
@@ -35174,11 +46267,22 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.3": {
@@ -35196,11 +46300,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.5": {
@@ -35218,11 +46333,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.6": {
@@ -35241,11 +46366,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-build-0.1": {
@@ -35263,8 +46399,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-imagine-image": {
@@ -35281,8 +46423,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "grok-imagine-image-2.0": {
@@ -35299,8 +46447,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "grok-imagine-image-quality": {
@@ -35317,8 +46471,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "grok-imagine-video": {
@@ -35335,7 +46495,11 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
             "output": []
           }
         },
@@ -35353,7 +46517,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
             "output": []
           }
         }
@@ -35377,8 +46546,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-omni": {
@@ -35399,8 +46572,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-pro": {
@@ -35421,8 +46601,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -35443,8 +46627,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -35465,8 +46655,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro-ultraspeed": {
@@ -35487,8 +46681,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -35512,8 +46710,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-tts": {
@@ -35531,8 +46733,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -35554,8 +46760,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -35577,8 +46789,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-tts": {
@@ -35596,8 +46812,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -35615,8 +46835,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -35634,8 +46858,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -35659,8 +46887,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-tts": {
@@ -35678,8 +46910,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -35701,8 +46937,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -35724,8 +46966,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-tts": {
@@ -35743,8 +46989,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -35762,8 +47012,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -35781,8 +47035,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -35806,8 +47064,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-tts": {
@@ -35825,8 +47087,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -35848,8 +47114,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -35871,8 +47143,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-tts": {
@@ -35890,8 +47166,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -35909,8 +47189,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -35928,8 +47212,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -35952,8 +47240,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.5-air": {
@@ -35974,8 +47266,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.5-flash": {
@@ -35997,8 +47293,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.5v": {
@@ -36019,8 +47319,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.6": {
@@ -36041,8 +47346,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.6v": {
@@ -36063,8 +47372,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7": {
@@ -36085,8 +47399,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7-flash": {
@@ -36108,8 +47426,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7-flashx": {
@@ -36130,8 +47452,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -36151,8 +47477,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5-turbo": {
@@ -36173,8 +47503,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -36195,8 +47529,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -36214,11 +47552,80 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "glm-5.3": {
+          "displayName": "GLM-5.3",
+          "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.z.ai/guides/overview/pricing",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "glm-5.3-flash": {
+          "displayName": "GLM-5.3-Flash",
+          "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.z.ai/guides/overview/pricing",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5v-turbo": {
@@ -36238,8 +47645,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -36263,8 +47676,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5-turbo": {
@@ -36286,8 +47703,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -36306,11 +47727,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2-highspeed": {
@@ -36329,11 +47757,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3": {
@@ -36352,11 +47787,83 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "glm-5.3-flash": {
+          "displayName": "GLM-5.3-Flash",
+          "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.z.ai/devpack/overview",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "glm-5.3-highspeed": {
+          "displayName": "GLM-5.3 Highspeed",
+          "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+          "lifecycle": "active",
+          "docsUrl": "https://docs.z.ai/devpack/overview",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -36376,8 +47883,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-3.7-sonnet": {
@@ -36395,11 +47907,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-fable-5": {
@@ -36417,11 +47939,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -36439,8 +47971,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4": {
@@ -36458,11 +47995,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.1": {
@@ -36480,11 +48027,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -36502,11 +48059,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -36524,11 +48091,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -36546,11 +48122,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -36568,11 +48154,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -36590,11 +48186,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -36612,11 +48218,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -36634,11 +48250,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -36656,11 +48281,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-5-free": {
@@ -36679,11 +48314,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "baidu/ernie-5.0-thinking-preview": {
@@ -36701,8 +48346,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-chat": {
@@ -36720,8 +48370,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -36742,8 +48396,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2-exp": {
@@ -36764,8 +48422,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -36784,12 +48446,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -36808,12 +48478,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash": {
@@ -36831,11 +48509,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text", "audio"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -36853,8 +48542,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["pdf", "image", "text", "audio"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro": {
@@ -36872,11 +48568,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text", "audio"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-flash-preview": {
@@ -36894,11 +48601,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -36917,11 +48635,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite-preview": {
@@ -36938,8 +48667,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -36957,11 +48692,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash": {
@@ -36980,11 +48726,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ling-1t": {
@@ -37002,8 +48759,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ring-1t": {
@@ -37021,8 +48782,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ring-2.6-1t": {
@@ -37040,8 +48805,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kuaishou/kat-coder-pro-v2": {
@@ -37058,8 +48827,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2": {
@@ -37077,8 +48850,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.1": {
@@ -37096,8 +48873,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5": {
@@ -37115,8 +48896,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5-lightning": {
@@ -37134,8 +48919,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7": {
@@ -37153,8 +48942,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7-highspeed": {
@@ -37172,8 +48965,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m3": {
@@ -37181,8 +48978,8 @@
           "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
           "lifecycle": "active",
           "docsUrl": "https://docs.zenmux.ai",
-          "contextWindow": 512000,
-          "maxOutputTokens": 128000,
+          "contextWindow": 1048576,
+          "maxOutputTokens": 512000,
           "lastUpdated": "2026-06-01",
           "capabilities": {
             "vision": true,
@@ -37193,8 +48990,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-0905": {
@@ -37212,8 +49014,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -37231,8 +49037,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-thinking-turbo": {
@@ -37250,8 +49060,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -37272,8 +49086,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -37294,8 +49113,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -37314,8 +49138,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code-free": {
@@ -37335,8 +49164,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3": {
@@ -37354,12 +49188,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max"],
+            "efforts": [
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3-free": {
@@ -37378,12 +49219,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max"],
+            "efforts": [
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5": {
@@ -37401,11 +49249,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-codex": {
@@ -37423,11 +49281,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1": {
@@ -37445,11 +49312,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-chat": {
@@ -37467,8 +49344,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -37486,11 +49369,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -37508,11 +49400,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2": {
@@ -37530,11 +49431,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -37552,11 +49463,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -37574,11 +49495,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-chat": {
@@ -37596,8 +49527,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -37615,11 +49550,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4": {
@@ -37637,11 +49580,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -37659,8 +49611,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -37678,8 +49634,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -37697,11 +49657,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5": {
@@ -37721,11 +49690,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-instant": {
@@ -37745,11 +49724,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -37769,11 +49758,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -37793,11 +49792,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -37817,11 +49829,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -37841,11 +49866,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-plus": {
@@ -37863,8 +49901,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-max": {
@@ -37882,8 +49924,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-flash": {
@@ -37901,8 +49947,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-plus": {
@@ -37920,11 +49971,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-plus": {
@@ -37944,8 +50004,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-max": {
@@ -37965,8 +50029,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-plus": {
@@ -37987,8 +50055,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sapiens-ai/agnes-1.5-lite": {
@@ -38005,8 +50078,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sapiens-ai/agnes-1.5-pro": {
@@ -38023,8 +50101,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3": {
@@ -38042,8 +50124,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -38061,8 +50148,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -38081,11 +50172,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.7-flash-free": {
@@ -38105,11 +50205,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy3-preview": {
@@ -38126,11 +50235,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-1.8": {
@@ -38148,11 +50265,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-2.0-code": {
@@ -38170,8 +50296,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-2.0-lite": {
@@ -38189,11 +50319,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-2.0-mini": {
@@ -38211,11 +50350,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-2.0-pro": {
@@ -38233,11 +50381,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-code": {
@@ -38255,11 +50412,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4": {
@@ -38277,8 +50443,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4-fast": {
@@ -38299,8 +50470,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.1-fast": {
@@ -38321,8 +50497,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.1-fast-non-reasoning": {
@@ -38340,8 +50521,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.2-fast": {
@@ -38359,8 +50545,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.2-fast-non-reasoning": {
@@ -38378,8 +50569,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.3": {
@@ -38397,11 +50593,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.5": {
@@ -38419,11 +50626,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-build-0.1": {
@@ -38441,8 +50658,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-code-fast-1": {
@@ -38460,8 +50683,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2-flash": {
@@ -38482,8 +50709,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2-omni": {
@@ -38504,8 +50735,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2-pro": {
@@ -38526,8 +50764,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -38548,8 +50790,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -38570,8 +50818,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5": {
@@ -38592,8 +50844,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5-air": {
@@ -38614,8 +50870,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6": {
@@ -38633,8 +50893,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6v": {
@@ -38652,8 +50916,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6v-flash": {
@@ -38671,8 +50940,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6v-flash-free": {
@@ -38691,8 +50965,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7": {
@@ -38710,8 +50989,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7-flash-free": {
@@ -38730,8 +51013,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7-flashx": {
@@ -38749,8 +51036,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5": {
@@ -38768,8 +51059,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5-turbo": {
@@ -38787,8 +51082,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.1": {
@@ -38809,8 +51108,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.2": {
@@ -38828,11 +51131,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.2-free": {
@@ -38851,11 +51161,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5v-turbo": {
@@ -38872,8 +51189,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       }
@@ -39109,16 +51432,6 @@
         "outputUsdPer1M": 0.035
       },
       {
-        "modelKey": "alibaba:qwen3-coder-30b-a3b-instruct",
-        "inputUsdPer1M": 0.45,
-        "outputUsdPer1M": 2.25
-      },
-      {
-        "modelKey": "alibaba:qwen3-coder-480b-a35b-instruct",
-        "inputUsdPer1M": 1.5,
-        "outputUsdPer1M": 7.5
-      },
-      {
         "modelKey": "alibaba:qwen3-coder-flash",
         "inputUsdPer1M": 0.3,
         "outputUsdPer1M": 1.5
@@ -39229,6 +51542,13 @@
         "cacheWriteUsdPer1M": 3.125
       },
       {
+        "modelKey": "alibaba:qwen3.8-flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.47,
+        "cacheReadUsdPer1M": 0.016,
+        "cacheWriteUsdPer1M": 0.2
+      },
+      {
         "modelKey": "alibaba:qwen3.8-max",
         "inputUsdPer1M": 2,
         "outputUsdPer1M": 6,
@@ -39306,17 +51626,6 @@
         "inputUsdPer1M": 0.435,
         "outputUsdPer1M": 0.87,
         "cacheReadUsdPer1M": 0.003625
-      },
-      {
-        "modelKey": "alibaba-cn:glm-5",
-        "inputUsdPer1M": 0.86,
-        "outputUsdPer1M": 3.15
-      },
-      {
-        "modelKey": "alibaba-cn:glm-5.1",
-        "inputUsdPer1M": 0.87,
-        "outputUsdPer1M": 3.48,
-        "cacheReadUsdPer1M": 0.17
       },
       {
         "modelKey": "alibaba-cn:glm-5.2",
@@ -39426,7 +51735,9 @@
       {
         "modelKey": "alibaba-cn:qwen-plus",
         "inputUsdPer1M": 0.115,
-        "outputUsdPer1M": 0.287
+        "outputUsdPer1M": 0.287,
+        "cacheReadUsdPer1M": 0.012,
+        "cacheWriteUsdPer1M": 0.144
       },
       {
         "modelKey": "alibaba-cn:qwen-plus-character",
@@ -39534,16 +51845,6 @@
         "outputUsdPer1M": 0.032
       },
       {
-        "modelKey": "alibaba-cn:qwen3-coder-30b-a3b-instruct",
-        "inputUsdPer1M": 0.216,
-        "outputUsdPer1M": 0.861
-      },
-      {
-        "modelKey": "alibaba-cn:qwen3-coder-480b-a35b-instruct",
-        "inputUsdPer1M": 0.861,
-        "outputUsdPer1M": 3.441
-      },
-      {
         "modelKey": "alibaba-cn:qwen3-coder-flash",
         "inputUsdPer1M": 0.144,
         "outputUsdPer1M": 0.574
@@ -39594,11 +51895,6 @@
         "outputUsdPer1M": 1.433525
       },
       {
-        "modelKey": "alibaba-cn:qwen3.5-397b-a17b",
-        "inputUsdPer1M": 0.43,
-        "outputUsdPer1M": 2.58
-      },
-      {
         "modelKey": "alibaba-cn:qwen3.5-flash",
         "inputUsdPer1M": 0.172,
         "outputUsdPer1M": 1.72
@@ -39626,6 +51922,13 @@
         "outputUsdPer1M": 7.5,
         "cacheReadUsdPer1M": 0.5,
         "cacheWriteUsdPer1M": 3.125
+      },
+      {
+        "modelKey": "alibaba-cn:qwen3.8-flash",
+        "inputUsdPer1M": 0.11875,
+        "outputUsdPer1M": 0.40073,
+        "cacheReadUsdPer1M": 0.01187,
+        "cacheWriteUsdPer1M": 0.14844
       },
       {
         "modelKey": "alibaba-cn:qwen3.8-max",
@@ -39859,6 +52162,18 @@
         "inputUsdPer1M": 1.4,
         "outputUsdPer1M": 4.4,
         "cacheReadUsdPer1M": 0.26
+      },
+      {
+        "modelKey": "cloudflare-workers-ai:@cf/zai-org/glm-5.3",
+        "inputUsdPer1M": 1.4,
+        "outputUsdPer1M": 4.4,
+        "cacheReadUsdPer1M": 0.26
+      },
+      {
+        "modelKey": "cloudflare-workers-ai:@cf/zai-org/glm-5.3-flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.5,
+        "cacheReadUsdPer1M": 0.03
       },
       {
         "modelKey": "deepinfra:deepseek-ai/DeepSeek-R1-0528",
@@ -40171,19 +52486,25 @@
         "cacheReadUsdPer1M": 0.14
       },
       {
-        "modelKey": "deepseek:deepseek-chat",
-        "inputUsdPer1M": 0.14,
-        "outputUsdPer1M": 0.28,
-        "cacheReadUsdPer1M": 0.0028
+        "modelKey": "deepinfra:zai-org/GLM-5.3",
+        "inputUsdPer1M": 1.2,
+        "outputUsdPer1M": 4,
+        "cacheReadUsdPer1M": 0.12
       },
       {
-        "modelKey": "deepseek:deepseek-reasoner",
-        "inputUsdPer1M": 0.14,
-        "outputUsdPer1M": 0.28,
-        "cacheReadUsdPer1M": 0.0028
+        "modelKey": "deepinfra:zai-org/GLM-5.3-Flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.5,
+        "cacheReadUsdPer1M": 0.03
       },
       {
         "modelKey": "deepseek:deepseek-v4-flash",
+        "inputUsdPer1M": 0.14,
+        "outputUsdPer1M": 0.28,
+        "cacheReadUsdPer1M": 0.0028
+      },
+      {
+        "modelKey": "deepseek:deepseek-v4-flash-vision-exp",
         "inputUsdPer1M": 0.14,
         "outputUsdPer1M": 0.28,
         "cacheReadUsdPer1M": 0.0028
@@ -40195,22 +52516,10 @@
         "cacheReadUsdPer1M": 0.003625
       },
       {
-        "modelKey": "fireworks-ai:accounts/fireworks/models/deepseek-v4-flash",
-        "inputUsdPer1M": 0.14,
-        "outputUsdPer1M": 0.28,
-        "cacheReadUsdPer1M": 0.028
-      },
-      {
         "modelKey": "fireworks-ai:accounts/fireworks/models/deepseek-v4-flash-0731",
         "inputUsdPer1M": 0.14,
         "outputUsdPer1M": 0.28,
         "cacheReadUsdPer1M": 0.028
-      },
-      {
-        "modelKey": "fireworks-ai:accounts/fireworks/models/deepseek-v4-pro",
-        "inputUsdPer1M": 1.74,
-        "outputUsdPer1M": 3.48,
-        "cacheReadUsdPer1M": 0.145
       },
       {
         "modelKey": "fireworks-ai:accounts/fireworks/models/deepseek-v4-pro-0813",
@@ -40225,16 +52534,22 @@
         "cacheReadUsdPer1M": 0.14
       },
       {
+        "modelKey": "fireworks-ai:accounts/fireworks/models/glm-5p3",
+        "inputUsdPer1M": 1.4,
+        "outputUsdPer1M": 4.4,
+        "cacheReadUsdPer1M": 0.26
+      },
+      {
+        "modelKey": "fireworks-ai:accounts/fireworks/models/glm-5p3-flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.5,
+        "cacheReadUsdPer1M": 0.029
+      },
+      {
         "modelKey": "fireworks-ai:accounts/fireworks/models/gpt-oss-120b",
         "inputUsdPer1M": 0.15,
         "outputUsdPer1M": 0.6,
         "cacheReadUsdPer1M": 0.015
-      },
-      {
-        "modelKey": "fireworks-ai:accounts/fireworks/models/gpt-oss-20b",
-        "inputUsdPer1M": 0.07,
-        "outputUsdPer1M": 0.3,
-        "cacheReadUsdPer1M": 0.035
       },
       {
         "modelKey": "fireworks-ai:accounts/fireworks/models/inkling",
@@ -40259,12 +52574,6 @@
         "inputUsdPer1M": 3,
         "outputUsdPer1M": 15,
         "cacheReadUsdPer1M": 0.3
-      },
-      {
-        "modelKey": "fireworks-ai:accounts/fireworks/models/minimax-m2p7",
-        "inputUsdPer1M": 0.3,
-        "outputUsdPer1M": 1.2,
-        "cacheReadUsdPer1M": 0.06
       },
       {
         "modelKey": "fireworks-ai:accounts/fireworks/models/minimax-m3",
@@ -40307,24 +52616,6 @@
         "inputUsdPer1M": 2.1,
         "outputUsdPer1M": 6.6,
         "cacheReadUsdPer1M": 0.21
-      },
-      {
-        "modelKey": "fireworks-ai:accounts/fireworks/routers/kimi-k2p6-fast",
-        "inputUsdPer1M": 2,
-        "outputUsdPer1M": 8,
-        "cacheReadUsdPer1M": 0.3
-      },
-      {
-        "modelKey": "fireworks-ai:accounts/fireworks/routers/kimi-k2p6-turbo",
-        "inputUsdPer1M": 2,
-        "outputUsdPer1M": 8,
-        "cacheReadUsdPer1M": 0.3
-      },
-      {
-        "modelKey": "fireworks-ai:accounts/fireworks/routers/kimi-k2p7-code-fast",
-        "inputUsdPer1M": 1.9,
-        "outputUsdPer1M": 8,
-        "cacheReadUsdPer1M": 0.38
       },
       {
         "modelKey": "fireworks-ai:accounts/fireworks/routers/kimi-k3-fast",
@@ -40470,11 +52761,6 @@
         "outputUsdPer1M": 17.5
       },
       {
-        "modelKey": "google:gemini-robotics-er-1.6-preview",
-        "inputUsdPer1M": 1,
-        "outputUsdPer1M": 5
-      },
-      {
         "modelKey": "google:lyria-3-clip-preview",
         "inputUsdPer1M": 0,
         "outputUsdPer1M": 0
@@ -40531,6 +52817,11 @@
         "inputUsdPer1M": 0.6,
         "outputUsdPer1M": 3,
         "cacheReadUsdPer1M": 0.3
+      },
+      {
+        "modelKey": "groq:qwen/qwen3.8-27b",
+        "inputUsdPer1M": 0.8,
+        "outputUsdPer1M": 4
       },
       {
         "modelKey": "huggingface:deepseek-ai/DeepSeek-R1",
@@ -40794,6 +53085,11 @@
         "outputUsdPer1M": 6.25
       },
       {
+        "modelKey": "huggingface:Qwen/Qwen3.8-27B",
+        "inputUsdPer1M": 0.4,
+        "outputUsdPer1M": 3
+      },
+      {
         "modelKey": "huggingface:stepfun-ai/Step-3.5-Flash",
         "inputUsdPer1M": 0.1,
         "outputUsdPer1M": 0.3
@@ -40885,6 +53181,16 @@
         "modelKey": "huggingface:zai-org/GLM-5.2",
         "inputUsdPer1M": 1.4,
         "outputUsdPer1M": 4.4
+      },
+      {
+        "modelKey": "huggingface:zai-org/GLM-5.3",
+        "inputUsdPer1M": 1.4,
+        "outputUsdPer1M": 4.4
+      },
+      {
+        "modelKey": "huggingface:zai-org/GLM-5.3-Flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.5
       },
       {
         "modelKey": "MiniMax:MiniMax-M2",
@@ -41082,6 +53388,12 @@
         "outputUsdPer1M": 0.3
       },
       {
+        "modelKey": "mistral:zai-glm-5-2",
+        "inputUsdPer1M": 1.4,
+        "outputUsdPer1M": 4.4,
+        "cacheReadUsdPer1M": 0.14
+      },
+      {
         "modelKey": "moonshot:kimi-k2-0711-preview",
         "inputUsdPer1M": 0.6,
         "outputUsdPer1M": 2.5,
@@ -41183,10 +53495,20 @@
         "cacheReadUsdPer1M": 0.0028
       },
       {
+        "modelKey": "nvidia:deepseek-ai/deepseek-v4-flash-0731",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
         "modelKey": "nvidia:deepseek-ai/deepseek-v4-pro",
         "inputUsdPer1M": 0.435,
         "outputUsdPer1M": 0.87,
         "cacheReadUsdPer1M": 0.003625
+      },
+      {
+        "modelKey": "nvidia:deepseek-ai/deepseek-v4-pro-0813",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
       },
       {
         "modelKey": "nvidia:google/gemma-2-2b-it",
@@ -41360,6 +53682,11 @@
       },
       {
         "modelKey": "nvidia:moonshotai/kimi-k2.6",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
+        "modelKey": "nvidia:moonshotai/kimi-k3",
         "inputUsdPer1M": 0,
         "outputUsdPer1M": 0
       },
@@ -42187,6 +54514,12 @@
         "outputUsdPer1M": 0
       },
       {
+        "modelKey": "opencode:ling-3.0-flash-fin-free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0,
+        "cacheReadUsdPer1M": 0
+      },
+      {
         "modelKey": "opencode:ling-3.0-flash-free",
         "inputUsdPer1M": 0,
         "outputUsdPer1M": 0,
@@ -42375,22 +54708,22 @@
       },
       {
         "modelKey": "openrouter:~deepseek/deepseek-v4-flash-latest",
-        "inputUsdPer1M": 0.065,
-        "outputUsdPer1M": 0.18,
-        "cacheReadUsdPer1M": 0.02
+        "inputUsdPer1M": 0.05,
+        "outputUsdPer1M": 0.16,
+        "cacheReadUsdPer1M": 0.013
       },
       {
         "modelKey": "openrouter:~google/gemini-flash-latest",
-        "inputUsdPer1M": 0.375,
-        "outputUsdPer1M": 1.875,
-        "cacheReadUsdPer1M": 0.0375,
-        "cacheWriteUsdPer1M": 0.020833
+        "inputUsdPer1M": 0.75,
+        "outputUsdPer1M": 3.75,
+        "cacheReadUsdPer1M": 0.075,
+        "cacheWriteUsdPer1M": 0.041667
       },
       {
         "modelKey": "openrouter:~moonshotai/kimi-latest",
-        "inputUsdPer1M": 2.6,
-        "outputUsdPer1M": 13,
-        "cacheReadUsdPer1M": 0.29
+        "inputUsdPer1M": 2.55,
+        "outputUsdPer1M": 12.75,
+        "cacheReadUsdPer1M": 0.256
       },
       {
         "modelKey": "openrouter:~openai/gpt-mini-latest",
@@ -42400,9 +54733,9 @@
       },
       {
         "modelKey": "openrouter:~z-ai/glm-latest",
-        "inputUsdPer1M": 1.4,
-        "outputUsdPer1M": 4.4,
-        "cacheReadUsdPer1M": 0.26
+        "inputUsdPer1M": 1.17,
+        "outputUsdPer1M": 3.96,
+        "cacheReadUsdPer1M": 0.234
       },
       {
         "modelKey": "openrouter:aion-labs/aion-2.0",
@@ -42426,11 +54759,6 @@
         "modelKey": "openrouter:aion-labs/aion-rp-llama-3.1-8b",
         "inputUsdPer1M": 0.8,
         "outputUsdPer1M": 1.6
-      },
-      {
-        "modelKey": "openrouter:allenai/olmo-3-32b-think",
-        "inputUsdPer1M": 0.15,
-        "outputUsdPer1M": 0.5
       },
       {
         "modelKey": "openrouter:amazon/nova-2-lite-v1",
@@ -42549,14 +54877,9 @@
       },
       {
         "modelKey": "openrouter:arcee-ai/trinity-large-thinking",
-        "inputUsdPer1M": 0.22,
-        "outputUsdPer1M": 0.85,
+        "inputUsdPer1M": 0.25,
+        "outputUsdPer1M": 0.8,
         "cacheReadUsdPer1M": 0.06
-      },
-      {
-        "modelKey": "openrouter:arcee-ai/virtuoso-large",
-        "inputUsdPer1M": 0.75,
-        "outputUsdPer1M": 1.2
       },
       {
         "modelKey": "openrouter:baidu/ernie-4.5-vl-424b-a47b",
@@ -42605,11 +54928,6 @@
         "outputUsdPer1M": 0
       },
       {
-        "modelKey": "openrouter:deepcogito/cogito-v2.1-671b",
-        "inputUsdPer1M": 1.25,
-        "outputUsdPer1M": 1.25
-      },
-      {
         "modelKey": "openrouter:deepseek/deepseek-chat",
         "inputUsdPer1M": 0.2574,
         "outputUsdPer1M": 1.0287
@@ -42621,9 +54939,9 @@
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-chat-v3.1",
-        "inputUsdPer1M": 0.25,
-        "outputUsdPer1M": 0.95,
-        "cacheReadUsdPer1M": 0.13
+        "inputUsdPer1M": 0.55,
+        "outputUsdPer1M": 1.65,
+        "cacheReadUsdPer1M": 0.55
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-r1",
@@ -42660,13 +54978,13 @@
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-v4-flash",
-        "inputUsdPer1M": 0.0826,
-        "outputUsdPer1M": 0.1652,
-        "cacheReadUsdPer1M": 0.01652
+        "inputUsdPer1M": 0.08092,
+        "outputUsdPer1M": 0.16184,
+        "cacheReadUsdPer1M": 0.016184
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-v4-flash-0731",
-        "inputUsdPer1M": 0.08,
+        "inputUsdPer1M": 0.065,
         "outputUsdPer1M": 0.18,
         "cacheReadUsdPer1M": 0.016
       },
@@ -42678,15 +54996,15 @@
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-v4-pro",
-        "inputUsdPer1M": 1.6,
-        "outputUsdPer1M": 3.2,
-        "cacheReadUsdPer1M": 0.135
+        "inputUsdPer1M": 0.87,
+        "outputUsdPer1M": 1.74,
+        "cacheReadUsdPer1M": 0.0725
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-v4-pro-0813",
-        "inputUsdPer1M": 1.188,
-        "outputUsdPer1M": 3.564,
-        "cacheReadUsdPer1M": 0.0396
+        "inputUsdPer1M": 0.66,
+        "outputUsdPer1M": 1.98,
+        "cacheReadUsdPer1M": 0.022
       },
       {
         "modelKey": "openrouter:dots-studio/dots-3-note-preview:free",
@@ -42787,10 +55105,10 @@
       },
       {
         "modelKey": "openrouter:google/gemini-3.7-flash",
-        "inputUsdPer1M": 0.375,
-        "outputUsdPer1M": 1.875,
-        "cacheReadUsdPer1M": 0.0375,
-        "cacheWriteUsdPer1M": 0.020833
+        "inputUsdPer1M": 0.75,
+        "outputUsdPer1M": 3.75,
+        "cacheReadUsdPer1M": 0.075,
+        "cacheWriteUsdPer1M": 0.041667
       },
       {
         "modelKey": "openrouter:google/gemma-2-27b-it",
@@ -42814,11 +55132,6 @@
         "outputUsdPer1M": 0.1
       },
       {
-        "modelKey": "openrouter:google/gemma-3n-e4b-it",
-        "inputUsdPer1M": 0.06,
-        "outputUsdPer1M": 0.12
-      },
-      {
         "modelKey": "openrouter:google/gemma-4-26b-a4b-it",
         "inputUsdPer1M": 0.07,
         "outputUsdPer1M": 0.34
@@ -42830,9 +55143,9 @@
       },
       {
         "modelKey": "openrouter:google/gemma-4-31b-it",
-        "inputUsdPer1M": 0.1,
+        "inputUsdPer1M": 0.09,
         "outputUsdPer1M": 0.34,
-        "cacheReadUsdPer1M": 0.1
+        "cacheReadUsdPer1M": 0.05
       },
       {
         "modelKey": "openrouter:google/gemma-4-31b-it:free",
@@ -42866,22 +55179,16 @@
         "cacheReadUsdPer1M": 0.05
       },
       {
+        "modelKey": "openrouter:ibm-granite/granite-4.2-8b",
+        "inputUsdPer1M": 0.1,
+        "outputUsdPer1M": 0.15,
+        "cacheReadUsdPer1M": 0.05
+      },
+      {
         "modelKey": "openrouter:inception/mercury-2",
         "inputUsdPer1M": 0.25,
         "outputUsdPer1M": 0.75,
         "cacheReadUsdPer1M": 0.025
-      },
-      {
-        "modelKey": "openrouter:inclusionai/ling-2.6-1t",
-        "inputUsdPer1M": 0.075,
-        "outputUsdPer1M": 0.625,
-        "cacheReadUsdPer1M": 0.015
-      },
-      {
-        "modelKey": "openrouter:inclusionai/ling-2.6-flash",
-        "inputUsdPer1M": 0.01,
-        "outputUsdPer1M": 0.03,
-        "cacheReadUsdPer1M": 0.002
       },
       {
         "modelKey": "openrouter:inclusionai/ling-3.0-flash",
@@ -42890,16 +55197,9 @@
         "cacheReadUsdPer1M": 0.0042
       },
       {
-        "modelKey": "openrouter:inclusionai/ring-2.6-1t",
-        "inputUsdPer1M": 0.075,
-        "outputUsdPer1M": 0.625,
-        "cacheReadUsdPer1M": 0.015
-      },
-      {
-        "modelKey": "openrouter:kwaipilot/kat-coder-air-v2.5",
-        "inputUsdPer1M": 0.15,
-        "outputUsdPer1M": 0.6,
-        "cacheReadUsdPer1M": 0.03
+        "modelKey": "openrouter:inclusionai/ling-3.0-flash-fin:free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
       },
       {
         "modelKey": "openrouter:kwaipilot/kat-coder-pro-v2",
@@ -42952,18 +55252,20 @@
       },
       {
         "modelKey": "openrouter:meta-llama/llama-3.3-70b-instruct",
-        "inputUsdPer1M": 0.1,
-        "outputUsdPer1M": 0.32
+        "inputUsdPer1M": 0.71,
+        "outputUsdPer1M": 0.71,
+        "cacheReadUsdPer1M": 0.71
       },
       {
         "modelKey": "openrouter:meta-llama/llama-4-maverick",
         "inputUsdPer1M": 0.2,
-        "outputUsdPer1M": 0.8
+        "outputUsdPer1M": 0.696
       },
       {
         "modelKey": "openrouter:meta-llama/llama-4-scout",
-        "inputUsdPer1M": 0.1,
-        "outputUsdPer1M": 0.3
+        "inputUsdPer1M": 0.11,
+        "outputUsdPer1M": 0.34,
+        "cacheReadUsdPer1M": 0.055
       },
       {
         "modelKey": "openrouter:meta-llama/llama-guard-4-12b",
@@ -42973,7 +55275,7 @@
       {
         "modelKey": "openrouter:meta/muse-glimmer-30b",
         "inputUsdPer1M": 0.3,
-        "outputUsdPer1M": 1.1,
+        "outputUsdPer1M": 1.2,
         "cacheReadUsdPer1M": 0.04
       },
       {
@@ -42987,6 +55289,12 @@
         "inputUsdPer1M": 1.25,
         "outputUsdPer1M": 4.25,
         "cacheReadUsdPer1M": 0.15
+      },
+      {
+        "modelKey": "openrouter:meta/muse-spark-1.2-contributor",
+        "inputUsdPer1M": 0.1,
+        "outputUsdPer1M": 0.2,
+        "cacheReadUsdPer1M": 0.002
       },
       {
         "modelKey": "openrouter:microsoft/phi-4",
@@ -43028,8 +55336,8 @@
       {
         "modelKey": "openrouter:minimax/minimax-m2.5",
         "inputUsdPer1M": 0.27,
-        "outputUsdPer1M": 0.95,
-        "cacheReadUsdPer1M": 0.03
+        "outputUsdPer1M": 1.08,
+        "cacheReadUsdPer1M": 0.027
       },
       {
         "modelKey": "openrouter:minimax/minimax-m2.7",
@@ -43038,16 +55346,32 @@
         "cacheReadUsdPer1M": 0.06
       },
       {
+        "modelKey": "openrouter:minimax/minimax-m2.7:free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
         "modelKey": "openrouter:minimax/minimax-m3",
         "inputUsdPer1M": 0.3,
         "outputUsdPer1M": 1.2,
         "cacheReadUsdPer1M": 0.06
       },
       {
+        "modelKey": "openrouter:minimax/minimax-m3:free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
         "modelKey": "openrouter:mistralai/codestral-2508",
         "inputUsdPer1M": 0.3,
         "outputUsdPer1M": 0.9,
         "cacheReadUsdPer1M": 0.03
+      },
+      {
+        "modelKey": "openrouter:mistralai/devstral-2512",
+        "inputUsdPer1M": 0.4,
+        "outputUsdPer1M": 2,
+        "cacheReadUsdPer1M": 0.04
       },
       {
         "modelKey": "openrouter:mistralai/ministral-14b-2512",
@@ -43060,11 +55384,6 @@
         "inputUsdPer1M": 0.1,
         "outputUsdPer1M": 0.1,
         "cacheReadUsdPer1M": 0.01
-      },
-      {
-        "modelKey": "openrouter:mistralai/ministral-8b",
-        "inputUsdPer1M": 0.11,
-        "outputUsdPer1M": 0.11
       },
       {
         "modelKey": "openrouter:mistralai/ministral-8b-2512",
@@ -43136,8 +55455,8 @@
       },
       {
         "modelKey": "openrouter:mistralai/mistral-small-3.2-24b-instruct",
-        "inputUsdPer1M": 0.09375,
-        "outputUsdPer1M": 0.25
+        "inputUsdPer1M": 0.075,
+        "outputUsdPer1M": 0.2
       },
       {
         "modelKey": "openrouter:mistralai/mixtral-8x22b-instruct",
@@ -43181,9 +55500,9 @@
       },
       {
         "modelKey": "openrouter:moonshotai/kimi-k2.7-code",
-        "inputUsdPer1M": 0.67,
+        "inputUsdPer1M": 0.66,
         "outputUsdPer1M": 3.4,
-        "cacheReadUsdPer1M": 0.17
+        "cacheReadUsdPer1M": 0.18
       },
       {
         "modelKey": "openrouter:moonshotai/kimi-k3",
@@ -43237,12 +55556,7 @@
         "modelKey": "openrouter:nvidia/nemotron-3-nano-30b-a3b",
         "inputUsdPer1M": 0.05,
         "outputUsdPer1M": 0.2,
-        "cacheReadUsdPer1M": 0.03
-      },
-      {
-        "modelKey": "openrouter:nvidia/nemotron-3-nano-30b-a3b:free",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0
+        "cacheReadUsdPer1M": 0.025
       },
       {
         "modelKey": "openrouter:nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
@@ -43261,9 +55575,9 @@
       },
       {
         "modelKey": "openrouter:nvidia/nemotron-3-ultra-550b-a55b",
-        "inputUsdPer1M": 0.6,
-        "outputUsdPer1M": 3.6,
-        "cacheReadUsdPer1M": 0.2
+        "inputUsdPer1M": 0.5,
+        "outputUsdPer1M": 2.2,
+        "cacheReadUsdPer1M": 0.1
       },
       {
         "modelKey": "openrouter:nvidia/nemotron-3-ultra-550b-a55b:free",
@@ -43283,16 +55597,6 @@
       },
       {
         "modelKey": "openrouter:nvidia/nemotron-3.5-lightning:free",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0
-      },
-      {
-        "modelKey": "openrouter:nvidia/nemotron-nano-12b-v2-vl:free",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0
-      },
-      {
-        "modelKey": "openrouter:nvidia/nemotron-nano-9b-v2:free",
         "inputUsdPer1M": 0,
         "outputUsdPer1M": 0
       },
@@ -43508,20 +55812,14 @@
       },
       {
         "modelKey": "openrouter:openai/gpt-oss-120b",
-        "inputUsdPer1M": 0.03,
-        "outputUsdPer1M": 0.17,
-        "cacheReadUsdPer1M": 0.03
+        "inputUsdPer1M": 0.037,
+        "outputUsdPer1M": 0.17
       },
       {
         "modelKey": "openrouter:openai/gpt-oss-20b",
         "inputUsdPer1M": 0.03,
         "outputUsdPer1M": 0.13,
         "cacheReadUsdPer1M": 0.03
-      },
-      {
-        "modelKey": "openrouter:openai/gpt-oss-20b:free",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0
       },
       {
         "modelKey": "openrouter:openai/gpt-oss-safeguard-20b",
@@ -43649,9 +55947,8 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen2.5-vl-72b-instruct",
-        "inputUsdPer1M": 0.8,
-        "outputUsdPer1M": 1,
-        "cacheReadUsdPer1M": 0.4
+        "inputUsdPer1M": 0.25,
+        "outputUsdPer1M": 0.75
       },
       {
         "modelKey": "openrouter:qwen/qwen3-14b",
@@ -43665,8 +55962,9 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3-235b-a22b-2507",
-        "inputUsdPer1M": 0.09,
-        "outputUsdPer1M": 0.55
+        "inputUsdPer1M": 0.0875,
+        "outputUsdPer1M": 0.35,
+        "cacheReadUsdPer1M": 0.0175
       },
       {
         "modelKey": "openrouter:qwen/qwen3-235b-a22b-thinking-2507",
@@ -43675,8 +55973,8 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3-30b-a3b",
-        "inputUsdPer1M": 0.13,
-        "outputUsdPer1M": 0.52
+        "inputUsdPer1M": 0.12,
+        "outputUsdPer1M": 0.5
       },
       {
         "modelKey": "openrouter:qwen/qwen3-30b-a3b-instruct-2507",
@@ -43717,8 +56015,9 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3-next-80b-a3b-instruct",
-        "inputUsdPer1M": 0.09,
-        "outputUsdPer1M": 1.1
+        "inputUsdPer1M": 0.1,
+        "outputUsdPer1M": 1.1,
+        "cacheReadUsdPer1M": 0.07
       },
       {
         "modelKey": "openrouter:qwen/qwen3-next-80b-a3b-thinking",
@@ -43738,8 +56037,8 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3-vl-30b-a3b-instruct",
-        "inputUsdPer1M": 0.13,
-        "outputUsdPer1M": 0.52
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.6
       },
       {
         "modelKey": "openrouter:qwen/qwen3-vl-30b-a3b-thinking",
@@ -43763,8 +56062,8 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3.5-122b-a10b",
-        "inputUsdPer1M": 0.26,
-        "outputUsdPer1M": 2.08
+        "inputUsdPer1M": 0.29,
+        "outputUsdPer1M": 2.4
       },
       {
         "modelKey": "openrouter:qwen/qwen3.5-27b",
@@ -43800,8 +56099,8 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3.6-35b-a3b",
-        "inputUsdPer1M": 0.14,
-        "outputUsdPer1M": 1,
+        "inputUsdPer1M": 0.1,
+        "outputUsdPer1M": 0.9,
         "cacheReadUsdPer1M": 0.05
       },
       {
@@ -43819,9 +56118,17 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3.8-27b",
-        "inputUsdPer1M": 0.45,
-        "outputUsdPer1M": 3.2,
-        "cacheReadUsdPer1M": 0.05
+        "inputUsdPer1M": 0.425,
+        "outputUsdPer1M": 2.55,
+        "cacheReadUsdPer1M": 0.085,
+        "cacheWriteUsdPer1M": 0.53125
+      },
+      {
+        "modelKey": "openrouter:qwen/qwen3.8-flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.47,
+        "cacheReadUsdPer1M": 0.016,
+        "cacheWriteUsdPer1M": 0.2
       },
       {
         "modelKey": "openrouter:qwen/qwen3.8-max",
@@ -43872,11 +56179,6 @@
         "outputUsdPer1M": 0.75
       },
       {
-        "modelKey": "openrouter:stealth/ox-alpha",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0
-      },
-      {
         "modelKey": "openrouter:stepfun/step-3.5-flash",
         "inputUsdPer1M": 0.1,
         "outputUsdPer1M": 0.3
@@ -43903,10 +56205,15 @@
         "outputUsdPer1M": 0.295
       },
       {
+        "modelKey": "openrouter:tencent/hy-mt2-7b",
+        "inputUsdPer1M": 0.074,
+        "outputUsdPer1M": 0.295
+      },
+      {
         "modelKey": "openrouter:tencent/hy3",
-        "inputUsdPer1M": 0.132,
-        "outputUsdPer1M": 0.528,
-        "cacheReadUsdPer1M": 0.033
+        "inputUsdPer1M": 0.0825,
+        "outputUsdPer1M": 0.33,
+        "cacheReadUsdPer1M": 0.020625
       },
       {
         "modelKey": "openrouter:tencent/hy3-preview",
@@ -43915,15 +56222,16 @@
         "cacheReadUsdPer1M": 0.06
       },
       {
+        "modelKey": "openrouter:tencent/hy4-preview",
+        "inputUsdPer1M": 0.834,
+        "outputUsdPer1M": 2.501,
+        "cacheReadUsdPer1M": 0.042
+      },
+      {
         "modelKey": "openrouter:thedrummer/cydonia-24b-v4.1",
         "inputUsdPer1M": 0.3,
         "outputUsdPer1M": 0.5,
         "cacheReadUsdPer1M": 0.15
-      },
-      {
-        "modelKey": "openrouter:thedrummer/rocinante-12b",
-        "inputUsdPer1M": 0.25,
-        "outputUsdPer1M": 0.5
       },
       {
         "modelKey": "openrouter:thedrummer/skyfall-36b-v2",
@@ -43938,15 +56246,25 @@
       },
       {
         "modelKey": "openrouter:thinkingmachines/inkling",
-        "inputUsdPer1M": 0.95,
+        "inputUsdPer1M": 1,
         "outputUsdPer1M": 4.05,
-        "cacheReadUsdPer1M": 0.16
+        "cacheReadUsdPer1M": 0.17
       },
       {
         "modelKey": "openrouter:thinkingmachines/inkling-small",
         "inputUsdPer1M": 0.45,
         "outputUsdPer1M": 1.2,
         "cacheReadUsdPer1M": 0.1
+      },
+      {
+        "modelKey": "openrouter:thinkingmachines/inkling-small:free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
+        "modelKey": "openrouter:thinkingmachines/inkling:free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
       },
       {
         "modelKey": "openrouter:undi95/remm-slerp-l2-13b",
@@ -44002,9 +56320,9 @@
       },
       {
         "modelKey": "openrouter:z-ai/glm-4.6",
-        "inputUsdPer1M": 0.5,
-        "outputUsdPer1M": 2,
-        "cacheReadUsdPer1M": 0.1
+        "inputUsdPer1M": 0.43,
+        "outputUsdPer1M": 1.75,
+        "cacheReadUsdPer1M": 0.08
       },
       {
         "modelKey": "openrouter:z-ai/glm-4.6v",
@@ -44044,9 +56362,9 @@
       },
       {
         "modelKey": "openrouter:z-ai/glm-5.2",
-        "inputUsdPer1M": 0.966,
-        "outputUsdPer1M": 3.036,
-        "cacheReadUsdPer1M": 0.1932
+        "inputUsdPer1M": 1.19,
+        "outputUsdPer1M": 3.74,
+        "cacheReadUsdPer1M": 0.221
       },
       {
         "modelKey": "openrouter:z-ai/glm-5.2:free",
@@ -44058,6 +56376,12 @@
         "inputUsdPer1M": 1.4,
         "outputUsdPer1M": 4.4,
         "cacheReadUsdPer1M": 0.26
+      },
+      {
+        "modelKey": "openrouter:z-ai/glm-5.3-flash",
+        "inputUsdPer1M": 0.075,
+        "outputUsdPer1M": 0.25,
+        "cacheReadUsdPer1M": 0.015
       },
       {
         "modelKey": "openrouter:z-ai/glm-5v-turbo",
@@ -44579,6 +56903,18 @@
         "cacheReadUsdPer1M": 0.26
       },
       {
+        "modelKey": "togetherai:zai-org/GLM-5.3",
+        "inputUsdPer1M": 1.4,
+        "outputUsdPer1M": 4.4,
+        "cacheReadUsdPer1M": 0.26
+      },
+      {
+        "modelKey": "togetherai:zai-org/GLM-5.3-Flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.5,
+        "cacheReadUsdPer1M": 0.03
+      },
+      {
         "modelKey": "tencent-tokenhub:hy3",
         "inputUsdPer1M": 0,
         "outputUsdPer1M": 0,
@@ -44591,6 +56927,12 @@
         "outputUsdPer1M": 0,
         "cacheReadUsdPer1M": 0,
         "cacheWriteUsdPer1M": 0
+      },
+      {
+        "modelKey": "tencent-tokenhub:hy4-preview",
+        "inputUsdPer1M": 0.834,
+        "outputUsdPer1M": 2.501,
+        "cacheReadUsdPer1M": 0.042
       },
       {
         "modelKey": "vercel:alibaba/qwen-3-14b",
@@ -44740,13 +57082,27 @@
         "modelKey": "vercel:alibaba/qwen3.8-2.4t-a95b",
         "inputUsdPer1M": 2,
         "outputUsdPer1M": 6,
-        "cacheReadUsdPer1M": 0.2
+        "cacheReadUsdPer1M": 0.25
       },
       {
         "modelKey": "vercel:alibaba/qwen3.8-27b",
-        "inputUsdPer1M": 0.55,
-        "outputUsdPer1M": 3.3,
-        "cacheReadUsdPer1M": 0.11
+        "inputUsdPer1M": 0.5,
+        "outputUsdPer1M": 3,
+        "cacheReadUsdPer1M": 0.1,
+        "cacheWriteUsdPer1M": 0.625
+      },
+      {
+        "modelKey": "vercel:alibaba/qwen3.8-flash",
+        "inputUsdPer1M": 0.16,
+        "outputUsdPer1M": 0.47,
+        "cacheReadUsdPer1M": 0.016,
+        "cacheWriteUsdPer1M": 0.2
+      },
+      {
+        "modelKey": "vercel:alibaba/qwen3.8-flash-next",
+        "inputUsdPer1M": 0.12,
+        "outputUsdPer1M": 0.4,
+        "cacheReadUsdPer1M": 0.01
       },
       {
         "modelKey": "vercel:alibaba/qwen3.8-max",
@@ -44883,11 +57239,6 @@
         "outputUsdPer1M": 0.8999999999999999
       },
       {
-        "modelKey": "vercel:arcee-ai/trinity-mini",
-        "inputUsdPer1M": 0.045,
-        "outputUsdPer1M": 0.15
-      },
-      {
         "modelKey": "vercel:bytedance/seed-1.6",
         "inputUsdPer1M": 0.25,
         "outputUsdPer1M": 2,
@@ -44946,21 +57297,27 @@
       },
       {
         "modelKey": "vercel:deepseek/deepseek-v4-flash-0731",
-        "inputUsdPer1M": 0.13,
-        "outputUsdPer1M": 0.26,
-        "cacheReadUsdPer1M": 0.028
+        "inputUsdPer1M": 0.076,
+        "outputUsdPer1M": 0.153,
+        "cacheReadUsdPer1M": 0.014
+      },
+      {
+        "modelKey": "vercel:deepseek/deepseek-v4-flash-vision-exp",
+        "inputUsdPer1M": 0.22,
+        "outputUsdPer1M": 0.66,
+        "cacheReadUsdPer1M": 0.007
       },
       {
         "modelKey": "vercel:deepseek/deepseek-v4-pro",
-        "inputUsdPer1M": 1.74,
-        "outputUsdPer1M": 3.48,
-        "cacheReadUsdPer1M": 0.14
+        "inputUsdPer1M": 0.66,
+        "outputUsdPer1M": 1.98,
+        "cacheReadUsdPer1M": 0.022
       },
       {
         "modelKey": "vercel:deepseek/deepseek-v4-pro-0813",
-        "inputUsdPer1M": 1.32,
-        "outputUsdPer1M": 3.96,
-        "cacheReadUsdPer1M": 0.132
+        "inputUsdPer1M": 0.66,
+        "outputUsdPer1M": 1.98,
+        "cacheReadUsdPer1M": 0.066
       },
       {
         "modelKey": "vercel:google/gemini-2.5-flash",
@@ -45035,6 +57392,11 @@
         "cacheReadUsdPer1M": 0.03
       },
       {
+        "modelKey": "vercel:google/gemini-3.5-transcribe",
+        "inputUsdPer1M": 2,
+        "outputUsdPer1M": 12
+      },
+      {
         "modelKey": "vercel:google/gemini-3.6-flash",
         "inputUsdPer1M": 0.75,
         "outputUsdPer1M": 3.75,
@@ -45078,6 +57440,16 @@
         "inputUsdPer1M": 0.06,
         "outputUsdPer1M": 0.18,
         "cacheReadUsdPer1M": 0.012
+      },
+      {
+        "modelKey": "vercel:inclusionai/ling-3.0-flash-fin",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
+        "modelKey": "vercel:inclusionai/ling-3.0-flash-fin-free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
       },
       {
         "modelKey": "vercel:interfaze/interfaze-beta",
@@ -45200,6 +57572,11 @@
         "cacheWriteUsdPer1M": 0.375
       },
       {
+        "modelKey": "vercel:minimax/minimax-m2.7-free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
         "modelKey": "vercel:minimax/minimax-m2.7-highspeed",
         "inputUsdPer1M": 0.6,
         "outputUsdPer1M": 2.4,
@@ -45211,6 +57588,12 @@
         "inputUsdPer1M": 0.3,
         "outputUsdPer1M": 1.2,
         "cacheReadUsdPer1M": 0.06
+      },
+      {
+        "modelKey": "vercel:minimax/minimax-m3-free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0,
+        "cacheReadUsdPer1M": 0
       },
       {
         "modelKey": "vercel:mistral/codestral",
@@ -45226,16 +57609,6 @@
         "modelKey": "vercel:mistral/devstral-small-2",
         "inputUsdPer1M": 0.1,
         "outputUsdPer1M": 0.3
-      },
-      {
-        "modelKey": "vercel:mistral/magistral-medium",
-        "inputUsdPer1M": 2,
-        "outputUsdPer1M": 5
-      },
-      {
-        "modelKey": "vercel:mistral/magistral-small",
-        "inputUsdPer1M": 0.5,
-        "outputUsdPer1M": 1.5
       },
       {
         "modelKey": "vercel:mistral/ministral-14b",
@@ -45309,7 +57682,7 @@
         "modelKey": "vercel:moonshotai/kimi-k2.7-code",
         "inputUsdPer1M": 0.95,
         "outputUsdPer1M": 4,
-        "cacheReadUsdPer1M": 0.19
+        "cacheReadUsdPer1M": 0.16
       },
       {
         "modelKey": "vercel:moonshotai/kimi-k2.7-code-highspeed",
@@ -45440,11 +57813,6 @@
         "inputUsdPer1M": 0.25,
         "outputUsdPer1M": 1,
         "cacheReadUsdPer1M": 0.125
-      },
-      {
-        "modelKey": "vercel:openai/gpt-4o-mini-search-preview",
-        "inputUsdPer1M": 0.15,
-        "outputUsdPer1M": 0.6
       },
       {
         "modelKey": "vercel:openai/gpt-4o-mini-transcribe",
@@ -45630,17 +57998,17 @@
       },
       {
         "modelKey": "vercel:openai/gpt-5.6-sol",
-        "inputUsdPer1M": 2.5,
-        "outputUsdPer1M": 15,
-        "cacheReadUsdPer1M": 0.25,
-        "cacheWriteUsdPer1M": 3.125
+        "inputUsdPer1M": 2,
+        "outputUsdPer1M": 10,
+        "cacheReadUsdPer1M": 0.2,
+        "cacheWriteUsdPer1M": 2.5
       },
       {
         "modelKey": "vercel:openai/gpt-5.6-sol-fast",
-        "inputUsdPer1M": 5,
-        "outputUsdPer1M": 30,
-        "cacheReadUsdPer1M": 0.5,
-        "cacheWriteUsdPer1M": 3.125
+        "inputUsdPer1M": 4,
+        "outputUsdPer1M": 20,
+        "cacheReadUsdPer1M": 0.4,
+        "cacheWriteUsdPer1M": 2.5
       },
       {
         "modelKey": "vercel:openai/gpt-5.6-terra",
@@ -45691,10 +58059,14 @@
         "outputUsdPer1M": 0.2
       },
       {
+        "modelKey": "vercel:openai/gpt-oss-safeguard-120b",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.6
+      },
+      {
         "modelKey": "vercel:openai/gpt-oss-safeguard-20b",
-        "inputUsdPer1M": 0.075,
-        "outputUsdPer1M": 0.3,
-        "cacheReadUsdPer1M": 0.037
+        "inputUsdPer1M": 0.07,
+        "outputUsdPer1M": 0.2
       },
       {
         "modelKey": "vercel:openai/gpt-realtime-1.5",
@@ -45731,12 +58103,6 @@
         "inputUsdPer1M": 2,
         "outputUsdPer1M": 8,
         "cacheReadUsdPer1M": 0.5
-      },
-      {
-        "modelKey": "vercel:openai/o3-deep-research",
-        "inputUsdPer1M": 10,
-        "outputUsdPer1M": 40,
-        "cacheReadUsdPer1M": 2.5
       },
       {
         "modelKey": "vercel:openai/o3-fast",
@@ -45891,9 +58257,15 @@
       },
       {
         "modelKey": "vercel:tencent/hy3",
-        "inputUsdPer1M": 0.132,
-        "outputUsdPer1M": 0.528,
-        "cacheReadUsdPer1M": 0.033
+        "inputUsdPer1M": 0.14,
+        "outputUsdPer1M": 0.58,
+        "cacheReadUsdPer1M": 0.035
+      },
+      {
+        "modelKey": "vercel:tencent/hy4-preview",
+        "inputUsdPer1M": 0.834,
+        "outputUsdPer1M": 2.501,
+        "cacheReadUsdPer1M": 0.042
       },
       {
         "modelKey": "vercel:thinkingmachines/inkling",
@@ -45993,7 +58365,13 @@
         "modelKey": "vercel:zai/glm-5.3",
         "inputUsdPer1M": 1.4,
         "outputUsdPer1M": 4.4,
-        "cacheReadUsdPer1M": 0.26
+        "cacheReadUsdPer1M": 0.14
+      },
+      {
+        "modelKey": "vercel:zai/glm-5.3-flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.5,
+        "cacheReadUsdPer1M": 0.03
       },
       {
         "modelKey": "vercel:zai/glm-5v-turbo",
@@ -46122,6 +58500,20 @@
         "inputUsdPer1M": 1.4,
         "outputUsdPer1M": 4.4,
         "cacheReadUsdPer1M": 0.26,
+        "cacheWriteUsdPer1M": 0
+      },
+      {
+        "modelKey": "zai:glm-5.3",
+        "inputUsdPer1M": 1.4,
+        "outputUsdPer1M": 4.4,
+        "cacheReadUsdPer1M": 0.26,
+        "cacheWriteUsdPer1M": 0
+      },
+      {
+        "modelKey": "zai:glm-5.3-flash",
+        "inputUsdPer1M": 0.075,
+        "outputUsdPer1M": 0.25,
+        "cacheReadUsdPer1M": 0.015,
         "cacheWriteUsdPer1M": 0
       },
       {
@@ -47249,6 +59641,9 @@
         "grok-4.5": {
           "npm": "@ai-sdk/openai"
         },
+        "grok-4.6": {
+          "npm": "@ai-sdk/openai"
+        },
         "minimax-m2.5": {
           "npm": "@ai-sdk/anthropic"
         },
@@ -47260,6 +59655,9 @@
         },
         "muse-spark-1.2-contributor": {
           "npm": "@ai-sdk/openai"
+        },
+        "qwen3.8-flash": {
+          "npm": "@ai-sdk/anthropic"
         }
       },
       "openrouter": {},

--- a/scripts/model-metadata/models-dev-api.snapshot.json
+++ b/scripts/model-metadata/models-dev-api.snapshot.json
@@ -26,23 +26,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-haiku-4-5": {
@@ -61,14 +49,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-haiku-4-5-20251001": {
@@ -87,14 +69,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-5": {
@@ -113,21 +89,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-5-20251101": {
@@ -146,21 +112,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-6": {
@@ -179,22 +135,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-7": {
@@ -213,23 +158,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-8": {
@@ -248,23 +181,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-5": {
@@ -283,23 +204,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-5": {
@@ -318,14 +227,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-5-20250929": {
@@ -344,14 +247,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-6": {
@@ -370,22 +267,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-5": {
@@ -404,24 +290,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -442,19 +316,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -472,23 +339,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qvq-max": {
@@ -506,13 +361,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-flash": {
@@ -533,12 +383,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-max": {
@@ -556,12 +402,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-mt-plus": {
@@ -579,12 +421,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-mt-turbo": {
@@ -602,12 +440,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-omni-turbo": {
@@ -625,15 +459,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen-omni-turbo-realtime": {
@@ -651,15 +478,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen-plus": {
@@ -680,12 +500,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-plus-character-ja": {
@@ -703,12 +519,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-turbo": {
@@ -729,12 +541,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-vl-max": {
@@ -752,13 +560,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-vl-ocr": {
@@ -776,13 +579,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-vl-plus": {
@@ -800,13 +598,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen2-5-14b-instruct": {
@@ -824,12 +617,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-32b-instruct": {
@@ -847,12 +636,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-72b-instruct": {
@@ -870,12 +655,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-7b-instruct": {
@@ -893,12 +674,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-omni-7b": {
@@ -916,15 +693,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen2-5-vl-72b-instruct": {
@@ -942,13 +712,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen2-5-vl-7b-instruct": {
@@ -966,13 +731,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-14b": {
@@ -993,12 +753,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-235b-a22b": {
@@ -1019,12 +775,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-32b": {
@@ -1045,12 +797,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-8b": {
@@ -1071,12 +819,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-asr-flash": {
@@ -1094,12 +838,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-30b-a3b-instruct": {
@@ -1117,12 +857,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-480b-a35b-instruct": {
@@ -1140,12 +876,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-flash": {
@@ -1163,12 +895,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-plus": {
@@ -1186,12 +914,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-livetranslate-flash-realtime": {
@@ -1209,15 +933,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-max": {
@@ -1235,12 +952,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-next-80b-a3b-instruct": {
@@ -1258,12 +971,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-next-80b-a3b-thinking": {
@@ -1281,12 +990,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-omni-flash": {
@@ -1307,15 +1012,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-omni-flash-realtime": {
@@ -1333,15 +1031,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-vl-235b-a22b": {
@@ -1359,13 +1050,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-vl-30b-a3b": {
@@ -1383,13 +1069,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-vl-plus": {
@@ -1410,13 +1091,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.5-122b-a10b": {
@@ -1437,14 +1113,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.5-27b": {
@@ -1465,14 +1135,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.5-35b-a3b": {
@@ -1493,14 +1157,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.5-397b-a17b": {
@@ -1521,14 +1179,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -1549,13 +1201,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-27b": {
@@ -1576,14 +1223,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.6-35b-a3b": {
@@ -1604,14 +1245,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.6-flash": {
@@ -1632,13 +1267,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-max-preview": {
@@ -1659,12 +1289,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -1685,13 +1311,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -1711,12 +1332,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -1737,13 +1354,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -1761,21 +1373,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -1793,22 +1396,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "qwq-plus": {
@@ -1826,12 +1419,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -1850,12 +1439,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-0528": {
@@ -1872,12 +1457,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-llama-70b": {
@@ -1894,12 +1475,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-llama-8b": {
@@ -1917,12 +1494,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-qwen-1-5b": {
@@ -1940,12 +1513,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-qwen-14b": {
@@ -1962,12 +1531,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-qwen-32b": {
@@ -1984,12 +1549,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-qwen-7b": {
@@ -2006,12 +1567,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v3": {
@@ -2028,12 +1585,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v3-1": {
@@ -2050,12 +1603,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v3-2-exp": {
@@ -2072,12 +1621,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash": {
@@ -2096,19 +1641,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -2127,19 +1665,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -2159,12 +1690,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -2185,12 +1712,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -2208,12 +1731,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2-thinking": {
@@ -2231,12 +1750,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -2258,13 +1773,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -2286,13 +1796,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi/kimi-k2.5": {
@@ -2314,13 +1819,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -2337,12 +1837,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax/MiniMax-M2.7": {
@@ -2359,12 +1855,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshot-kimi-k2-instruct": {
@@ -2382,12 +1874,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qvq-max": {
@@ -2405,13 +1893,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-deep-research": {
@@ -2429,12 +1912,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-doc-turbo": {
@@ -2452,12 +1931,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-flash": {
@@ -2478,12 +1953,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-long": {
@@ -2501,12 +1972,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-math-plus": {
@@ -2524,12 +1991,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-math-turbo": {
@@ -2547,12 +2010,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-max": {
@@ -2570,12 +2029,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-mt-plus": {
@@ -2593,12 +2048,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-mt-turbo": {
@@ -2616,12 +2067,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-omni-turbo": {
@@ -2639,15 +2086,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen-omni-turbo-realtime": {
@@ -2665,15 +2105,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen-plus": {
@@ -2694,12 +2127,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-plus-character": {
@@ -2717,12 +2146,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-turbo": {
@@ -2743,12 +2168,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-vl-max": {
@@ -2766,13 +2187,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-vl-ocr": {
@@ -2790,13 +2206,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-vl-plus": {
@@ -2814,13 +2225,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen2-5-14b-instruct": {
@@ -2838,12 +2244,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-32b-instruct": {
@@ -2861,12 +2263,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-72b-instruct": {
@@ -2884,12 +2282,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-7b-instruct": {
@@ -2907,12 +2301,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-coder-32b-instruct": {
@@ -2930,12 +2320,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-coder-7b-instruct": {
@@ -2953,12 +2339,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-math-72b-instruct": {
@@ -2976,12 +2358,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-math-7b-instruct": {
@@ -2999,12 +2377,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-omni-7b": {
@@ -3022,15 +2396,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen2-5-vl-72b-instruct": {
@@ -3048,13 +2415,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen2-5-vl-7b-instruct": {
@@ -3072,13 +2434,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-14b": {
@@ -3099,12 +2456,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-235b-a22b": {
@@ -3125,12 +2478,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-32b": {
@@ -3151,12 +2500,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-8b": {
@@ -3177,12 +2522,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-asr-flash": {
@@ -3200,12 +2541,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-30b-a3b-instruct": {
@@ -3223,12 +2560,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-480b-a35b-instruct": {
@@ -3246,12 +2579,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-flash": {
@@ -3269,12 +2598,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-plus": {
@@ -3292,12 +2617,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-max": {
@@ -3315,12 +2636,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-next-80b-a3b-instruct": {
@@ -3338,12 +2655,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-next-80b-a3b-thinking": {
@@ -3361,12 +2674,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-omni-flash": {
@@ -3387,15 +2696,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-omni-flash-realtime": {
@@ -3413,15 +2715,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-vl-235b-a22b": {
@@ -3439,13 +2734,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-vl-30b-a3b": {
@@ -3463,13 +2753,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-vl-plus": {
@@ -3490,13 +2775,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.5-397b-a17b": {
@@ -3517,13 +2797,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.5-flash": {
@@ -3545,13 +2820,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -3572,13 +2842,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-flash": {
@@ -3599,13 +2864,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-max-preview": {
@@ -3626,12 +2886,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -3652,13 +2908,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.7-flash": {
@@ -3680,13 +2931,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -3706,12 +2952,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -3732,13 +2974,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -3756,21 +2993,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -3788,22 +3016,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "qwq-32b": {
@@ -3821,12 +3039,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwq-plus": {
@@ -3844,12 +3058,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "siliconflow/deepseek-r1-0528": {
@@ -3867,12 +3077,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "siliconflow/deepseek-v3-0324": {
@@ -3890,12 +3096,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "siliconflow/deepseek-v3.1-terminus": {
@@ -3916,12 +3118,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "siliconflow/deepseek-v3.2": {
@@ -3942,12 +3140,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tongyi-intent-detect-v3": {
@@ -3965,12 +3159,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -3994,12 +3184,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -4020,12 +3206,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -4047,13 +3229,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -4071,12 +3248,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-next": {
@@ -4095,12 +3268,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-plus": {
@@ -4119,12 +3288,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-max-2026-01-23": {
@@ -4143,12 +3308,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -4170,13 +3331,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-flash": {
@@ -4197,13 +3353,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -4225,13 +3376,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -4251,12 +3397,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -4278,13 +3420,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -4308,12 +3445,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -4334,12 +3467,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -4361,13 +3490,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -4386,12 +3510,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-next": {
@@ -4410,12 +3530,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-plus": {
@@ -4434,12 +3550,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-max-2026-01-23": {
@@ -4458,12 +3570,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -4485,13 +3593,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-flash": {
@@ -4512,13 +3615,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -4540,13 +3638,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -4566,12 +3659,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -4593,13 +3682,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -4624,12 +3708,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash": {
@@ -4649,19 +3729,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-0731": {
@@ -4681,19 +3754,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -4713,19 +3779,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro-0813": {
@@ -4744,19 +3803,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -4778,12 +3830,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -4805,12 +3853,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -4829,18 +3873,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "happyhorse-1.1-i2v": {
@@ -4858,10 +3895,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
+            "input": ["image", "text"],
             "output": []
           }
         },
@@ -4880,10 +3914,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
+            "input": ["image", "text"],
             "output": []
           }
         },
@@ -4902,9 +3933,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -4928,13 +3957,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -4957,13 +3981,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -4986,13 +4005,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -5011,12 +4025,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-image-2.0": {
@@ -5034,12 +4044,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "qwen-image-2.0-pro": {
@@ -5057,12 +4063,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "qwen3.6-flash": {
@@ -5084,13 +4086,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -5113,13 +4110,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -5141,12 +4133,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -5169,13 +4157,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -5194,21 +4177,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -5227,22 +4201,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max-preview": {
@@ -5261,20 +4225,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "wan2.7-image": {
@@ -5292,12 +4247,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "wan2.7-image-pro": {
@@ -5315,12 +4266,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         }
       },
@@ -5345,12 +4292,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash": {
@@ -5370,19 +4313,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-0731": {
@@ -5402,19 +4338,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -5434,19 +4363,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro-0813": {
@@ -5465,19 +4387,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -5499,12 +4414,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -5526,12 +4437,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -5550,18 +4457,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "happyhorse-1.1-i2v": {
@@ -5579,10 +4479,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
+            "input": ["image", "text"],
             "output": []
           }
         },
@@ -5601,10 +4498,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
+            "input": ["image", "text"],
             "output": []
           }
         },
@@ -5623,9 +4517,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -5649,13 +4541,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -5678,13 +4565,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -5707,13 +4589,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -5732,12 +4609,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-image-2.0": {
@@ -5755,12 +4628,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "qwen-image-2.0-pro": {
@@ -5778,12 +4647,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "qwen3.6-flash": {
@@ -5805,13 +4670,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -5834,13 +4694,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -5862,12 +4717,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -5890,13 +4741,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -5915,21 +4761,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -5948,22 +4785,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max-preview": {
@@ -5982,20 +4809,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "wan2.7-image": {
@@ -6013,12 +4831,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "wan2.7-image-pro": {
@@ -6036,12 +4850,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         }
       },
@@ -6061,21 +4871,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-oss-120b": {
@@ -6093,19 +4893,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -6124,12 +4916,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "c4ai-aya-expanse-8b": {
@@ -6146,12 +4934,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "c4ai-aya-vision-32b": {
@@ -6168,13 +4952,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "c4ai-aya-vision-8b": {
@@ -6191,13 +4970,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "command-a-03-2025": {
@@ -6215,12 +4989,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-a-plus-05-2026": {
@@ -6242,13 +5012,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "command-a-reasoning-08-2025": {
@@ -6269,12 +5034,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-a-translate-08-2025": {
@@ -6292,12 +5053,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-a-vision-07-2025": {
@@ -6315,13 +5072,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "command-r-08-2024": {
@@ -6339,12 +5091,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-r-plus-08-2024": {
@@ -6362,12 +5110,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-r7b-12-2024": {
@@ -6385,12 +5129,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-r7b-arabic-02-2025": {
@@ -6408,12 +5148,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "north-mini-code-1-0": {
@@ -6433,18 +5169,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -6464,12 +5193,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
@@ -6488,12 +5213,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/deepseek-ai/deepseek-v4-flash-0731": {
@@ -6512,19 +5233,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/deepseek-ai/deepseek-v4-pro-0813": {
@@ -6542,19 +5256,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/google/gemma-4-26b-a4b-it": {
@@ -6572,21 +5279,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/ibm-granite/granite-4.0-h-micro": {
@@ -6604,12 +5302,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.1-8b-instruct-fp8": {
@@ -6628,12 +5322,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.2-11b-vision-instruct": {
@@ -6652,13 +5342,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.2-1b-instruct": {
@@ -6677,12 +5362,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.2-3b-instruct": {
@@ -6701,12 +5382,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
@@ -6725,12 +5402,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-4-scout-17b-16e-instruct": {
@@ -6749,13 +5422,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-guard-3-8b": {
@@ -6774,12 +5442,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/mistralai/mistral-small-3.1-24b-instruct": {
@@ -6797,12 +5461,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/moonshotai/kimi-k2.6": {
@@ -6821,21 +5481,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/moonshotai/kimi-k2.7-code": {
@@ -6854,21 +5505,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/nvidia/nemotron-3-120b-a12b": {
@@ -6886,20 +5528,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/openai/gpt-oss-120b": {
@@ -6917,19 +5551,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/openai/gpt-oss-20b": {
@@ -6947,12 +5573,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/qwen/qwen2.5-coder-32b-instruct": {
@@ -6970,12 +5592,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/qwen/qwen3-30b-a3b-fp8": {
@@ -6993,12 +5611,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/qwen/qwen3.8-27b": {
@@ -7016,21 +5630,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/qwen/qwq-32b": {
@@ -7049,12 +5654,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/zai-org/glm-4.7-flash": {
@@ -7073,20 +5674,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/zai-org/glm-5.2": {
@@ -7104,20 +5697,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/zai-org/glm-5.3": {
@@ -7135,20 +5720,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/zai-org/glm-5.3-flash": {
@@ -7166,13 +5743,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -7192,21 +5764,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "ByteDance/Seed-2.0-mini": {
@@ -7224,13 +5786,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "ByteDance/Seed-2.0-pro": {
@@ -7248,13 +5805,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-R1-0528": {
@@ -7273,12 +5825,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -7296,12 +5844,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3-0324": {
@@ -7319,12 +5863,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -7345,12 +5885,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -7372,12 +5908,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -7396,21 +5928,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -7432,12 +5955,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -7456,21 +5975,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -7488,19 +5998,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -7521,13 +6024,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31B-it": {
@@ -7548,13 +6046,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-E4B-it": {
@@ -7575,14 +6068,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -7600,12 +6087,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
@@ -7623,13 +6106,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
@@ -7647,13 +6125,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -7671,12 +6144,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -7693,12 +6162,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -7716,13 +6181,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -7744,13 +6204,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -7772,13 +6227,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -7800,13 +6250,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -7824,20 +6269,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/Llama-3.3-Nemotron-Super-49B-v1.5": {
@@ -7855,12 +6291,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/Nemotron-3-Nano-30B-A3B": {
@@ -7880,12 +6312,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning": {
@@ -7903,14 +6331,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -7928,19 +6350,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -7958,19 +6372,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507": {
@@ -7988,12 +6394,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-30B-A3B": {
@@ -8011,12 +6413,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -8035,12 +6433,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo": {
@@ -8059,12 +6453,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Max": {
@@ -8083,12 +6473,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Instruct": {
@@ -8107,12 +6493,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -8131,13 +6513,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -8155,14 +6532,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -8180,14 +6551,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -8206,13 +6571,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -8231,13 +6591,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -8255,13 +6610,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -8279,14 +6629,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -8304,13 +6648,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.7-Max": {
@@ -8328,12 +6667,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-2.4T-A95B": {
@@ -8351,19 +6686,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-27B": {
@@ -8381,21 +6708,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-Max": {
@@ -8413,14 +6731,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/Step-3.7-Flash": {
@@ -8438,13 +6750,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "tencent/Hy3": {
@@ -8462,12 +6769,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling": {
@@ -8484,14 +6787,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling-Small": {
@@ -8509,14 +6806,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2.5": {
@@ -8538,14 +6829,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2.5-Pro": {
@@ -8567,13 +6852,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.6": {
@@ -8595,12 +6875,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.7": {
@@ -8622,12 +6898,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.7-Flash": {
@@ -8646,12 +6918,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5": {
@@ -8673,12 +6941,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.1": {
@@ -8700,12 +6964,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.2": {
@@ -8723,21 +6983,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3": {
@@ -8755,19 +7006,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3-Flash": {
@@ -8785,21 +7028,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -8820,20 +7053,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-vision-exp": {
@@ -8851,21 +7076,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -8883,19 +7099,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -8916,20 +7125,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/deepseek-v4-pro-0813": {
@@ -8947,19 +7148,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/glm-5p2": {
@@ -8976,19 +7170,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/glm-5p3": {
@@ -9006,18 +7193,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/glm-5p3-flash": {
@@ -9035,20 +7215,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/gpt-oss-120b": {
@@ -9065,19 +7236,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/inkling": {
@@ -9094,14 +7257,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/kimi-k2p6": {
@@ -9121,13 +7278,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/kimi-k2p7-code": {
@@ -9147,13 +7299,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/kimi-k3": {
@@ -9171,22 +7318,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/minimax-m3": {
@@ -9203,20 +7340,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/muse-glimmer-30b": {
@@ -9235,21 +7363,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
@@ -9269,12 +7387,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
@@ -9295,12 +7409,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/qwen3p7-plus": {
@@ -9317,21 +7427,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/qwen3p8-max": {
@@ -9351,12 +7452,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/routers/glm-5p2-fast": {
@@ -9373,19 +7470,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/routers/kimi-k3-fast": {
@@ -9403,22 +7493,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -9438,23 +7518,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-haiku-4.5": {
@@ -9473,14 +7541,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4.5": {
@@ -9499,14 +7561,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4.6": {
@@ -9525,22 +7581,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4.7": {
@@ -9559,23 +7604,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4.8": {
@@ -9594,23 +7627,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-5": {
@@ -9630,23 +7651,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4": {
@@ -9665,14 +7674,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4.5": {
@@ -9691,14 +7694,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4.6": {
@@ -9717,22 +7714,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-5": {
@@ -9750,23 +7736,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.1-pro-preview": {
@@ -9786,22 +7760,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash": {
@@ -9821,23 +7784,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.6-flash": {
@@ -9857,22 +7808,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.7-flash": {
@@ -9892,20 +7832,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4.1": {
@@ -9925,14 +7856,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5-mini": {
@@ -9952,20 +7877,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2": {
@@ -9985,13 +7901,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2-codex": {
@@ -10011,14 +7922,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex": {
@@ -10038,22 +7943,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4": {
@@ -10073,23 +7967,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-mini": {
@@ -10109,22 +7991,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-nano": {
@@ -10144,13 +8015,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.5": {
@@ -10170,23 +8036,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-luna": {
@@ -10206,24 +8060,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-sol": {
@@ -10243,24 +8084,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-terra": {
@@ -10280,24 +8108,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.5": {
@@ -10316,20 +8131,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "grok-4.6": {
@@ -10349,21 +8155,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -10383,13 +8179,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -10407,20 +8198,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mai-code-1-flash-picker": {
@@ -10440,19 +8222,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mai-code-1.1-flash": {
@@ -10471,21 +8245,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -10505,16 +8269,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "deep-research-preview-04-2026": {
@@ -10532,16 +8288,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "gemini-2.5-computer-use-preview-10-2025": {
@@ -10559,13 +8307,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gemini-2.5-flash": {
@@ -10587,15 +8330,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-2.5-flash-image": {
@@ -10613,14 +8349,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gemini-2.5-flash-lite": {
@@ -10642,15 +8372,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-2.5-flash-preview-tts": {
@@ -10668,12 +8391,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "gemini-2.5-pro": {
@@ -10692,15 +8411,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-2.5-pro-preview-tts": {
@@ -10718,12 +8430,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "gemini-3-flash-preview": {
@@ -10742,23 +8450,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3-pro-image": {
@@ -10776,20 +8472,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3-pro-image-preview": {
@@ -10807,14 +8494,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3.1-flash-image": {
@@ -10832,21 +8513,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3.1-flash-image-preview": {
@@ -10864,21 +8535,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3.1-flash-lite": {
@@ -10897,23 +8558,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.1-flash-lite-image": {
@@ -10932,20 +8581,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3.1-flash-lite-preview": {
@@ -10964,23 +8604,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.1-flash-live-preview": {
@@ -10999,23 +8627,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "gemini-3.1-flash-tts-preview": {
@@ -11033,12 +8649,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "gemini-3.1-pro-preview": {
@@ -11057,22 +8669,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.1-pro-preview-customtools": {
@@ -11091,22 +8692,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash": {
@@ -11125,23 +8715,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash-lite": {
@@ -11160,23 +8738,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-live-translate-preview": {
@@ -11194,13 +8760,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "audio",
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["audio", "text"]
           }
         },
         "gemini-3.6-flash": {
@@ -11219,23 +8780,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.7-flash": {
@@ -11254,22 +8803,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-embedding-001": {
@@ -11287,12 +8825,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gemini-embedding-2": {
@@ -11310,15 +8844,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-flash-latest": {
@@ -11337,22 +8864,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-flash-lite-latest": {
@@ -11371,23 +8887,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-omni-flash-preview": {
@@ -11404,10 +8908,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -11429,13 +8930,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gemma-4-31b-it": {
@@ -11456,13 +8952,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "lyria-3-clip-preview": {
@@ -11481,14 +8972,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "audio"]
           }
         },
         "lyria-3-pro-preview": {
@@ -11507,14 +8992,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "audio"]
           }
         },
         "veo-3.1-fast-generate-preview": {
@@ -11531,10 +9010,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -11552,10 +9028,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -11573,10 +9046,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         }
@@ -11597,12 +9067,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "canopylabs/orpheus-arabic-saudi": {
@@ -11619,12 +9085,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "canopylabs/orpheus-v1-english": {
@@ -11641,12 +9103,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "groq/compound": {
@@ -11663,12 +9121,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "groq/compound-mini": {
@@ -11685,12 +9139,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "llama-3.1-8b-instant": {
@@ -11708,12 +9158,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "llama-3.3-70b-versatile": {
@@ -11731,12 +9177,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-prompt-guard-2-22m": {
@@ -11753,12 +9195,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-prompt-guard-2-86m": {
@@ -11775,12 +9213,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -11798,19 +9232,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -11828,19 +9254,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -11858,19 +9276,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-27b": {
@@ -11888,19 +9298,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "default"
-            ]
+            "efforts": ["none", "default"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-27b": {
@@ -11918,22 +9320,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "default",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "default", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "whisper-large-v3": {
@@ -11950,12 +9341,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "whisper-large-v3-turbo": {
@@ -11972,12 +9359,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         }
       },
@@ -11998,12 +9381,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-R1-0528": {
@@ -12021,12 +9400,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -12044,12 +9419,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3-0324": {
@@ -12067,12 +9438,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -12090,12 +9457,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -12113,12 +9476,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -12137,12 +9496,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -12161,18 +9516,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -12191,17 +9539,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -12219,19 +9561,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -12249,13 +9583,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31B-it": {
@@ -12273,13 +9602,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-3.1-8B-Instruct": {
@@ -12298,12 +9622,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct": {
@@ -12322,12 +9642,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2": {
@@ -12344,12 +9660,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.1": {
@@ -12367,12 +9679,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -12389,12 +9697,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -12412,12 +9716,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -12435,13 +9735,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2-Instruct": {
@@ -12459,12 +9754,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2-Instruct-0905": {
@@ -12482,12 +9773,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2-Thinking": {
@@ -12505,12 +9792,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -12528,13 +9811,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -12552,13 +9830,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -12577,13 +9850,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -12601,20 +9869,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -12632,19 +9891,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -12662,19 +9913,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen2.5-Coder-32B-Instruct": {
@@ -12692,12 +9935,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B": {
@@ -12716,12 +9955,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507": {
@@ -12739,12 +9974,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -12762,12 +9993,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-30B-A3B": {
@@ -12785,12 +10012,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -12809,12 +10032,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
@@ -12833,12 +10052,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
@@ -12856,12 +10071,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-Next": {
@@ -12879,12 +10090,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Embedding-4B": {
@@ -12902,12 +10109,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Embedding-8B": {
@@ -12925,12 +10128,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Instruct": {
@@ -12948,12 +10147,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Thinking": {
@@ -12971,12 +10166,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -12995,13 +10186,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Thinking": {
@@ -13020,20 +10206,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -13051,13 +10228,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -13075,13 +10247,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -13099,13 +10266,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -13123,21 +10285,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -13155,13 +10307,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -13179,13 +10326,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -13203,13 +10345,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-2.4T-A95B": {
@@ -13227,19 +10364,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-27B": {
@@ -13257,20 +10386,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/Step-3.5-Flash": {
@@ -13288,12 +10408,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/Step-3.7-Flash": {
@@ -13311,20 +10427,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "tencent/Hy3": {
@@ -13342,19 +10449,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling": {
@@ -13372,20 +10471,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling-Small": {
@@ -13402,13 +10492,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2-Flash": {
@@ -13426,12 +10511,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2.5": {
@@ -13450,22 +10531,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["none", "low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2.5-Pro": {
@@ -13484,22 +10555,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["none", "low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.5": {
@@ -13517,12 +10578,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.5-Air": {
@@ -13540,12 +10597,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.5V": {
@@ -13563,13 +10616,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.6": {
@@ -13587,12 +10635,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.6V-Flash": {
@@ -13612,13 +10656,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.7": {
@@ -13636,12 +10675,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.7-Flash": {
@@ -13660,12 +10695,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5": {
@@ -13682,12 +10713,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.1": {
@@ -13704,12 +10731,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.2": {
@@ -13727,12 +10750,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3": {
@@ -13750,19 +10769,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3-Flash": {
@@ -13780,20 +10791,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -13814,21 +10816,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "k3-256k": {
@@ -13847,20 +10840,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-for-coding": {
@@ -13880,13 +10864,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-for-coding-highspeed": {
@@ -13906,13 +10885,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -13931,12 +10905,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.1": {
@@ -13953,12 +10923,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -13975,12 +10941,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -13997,12 +10959,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7": {
@@ -14019,12 +10977,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -14041,12 +10995,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M3": {
@@ -14066,13 +11016,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -14091,12 +11036,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.1": {
@@ -14113,12 +11054,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -14135,12 +11072,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -14157,12 +11090,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7": {
@@ -14179,12 +11108,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -14201,12 +11126,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M3": {
@@ -14226,13 +11147,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -14252,12 +11168,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.1": {
@@ -14275,12 +11187,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -14298,12 +11206,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -14321,12 +11225,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7": {
@@ -14344,12 +11244,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -14367,12 +11263,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M3": {
@@ -14393,13 +11285,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -14419,12 +11306,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-2512": {
@@ -14442,12 +11325,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-latest": {
@@ -14465,12 +11344,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-medium-2507": {
@@ -14488,12 +11363,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-medium-latest": {
@@ -14511,12 +11382,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-small-2505": {
@@ -14534,12 +11401,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-small-2507": {
@@ -14557,12 +11420,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "labs-devstral-small-2512": {
@@ -14581,13 +11440,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "magistral-medium-latest": {
@@ -14605,12 +11459,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "magistral-small": {
@@ -14628,12 +11478,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ministral-3b-latest": {
@@ -14651,12 +11497,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ministral-8b-latest": {
@@ -14674,12 +11516,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral-embed": {
@@ -14696,12 +11534,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral-large-2411": {
@@ -14719,12 +11553,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral-large-2512": {
@@ -14742,13 +11572,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-large-latest": {
@@ -14766,13 +11591,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-medium-2505": {
@@ -14790,13 +11610,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-medium-2508": {
@@ -14814,13 +11629,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-medium-2604": {
@@ -14838,19 +11648,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-medium-latest": {
@@ -14868,19 +11670,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-nemo": {
@@ -14898,12 +11692,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral-small-2506": {
@@ -14921,13 +11711,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-small-2603": {
@@ -14945,19 +11730,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-small-latest": {
@@ -14975,19 +11752,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "open-mistral-7b": {
@@ -15005,12 +11774,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "open-mistral-nemo": {
@@ -15028,12 +11793,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "open-mixtral-8x22b": {
@@ -15051,12 +11812,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "open-mixtral-8x7b": {
@@ -15074,12 +11831,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "pixtral-12b": {
@@ -15097,13 +11850,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "pixtral-large-latest": {
@@ -15121,13 +11869,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "voxtral-mini-latest": {
@@ -15144,12 +11887,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "voxtral-mini-tts-latest": {
@@ -15166,12 +11905,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "voxtral-small-latest": {
@@ -15188,13 +11923,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text"]
           }
         },
         "zai-glm-5-2": {
@@ -15212,18 +11942,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -15243,12 +11966,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2-0905-preview": {
@@ -15266,12 +11985,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2-thinking": {
@@ -15289,12 +12004,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2-thinking-turbo": {
@@ -15312,12 +12023,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2-turbo-preview": {
@@ -15335,12 +12042,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -15362,13 +12065,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -15390,13 +12088,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -15415,13 +12108,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code-highspeed": {
@@ -15440,13 +12128,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -15464,21 +12147,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -15498,12 +12172,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "baai/bge-m3": {
@@ -15521,12 +12191,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "black-forest-labs/flux_1-kontext-dev": {
@@ -15544,13 +12210,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "black-forest-labs/flux_1-schnell": {
@@ -15571,12 +12232,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "black-forest-labs/flux_2-klein-4b": {
@@ -15595,13 +12252,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["image", "text"],
+            "output": ["image"]
           }
         },
         "black-forest-labs/flux.1-dev": {
@@ -15620,12 +12272,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seed-oss-36b-instruct": {
@@ -15644,12 +12292,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/deepseek-v4-flash": {
@@ -15668,19 +12312,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/deepseek-v4-flash-0731": {
@@ -15700,19 +12336,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/deepseek-v4-pro": {
@@ -15731,19 +12359,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/deepseek-v4-pro-0813": {
@@ -15762,19 +12382,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-2-2b-it": {
@@ -15793,12 +12405,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-12b-it": {
@@ -15816,13 +12424,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-4b-it": {
@@ -15840,13 +12443,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3n-e2b-it": {
@@ -15866,13 +12464,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3n-e4b-it": {
@@ -15892,13 +12485,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31b-it": {
@@ -15920,13 +12508,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/google-paligemma": {
@@ -15944,13 +12527,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/esm2-650m": {
@@ -15968,12 +12546,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/esmfold": {
@@ -15991,12 +12565,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.1-70b-instruct": {
@@ -16015,12 +12585,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.1-8b-instruct": {
@@ -16039,12 +12605,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.2-11b-vision-instruct": {
@@ -16064,13 +12626,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.2-1b-instruct": {
@@ -16090,12 +12647,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.2-3b-instruct": {
@@ -16114,12 +12667,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.2-90b-vision-instruct": {
@@ -16138,13 +12687,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.3-70b-instruct": {
@@ -16163,12 +12707,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-4-maverick-17b-128e-instruct": {
@@ -16188,13 +12728,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-guard-4-12b": {
@@ -16212,13 +12747,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -16238,23 +12768,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "microsoft/phi-4-mini-instruct": {
@@ -16273,12 +12791,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "microsoft/phi-4-multimodal-instruct": {
@@ -16298,12 +12812,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimaxai/minimax-m2.7": {
@@ -16321,12 +12831,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimaxai/minimax-m3": {
@@ -16347,13 +12853,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/magistral-small-2506": {
@@ -16373,12 +12874,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/ministral-14b-instruct-2512": {
@@ -16396,13 +12893,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-7b-instruct-v0.3": {
@@ -16421,12 +12913,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-large-3-675b-instruct-2512": {
@@ -16446,13 +12934,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3-instruct": {
@@ -16472,13 +12955,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3.5-128b": {
@@ -16497,19 +12975,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-nemotron": {
@@ -16527,12 +12997,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-4-119b-2603": {
@@ -16551,19 +13017,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mixtral-8x22b-instruct": {
@@ -16581,12 +13039,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mixtral-8x7b-instruct": {
@@ -16604,12 +13058,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-instruct-0905": {
@@ -16628,12 +13078,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -16653,24 +13099,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3": {
@@ -16689,21 +13122,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/active-speaker-detection": {
@@ -16722,9 +13146,7 @@
           },
           "modalities": {
             "input": [],
-            "output": [
-              "text"
-            ]
+            "output": ["text"]
           }
         },
         "nvidia/bevformer": {
@@ -16743,9 +13165,7 @@
           },
           "modalities": {
             "input": [],
-            "output": [
-              "text"
-            ]
+            "output": ["text"]
           }
         },
         "nvidia/cosmos-predict1-5b": {
@@ -16763,10 +13183,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -16785,13 +13202,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/cosmos-transfer1-7b": {
@@ -16809,10 +13221,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -16831,10 +13240,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -16853,12 +13259,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3_2-nemoretriever-300m-embed-v1": {
@@ -16876,12 +13278,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-70b-instruct": {
@@ -16899,12 +13297,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-nano-8b-v1": {
@@ -16925,12 +13319,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-nano-vl-8b-v1": {
@@ -16948,13 +13338,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-safety-guard-8b-v3": {
@@ -16972,12 +13357,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-ultra-253b-v1": {
@@ -16998,12 +13379,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.3-nemotron-super-49b-v1": {
@@ -17024,12 +13401,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.3-nemotron-super-49b-v1.5": {
@@ -17050,12 +13423,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-nemotron-embed-vl-1b-v2": {
@@ -17073,13 +13442,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-nemotron-rerank-vl-1b-v2": {
@@ -17097,13 +13461,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/magpie-tts-zeroshot": {
@@ -17121,13 +13480,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["audio"]
           }
         },
         "nvidia/nemotron-3-content-safety": {
@@ -17145,12 +13499,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -17172,12 +13522,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
@@ -17199,14 +13545,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -17227,12 +13567,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -17253,12 +13589,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-lightning-30b-a3b": {
@@ -17280,12 +13612,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-content-safety-reasoning-4b": {
@@ -17303,12 +13631,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-mini-4b-instruct": {
@@ -17326,12 +13650,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-nano-12b-v2-vl": {
@@ -17349,13 +13669,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-voicechat": {
@@ -17373,13 +13688,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text"]
           }
         },
         "nvidia/nv-embed-v1": {
@@ -17397,12 +13707,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nv-embedcode-7b-v1": {
@@ -17420,12 +13726,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nvidia-nemotron-nano-9b-v2": {
@@ -17447,12 +13749,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/rerank-qa-mistral-4b": {
@@ -17470,12 +13768,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/riva-translate-4b-instruct-v1.1": {
@@ -17493,12 +13787,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/sparsedrive": {
@@ -17517,9 +13807,7 @@
           },
           "modalities": {
             "input": [],
-            "output": [
-              "text"
-            ]
+            "output": ["text"]
           }
         },
         "nvidia/streampetr": {
@@ -17538,9 +13826,7 @@
           },
           "modalities": {
             "input": [],
-            "output": [
-              "text"
-            ]
+            "output": ["text"]
           }
         },
         "nvidia/studiovoice": {
@@ -17558,12 +13844,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/synthetic-video-detector": {
@@ -17582,9 +13864,7 @@
           },
           "modalities": {
             "input": [],
-            "output": [
-              "text"
-            ]
+            "output": ["text"]
           }
         },
         "nvidia/usdcode": {
@@ -17602,12 +13882,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/usdvalidate": {
@@ -17625,12 +13901,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -17650,19 +13922,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -17681,19 +13945,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/whisper-large-v3": {
@@ -17712,12 +13968,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-xs-2.1": {
@@ -17736,12 +13988,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-image": {
@@ -17760,13 +14008,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "qwen/qwen-image-edit": {
@@ -17785,13 +14028,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "qwen/qwen2.5-coder-32b-instruct": {
@@ -17810,12 +14048,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-480b-a35b-instruct": {
@@ -17834,12 +14068,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-next-80b-a3b-instruct": {
@@ -17858,12 +14088,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-122b-a10b": {
@@ -17885,14 +14111,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-397b-a17b": {
@@ -17915,13 +14135,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "sarvamai/sarvam-m": {
@@ -17939,12 +14154,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/step-3.5-flash": {
@@ -17962,19 +14173,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/step-3.7-flash": {
@@ -17992,23 +14195,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling": {
@@ -18026,14 +14217,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "upstage/solar-10.7b-instruct": {
@@ -18051,12 +14236,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.2": {
@@ -18078,12 +14259,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -18102,19 +14279,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash:0731": {
@@ -18133,19 +14303,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -18162,19 +14325,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gemma4:31b": {
@@ -18195,13 +14351,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -18221,12 +14372,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -18244,18 +14391,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3": {
@@ -18273,19 +14413,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3-flash": {
@@ -18303,21 +14435,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-oss:120b": {
@@ -18334,19 +14456,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gpt-oss:20b": {
@@ -18363,19 +14477,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -18395,13 +14501,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -18421,13 +14522,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -18449,13 +14545,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -18473,21 +14564,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5": {
@@ -18505,12 +14587,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.7": {
@@ -18530,12 +14608,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m3": {
@@ -18553,22 +14627,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-large-3:675b": {
@@ -18585,13 +14649,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nemotron-3-nano:30b": {
@@ -18611,12 +14670,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nemotron-3-super": {
@@ -18636,12 +14691,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nemotron-3-ultra": {
@@ -18661,12 +14712,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.5:397b": {
@@ -18686,13 +14733,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -18712,14 +14754,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gpt-3.5-turbo": {
@@ -18738,12 +14774,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gpt-4": {
@@ -18762,12 +14794,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gpt-4-turbo": {
@@ -18786,13 +14814,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4.1": {
@@ -18811,14 +14834,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-4.1-mini": {
@@ -18837,14 +14854,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-4.1-nano": {
@@ -18863,13 +14874,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4o": {
@@ -18888,14 +14894,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-4o-2024-05-13": {
@@ -18914,13 +14914,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4o-2024-08-06": {
@@ -18939,13 +14934,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4o-2024-11-20": {
@@ -18964,13 +14954,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4o-mini": {
@@ -18989,14 +14974,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5": {
@@ -19016,21 +14995,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-mini": {
@@ -19050,21 +15019,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-nano": {
@@ -19084,21 +15043,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-pro": {
@@ -19118,18 +15067,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1": {
@@ -19149,21 +15091,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2": {
@@ -19183,22 +15115,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2-chat-latest": {
@@ -19217,18 +15138,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium"
-            ]
+            "efforts": ["medium"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2-pro": {
@@ -19248,20 +15162,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-chat-latest": {
@@ -19280,13 +15185,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex": {
@@ -19306,23 +15206,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex-spark": {
@@ -19342,23 +15230,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4": {
@@ -19378,23 +15254,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-mini": {
@@ -19414,22 +15278,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-nano": {
@@ -19449,22 +15302,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-pro": {
@@ -19484,20 +15326,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.5": {
@@ -19517,23 +15350,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.5-pro": {
@@ -19553,21 +15374,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6": {
@@ -19587,24 +15398,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-luna": {
@@ -19624,24 +15422,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-sol": {
@@ -19661,24 +15446,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-terra": {
@@ -19698,24 +15470,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-image-1": {
@@ -19733,13 +15492,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "gpt-image-1-mini": {
@@ -19757,14 +15511,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gpt-image-1.5": {
@@ -19782,14 +15530,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gpt-image-2": {
@@ -19807,13 +15549,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "gpt-realtime-2.1": {
@@ -19833,24 +15570,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio", "image"],
+            "output": ["text", "audio"]
           }
         },
         "o1": {
@@ -19869,21 +15593,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "o1-pro": {
@@ -19902,20 +15616,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "o3": {
@@ -19934,21 +15639,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "o3-mini": {
@@ -19967,19 +15662,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "o3-pro": {
@@ -19998,20 +15685,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "o4-mini": {
@@ -20030,20 +15708,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "text-embedding-3-large": {
@@ -20061,12 +15730,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "text-embedding-3-small": {
@@ -20084,12 +15749,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "text-embedding-ada-002": {
@@ -20107,12 +15768,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -20135,12 +15792,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "claude-3-5-haiku": {
@@ -20158,14 +15811,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-fable-5": {
@@ -20183,23 +15830,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-haiku-4-5": {
@@ -20217,14 +15852,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-1": {
@@ -20242,14 +15871,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-5": {
@@ -20267,21 +15890,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-6": {
@@ -20299,22 +15912,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-7": {
@@ -20332,23 +15934,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-8": {
@@ -20366,23 +15956,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-5": {
@@ -20400,23 +15978,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4": {
@@ -20434,14 +16000,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-5": {
@@ -20459,14 +16019,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-6": {
@@ -20484,22 +16038,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-5": {
@@ -20517,23 +16060,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash": {
@@ -20552,20 +16083,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-free": {
@@ -20585,19 +16108,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -20616,19 +16131,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gemini-3-flash": {
@@ -20647,23 +16155,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3-pro": {
@@ -20682,21 +16178,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.1-pro": {
@@ -20715,22 +16201,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash": {
@@ -20749,23 +16224,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash-lite": {
@@ -20784,23 +16247,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.6-flash": {
@@ -20819,23 +16270,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.7-flash": {
@@ -20854,22 +16293,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "glm-4.6": {
@@ -20890,12 +16318,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.7": {
@@ -20916,12 +16340,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.7-free": {
@@ -20943,12 +16363,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -20969,12 +16385,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5-free": {
@@ -20996,12 +16408,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -21022,12 +16430,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -21045,18 +16449,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gpt-5": {
@@ -21076,21 +16473,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-codex": {
@@ -21110,20 +16497,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-nano": {
@@ -21143,21 +16521,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1": {
@@ -21177,21 +16545,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1-codex": {
@@ -21211,20 +16569,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1-codex-max": {
@@ -21244,21 +16593,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1-codex-mini": {
@@ -21278,20 +16617,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2": {
@@ -21311,22 +16641,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2-codex": {
@@ -21346,22 +16665,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex": {
@@ -21381,23 +16689,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex-spark": {
@@ -21417,20 +16713,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gpt-5.4": {
@@ -21450,23 +16737,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-mini": {
@@ -21486,23 +16761,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-nano": {
@@ -21522,23 +16785,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-pro": {
@@ -21558,21 +16809,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.5": {
@@ -21592,23 +16833,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.5-pro": {
@@ -21628,21 +16857,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-luna": {
@@ -21662,24 +16881,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-sol": {
@@ -21699,24 +16905,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-terra": {
@@ -21736,24 +16929,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.5": {
@@ -21771,20 +16951,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "grok-4.6": {
@@ -21803,21 +16974,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "grok-build-0.1": {
@@ -21835,14 +16996,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-code": {
@@ -21860,12 +17015,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy3-free": {
@@ -21884,20 +17035,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy3-preview-free": {
@@ -21916,12 +17059,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2": {
@@ -21939,12 +17078,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2-thinking": {
@@ -21962,12 +17097,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -21988,13 +17119,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5-free": {
@@ -22016,13 +17142,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -22043,13 +17164,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -22068,13 +17184,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -22092,18 +17203,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max"
-            ]
+            "efforts": ["max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "laguna-s-2.1-free": {
@@ -22122,19 +17226,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ling-2.6-flash-free": {
@@ -22153,12 +17249,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ling-3.0-flash-fin-free": {
@@ -22180,12 +17272,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ling-3.0-flash-free": {
@@ -22204,19 +17292,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ling-3.0-tiny-free": {
@@ -22235,12 +17315,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "longcat-2.0-free": {
@@ -22261,12 +17337,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-flash-free": {
@@ -22285,12 +17357,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-omni-free": {
@@ -22309,15 +17377,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "mimo-v2-pro-free": {
@@ -22336,12 +17397,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-free": {
@@ -22360,14 +17417,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "minimax-m2.1": {
@@ -22385,12 +17436,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.1-free": {
@@ -22409,12 +17456,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5": {
@@ -22432,12 +17475,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5-free": {
@@ -22456,12 +17495,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.7": {
@@ -22479,12 +17514,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m3": {
@@ -22501,13 +17532,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "minimax-m3-free": {
@@ -22529,13 +17555,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "muse-spark-1.2": {
@@ -22553,24 +17574,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "muse-spark-1.2-contributor-free": {
@@ -22589,24 +17597,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "nemotron-3-super-free": {
@@ -22625,12 +17620,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nemotron-3-ultra-free": {
@@ -22649,12 +17640,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nemotron-3.5-lightning-free": {
@@ -22673,12 +17660,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "north-mini-code-free": {
@@ -22698,18 +17681,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder": {
@@ -22727,12 +17703,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -22753,13 +17725,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -22780,13 +17747,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus-free": {
@@ -22808,13 +17770,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "ring-2.6-1t-free": {
@@ -22833,12 +17790,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "trinity-large-preview-free": {
@@ -22857,12 +17810,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "x-preview-f-free": {
@@ -22881,20 +17830,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -22915,19 +17855,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-vision-exp": {
@@ -22945,21 +17877,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -22978,18 +17901,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -23007,12 +17923,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -23030,12 +17942,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -23053,18 +17961,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3": {
@@ -23082,19 +17983,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3-flash": {
@@ -23112,21 +18005,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-luna": {
@@ -23146,24 +18029,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.5": {
@@ -23181,20 +18051,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "grok-4.6": {
@@ -23213,21 +18074,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "hy3": {
@@ -23244,19 +18095,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy4-preview": {
@@ -23273,18 +18116,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -23302,13 +18138,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -23326,13 +18157,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -23351,13 +18177,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -23375,18 +18196,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max"
-            ]
+            "efforts": ["max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "longcat-2.0": {
@@ -23406,12 +18220,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-omni": {
@@ -23429,15 +18239,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "mimo-v2-pro": {
@@ -23455,12 +18258,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5": {
@@ -23478,14 +18277,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -23503,12 +18296,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5": {
@@ -23526,12 +18315,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.7": {
@@ -23549,12 +18334,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m3": {
@@ -23575,13 +18356,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "muse-spark-1.2-contributor": {
@@ -23599,24 +18375,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "ox-alpha-free": {
@@ -23635,20 +18398,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -23669,13 +18423,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -23696,13 +18445,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -23722,12 +18466,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -23747,13 +18487,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -23771,21 +18506,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -23803,21 +18529,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -23837,23 +18554,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~anthropic/claude-haiku-latest": {
@@ -23874,14 +18579,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~anthropic/claude-opus-latest": {
@@ -23899,24 +18598,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~anthropic/claude-sonnet-latest": {
@@ -23935,24 +18622,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~deepseek/deepseek-v4-flash-latest": {
@@ -23970,20 +18645,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "~google/gemini-flash-latest": {
@@ -24002,22 +18669,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "~google/gemini-pro-latest": {
@@ -24036,22 +18692,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "audio",
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio", "pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "~moonshotai/kimi-latest": {
@@ -24069,21 +18714,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "~openai/gpt-latest": {
@@ -24102,24 +18738,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "~openai/gpt-mini-latest": {
@@ -24138,23 +18761,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "~x-ai/grok-latest": {
@@ -24172,22 +18783,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~z-ai/glm-latest": {
@@ -24205,19 +18805,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "aion-labs/aion-2.0": {
@@ -24235,12 +18827,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "aion-labs/aion-3.0": {
@@ -24258,12 +18846,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "aion-labs/aion-3.0-mini": {
@@ -24281,12 +18865,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "aion-labs/aion-rp-llama-3.1-8b": {
@@ -24305,12 +18885,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "amazon/nova-2-lite-v1": {
@@ -24331,14 +18907,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "amazon/nova-lite-v1": {
@@ -24357,13 +18927,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "amazon/nova-micro-v1": {
@@ -24382,12 +18947,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "amazon/nova-premier-v1": {
@@ -24405,13 +18966,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "amazon/nova-pro-v1": {
@@ -24430,13 +18986,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthracite-org/magnum-v4-72b": {
@@ -24455,12 +19006,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-3-haiku": {
@@ -24479,13 +19026,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-fable-5": {
@@ -24504,23 +19046,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -24542,14 +19072,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4": {
@@ -24571,14 +19095,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.1": {
@@ -24600,14 +19118,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -24629,14 +19141,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -24655,23 +19161,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -24690,24 +19185,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.7-fast": {
@@ -24726,24 +19209,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -24762,24 +19233,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.8-fast": {
@@ -24798,24 +19257,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-5": {
@@ -24834,24 +19281,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-5-fast": {
@@ -24870,24 +19305,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -24909,14 +19332,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -24938,14 +19355,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -24964,23 +19375,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -24999,24 +19399,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "arcee-ai/trinity-large-thinking": {
@@ -25034,12 +19422,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "baidu/ernie-4.5-vl-424b-a47b": {
@@ -25061,13 +19445,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-1.6": {
@@ -25088,13 +19467,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-1.6-flash": {
@@ -25115,13 +19489,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-2-1-turbo": {
@@ -25142,13 +19511,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-2.0-code": {
@@ -25166,21 +19530,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-2.0-lite": {
@@ -25198,22 +19553,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-2.0-mini": {
@@ -25231,22 +19576,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "bytedance/ui-tars-1.5-7b": {
@@ -25265,13 +19600,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
@@ -25290,12 +19620,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/command-a": {
@@ -25314,12 +19640,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/command-r-08-2024": {
@@ -25338,12 +19660,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/command-r-plus-08-2024": {
@@ -25362,12 +19680,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/command-r7b-12-2024": {
@@ -25386,12 +19700,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/north-mini-code:free": {
@@ -25413,12 +19723,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-chat": {
@@ -25437,12 +19743,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-chat-v3-0324": {
@@ -25461,12 +19763,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-chat-v3.1": {
@@ -25488,12 +19786,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-r1": {
@@ -25512,12 +19806,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-r1-0528": {
@@ -25536,12 +19826,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-r1-distill-llama-70b": {
@@ -25563,12 +19849,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.1-terminus": {
@@ -25590,12 +19872,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -25617,12 +19895,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2-exp": {
@@ -25644,12 +19918,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -25668,19 +19938,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -25699,20 +19962,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash-vision-exp": {
@@ -25730,21 +19985,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -25763,19 +20009,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
@@ -25793,20 +20032,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "dots-studio/dots-3-note-preview:free": {
@@ -25828,13 +20059,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash": {
@@ -25856,15 +20082,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash-image": {
@@ -25883,14 +20102,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -25912,15 +20125,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro": {
@@ -25939,15 +20145,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro-preview": {
@@ -25966,15 +20165,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro-preview-05-06": {
@@ -25993,15 +20185,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-flash-preview": {
@@ -26020,24 +20205,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-pro-image": {
@@ -26056,14 +20229,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3-pro-image-preview": {
@@ -26082,14 +20249,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-image": {
@@ -26108,21 +20269,12 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ],
+            "efforts": ["minimal", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["image", "text"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-image-preview": {
@@ -26141,21 +20293,12 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ],
+            "efforts": ["minimal", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["image", "text"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -26174,24 +20317,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-flash-lite-image": {
@@ -26210,21 +20341,12 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ],
+            "efforts": ["minimal", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-lite-preview": {
@@ -26243,24 +20365,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -26279,22 +20389,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-pro-preview-customtools": {
@@ -26313,22 +20412,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash": {
@@ -26347,23 +20435,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash-lite": {
@@ -26382,23 +20458,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.6-flash": {
@@ -26417,23 +20481,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.7-flash": {
@@ -26452,22 +20504,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemma-2-27b-it": {
@@ -26486,12 +20527,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-12b-it": {
@@ -26510,13 +20547,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-27b-it": {
@@ -26535,13 +20567,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-4b-it": {
@@ -26560,13 +20587,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26b-a4b-it": {
@@ -26587,13 +20609,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26b-a4b-it:free": {
@@ -26615,13 +20632,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31b-it": {
@@ -26642,13 +20654,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31b-it:free": {
@@ -26670,13 +20677,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "google/lyria-3-clip-preview": {
@@ -26695,14 +20697,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "audio"]
           }
         },
         "google/lyria-3-pro-preview": {
@@ -26721,14 +20717,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "audio"]
           }
         },
         "gryphe/mythomax-l2-13b": {
@@ -26747,12 +20737,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ibm-granite/granite-4.0-h-micro": {
@@ -26770,12 +20756,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ibm-granite/granite-4.1-8b": {
@@ -26793,12 +20775,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ibm-granite/granite-4.2-8b": {
@@ -26816,19 +20794,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inception/mercury-2": {
@@ -26846,20 +20816,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash": {
@@ -26880,12 +20841,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-fin:free": {
@@ -26907,12 +20864,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v2": {
@@ -26930,12 +20883,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v2.5": {
@@ -26953,12 +20902,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "liquid/lfm-2.5-2.6b:free": {
@@ -26977,12 +20922,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mancer/weaver": {
@@ -27001,12 +20942,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meituan/longcat-2.0": {
@@ -27027,12 +20964,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.1-70b-instruct": {
@@ -27051,12 +20984,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.1-8b-instruct": {
@@ -27075,12 +21004,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.2-1b-instruct": {
@@ -27099,12 +21024,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.2-3b-instruct": {
@@ -27123,12 +21044,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.3-70b-instruct": {
@@ -27147,12 +21064,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-4-maverick": {
@@ -27171,13 +21084,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-4-scout": {
@@ -27196,13 +21104,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-guard-4-12b": {
@@ -27221,13 +21124,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -27246,21 +21144,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.1": {
@@ -27278,24 +21166,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.2": {
@@ -27313,24 +21188,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.2-contributor": {
@@ -27348,24 +21210,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "microsoft/phi-4": {
@@ -27384,12 +21233,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "microsoft/wizardlm-2-8x22b": {
@@ -27408,12 +21253,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-01": {
@@ -27432,13 +21273,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m1": {
@@ -27460,12 +21296,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2": {
@@ -27483,12 +21315,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2-her": {
@@ -27506,12 +21334,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.1": {
@@ -27529,12 +21353,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5": {
@@ -27552,12 +21372,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7": {
@@ -27575,12 +21391,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7:free": {
@@ -27599,12 +21411,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m3": {
@@ -27625,13 +21433,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m3:free": {
@@ -27653,13 +21456,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/codestral-2508": {
@@ -27678,13 +21476,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/devstral-2512": {
@@ -27703,13 +21496,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/ministral-14b-2512": {
@@ -27727,13 +21515,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/ministral-3b-2512": {
@@ -27751,13 +21534,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/ministral-8b-2512": {
@@ -27775,13 +21553,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-large": {
@@ -27800,13 +21573,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-large-2407": {
@@ -27825,13 +21593,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-large-2512": {
@@ -27850,14 +21613,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3": {
@@ -27876,14 +21633,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3-5": {
@@ -27901,20 +21652,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3.1": {
@@ -27933,14 +21675,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-nemo": {
@@ -27959,12 +21695,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-saba": {
@@ -27983,13 +21715,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-24b-instruct-2501": {
@@ -28008,12 +21735,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-2603": {
@@ -28032,19 +21755,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-3.1-24b-instruct": {
@@ -28063,13 +21778,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-3.2-24b-instruct": {
@@ -28088,13 +21798,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "mistralai/mixtral-8x22b-instruct": {
@@ -28113,13 +21818,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/voxtral-small-24b-2507": {
@@ -28137,14 +21837,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2": {
@@ -28163,12 +21857,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-0905": {
@@ -28187,12 +21877,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -28211,12 +21897,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -28238,13 +21920,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -28266,13 +21943,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -28291,13 +21963,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3": {
@@ -28315,21 +21982,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "morph/morph-v3-fast": {
@@ -28347,12 +22005,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "morph/morph-v3-large": {
@@ -28370,12 +22024,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nex-agi/nex-n2-mini": {
@@ -28396,13 +22046,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nex-agi/nex-n2-pro": {
@@ -28423,13 +22068,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nousresearch/hermes-3-llama-3.1-405b": {
@@ -28448,12 +22088,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nousresearch/hermes-3-llama-3.1-70b": {
@@ -28472,12 +22108,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nousresearch/hermes-4-405b": {
@@ -28499,12 +22131,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nousresearch/hermes-4-70b": {
@@ -28526,12 +22154,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -28552,12 +22176,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
@@ -28579,14 +22199,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -28604,19 +22218,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium"
-            ],
+            "efforts": ["low", "medium"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b:free": {
@@ -28635,19 +22242,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium"
-            ],
+            "efforts": ["low", "medium"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -28665,19 +22265,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high"
-            ],
+            "efforts": ["medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b:free": {
@@ -28696,19 +22289,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high"
-            ],
+            "efforts": ["medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-content-safety:free": {
@@ -28730,13 +22316,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-lightning": {
@@ -28757,12 +22338,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-lightning:free": {
@@ -28784,12 +22361,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo": {
@@ -28808,12 +22381,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo-0613": {
@@ -28832,12 +22401,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo-16k": {
@@ -28856,12 +22421,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo-instruct": {
@@ -28880,12 +22441,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4": {
@@ -28904,12 +22461,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4-turbo": {
@@ -28928,13 +22481,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4-turbo-preview": {
@@ -28953,12 +22501,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1": {
@@ -28977,14 +22521,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-mini": {
@@ -29003,14 +22541,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-nano": {
@@ -29029,14 +22561,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o": {
@@ -29055,14 +22581,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-2024-05-13": {
@@ -29081,14 +22601,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-2024-08-06": {
@@ -29107,14 +22621,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-2024-11-20": {
@@ -29133,14 +22641,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini": {
@@ -29159,14 +22661,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini-2024-07-18": {
@@ -29185,14 +22681,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5": {
@@ -29212,22 +22702,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-image": {
@@ -29246,15 +22725,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "image",
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["image", "text"]
           }
         },
         "openai/gpt-5-image-mini": {
@@ -29272,15 +22744,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "image",
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["image", "text"]
           }
         },
         "openai/gpt-5-mini": {
@@ -29300,22 +22765,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-nano": {
@@ -29335,22 +22789,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-pro": {
@@ -29370,19 +22813,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1": {
@@ -29402,22 +22837,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -29437,20 +22861,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-max": {
@@ -29470,21 +22885,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -29504,21 +22909,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2": {
@@ -29538,23 +22934,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-chat": {
@@ -29573,14 +22957,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -29600,21 +22978,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -29634,21 +23002,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -29668,23 +23026,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4": {
@@ -29704,23 +23050,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-image-2": {
@@ -29738,24 +23072,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "image",
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["image", "text"]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -29775,23 +23096,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -29811,23 +23120,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -29847,21 +23144,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5": {
@@ -29881,23 +23168,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -29917,21 +23192,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -29951,24 +23216,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna-pro": {
@@ -29988,24 +23240,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -30025,24 +23264,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol-pro": {
@@ -30062,24 +23288,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -30099,24 +23312,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra-pro": {
@@ -30136,24 +23336,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-audio": {
@@ -30171,14 +23358,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-audio-mini": {
@@ -30196,14 +23377,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-chat-latest": {
@@ -30221,14 +23396,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -30246,19 +23415,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -30276,19 +23437,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -30306,19 +23459,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/o1": {
@@ -30340,14 +23485,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o1-pro": {
@@ -30369,14 +23508,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3": {
@@ -30398,14 +23531,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-mini": {
@@ -30427,13 +23554,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-mini-high": {
@@ -30452,18 +23574,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-pro": {
@@ -30485,14 +23600,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf", "image"],
+            "output": ["text"]
           }
         },
         "openai/o4-mini": {
@@ -30514,14 +23623,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o4-mini-high": {
@@ -30540,19 +23643,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openrouter/auto": {
@@ -30570,16 +23665,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "openrouter/bodybuilder": {
@@ -30597,12 +23684,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openrouter/free": {
@@ -30622,13 +23705,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openrouter/fusion": {
@@ -30646,12 +23724,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openrouter/pareto-code": {
@@ -30669,12 +23743,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "perceptron/perceptron-mk1": {
@@ -30695,13 +23765,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar": {
@@ -30719,13 +23784,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-deep-research": {
@@ -30746,12 +23806,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-pro": {
@@ -30769,13 +23825,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-pro-search": {
@@ -30793,13 +23844,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-reasoning-pro": {
@@ -30820,13 +23866,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-s-2.1": {
@@ -30847,12 +23888,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-s-2.1:free": {
@@ -30874,12 +23911,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-xs-2.1": {
@@ -30900,12 +23933,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-xs-2.1:free": {
@@ -30927,12 +23956,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-2.5-72b-instruct": {
@@ -30951,12 +23976,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-2.5-7b-instruct": {
@@ -30975,12 +23996,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-2.5-coder-32b-instruct": {
@@ -30999,12 +24016,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-plus": {
@@ -31023,12 +24036,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-plus-2025-07-28": {
@@ -31047,12 +24056,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen2.5-vl-72b-instruct": {
@@ -31071,13 +24076,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-14b": {
@@ -31099,12 +24099,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-235b-a22b": {
@@ -31126,12 +24122,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-235b-a22b-2507": {
@@ -31150,12 +24142,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-235b-a22b-thinking-2507": {
@@ -31174,12 +24162,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-30b-a3b": {
@@ -31200,12 +24184,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-30b-a3b-instruct-2507": {
@@ -31224,12 +24204,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-30b-a3b-thinking-2507": {
@@ -31248,12 +24224,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-32b": {
@@ -31275,12 +24247,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-8b": {
@@ -31302,12 +24270,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder": {
@@ -31326,12 +24290,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-30b-a3b-instruct": {
@@ -31350,12 +24310,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-flash": {
@@ -31374,12 +24330,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-next": {
@@ -31398,12 +24350,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-plus": {
@@ -31422,12 +24370,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-max": {
@@ -31446,12 +24390,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-max-thinking": {
@@ -31472,12 +24412,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-next-80b-a3b-instruct": {
@@ -31496,12 +24432,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-next-80b-a3b-thinking": {
@@ -31520,12 +24452,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-235b-a22b-instruct": {
@@ -31544,13 +24472,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-235b-a22b-thinking": {
@@ -31569,13 +24492,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-30b-a3b-instruct": {
@@ -31594,13 +24512,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-30b-a3b-thinking": {
@@ -31619,13 +24532,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-32b-instruct": {
@@ -31643,13 +24551,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-8b-instruct": {
@@ -31667,13 +24570,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-8b-thinking": {
@@ -31691,13 +24589,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-122b-a10b": {
@@ -31718,13 +24611,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-27b": {
@@ -31745,13 +24633,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-35b-a3b": {
@@ -31772,13 +24655,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-397b-a17b": {
@@ -31799,13 +24677,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-9b": {
@@ -31826,13 +24699,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-flash-02-23": {
@@ -31853,13 +24721,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-plus-02-15": {
@@ -31881,13 +24744,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-plus-20260420": {
@@ -31908,13 +24766,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-27b": {
@@ -31935,13 +24788,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-35b-a3b": {
@@ -31962,13 +24810,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-flash": {
@@ -31989,13 +24832,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-max-preview": {
@@ -32017,12 +24855,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-plus": {
@@ -32044,13 +24878,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-flash": {
@@ -32072,13 +24901,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-max": {
@@ -32099,12 +24923,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-plus": {
@@ -32126,13 +24946,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-2.4t-a95b": {
@@ -32150,19 +24965,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-27b": {
@@ -32180,21 +24987,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-flash": {
@@ -32215,13 +25013,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-max": {
@@ -32239,22 +25032,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "rekaai/reka-edge": {
@@ -32272,13 +25054,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "rekaai/reka-flash-3": {
@@ -32297,12 +25074,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "relace/relace-apply-3": {
@@ -32320,12 +25093,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "relace/relace-search": {
@@ -32343,12 +25112,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "sakana/fugu-ultra": {
@@ -32366,20 +25131,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "sakana/sakana-namazu": {
@@ -32397,20 +25153,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "sao10k/l3-lunaris-8b": {
@@ -32429,12 +25176,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "sao10k/l3.1-euryale-70b": {
@@ -32453,12 +25196,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "sao10k/l3.3-euryale-70b": {
@@ -32477,12 +25216,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -32501,12 +25236,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -32526,20 +25257,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "tencent/hunyuan-a13b-instruct": {
@@ -32561,12 +25283,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-1.8b": {
@@ -32584,12 +25302,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-30b-a3b": {
@@ -32607,12 +25321,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-7b": {
@@ -32630,12 +25340,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy3": {
@@ -32653,19 +25359,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy3-preview": {
@@ -32683,19 +25381,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy4-preview": {
@@ -32713,19 +25403,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thedrummer/cydonia-24b-v4.1": {
@@ -32744,12 +25426,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thedrummer/skyfall-36b-v2": {
@@ -32768,12 +25446,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thedrummer/unslopnemo-12b": {
@@ -32792,12 +25466,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling": {
@@ -32815,24 +25485,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling-small": {
@@ -32850,24 +25507,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling-small:free": {
@@ -32886,24 +25530,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling:free": {
@@ -32922,24 +25553,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "undi95/remm-slerp-l2-13b": {
@@ -32958,12 +25576,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "upstage/solar-pro-3": {
@@ -32984,12 +25598,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "upstage/solar-pro4": {
@@ -33010,12 +25620,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "writer/palmyra-x5": {
@@ -33033,12 +25639,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.20": {
@@ -33060,14 +25662,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.20-multi-agent": {
@@ -33086,22 +25682,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.3": {
@@ -33119,22 +25704,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.5": {
@@ -33152,21 +25726,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.6": {
@@ -33185,22 +25749,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-build-0.1": {
@@ -33218,14 +25771,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -33247,14 +25794,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -33276,12 +25817,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5": {
@@ -33303,12 +25840,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5-air": {
@@ -33330,12 +25863,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5v": {
@@ -33357,13 +25886,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6": {
@@ -33385,12 +25909,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6v": {
@@ -33412,13 +25932,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7": {
@@ -33440,12 +25955,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7-flash": {
@@ -33467,12 +25978,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5": {
@@ -33493,12 +26000,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5-turbo": {
@@ -33519,12 +26022,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.1": {
@@ -33545,12 +26044,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.2": {
@@ -33568,19 +26063,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.2:free": {
@@ -33599,19 +26087,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.3": {
@@ -33629,19 +26110,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.3-flash": {
@@ -33659,20 +26132,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5v-turbo": {
@@ -33693,13 +26157,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         }
       },
@@ -33719,12 +26178,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ByteDance-Seed/Seed-OSS-36B-Instruct": {
@@ -33742,12 +26197,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-R1": {
@@ -33765,12 +26216,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -33788,12 +26235,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -33814,12 +26257,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.1-Terminus": {
@@ -33840,12 +26279,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -33866,12 +26301,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.2-Exp": {
@@ -33892,12 +26323,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -33916,12 +26343,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -33940,12 +26363,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -33963,12 +26382,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31B-it": {
@@ -33986,12 +26401,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionAI/Ling-flash-2.0": {
@@ -34009,12 +26420,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -34032,12 +26439,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -34055,13 +26458,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -34079,13 +26477,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -34103,12 +26496,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -34126,12 +26515,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen2.5-72B-Instruct": {
@@ -34149,12 +26534,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen2.5-7B-Instruct": {
@@ -34172,12 +26553,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-14B": {
@@ -34198,12 +26575,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -34221,12 +26594,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-30B-A3B-Instruct-2507": {
@@ -34244,12 +26613,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -34270,12 +26635,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-8B": {
@@ -34296,12 +26657,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
@@ -34319,12 +26676,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
@@ -34342,12 +26695,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -34365,13 +26714,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Thinking": {
@@ -34389,13 +26733,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-30B-A3B-Instruct": {
@@ -34413,13 +26752,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-30B-A3B-Thinking": {
@@ -34437,13 +26771,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-32B-Instruct": {
@@ -34461,13 +26790,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-32B-Thinking": {
@@ -34485,13 +26809,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-8B-Instruct": {
@@ -34509,13 +26828,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -34533,12 +26847,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -34556,12 +26866,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -34579,12 +26885,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -34602,12 +26904,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -34625,12 +26923,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -34648,12 +26942,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -34671,12 +26961,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/Step-3.5-Flash": {
@@ -34694,12 +26980,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/Hunyuan-A13B-Instruct": {
@@ -34720,12 +27002,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/Hy3-preview": {
@@ -34742,12 +27020,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.5-Air": {
@@ -34765,12 +27039,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5": {
@@ -34788,12 +27058,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.1": {
@@ -34811,12 +27077,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.2": {
@@ -34834,18 +27096,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5V-Turbo": {
@@ -34865,13 +27120,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -34892,12 +27142,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-2-16k": {
@@ -34916,12 +27162,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash": {
@@ -34940,18 +27182,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash-2603": {
@@ -34970,18 +27205,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.7-flash": {
@@ -35000,20 +27228,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "step-tts-2": {
@@ -35030,12 +27249,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "stepaudio-2.5-asr": {
@@ -35052,12 +27267,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "stepaudio-2.5-tts": {
@@ -35074,12 +27285,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -35100,12 +27307,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-2-16k": {
@@ -35124,12 +27327,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash": {
@@ -35148,18 +27347,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash-2603": {
@@ -35178,18 +27370,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.7-flash": {
@@ -35208,20 +27393,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "step-tts-2": {
@@ -35238,12 +27414,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "stepaudio-2.5-asr": {
@@ -35260,12 +27432,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "stepaudio-2.5-tts": {
@@ -35282,12 +27450,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -35308,18 +27472,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash-2603": {
@@ -35338,18 +27495,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.7-flash": {
@@ -35368,20 +27518,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -35402,18 +27543,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash-2603": {
@@ -35432,18 +27566,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.7-flash": {
@@ -35462,20 +27589,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "step-router-v1": {
@@ -35494,12 +27612,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -35521,12 +27635,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-R1": {
@@ -35544,12 +27654,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -35567,12 +27673,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3-1": {
@@ -35593,12 +27695,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -35617,19 +27715,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -35647,19 +27738,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -35677,20 +27761,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "essentialai/Rnj-1-Instruct": {
@@ -35708,12 +27784,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-3n-E4B-it": {
@@ -35731,12 +27803,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31B-it": {
@@ -35755,13 +27823,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "LiquidAI/LFM2-24B-A2B": {
@@ -35778,12 +27841,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -35801,12 +27860,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/Meta-Llama-3-8B-Instruct-Lite": {
@@ -35823,12 +27878,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -35845,12 +27896,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -35868,12 +27915,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -35891,13 +27934,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -35918,13 +27956,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -35946,13 +27979,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -35970,12 +27998,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -35993,20 +28017,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -36027,12 +28042,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -36050,19 +28061,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -36080,19 +28083,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "pearl-ai/gemma-4-31b-it": {
@@ -36109,12 +28104,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen2.5-7B-Instruct-Turbo": {
@@ -36132,12 +28123,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
@@ -36155,12 +28142,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
@@ -36178,12 +28161,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-Next-FP8": {
@@ -36201,12 +28180,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -36226,13 +28201,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -36253,13 +28223,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-Plus": {
@@ -36279,12 +28244,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.7-Max": {
@@ -36301,12 +28262,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling": {
@@ -36324,24 +28281,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max",
-              "xhigh",
-              "high",
-              "medium",
-              "low",
-              "none"
-            ]
+            "efforts": ["max", "xhigh", "high", "medium", "low", "none"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5": {
@@ -36362,12 +28306,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.1": {
@@ -36389,12 +28329,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.2": {
@@ -36412,19 +28348,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3": {
@@ -36442,19 +28371,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3-Flash": {
@@ -36472,20 +28393,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -36508,12 +28420,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hunyuan-2.0-instruct": {
@@ -36531,12 +28439,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hunyuan-2.0-thinking": {
@@ -36554,12 +28458,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hunyuan-t1": {
@@ -36577,12 +28477,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hunyuan-turbos": {
@@ -36600,12 +28496,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -36627,13 +28519,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5": {
@@ -36651,12 +28538,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tc-code-latest": {
@@ -36674,12 +28557,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -36699,19 +28578,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ],
+            "efforts": ["none", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy4-preview": {
@@ -36728,19 +28600,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ],
+            "efforts": ["none", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -36760,19 +28625,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ],
+            "efforts": ["none", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy3-preview": {
@@ -36790,20 +28648,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy4-preview": {
@@ -36820,19 +28670,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ],
+            "efforts": ["none", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -36855,12 +28698,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen-3-235b": {
@@ -36878,12 +28717,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen-3-30b": {
@@ -36904,12 +28739,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen-3-32b": {
@@ -36930,12 +28761,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen-3.6-max-preview": {
@@ -36955,12 +28782,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-235b-a22b-thinking": {
@@ -36978,14 +28801,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-coder": {
@@ -37003,12 +28820,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-coder-30b-a3b": {
@@ -37026,12 +28839,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-coder-next": {
@@ -37050,12 +28859,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-coder-plus": {
@@ -37073,12 +28878,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-embedding-0.6b": {
@@ -37095,12 +28896,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-embedding-4b": {
@@ -37117,12 +28914,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-embedding-8b": {
@@ -37139,12 +28932,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-max": {
@@ -37162,12 +28951,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-max-preview": {
@@ -37185,12 +28970,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-max-thinking": {
@@ -37208,12 +28989,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-next-80b-a3b-instruct": {
@@ -37231,12 +29008,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-next-80b-a3b-thinking": {
@@ -37254,12 +29027,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-vl-235b-a22b-instruct": {
@@ -37278,13 +29047,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-vl-instruct": {
@@ -37302,13 +29066,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-vl-thinking": {
@@ -37326,14 +29085,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.5-flash": {
@@ -37354,14 +29107,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.5-plus": {
@@ -37382,14 +29129,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.6-27b": {
@@ -37410,14 +29151,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.6-plus": {
@@ -37438,14 +29173,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.7-flash": {
@@ -37463,14 +29192,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.7-max": {
@@ -37490,12 +29213,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.7-plus": {
@@ -37516,14 +29235,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-2.4t-a95b": {
@@ -37541,20 +29254,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-27b": {
@@ -37572,22 +29276,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-flash": {
@@ -37608,14 +29301,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-flash-next": {
@@ -37633,20 +29320,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-max": {
@@ -37663,20 +29341,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/wan-v2.5-t2v-preview": {
@@ -37693,9 +29362,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -37713,9 +29380,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -37733,9 +29398,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -37753,9 +29416,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -37773,9 +29434,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -37793,9 +29452,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -37813,9 +29470,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -37833,9 +29488,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -37853,10 +29506,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -37874,10 +29524,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -37896,22 +29543,12 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "amazon/nova-lite": {
@@ -37929,13 +29566,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "amazon/nova-micro": {
@@ -37953,12 +29585,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "amazon/nova-pro": {
@@ -37976,13 +29604,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "amazon/titan-embed-text-v2": {
@@ -37999,12 +29622,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-3-haiku": {
@@ -38022,13 +29641,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-fable-5": {
@@ -38046,23 +29660,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -38083,14 +29686,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4": {
@@ -38108,14 +29705,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -38136,14 +29727,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -38161,22 +29746,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -38194,23 +29769,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -38228,23 +29792,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.8-fast": {
@@ -38262,23 +29815,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-5": {
@@ -38296,23 +29838,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-5-fast": {
@@ -38330,23 +29860,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -38364,14 +29882,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -38390,14 +29902,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -38415,22 +29921,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -38448,23 +29944,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "arcee-ai/trinity-large-thinking": {
@@ -38481,12 +29966,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "bfl/flux-2-flex": {
@@ -38503,12 +29984,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-2-klein-4b": {
@@ -38525,12 +30002,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-2-klein-9b": {
@@ -38547,12 +30020,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-2-max": {
@@ -38569,12 +30038,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-2-pro": {
@@ -38591,12 +30056,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-3-video": {
@@ -38613,9 +30074,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -38633,12 +30092,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-kontext-pro": {
@@ -38655,12 +30110,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-pro-1.0-fill": {
@@ -38677,12 +30128,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-pro-1.1": {
@@ -38699,12 +30146,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-pro-1.1-ultra": {
@@ -38721,12 +30164,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seed-1.6": {
@@ -38747,13 +30186,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "bytedance/seed-1.8": {
@@ -38771,22 +30205,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "bytedance/seedance-2.0": {
@@ -38803,10 +30227,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -38824,10 +30245,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -38845,10 +30263,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -38866,9 +30281,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -38886,9 +30299,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -38906,9 +30317,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -38926,9 +30335,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -38946,12 +30353,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seedream-4.5": {
@@ -38968,12 +30371,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seedream-5.0-lite": {
@@ -38990,12 +30389,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seedream-5.0-pro": {
@@ -39012,12 +30407,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "cohere/command-a": {
@@ -39035,12 +30426,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/embed-v4.0": {
@@ -39057,12 +30444,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/rerank-v3.5": {
@@ -39079,12 +30462,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/rerank-v4-fast": {
@@ -39101,12 +30480,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/rerank-v4-pro": {
@@ -39123,12 +30498,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-r1": {
@@ -39146,12 +30517,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3": {
@@ -39168,12 +30535,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.1": {
@@ -39193,12 +30556,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.1-terminus": {
@@ -39219,12 +30578,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -39243,12 +30598,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2-thinking": {
@@ -39266,12 +30617,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -39290,19 +30637,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -39321,12 +30661,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash-vision-exp": {
@@ -39344,20 +30680,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -39376,19 +30704,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
@@ -39406,19 +30727,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "fish-audio/s1": {
@@ -39435,12 +30749,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s1-free": {
@@ -39457,12 +30767,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s2-pro": {
@@ -39479,12 +30785,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s2-pro-free": {
@@ -39501,12 +30803,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s2.1-pro": {
@@ -39523,12 +30821,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s2.1-pro-free": {
@@ -39545,12 +30839,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/transcribe-1": {
@@ -39567,12 +30857,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "fish-audio/transcribe-1-free": {
@@ -39589,12 +30875,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash": {
@@ -39616,15 +30898,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash-image": {
@@ -39642,14 +30917,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -39671,14 +30940,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro": {
@@ -39697,15 +30960,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-flash": {
@@ -39723,22 +30979,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-pro-image": {
@@ -39756,14 +31001,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-image": {
@@ -39781,20 +31020,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-image-preview": {
@@ -39812,20 +31042,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -39844,22 +31065,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-flash-lite-image": {
@@ -39878,14 +31088,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -39904,21 +31108,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash": {
@@ -39937,22 +31131,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash-lite": {
@@ -39971,22 +31154,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-transcribe": {
@@ -40003,12 +31175,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-transcribe-live": {
@@ -40025,12 +31193,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.6-flash": {
@@ -40049,22 +31213,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.7-flash": {
@@ -40083,21 +31236,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-embedding-001": {
@@ -40115,12 +31258,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemini-embedding-2": {
@@ -40138,12 +31277,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemini-omni-flash-preview": {
@@ -40160,14 +31295,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26b-a4b-it": {
@@ -40185,14 +31314,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31b-it": {
@@ -40210,14 +31333,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/text-embedding-005": {
@@ -40234,12 +31351,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/text-multilingual-embedding-002": {
@@ -40256,12 +31369,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/veo-3.0-fast-generate-001": {
@@ -40278,9 +31387,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40298,9 +31405,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40318,9 +31423,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40338,9 +31441,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40358,9 +31459,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40378,19 +31477,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inception/mercury-coder-small": {
@@ -40407,12 +31498,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash": {
@@ -40429,12 +31516,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-fin": {
@@ -40455,12 +31538,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-fin-free": {
@@ -40481,12 +31560,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "interfaze/interfaze-beta": {
@@ -40503,21 +31578,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "klingai/kling-v2.5-turbo-i2v": {
@@ -40534,9 +31599,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40554,9 +31617,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40574,9 +31635,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40594,9 +31653,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40614,9 +31671,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40634,9 +31689,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40654,9 +31707,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40674,9 +31725,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -40694,13 +31743,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v1": {
@@ -40718,12 +31762,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v2": {
@@ -40740,12 +31780,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v2.5": {
@@ -40762,13 +31798,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.1-70b": {
@@ -40786,12 +31817,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.1-8b": {
@@ -40809,12 +31836,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.3-70b": {
@@ -40833,12 +31856,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-4-maverick": {
@@ -40857,13 +31876,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-4-scout": {
@@ -40882,13 +31896,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -40907,21 +31916,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/muse-image-1.0": {
@@ -40938,13 +31937,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "meta/muse-spark-1.1": {
@@ -40962,23 +31956,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.2": {
@@ -40996,14 +31978,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.2-contributor": {
@@ -41020,14 +31996,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-h3": {
@@ -41044,10 +32014,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -41065,10 +32032,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "output": []
           }
         },
@@ -41087,12 +32051,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.1": {
@@ -41109,12 +32069,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.1-lightning": {
@@ -41132,12 +32088,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5": {
@@ -41154,12 +32106,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5-highspeed": {
@@ -41176,12 +32124,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7": {
@@ -41198,12 +32142,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7-free": {
@@ -41221,12 +32161,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7-highspeed": {
@@ -41243,12 +32179,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m3": {
@@ -41268,14 +32200,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m3-free": {
@@ -41296,13 +32222,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/codestral": {
@@ -41320,12 +32241,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/codestral-embed": {
@@ -41342,12 +32259,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/devstral-2": {
@@ -41365,12 +32278,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/devstral-small-2": {
@@ -41388,13 +32297,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/ministral-14b": {
@@ -41412,14 +32316,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistral/ministral-3b": {
@@ -41437,12 +32335,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/ministral-8b": {
@@ -41460,12 +32354,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-embed": {
@@ -41482,12 +32372,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-large-3": {
@@ -41505,13 +32391,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-medium": {
@@ -41529,13 +32410,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-medium-3.5": {
@@ -41552,19 +32428,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-nemo": {
@@ -41582,13 +32450,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-small": {
@@ -41606,13 +32469,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/pixtral-12b": {
@@ -41630,13 +32488,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2": {
@@ -41653,12 +32506,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -41676,12 +32525,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -41703,13 +32548,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -41731,13 +32571,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -41756,14 +32591,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code-highspeed": {
@@ -41782,14 +32611,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3": {
@@ -41807,14 +32630,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3-fast": {
@@ -41832,21 +32649,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "morph/morph-v3-fast": {
@@ -41863,12 +32670,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "morph/morph-v3-large": {
@@ -41885,12 +32688,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -41910,12 +32709,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -41935,12 +32730,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -41960,12 +32751,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-lightning": {
@@ -41986,12 +32773,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-nano-12b-v2-vl": {
@@ -42011,13 +32794,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-nano-9b-v2": {
@@ -42037,12 +32815,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo": {
@@ -42062,12 +32836,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4-turbo": {
@@ -42086,13 +32856,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1": {
@@ -42111,14 +32876,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-fast": {
@@ -42138,14 +32897,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-mini": {
@@ -42164,14 +32917,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-mini-fast": {
@@ -42191,14 +32938,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-nano": {
@@ -42217,13 +32958,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-nano-fast": {
@@ -42243,14 +32979,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o": {
@@ -42269,14 +32999,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-fast": {
@@ -42296,14 +33020,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini": {
@@ -42322,14 +33040,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini-fast": {
@@ -42349,14 +33061,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini-transcribe": {
@@ -42373,12 +33079,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-transcribe": {
@@ -42395,12 +33097,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5": {
@@ -42420,21 +33118,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-codex": {
@@ -42454,21 +33142,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-fast": {
@@ -42488,22 +33166,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-mini": {
@@ -42523,21 +33190,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-mini-fast": {
@@ -42557,22 +33214,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-nano": {
@@ -42592,21 +33238,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-pro": {
@@ -42626,19 +33262,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -42658,21 +33286,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-max": {
@@ -42692,22 +33310,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -42727,21 +33334,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-thinking": {
@@ -42760,23 +33357,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "openai/gpt-5.1-thinking-fast": {
@@ -42794,14 +33379,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2": {
@@ -42821,23 +33400,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -42857,22 +33424,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-fast": {
@@ -42892,23 +33448,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -42928,21 +33472,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -42962,22 +33496,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-codex-fast": {
@@ -42997,22 +33520,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4": {
@@ -43032,23 +33544,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-fast": {
@@ -43068,23 +33568,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -43104,23 +33592,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-mini-fast": {
@@ -43140,23 +33616,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -43176,23 +33640,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -43212,21 +33664,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5": {
@@ -43246,23 +33688,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-fast": {
@@ -43282,23 +33712,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -43318,21 +33736,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -43352,24 +33760,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna-fast": {
@@ -43389,24 +33784,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -43426,24 +33808,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol-fast": {
@@ -43463,24 +33832,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -43500,24 +33856,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra-fast": {
@@ -43537,24 +33880,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-image-1": {
@@ -43571,12 +33901,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-image-1-mini": {
@@ -43593,12 +33919,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-image-1.5": {
@@ -43615,12 +33937,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-image-2": {
@@ -43637,12 +33955,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -43661,19 +33975,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -43693,19 +33999,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-safeguard-120b": {
@@ -43724,19 +34022,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -43755,19 +34045,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-realtime-1.5": {
@@ -43784,14 +34066,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-realtime-2": {
@@ -43808,14 +34084,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-realtime-2.1": {
@@ -43835,23 +34105,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-realtime-mini": {
@@ -43868,14 +34126,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-realtime-whisper": {
@@ -43892,12 +34144,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "openai/o1": {
@@ -43916,21 +34164,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3": {
@@ -43949,21 +34187,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-fast": {
@@ -43983,21 +34211,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-mini": {
@@ -44016,19 +34234,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/o3-pro": {
@@ -44048,21 +34258,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o4-mini": {
@@ -44081,20 +34281,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/o4-mini-fast": {
@@ -44114,21 +34305,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/text-embedding-3-large": {
@@ -44146,12 +34327,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/text-embedding-3-small": {
@@ -44169,12 +34346,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/text-embedding-ada-002": {
@@ -44192,12 +34365,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/tts-1": {
@@ -44214,12 +34383,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "openai/tts-1-hd": {
@@ -44236,12 +34401,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "openai/whisper-1": {
@@ -44258,12 +34419,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "perplexity/pplx-embed-v1-0.6b": {
@@ -44280,12 +34437,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "perplexity/pplx-embed-v1-4b": {
@@ -44302,12 +34455,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar": {
@@ -44325,13 +34474,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-pro": {
@@ -44349,13 +34493,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-reasoning-pro": {
@@ -44373,21 +34512,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-s-2.1": {
@@ -44408,12 +34537,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-s-2.1-free": {
@@ -44435,12 +34560,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "prodia/flux-fast-schnell": {
@@ -44457,12 +34578,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "quiverai/arrow-1.1": {
@@ -44479,12 +34596,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v2": {
@@ -44501,12 +34614,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v3": {
@@ -44523,12 +34632,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4": {
@@ -44545,12 +34650,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4-pro": {
@@ -44567,12 +34668,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4.1": {
@@ -44589,12 +34686,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4.1-pro": {
@@ -44611,12 +34704,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4.1-utility": {
@@ -44633,12 +34722,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4.1-utility-pro": {
@@ -44655,12 +34740,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "sakana/fugu-ultra": {
@@ -44678,13 +34759,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "sakana/namazu": {
@@ -44701,14 +34777,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.1-fast-non-reasoning": {
@@ -44725,14 +34795,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.1-fast-reasoning": {
@@ -44749,14 +34813,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-multi-agent": {
@@ -44773,14 +34831,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-multi-agent-beta": {
@@ -44797,14 +34849,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-non-reasoning": {
@@ -44821,14 +34867,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-non-reasoning-beta": {
@@ -44845,14 +34885,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-reasoning": {
@@ -44869,14 +34903,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-reasoning-beta": {
@@ -44893,14 +34921,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.3": {
@@ -44918,21 +34940,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.5": {
@@ -44950,21 +34962,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.6": {
@@ -44983,20 +34985,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-build-0.1": {
@@ -45014,13 +35007,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-imagine-image": {
@@ -45037,12 +35025,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "spacexai/grok-imagine-image-2.0": {
@@ -45059,12 +35043,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "spacexai/grok-imagine-video": {
@@ -45081,9 +35061,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -45101,9 +35079,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -45121,9 +35097,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "output": []
           }
         },
@@ -45141,12 +35115,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-tts": {
@@ -45163,12 +35133,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "spacexai/grok-voice-think-fast-1.0": {
@@ -45185,14 +35151,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "spacexai/grok-voice-think-fast-2.0": {
@@ -45209,14 +35169,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -45234,20 +35188,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -45266,20 +35211,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-lite": {
@@ -45296,12 +35232,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-plus": {
@@ -45318,12 +35250,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-pro": {
@@ -45340,12 +35268,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy3": {
@@ -45362,19 +35286,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy4-preview": {
@@ -45391,18 +35307,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling": {
@@ -45419,25 +35328,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling-small": {
@@ -45454,25 +35349,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "voyage/rerank-2.5": {
@@ -45489,12 +35370,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/rerank-2.5-lite": {
@@ -45511,12 +35388,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-3-large": {
@@ -45533,12 +35406,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-3.5": {
@@ -45555,12 +35424,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-3.5-lite": {
@@ -45577,12 +35442,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-4": {
@@ -45599,12 +35460,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-4-large": {
@@ -45621,12 +35478,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-4-lite": {
@@ -45643,12 +35496,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-code-2": {
@@ -45665,12 +35514,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-code-3": {
@@ -45687,12 +35532,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-finance-2": {
@@ -45709,12 +35550,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-law-2": {
@@ -45731,12 +35568,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -45757,13 +35590,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -45784,12 +35612,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.5": {
@@ -45810,12 +35634,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.5-air": {
@@ -45836,12 +35656,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.5v": {
@@ -45862,13 +35678,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.6": {
@@ -45889,12 +35700,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.7": {
@@ -45915,12 +35722,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.7-flash": {
@@ -45941,12 +35744,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.7-flashx": {
@@ -45967,12 +35766,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5": {
@@ -45992,12 +35787,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5-turbo": {
@@ -46018,12 +35809,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.1": {
@@ -46044,12 +35831,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.2": {
@@ -46067,19 +35850,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.2-fast": {
@@ -46097,19 +35873,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.3": {
@@ -46127,19 +35896,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.3-flash": {
@@ -46157,20 +35918,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "zai/glm-5v-turbo": {
@@ -46190,14 +35942,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -46217,14 +35963,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.20-0309-reasoning": {
@@ -46242,14 +35982,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.20-multi-agent-0309": {
@@ -46267,22 +36001,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.3": {
@@ -46300,22 +36023,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.5": {
@@ -46333,21 +36045,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.6": {
@@ -46366,22 +36068,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-build-0.1": {
@@ -46399,14 +36090,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-imagine-image": {
@@ -46423,14 +36108,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["image"]
           }
         },
         "grok-imagine-image-2.0": {
@@ -46447,14 +36126,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["image"]
           }
         },
         "grok-imagine-image-quality": {
@@ -46471,14 +36144,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["image"]
           }
         },
         "grok-imagine-video": {
@@ -46495,11 +36162,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
+            "input": ["text", "image", "pdf"],
             "output": []
           }
         },
@@ -46517,12 +36180,7 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
+            "input": ["text", "image", "audio", "pdf"],
             "output": []
           }
         }
@@ -46546,12 +36204,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-omni": {
@@ -46572,15 +36226,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "mimo-v2-pro": {
@@ -46601,12 +36248,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5": {
@@ -46627,14 +36270,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -46655,12 +36292,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro-ultraspeed": {
@@ -46681,12 +36314,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -46710,12 +36339,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-tts": {
@@ -46733,12 +36358,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5": {
@@ -46760,14 +36381,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -46789,12 +36404,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-tts": {
@@ -46812,12 +36423,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -46835,12 +36442,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -46858,12 +36461,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -46887,12 +36486,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-tts": {
@@ -46910,12 +36505,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5": {
@@ -46937,14 +36528,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -46966,12 +36551,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-tts": {
@@ -46989,12 +36570,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -47012,12 +36589,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -47035,12 +36608,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -47064,12 +36633,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-tts": {
@@ -47087,12 +36652,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5": {
@@ -47114,14 +36675,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -47143,12 +36698,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-tts": {
@@ -47166,12 +36717,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -47189,12 +36736,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -47212,12 +36755,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -47240,12 +36779,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.5-air": {
@@ -47266,12 +36801,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.5-flash": {
@@ -47293,12 +36824,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.5v": {
@@ -47319,13 +36846,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "glm-4.6": {
@@ -47346,12 +36868,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.6v": {
@@ -47372,13 +36890,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "glm-4.7": {
@@ -47399,12 +36912,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.7-flash": {
@@ -47426,12 +36935,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.7-flashx": {
@@ -47452,12 +36957,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -47477,12 +36978,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5-turbo": {
@@ -47503,12 +37000,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -47529,12 +37022,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -47552,18 +37041,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3": {
@@ -47581,19 +37063,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3-flash": {
@@ -47611,21 +37085,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "glm-5v-turbo": {
@@ -47645,14 +37109,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -47676,12 +37134,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5-turbo": {
@@ -47703,12 +37157,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -47727,18 +37177,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2-highspeed": {
@@ -47757,18 +37200,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3": {
@@ -47787,19 +37223,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3-flash": {
@@ -47818,21 +37246,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "glm-5.3-highspeed": {
@@ -47851,19 +37269,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -47883,13 +37293,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-3.7-sonnet": {
@@ -47907,21 +37312,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-fable-5": {
@@ -47939,21 +37334,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -47971,13 +37356,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4": {
@@ -47995,21 +37375,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.1": {
@@ -48027,21 +37397,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -48059,21 +37419,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -48091,20 +37441,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -48122,21 +37463,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -48154,21 +37485,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -48186,21 +37507,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -48218,21 +37529,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -48250,20 +37551,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -48281,21 +37573,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-5-free": {
@@ -48314,21 +37596,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "baidu/ernie-5.0-thinking-preview": {
@@ -48346,13 +37618,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-chat": {
@@ -48370,12 +37637,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -48396,12 +37659,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2-exp": {
@@ -48422,12 +37681,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -48446,20 +37701,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -48478,20 +37725,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash": {
@@ -48509,22 +37748,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -48542,15 +37770,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro": {
@@ -48568,22 +37789,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-flash-preview": {
@@ -48601,22 +37811,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -48635,22 +37834,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-flash-lite-preview": {
@@ -48667,14 +37855,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -48692,22 +37874,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash": {
@@ -48726,22 +37897,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-1t": {
@@ -48759,12 +37919,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ring-1t": {
@@ -48782,12 +37938,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ring-2.6-1t": {
@@ -48805,12 +37957,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kuaishou/kat-coder-pro-v2": {
@@ -48827,12 +37975,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2": {
@@ -48850,12 +37994,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.1": {
@@ -48873,12 +38013,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5": {
@@ -48896,12 +38032,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5-lightning": {
@@ -48919,12 +38051,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7": {
@@ -48942,12 +38070,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7-highspeed": {
@@ -48965,12 +38089,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m3": {
@@ -48990,13 +38110,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-0905": {
@@ -49014,12 +38129,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -49037,12 +38148,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-thinking-turbo": {
@@ -49060,12 +38167,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -49086,13 +38189,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -49113,13 +38211,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -49138,13 +38231,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code-free": {
@@ -49164,13 +38252,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3": {
@@ -49188,19 +38271,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max"
-            ],
+            "efforts": ["max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3-free": {
@@ -49219,19 +38295,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max"
-            ],
+            "efforts": ["max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5": {
@@ -49249,21 +38318,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-codex": {
@@ -49281,20 +38340,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1": {
@@ -49312,21 +38362,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-chat": {
@@ -49344,14 +38384,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -49369,20 +38403,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -49400,20 +38425,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2": {
@@ -49431,21 +38447,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -49463,21 +38469,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -49495,21 +38491,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-chat": {
@@ -49527,12 +38513,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -49550,19 +38532,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4": {
@@ -49580,20 +38554,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -49611,12 +38576,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -49634,12 +38595,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -49657,20 +38614,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5": {
@@ -49690,21 +38638,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-instant": {
@@ -49724,21 +38662,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -49758,21 +38686,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -49792,24 +38710,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -49829,24 +38734,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -49866,24 +38758,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-plus": {
@@ -49901,12 +38780,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-max": {
@@ -49924,12 +38799,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-flash": {
@@ -49947,13 +38818,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-plus": {
@@ -49971,20 +38837,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-plus": {
@@ -50004,12 +38861,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-max": {
@@ -50029,12 +38882,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-plus": {
@@ -50055,13 +38904,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "sapiens-ai/agnes-1.5-lite": {
@@ -50078,13 +38922,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "sapiens-ai/agnes-1.5-pro": {
@@ -50101,12 +38940,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3": {
@@ -50124,13 +38959,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -50148,12 +38978,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -50172,20 +38998,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.7-flash-free": {
@@ -50205,20 +39022,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "tencent/hy3-preview": {
@@ -50235,19 +39043,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-1.8": {
@@ -50265,20 +39065,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-2.0-code": {
@@ -50296,12 +39087,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-2.0-lite": {
@@ -50319,20 +39106,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-2.0-mini": {
@@ -50350,20 +39128,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-2.0-pro": {
@@ -50381,20 +39150,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-code": {
@@ -50412,20 +39172,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4": {
@@ -50443,13 +39194,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4-fast": {
@@ -50470,13 +39216,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.1-fast": {
@@ -50497,13 +39238,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.1-fast-non-reasoning": {
@@ -50521,13 +39257,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.2-fast": {
@@ -50545,13 +39276,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.2-fast-non-reasoning": {
@@ -50569,13 +39295,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.3": {
@@ -50593,22 +39314,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.5": {
@@ -50626,21 +39336,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-build-0.1": {
@@ -50658,14 +39358,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-code-fast-1": {
@@ -50683,12 +39377,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2-flash": {
@@ -50709,12 +39399,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2-omni": {
@@ -50735,15 +39421,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2-pro": {
@@ -50764,12 +39443,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -50790,14 +39465,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -50818,12 +39487,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5": {
@@ -50844,12 +39509,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5-air": {
@@ -50870,12 +39531,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6": {
@@ -50893,12 +39550,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6v": {
@@ -50916,13 +39569,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6v-flash": {
@@ -50940,13 +39588,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6v-flash-free": {
@@ -50965,13 +39608,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7": {
@@ -50989,12 +39627,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7-flash-free": {
@@ -51013,12 +39647,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7-flashx": {
@@ -51036,12 +39666,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5": {
@@ -51059,12 +39685,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5-turbo": {
@@ -51082,12 +39704,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.1": {
@@ -51108,12 +39726,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.2": {
@@ -51131,18 +39745,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.2-free": {
@@ -51161,18 +39768,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5v-turbo": {
@@ -51189,14 +39789,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         }
       }

--- a/scripts/sync-model-metadata.mjs
+++ b/scripts/sync-model-metadata.mjs
@@ -547,7 +547,9 @@ export function toMetadata(providerId, modelId, provider, model) {
   // Filter rather than reject a modality value the wire format does not carry yet
   // (e.g. upstream adding 'video'): the model itself is real and otherwise valid,
   // so dropping the whole model would misreport it as removed from the catalog.
-  const knownInputModalities = model.modalities?.input.filter((value) => KNOWN_INPUT_MODALITIES.has(value));
+  const knownInputModalities = model.modalities?.input.filter((value) =>
+    KNOWN_INPUT_MODALITIES.has(value),
+  );
   const knownOutputModalities = model.modalities?.output.filter((value) =>
     KNOWN_OUTPUT_MODALITIES.has(value),
   );

--- a/scripts/sync-model-metadata.mjs
+++ b/scripts/sync-model-metadata.mjs
@@ -25,6 +25,11 @@ import { dirname } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const SOURCE_URL = 'https://models.dev/api.json';
+// Kept in sync with ModelInfo['modalities'] in packages/core/src/llm-connections.ts.
+// A value outside these sets (e.g. upstream's newly added 'video') is dropped rather
+// than rejected — see the filtering in toMetadata().
+const KNOWN_INPUT_MODALITIES = new Set(['text', 'image', 'audio', 'pdf']);
+const KNOWN_OUTPUT_MODALITIES = new Set(['text', 'image', 'audio']);
 const DEFAULT_SNAPSHOT = 'scripts/model-metadata/models-dev-api.snapshot.json';
 const DEFAULT_OUTPUT = 'packages/core/src/model-metadata.generated.ts';
 const DEFAULT_PRICING_OUTPUT = 'packages/runtime/src/telemetry/model-pricing.generated.ts';
@@ -539,15 +544,21 @@ export function toMetadata(providerId, modelId, provider, model) {
   ) {
     throw new Error(`models.dev model ${providerId}/${modelId} has an unsupported shape`);
   }
-  if (
-    model.modalities?.input.some(
-      (value) => value !== 'text' && value !== 'image' && value !== 'audio' && value !== 'pdf',
-    ) ||
-    model.modalities?.output.some(
-      (value) => value !== 'text' && value !== 'image' && value !== 'audio',
-    )
-  ) {
-    throw new Error(`models.dev model ${providerId}/${modelId} has unsupported modalities`);
+  // Filter rather than reject a modality value the wire format does not carry yet
+  // (e.g. upstream adding 'video'): the model itself is real and otherwise valid,
+  // so dropping the whole model would misreport it as removed from the catalog.
+  const knownInputModalities = model.modalities?.input.filter((value) => KNOWN_INPUT_MODALITIES.has(value));
+  const knownOutputModalities = model.modalities?.output.filter((value) =>
+    KNOWN_OUTPUT_MODALITIES.has(value),
+  );
+  const unknownModalities = [
+    ...(model.modalities?.input.filter((value) => !KNOWN_INPUT_MODALITIES.has(value)) ?? []),
+    ...(model.modalities?.output.filter((value) => !KNOWN_OUTPUT_MODALITIES.has(value)) ?? []),
+  ];
+  if (unknownModalities.length > 0) {
+    console.warn(
+      `sync-model-metadata: ${providerId}/${modelId} dropped unsupported modalit${unknownModalities.length === 1 ? 'y' : 'ies'} ${unknownModalities.map((value) => JSON.stringify(value)).join(', ')}`,
+    );
   }
   if (
     (model.description !== undefined && typeof model.description !== 'string') ||
@@ -609,8 +620,8 @@ export function toMetadata(providerId, modelId, provider, model) {
     ...(model.modalities
       ? {
           modalities: {
-            input: model.modalities.input,
-            output: model.modalities.output,
+            input: knownInputModalities,
+            output: knownOutputModalities,
           },
         }
       : {}),

--- a/scripts/sync-model-metadata.test.mjs
+++ b/scripts/sync-model-metadata.test.mjs
@@ -273,7 +273,7 @@ test('refresh rejects an empty required provider before replacing outputs', asyn
   }
 });
 
-test('refresh rejects unknown model modalities instead of dropping them', async () => {
+test('refresh drops an unknown model modality instead of rejecting the whole model', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-model-snapshot-modalities-'));
   try {
     const input = join(root, 'api.json');
@@ -283,20 +283,23 @@ test('refresh rejects unknown model modalities instead of dropping them', async 
     catalog.anthropic.models.model.modalities = { input: ['text', 'video'], output: ['text'] };
     await writeFile(input, JSON.stringify(catalog));
 
-    await assert.rejects(
-      main([
-        'node',
-        'sync-model-metadata.mjs',
-        '--refresh',
-        '--refresh-input',
-        input,
-        '--snapshot',
-        snapshot,
-        '--output',
-        metadata,
-      ]),
-      /unsupported modalities/,
-    );
+    await main([
+      'node',
+      'sync-model-metadata.mjs',
+      '--refresh',
+      '--refresh-input',
+      input,
+      '--snapshot',
+      snapshot,
+      '--output',
+      metadata,
+    ]);
+
+    const written = JSON.parse(await readFile(snapshot, 'utf8'));
+    assert.deepEqual(written.projection.metadata.anthropic.model.modalities, {
+      input: ['text'],
+      output: ['text'],
+    });
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Fixes the reported bug: `glm-5.3` (and `zai-coding-plan/glm-5.3-flash`) had no thinking-effort choices because the committed models.dev snapshot was stale — `sync-model-metadata.mjs` refused to complete *any* refresh once upstream introduced a modality value (`video`) the validator didn't recognize, so no one had been able to refresh successfully.
- `toMetadata()` now filters out an unrecognized modality value per-model instead of rejecting the whole model/refresh; the model keeps its other capabilities. Logged as a warning.
- Refreshed the committed snapshot against current models.dev (with `--accept-upstream-removals`, after reviewing the diff — a handful of models/effort options genuinely retired upstream).
- Added `scripts/check-model-metadata-floor.mjs`: a sanity floor (required providers present, total model count above a threshold) so a degraded upstream response can't silently pass through a scheduled refresh.
- Added `.github/workflows/model-metadata-refresh.yml`: nightly (+ manual) job that runs the refresh, enforces the floor, and opens a PR when the snapshot changes — closes the gap where nothing kept the snapshot from going stale again.

Addresses the snapshot-staleness root cause from #4398. The two larger architectural proposals in that issue (Runtime Host as sole model-catalog authority; runtime refresh over `HostChangeFeed`) are separate, larger changes not included here.

## Test plan
- [x] `node scripts/check-model-metadata-floor.mjs` passes (1905 models / 47 providers)
- [x] `npm run check:model-metadata` passes
- [x] `node --test scripts/sync-model-metadata.test.mjs` — 10/10 passing (updated the modality test to assert filtering instead of rejection)
- [x] Confirmed `zai/glm-5.3` now has `thinkingOptions.efforts: ["low","high","max"]` in the refreshed snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)