### PR TITLE
fix(windows): pin upgrade baseline to retained nightly

### DIFF
--- a/scripts/windows-upgrade-baseline.json
+++ b/scripts/windows-upgrade-baseline.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.9",
-  "tag": "v0.1.9",
-  "assetName": "Maka-0.1.9-win-x64.exe",
-  "sha256": "ebda293ab835ec8434df2f5bbeea21bb3ba9c82bc8348ab8ee8d4915e4b6fd4b"
+  "version": "0.2.0-dev.11.20260831",
+  "tag": "v0.2.0-dev.11.20260831",
+  "assetName": "Maka-0.2.0-dev.11.20260831-win-x64.exe",
+  "sha256": "0c5362707776af9a6146b55e3284dc0a2389b3329e2bed94cfc386b0eac86709"
 }


### PR DESCRIPTION
## Summary

- replace the pruned v0.1.9 release baseline with the retained v0.2.0-dev.11.20260831 GitHub prerelease installer
- preserve the existing exact SHA-256 verification and GitHub Release as the only download source

## Verification

- `node scripts/prepare-windows-upgrade-baseline.mjs 0.2.0 <temp-dir>`
- `node --test scripts/verify-windows-harness.test.mjs`
- `node --test scripts/ci-test-plan.test.mjs`