### PR TITLE
fix(desktop): skip archived session queries

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -760,7 +760,7 @@
           "useNewTaskChoice": 1,
           "useOnboardingSnapshot": 1,
           "usePlanModeState": 1,
-          "useRef": 16,
+          "useRef": 15,
           "useSessionCollaborationDialog": 1,
           "useSessionEventHealthPolling": 1,
           "useSessionNavigationReads": 1,
@@ -872,7 +872,7 @@
           "react": 1
         },
         "importSpecifiers": 108,
-        "nonTriviaTokens": 13697
+        "nonTriviaTokens": 13695
       },
       "src/renderer/use-app-shell-composer-quotes.ts": {
         "importDeclarations": 2,

--- a/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
@@ -142,6 +142,33 @@ describe('bootstrap selection lease', () => {
     assert.equal(state.activeId(), undefined);
   });
 
+  for (const { name, initialActiveId, sessions, expected } of [
+    {
+      name: 'the freshest session is archived',
+      initialActiveId: undefined,
+      sessions: [session('archived', 2, true), session('active', 1)],
+      expected: 'active',
+    },
+    {
+      name: 'the bootstrap-owned selection is archived',
+      initialActiveId: 'archived',
+      sessions: [session('archived', 2, true), session('active', 1)],
+      expected: 'active',
+    },
+    {
+      name: 'every session is archived',
+      initialActiveId: 'archived',
+      sessions: [session('archived', 1, true)],
+      expected: undefined,
+    },
+  ] as const) {
+    it(`skips archived sessions when ${name}`, () => {
+      const state = harness(initialActiveId);
+      assert.equal(state.lease.reconcile(sessions), true);
+      assert.equal(state.activeId(), expected);
+    });
+  }
+
   it('does not reconcile after release', () => {
     const state = harness();
     state.lease.release();

--- a/apps/desktop/src/main/__tests__/composer-mentions.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-mentions.test.ts
@@ -109,6 +109,11 @@ function installCatalogRenderer(t: TestContext) {
     }
   });
 
+  const automaticQueryGate = {
+    subscribe: () => () => {},
+    isAutomaticQueryBlocked: () => false,
+  };
+
   return {
     observations,
     latest() {
@@ -124,6 +129,7 @@ function installCatalogRenderer(t: TestContext) {
         sessionId,
         projectPath,
         skillCatalogRevision,
+        automaticQueryGate,
         children: createElement(Consumer, { sessionId }),
       })));
     },

--- a/apps/desktop/src/main/__tests__/plan-mode-panel-pending.test.ts
+++ b/apps/desktop/src/main/__tests__/plan-mode-panel-pending.test.ts
@@ -28,6 +28,7 @@ import type { SessionSummary } from '@maka/core/session';
 import type { PlanControlIpcResult } from '../../shared/plan-mode-ipc.js';
 import { AstryxLocaleProvider, LocaleProvider, ToastProvider } from '@maka/ui';
 import { usePlanModeState, type PlanModeState } from '../../renderer/plan-mode-panel.js';
+import { createSessionCatalogController } from '../../renderer/session-catalog-state.js';
 
 const originalGlobals = {
   document: globalThis.document,
@@ -96,9 +97,10 @@ test('plan controls stay pending until the bridge promise settles', async () => 
   const root = createRoot(container);
   mountedRoot = root;
 
+  const catalog = createSessionCatalogController();
   let controller: PlanModeState | undefined;
   function Harness() {
-    controller = usePlanModeState({ id: 'session-1' } as SessionSummary);
+    controller = usePlanModeState({ id: 'session-1' } as SessionSummary, catalog);
     return null;
   }
   await act(async () => {

--- a/apps/desktop/src/main/__tests__/session-navigation-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/session-navigation-controller.test.ts
@@ -108,7 +108,7 @@ function ports(
   return {
     activeIdRef: { current: activeSessionId },
     sessionsRef: { current: sessions },
-    pendingSessionRowActionsRef: { current: new Set<string>() },
+    acquireAutomaticQueryBlock: () => ({ release: () => undefined }),
     activateSession: (sessionId) => calls.push(`activate:${sessionId ?? 'none'}`),
     clearActiveMessages: () => calls.push('clear-messages'),
     clearSessionRendererState: (sessionId) => calls.push(`clear:${sessionId}`),

--- a/apps/desktop/src/main/__tests__/session-navigation-row-actions-revisions.test.ts
+++ b/apps/desktop/src/main/__tests__/session-navigation-row-actions-revisions.test.ts
@@ -90,14 +90,22 @@ describe('revision-family session row actions', () => {
     });
     const branch = summary('branch', { parentSessionId: 'root', branchOfTurnId: 'turn-1' });
     const activeIdRef = { current: 'root' as string | undefined };
+    const service = createService(calls);
     const actions = createSessionNavigationRowActions({
       uiLocale: 'en',
       activeIdRef,
+      acquireAutomaticQueryBlock: (ids) => {
+        calls.push(`acquire:${ids.join(',')}`);
+        return { release: () => calls.push('release') };
+      },
       clearActiveMessages: () => undefined,
       clearSessionRendererState: (id) => { cleared.push(id); },
       pendingSessionRowActionsRef: { current: new Set<string>() },
-      refreshSessions: async () => [root, version, branch],
-      service: createService(calls),
+      refreshSessions: async () => {
+        calls.push('refresh');
+        return [root, version, branch];
+      },
+      service,
       sessionsRef: { current: [root, version, branch] },
       setActiveId: (id) => { selections.push(id); activeIdRef.current = id; },
       toastApi: {
@@ -115,17 +123,84 @@ describe('revision-family session row actions', () => {
 
     assert.deepEqual(calls, [
       'flag:version:true:true',
+      'refresh',
       'rename:branch:Independent branch:true',
+      'refresh',
+      'acquire:root,version',
       'archive:version:true',
+      'refresh',
+      'release',
       // The delete asks the Host how many subtasks it would archive before the
       // confirm, then removes.
       'preview:root',
+      'acquire:root,version',
       // `root` is not archived, so the delete states no archived premise —
       // requiring one would refuse every delete from the rail.
       'remove:root:true:false',
+      'refresh',
+      'release',
     ]);
     assert.deepEqual(selections, [undefined, undefined]);
     assert.deepEqual(cleared, ['root', 'version', 'root', 'version']);
+
+    service.archive = async () => { throw new Error('archive failed'); };
+    await actions.archiveSession('root');
+    assert.deepEqual(calls.slice(-2), ['acquire:root,version', 'release']);
+  });
+
+  it('holds one query block through a bulk archive refresh', async () => {
+    const calls: string[] = [];
+    const root = summary('root');
+    const version = summary('version', {
+      revisionRootSessionId: 'root',
+      revisionParentSessionId: 'root',
+    });
+    const other = summary('other');
+    let rejectRefresh = false;
+    const actions = createSessionNavigationRowActions({
+      uiLocale: 'en',
+      activeIdRef: { current: undefined },
+      acquireAutomaticQueryBlock: (ids) => {
+        calls.push(`acquire:${ids.join(',')}`);
+        return { release: () => calls.push('release') };
+      },
+      clearActiveMessages: () => undefined,
+      clearSessionRendererState: () => undefined,
+      pendingSessionRowActionsRef: { current: new Set<string>() },
+      refreshSessions: async () => {
+        calls.push('refresh');
+        if (rejectRefresh) throw new Error('refresh failed');
+        return [];
+      },
+      service: createService(calls),
+      sessionsRef: { current: [root, version, other] },
+      setActiveId: () => undefined,
+      toastApi: {
+        success: () => undefined,
+        error: () => undefined,
+        confirm: async () => true,
+      },
+    });
+
+    await actions.archiveSelected(['version', 'other']);
+
+    assert.deepEqual(calls, [
+      'acquire:root,version,other',
+      'archive:version:true',
+      'archive:other:true',
+      'refresh',
+      'release',
+    ]);
+
+    calls.length = 0;
+    rejectRefresh = true;
+    await assert.rejects(actions.archiveSelected(['other']), /refresh failed/);
+    assert.deepEqual(calls, [
+      'acquire:other',
+      'archive:other:true',
+      'refresh',
+      'release',
+    ]);
   });
 });
 
@@ -138,9 +213,11 @@ function deleteHarness(
   const calls: string[] = [];
   const confirms: Array<{ title: string; description: string }> = [];
   const successes: Array<{ title: string; description?: string }> = [];
+  let leaseReleased = false;
   const actions = createSessionNavigationRowActions({
     uiLocale: 'en',
     activeIdRef: { current: undefined },
+    acquireAutomaticQueryBlock: () => ({ release: () => { leaseReleased = true; } }),
     clearActiveMessages: () => undefined,
     clearSessionRendererState: () => undefined,
     pendingSessionRowActionsRef: { current: new Set<string>() },
@@ -154,7 +231,7 @@ function deleteHarness(
       confirm: async (options) => { confirms.push({ title: options.title, description: options.description }); return true; },
     },
   });
-  return { actions, calls, confirms, successes };
+  return { actions, calls, confirms, successes, wasLeaseReleased: () => leaseReleased };
 }
 
 describe('delete confirm warns off the Host preview, toast reports the Host count', () => {
@@ -219,7 +296,7 @@ describe('delete confirm warns off the Host preview, toast reports the Host coun
   });
 
   it('stays silent on the toast when a concurrent restore calls the delete off', async () => {
-    const { actions, confirms, successes } = deleteHarness(
+    const { actions, confirms, successes, wasLeaseReleased } = deleteHarness(
       [summary('parent', { name: 'hi' })],
       'restored',
       0,
@@ -232,5 +309,6 @@ describe('delete confirm warns off the Host preview, toast reports the Host coun
     assert.match(confirms[0].description, /kept and moved to Archived/);
     // But nothing was deleted, so nothing moved to the archive.
     assert.deepEqual(successes, [{ title: 'hi was restored, so it was kept', description: undefined }]);
+    assert.equal(wasLeaseReleased(), true);
   });
 });

--- a/apps/desktop/src/main/__tests__/session-navigation-session-purge.test.ts
+++ b/apps/desktop/src/main/__tests__/session-navigation-session-purge.test.ts
@@ -142,6 +142,7 @@ function createActions(input: {
   return createSessionNavigationRowActions({
     uiLocale: 'en',
     activeIdRef: input.activeIdRef,
+    acquireAutomaticQueryBlock: () => ({ release: () => undefined }),
     clearActiveMessages: () => undefined,
     clearSessionRendererState: (id) => {
       input.harness.cleared.push(id);

--- a/apps/desktop/src/main/__tests__/session-query-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/session-query-gate.test.ts
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { deferred } from '@maka/core/test-only/async-primitives';
+import type { PlanSessionState } from '@maka/core/plan';
+import type { SessionSummary } from '@maka/core/session';
+import { LocaleProvider, ToastProvider } from '@maka/ui';
+import { act, createElement } from 'react';
+import type { DesktopSessionSummary } from '../../preload/bridge-contract.js';
+import {
+  ComposerMentionsProvider,
+  useComposerMentionsContext,
+} from '../../renderer/composer-mentions.js';
+import {
+  usePlanModeState,
+  type PlanModeState,
+} from '../../renderer/plan-mode-panel.js';
+import { createSessionCatalogController } from '../../renderer/session-catalog-state.js';
+import { cleanupFakeDom, installReactRenderer } from './fake-dom.js';
+
+afterEach(cleanupFakeDom);
+
+test('query blocking pauses, resumes, and fences automatic Skills and Plan reads', async () => {
+  const { root } = installReactRenderer();
+  const session = { id: 'session', isArchived: false } as SessionSummary;
+  const catalog = createSessionCatalogController();
+  catalog.commitSessions([{ ...session, isArchived: true } as DesktopSessionSummary]);
+  const firstSkillQuery = deferred<never[]>();
+  const firstPlanQuery = deferred<PlanSessionState>();
+  const stalePlanState = {
+    schemaVersion: 1,
+    sessionId: session.id,
+    storeVersion: 1,
+    proposals: [],
+    executions: [],
+  } satisfies PlanSessionState;
+  const freshPlanState = { ...stalePlanState, storeVersion: 2 } satisfies PlanSessionState;
+  let skillQueries = 0;
+  let planQueries = 0;
+  let revisionRequests = 0;
+  let planState: PlanSessionState | undefined;
+  let planMode: PlanModeState | undefined;
+  let skillsUnavailable = false;
+
+  (globalThis.window as unknown as { maka: unknown }).maka = {
+    skills: {
+      listInvocable: async () => {
+        skillQueries += 1;
+        return skillQueries === 1 ? firstSkillQuery.promise : [];
+      },
+    },
+    sessions: {
+      getPlanState: async () => {
+        planQueries += 1;
+        return planQueries === 1 ? firstPlanQuery.promise : freshPlanState;
+      },
+      requestPlanRevision: async () => {
+        revisionRequests += 1;
+        return { ok: true, value: freshPlanState };
+      },
+      subscribeChanges: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+      subscribePlanChanges: () => () => undefined,
+    },
+    mcp: { subscribeChanges: () => () => undefined },
+  };
+
+  function QueryProbe() {
+    const plan = usePlanModeState(session, catalog);
+    planMode = plan;
+    planState = plan.state;
+    skillsUnavailable = useComposerMentionsContext()?.mentionSkillsUnavailable ?? false;
+    return null;
+  }
+
+  await act(async () => {
+    root.render(createElement(LocaleProvider, {
+      locale: 'en',
+      children: createElement(ToastProvider, {
+        children: createElement(ComposerMentionsProvider, {
+          skillCatalogRevision: 0,
+          sessionId: session.id,
+          automaticQueryGate: catalog,
+          children: createElement(QueryProbe),
+        }),
+      }),
+    }));
+    await Promise.resolve();
+  });
+
+  assert.deepEqual([skillQueries, planQueries], [0, 0]);
+
+  await act(async () => {
+    catalog.commitSessions([session as DesktopSessionSummary]);
+    await Promise.resolve();
+  });
+
+  let lease!: ReturnType<typeof catalog.acquireAutomaticQueryBlock>;
+  let overlappingLease!: ReturnType<typeof catalog.acquireAutomaticQueryBlock>;
+  await act(async () => {
+    lease = catalog.acquireAutomaticQueryBlock([session.id]);
+    overlappingLease = catalog.acquireAutomaticQueryBlock([session.id]);
+    firstSkillQuery.reject(new Error('session archived'));
+    firstPlanQuery.resolve(stalePlanState);
+    await Promise.resolve();
+  });
+
+  assert.equal(planState, undefined);
+  assert.equal(skillsUnavailable, false);
+
+  await act(async () => {
+    lease.release();
+    await Promise.resolve();
+  });
+  assert.deepEqual([skillQueries, planQueries], [1, 1]);
+
+  await act(async () => {
+    overlappingLease.release();
+    await Promise.resolve();
+  });
+  assert.deepEqual([skillQueries, planQueries], [2, 2]);
+  assert.deepEqual(planState, freshPlanState);
+
+  let mutationLease!: ReturnType<typeof catalog.acquireAutomaticQueryBlock>;
+  await act(async () => {
+    mutationLease = catalog.acquireAutomaticQueryBlock([session.id]);
+    await planMode?.requestRevision('proposal');
+  });
+  assert.equal(revisionRequests, 1);
+  assert.equal(planQueries, 3);
+
+  await act(async () => {
+    mutationLease.release();
+    await Promise.resolve();
+  });
+  assert.deepEqual([skillQueries, planQueries], [3, 4]);
+});
+
+test('query block membership is part of the catalog snapshot', () => {
+  const catalog = createSessionCatalogController();
+  let notifications = 0;
+  const unsubscribe = catalog.subscribe(() => {
+    notifications += 1;
+  });
+
+  const first = catalog.acquireAutomaticQueryBlock(['session']);
+  assert.equal(catalog.getState().automaticQueryBlockedSessionIds.has('session'), true);
+  assert.equal(notifications, 1);
+
+  const nested = catalog.acquireAutomaticQueryBlock(['session']);
+  first.release();
+  assert.equal(catalog.getState().automaticQueryBlockedSessionIds.has('session'), true);
+  assert.equal(notifications, 1);
+
+  nested.release();
+  assert.equal(catalog.getState().automaticQueryBlockedSessionIds.has('session'), false);
+  assert.equal(notifications, 2);
+  unsubscribe();
+});

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -332,6 +332,7 @@ function AppShellContent({
     transcriptRangeRef,
     messageLoadPending,
     setMessageLoadPending,
+    sessionCatalogController,
     sessionUiController,
   } = useAppShellSessionWorkspace(toastApi);
   // A locally created task can become active before its catalog row arrives,
@@ -1065,7 +1066,7 @@ function AppShellContent({
     ? sessionSettingIntent.overlays.permissionMode[activeId]
       ?? activeBoundarySurface.permissionMode
     : activeBoundarySurface.permissionMode;
-  const planMode = usePlanModeState(ownerActiveId ? activeHostSession : undefined);
+  const planMode = usePlanModeState(ownerActiveId ? activeHostSession : undefined, sessionCatalogController);
   const planConversationItems = (planMode.state?.proposals ?? []).map((proposal) => ({
     id: proposal.proposalId,
     afterTurnId: proposal.turnId,
@@ -1332,6 +1333,7 @@ function AppShellContent({
   // `ComposerMentionsProvider` below, so its reloads do not re-render the shell.
   const composerMentionsSurface: ComposerMentionsSurfaceInput = {
     sessionId: ownerActiveId,
+    automaticQueryGate: sessionCatalogController,
     projectPath: activeId
       ? ownerActiveId
         ? projectInfo?.projectPath
@@ -1400,7 +1402,6 @@ function AppShellContent({
   useLayoutEffect(() => {
     openSessionInChatRef.current = openSession;
   }, [openSession]);
-  const pendingSessionRowActionsRef = useRef(new Set<string>());
   const sessionNavigationCommandsRef = useRef<SessionNavigationRowActions | null>(null);
   // Built inline: the rail reads these through a ref published on commit, so
   // their identity carries no information and this object never has to be
@@ -1408,7 +1409,7 @@ function AppShellContent({
   const sessionNavigationPorts: SessionNavigationPorts = {
     activeIdRef,
     sessionsRef,
-    pendingSessionRowActionsRef,
+    acquireAutomaticQueryBlock: sessionCatalogController.acquireAutomaticQueryBlock,
     activateSession: setActiveId,
     clearActiveMessages,
     clearSessionRendererState,

--- a/apps/desktop/src/renderer/composer-mentions.tsx
+++ b/apps/desktop/src/renderer/composer-mentions.tsx
@@ -59,6 +59,10 @@ export interface ComposerMentionsSurface {
   /** Handed over by the Module Hub boundary to invalidate Runtime's projection. */
   skillCatalogRevision: number;
   sessionId?: string;
+  automaticQueryGate: {
+    subscribe(listener: () => void): () => void;
+    isAutomaticQueryBlocked(sessionId: string): boolean;
+  };
   projectPath?: string;
   newSessionModel?: { llmConnectionSlug: string; model: string };
   newSessionCollaborationMode?: 'agent' | 'plan';
@@ -84,6 +88,7 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
   const {
     projectPath,
     sessionId,
+    automaticQueryGate,
     skillCatalogRevision,
     newSessionModel,
     newSessionCollaborationMode,
@@ -147,8 +152,11 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
   useEffect(() => {
     let cancelled = false;
     let requestVersion = 0;
+    const blocked = () => !!sessionId && automaticQueryGate.isAutomaticQueryBlocked(sessionId);
+    let queryBlocked = blocked();
     const refresh = () => {
       const version = ++requestVersion;
+      if (queryBlocked) return;
       setCatalog((previous) =>
         previous.contextKey === contextKey
           ? // A same-context refresh keeps both its settled verdict and the
@@ -178,7 +186,7 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
           : Promise.resolve([]);
       void request.then(
         (next) => {
-          if (cancelled || version !== requestVersion) return;
+          if (cancelled || version !== requestVersion || queryBlocked) return;
           setCatalog((previous) => ({
             contextKey,
             loading: false,
@@ -196,12 +204,18 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
         () => {
           // Fail soft: an unavailable projection leaves `/` with no suggestions.
           // Direct `/skill:<id>` input still reaches the same Runtime resolver.
-          if (cancelled || version !== requestVersion) return;
+          if (cancelled || version !== requestVersion || queryBlocked) return;
           setCatalog({ contextKey, loading: false, settled: 'empty', skills: EMPTY_SKILLS });
         },
       );
     };
     refresh();
+    const unsubscribeQueryGate = automaticQueryGate.subscribe(() => {
+      const next = blocked();
+      if (next === queryBlocked) return;
+      queryBlocked = next;
+      refresh();
+    });
     const unsubscribeSessions = window.maka.sessions.subscribeChanges((event) => {
       if (
         sessionId &&
@@ -220,12 +234,14 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
     return () => {
       cancelled = true;
       requestVersion += 1;
+      unsubscribeQueryGate();
       unsubscribeSessions();
       unsubscribeContext();
     };
   }, [
     newTaskProjectPath,
     sessionId,
+    automaticQueryGate,
     skillCatalogRevision,
     newTaskModel?.llmConnectionSlug,
     newTaskModel?.model,

--- a/apps/desktop/src/renderer/features/session-navigation/controller/session-row-actions.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/controller/session-row-actions.ts
@@ -90,6 +90,7 @@ export interface SessionNavigationRowActions {
 export function createSessionNavigationRowActions(deps: {
   uiLocale: UiLocale;
   activeIdRef: RefObject<string | undefined>;
+  acquireAutomaticQueryBlock(sessionIds: readonly string[]): { release(): void };
   clearActiveMessages: () => void;
   clearSessionRendererState: (sessionId: string) => void;
   pendingSessionRowActionsRef: RefObject<Set<string>>;
@@ -102,6 +103,7 @@ export function createSessionNavigationRowActions(deps: {
   const {
     uiLocale,
     activeIdRef,
+    acquireAutomaticQueryBlock,
     clearActiveMessages,
     clearSessionRendererState,
     pendingSessionRowActionsRef,
@@ -112,6 +114,26 @@ export function createSessionNavigationRowActions(deps: {
     toastApi,
   } = deps;
   const copy = getShellCopy(uiLocale).sessionRowActions;
+
+  async function withAutomaticQueryBlockOn<T>(
+    sessionIds: readonly string[],
+    action: () => Promise<T>,
+  ): Promise<T> {
+    const lease = acquireAutomaticQueryBlock(sessionIds);
+    try {
+      return await action();
+    } finally {
+      lease.release();
+    }
+  }
+
+  async function withAutomaticQueryBlock<T>(
+    sessionId: string,
+    action: (familyIds: readonly string[]) => Promise<T>,
+  ): Promise<T> {
+    const familyIds = revisionFamilySessionIds(sessionsRef.current, sessionId);
+    return withAutomaticQueryBlockOn(familyIds, () => action(familyIds));
+  }
 
   async function runSessionRowAction(
     sessionId: string,
@@ -146,14 +168,15 @@ export function createSessionNavigationRowActions(deps: {
 
   async function archiveSession(sessionId: string) {
     return runSessionRowAction(sessionId, 'archive', copy.archiveFailedTitle, async () => {
-      const familyIds = revisionFamilySessionIds(sessionsRef.current, sessionId);
-      await service.archive(sessionId, { revisionFamily: true });
-      if (activeIdRef.current && familyIds.includes(activeIdRef.current)) {
-        setActiveId(undefined);
-        clearActiveMessages();
-      }
-      for (const id of familyIds) clearSessionRendererState(id);
-      await refreshSessions();
+      await withAutomaticQueryBlock(sessionId, async (familyIds) => {
+        await service.archive(sessionId, { revisionFamily: true });
+        if (activeIdRef.current && familyIds.includes(activeIdRef.current)) {
+          setActiveId(undefined);
+          clearActiveMessages();
+        }
+        for (const id of familyIds) clearSessionRendererState(id);
+        await refreshSessions();
+      });
     });
   }
 
@@ -206,10 +229,16 @@ export function createSessionNavigationRowActions(deps: {
       if (!ok) return;
       // The confirm named an archived task, so a restore revokes it. An active
       // task has no such premise to lose.
-      const { disposition, archivedSubtaskCount } = await removeSessionFamily(sessionId, {
-        requireArchived: session?.isArchived === true,
-      });
-      await refreshSessions();
+      const { disposition, archivedSubtaskCount } = await withAutomaticQueryBlock(
+        sessionId,
+        async () => {
+          const outcome = await removeSessionFamily(sessionId, {
+            requireArchived: session?.isArchived === true,
+          });
+          await refreshSessions();
+          return outcome;
+        },
+      );
       // `restored` means nothing was deleted, so no subtask moved either. On a
       // real delete the count is the Host's executed number, not an estimate.
       if (disposition === 'restored') toastApi.success(copy.deleteRestoredTitle(name));
@@ -360,40 +389,45 @@ export function createSessionNavigationRowActions(deps: {
    * a run of them is what a sweep exists to avoid.
    */
   async function archiveSessions(sessionIds: readonly string[]): Promise<SessionArchiveOutcome> {
-    const failed: string[] = [];
-    let firstFailure: SessionArchiveOutcome['firstFailure'];
-    let archived = 0;
-    for (const sessionId of sessionIds) {
-      const key = `${sessionId}:archive`;
-      if (
-        Array.from(pendingSessionRowActionsRef.current).some((pending) =>
-          pending.startsWith(`${sessionId}:`),
-        )
-      ) {
-        failed.push(sessionId);
-        continue;
-      }
-      pendingSessionRowActionsRef.current.add(key);
-      try {
-        const familyIds = revisionFamilySessionIds(sessionsRef.current, sessionId);
-        await service.archive(sessionId, { revisionFamily: true });
-        if (activeIdRef.current && familyIds.includes(activeIdRef.current)) {
-          setActiveId(undefined);
-          clearActiveMessages();
+    const familyIds = [
+      ...new Set(sessionIds.flatMap((id) => revisionFamilySessionIds(sessionsRef.current, id))),
+    ];
+    return withAutomaticQueryBlockOn(familyIds, async () => {
+      const failed: string[] = [];
+      let firstFailure: SessionArchiveOutcome['firstFailure'];
+      let archived = 0;
+      for (const sessionId of sessionIds) {
+        const key = `${sessionId}:archive`;
+        if (
+          Array.from(pendingSessionRowActionsRef.current).some((pending) =>
+            pending.startsWith(`${sessionId}:`),
+          )
+        ) {
+          failed.push(sessionId);
+          continue;
         }
-        for (const id of familyIds) clearSessionRendererState(id);
-        archived += 1;
-      } catch (error) {
-        failed.push(sessionId);
-        firstFailure ??= { error, sessionId };
-      } finally {
-        pendingSessionRowActionsRef.current.delete(key);
+        pendingSessionRowActionsRef.current.add(key);
+        try {
+          const familyIds = revisionFamilySessionIds(sessionsRef.current, sessionId);
+          await service.archive(sessionId, { revisionFamily: true });
+          if (activeIdRef.current && familyIds.includes(activeIdRef.current)) {
+            setActiveId(undefined);
+            clearActiveMessages();
+          }
+          for (const id of familyIds) clearSessionRendererState(id);
+          archived += 1;
+        } catch (error) {
+          failed.push(sessionId);
+          firstFailure ??= { error, sessionId };
+        } finally {
+          pendingSessionRowActionsRef.current.delete(key);
+        }
       }
-    }
-    // Once, after the whole sweep. Refreshing per task would re-render the rail
-    // under the user's cursor for every id in the selection.
-    await refreshSessions();
-    return { archived, failed, firstFailure };
+      // Once, after the whole sweep. Refreshing per task would re-render the
+      // rail under the user's cursor for every id in the selection.
+      await refreshSessions();
+      return { archived, failed, firstFailure };
+    });
   }
 
   /**

--- a/apps/desktop/src/renderer/features/session-navigation/controller/use-session-navigation-controller.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/controller/use-session-navigation-controller.ts
@@ -98,6 +98,7 @@ export function useSessionNavigationController(
   // be upstream of the rail, where a single ordinary `function` declaration
   // anywhere in the chain silently undoes the whole thing (#4109).
   const portsRef = useRef(ports);
+  const pendingSessionRowActionsRef = useRef(new Set<string>());
   useLayoutEffect(() => {
     portsRef.current = ports;
   });
@@ -107,10 +108,12 @@ export function useSessionNavigationController(
       createSessionNavigationRowActions({
         uiLocale: locale,
         activeIdRef: portsRef.current.activeIdRef,
+        acquireAutomaticQueryBlock: (sessionIds) =>
+          portsRef.current.acquireAutomaticQueryBlock(sessionIds),
         clearActiveMessages: () => portsRef.current.clearActiveMessages(),
         clearSessionRendererState: (sessionId) =>
           portsRef.current.clearSessionRendererState(sessionId),
-        pendingSessionRowActionsRef: portsRef.current.pendingSessionRowActionsRef,
+        pendingSessionRowActionsRef,
         refreshSessions: () => portsRef.current.refreshSessions(),
         service,
         sessionsRef: portsRef.current.sessionsRef,

--- a/apps/desktop/src/renderer/features/session-navigation/ports.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/ports.ts
@@ -112,7 +112,7 @@ export interface SessionNavigationServices {
 export interface SessionNavigationPorts {
   activeIdRef: RefObject<string | undefined>;
   sessionsRef: RefObject<ReadonlyArray<SessionSummary>>;
-  pendingSessionRowActionsRef: RefObject<Set<string>>;
+  acquireAutomaticQueryBlock(sessionIds: readonly string[]): { release(): void };
   activateSession(sessionId: string | undefined): void;
   clearActiveMessages(): void;
   clearSessionRendererState(sessionId: string): void;

--- a/apps/desktop/src/renderer/plan-mode-panel.tsx
+++ b/apps/desktop/src/renderer/plan-mode-panel.tsx
@@ -42,7 +42,13 @@ export interface PlanModeState {
   abandon(executionId: string, title: string): Promise<void>;
 }
 
-export function usePlanModeState(session: SessionSummary | undefined): PlanModeState {
+export function usePlanModeState(
+  session: SessionSummary | undefined,
+  automaticQueryGate: {
+    subscribe(listener: () => void): () => void;
+    isAutomaticQueryBlocked(sessionId: string): boolean;
+  },
+): PlanModeState {
   const toastApi = useToast();
   const locale = useUiLocale();
   const copy = getPlanModeCopy(locale);
@@ -62,20 +68,44 @@ export function usePlanModeState(session: SessionSummary | undefined): PlanModeS
     turnId: string;
   } | undefined>(undefined);
 
-  const refresh = useCallback(async () => {
-    if (!session) return;
-    setState(await window.maka.sessions.getPlanState(session.id));
-  }, [session?.id]);
+  const refresh = useCallback(async (options: {
+    automatic?: boolean;
+    isCurrent?: () => boolean;
+  } = {}) => {
+    const { automatic = true, isCurrent = () => true } = options;
+    if (!session || (automatic && automaticQueryGate.isAutomaticQueryBlocked(session.id))) return;
+    const next = await window.maka.sessions.getPlanState(session.id);
+    if (isCurrent() && (!automatic || !automaticQueryGate.isAutomaticQueryBlocked(session.id))) {
+      setState(next);
+    }
+  }, [automaticQueryGate, session?.id]);
 
   useEffect(() => {
     setState(undefined);
     setError(undefined);
-    if (!session) return;
-    const refreshOrReport = () => void refresh().catch((cause) => {
-      reportUnexpectedError('plan-mode:refresh', cause);
-      setError(copy.operationFailed);
-    });
+    if (!session) {
+      return;
+    }
+    let requestVersion = 0;
+    const blocked = () => automaticQueryGate.isAutomaticQueryBlocked(session.id);
+    let queryBlocked = blocked();
+    const refreshOrReport = () => {
+      const version = ++requestVersion;
+      if (queryBlocked) return;
+      void refresh({ isCurrent: () => version === requestVersion }).catch((cause) => {
+        if (version === requestVersion && !queryBlocked) {
+          reportUnexpectedError('plan-mode:refresh', cause);
+          setError(copy.operationFailed);
+        }
+      });
+    };
     refreshOrReport();
+    const unsubscribeQueryGate = automaticQueryGate.subscribe(() => {
+      const next = blocked();
+      if (next === queryBlocked) return;
+      queryBlocked = next;
+      refreshOrReport();
+    });
     const unsubscribeEvents = window.maka.sessions.subscribeEvents(session.id, (event: SessionEvent) => {
       if (
         event.type === 'plan_submitted'
@@ -90,10 +120,12 @@ export function usePlanModeState(session: SessionSummary | undefined): PlanModeS
       refreshOrReport,
     );
     return () => {
+      requestVersion += 1;
+      unsubscribeQueryGate();
       unsubscribeEvents();
       unsubscribePlanChanges();
     };
-  }, [copy.operationFailed, session?.id, session?.collaborationMode, refresh]);
+  }, [automaticQueryGate, copy.operationFailed, session?.id, session?.collaborationMode, refresh]);
   const run = useCallback(
     async (action: () => Promise<PlanControlIpcResult<unknown>>): Promise<void> => {
       setPending(true);
@@ -104,7 +136,7 @@ export function usePlanModeState(session: SessionSummary | undefined): PlanModeS
           setError(planControlFailureCopy(result.error, copy));
           return;
         }
-        await refresh();
+        await refresh({ automatic: false });
       } catch (cause) {
         reportUnexpectedError('plan-mode:action', cause);
         setError(copy.operationFailed);

--- a/apps/desktop/src/renderer/session-catalog-state.ts
+++ b/apps/desktop/src/renderer/session-catalog-state.ts
@@ -40,6 +40,7 @@ export interface SessionCatalogState {
   readonly sessions: readonly DesktopSessionSummary[];
   readonly revision: number;
   readonly activeSessionId: string | undefined;
+  readonly automaticQueryBlockedSessionIds: ReadonlySet<string>;
 }
 
 export function createSessionCatalogController() {
@@ -47,11 +48,51 @@ export function createSessionCatalogController() {
     sessions: [],
     revision: 0,
     activeSessionId: undefined,
+    automaticQueryBlockedSessionIds: new Set(),
   });
+  const automaticQueryBlockCounts = new Map<string, number>();
+  const publishAutomaticQueryBlocks = () => {
+    const current = state.getState();
+    const next = new Set(automaticQueryBlockCounts.keys());
+    if (
+      current.automaticQueryBlockedSessionIds.size === next.size
+      && [...next].every((id) => current.automaticQueryBlockedSessionIds.has(id))
+    ) {
+      return;
+    }
+    state.replaceState({ ...current, automaticQueryBlockedSessionIds: next });
+  };
 
   return {
     getState: state.getState,
     subscribe: state.subscribe,
+    isAutomaticQueryBlocked(sessionId: string): boolean {
+      return (
+        state.getState().automaticQueryBlockedSessionIds.has(sessionId) ||
+        state.getState().sessions.some((session) => session.id === sessionId && session.isArchived)
+      );
+    },
+    acquireAutomaticQueryBlock(sessionIds: readonly string[]): { release(): void } {
+      const ids = [...new Set(sessionIds)];
+      for (const id of ids) {
+        automaticQueryBlockCounts.set(id, (automaticQueryBlockCounts.get(id) ?? 0) + 1);
+      }
+      publishAutomaticQueryBlocks();
+
+      let released = false;
+      return {
+        release(): void {
+          if (released) return;
+          released = true;
+          for (const id of ids) {
+            const count = automaticQueryBlockCounts.get(id) ?? 0;
+            if (count <= 1) automaticQueryBlockCounts.delete(id);
+            else automaticQueryBlockCounts.set(id, count - 1);
+          }
+          publishAutomaticQueryBlocks();
+        },
+      };
+    },
     commitSessions(next: readonly DesktopSessionSummary[]): void {
       const current = state.getState();
       state.replaceState({ ...current, sessions: next, revision: current.revision + 1 });

--- a/apps/desktop/stories/composer-slash-menu.stories.tsx
+++ b/apps/desktop/stories/composer-slash-menu.stories.tsx
@@ -49,6 +49,10 @@ import { withScopedMakaBridge } from './maka-bridge';
 const COMPOSER_INPUT = '.maka-composer-editor [contenteditable="true"]';
 const MENU_LABEL = '命令和技能';
 const SESSION_ID = 'session-slash-menu';
+const automaticQueryGate = {
+  subscribe: () => () => {},
+  isAutomaticQueryBlocked: () => false,
+};
 
 /**
  * What app-shell.tsx builds for `slashCommands`, from the same three
@@ -155,6 +159,7 @@ function SlashMenuHarness({
   return (
     <div style={{ display: 'flex', alignItems: 'flex-end', height: 520, padding: 24 }}>
       <ComposerMentionsProvider
+        automaticQueryGate={automaticQueryGate}
         skillCatalogRevision={0}
         sessionId={hasSession ? SESSION_ID : undefined}
         projectPath="/workspace/maka-agent"
@@ -185,6 +190,7 @@ function ContextSwitchHarness(): React.ReactElement {
       </button>
       <div style={{ display: 'flex', flex: 1, alignItems: 'flex-end' }}>
         <ComposerMentionsProvider
+          automaticQueryGate={automaticQueryGate}
           skillCatalogRevision={0}
           sessionId={hasSession ? SESSION_ID : undefined}
           projectPath="/workspace/maka-agent"


### PR DESCRIPTION
## Summary

Prevent archived sessions from remaining automatic query targets by:

- excluding archived sessions from bootstrap selection
- pausing automatic Skills and Plan refreshes while archive or delete actions are pending

This reuses the existing pending row-action state, so renderer cleanup still happens only after the Runtime Host confirms the operation.

Fixes #4430

## Verification

- `npm --workspace @maka/desktop run build:main` — passed
- `npm --workspace @maka/desktop run typecheck` — passed
- `npm run check:app-shell-hooks` — passed
- `npm --workspace @maka/desktop run check:architecture` — passed (60 tests)
- Biome check on the changed TypeScript files — passed
- Relevant Desktop regression suites — passed (16 tests)

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

OpenAI Codex assisted with diagnosis, implementation, regression tests, and code review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
