### PR TITLE
feat(desktop): import several conversations in one pass

### DIFF
--- a/apps/desktop/src/main/__tests__/import-tasks-settings-page.test.ts
+++ b/apps/desktop/src/main/__tests__/import-tasks-settings-page.test.ts
@@ -1204,6 +1204,12 @@ async function renderPage(options: {
   importResult?:
     | { ok: false; reason: 'commit_outcome_unknown' }
     | Promise<{ ok: false; reason: 'commit_outcome_unknown' }>;
+  /**
+   * Per-source answers for a batch: `ok` lands, `unknown` is the Host not
+   * answering, `throw` is a rejection. Keyed by source session id, because a
+   * batch is exactly the case where the ids must not share one answer.
+   */
+  importBySource?: Record<string, 'ok' | 'unknown' | 'throw'>;
   onOpenImported?: (sessionId: string) => void;
   locale?: 'en' | 'zh';
 }): Promise<{
@@ -1212,6 +1218,8 @@ async function renderPage(options: {
   listCalls(): number;
   listInputs(): Array<{ includeArchived: boolean }>;
   hostCalls(): Array<{ operation: 'listSources' | 'list' | 'import'; host?: DesktopRuntimeHostRef }>;
+  /** Source ids handed to `import`, in the order the batch walked them. */
+  importedIds(): string[];
 }> {
   const { document, window } = parseHTML('<div id="root"></div>');
   const matchMedia = (media: string) => ({
@@ -1240,6 +1248,7 @@ async function renderPage(options: {
     IS_REACT_ACT_ENVIRONMENT: true,
   });
   let listCalls = 0;
+  const importedIds: string[] = [];
   const listInputs: Array<{ includeArchived: boolean }> = [];
   const hostCalls: Array<{
     operation: 'listSources' | 'list' | 'import';
@@ -1272,8 +1281,16 @@ async function renderPage(options: {
         if (result instanceof Error) throw result;
         return result;
       },
-      import: async (_input: unknown, host?: DesktopRuntimeHostRef) => {
+      import: async (input: unknown, host?: DesktopRuntimeHostRef) => {
         hostCalls.push({ operation: 'import', host });
+        const sourceSessionId = (input as { sourceSessionId?: string }).sourceSessionId ?? '';
+        importedIds.push(sourceSessionId);
+        const perSource = options.importBySource?.[sourceSessionId];
+        if (perSource === 'throw') throw new Error(`import-failed:${sourceSessionId}`);
+        if (perSource === 'unknown') return { ok: false, reason: 'commit_outcome_unknown' };
+        if (perSource === 'ok') {
+          return { ok: true, session: { id: `imported-${sourceSessionId}` } };
+        }
         return options.importResult ?? Promise.reject(new Error('import is not used by this test'));
       },
     },
@@ -1305,6 +1322,7 @@ async function renderPage(options: {
     listCalls: () => listCalls,
     listInputs: () => listInputs,
     hostCalls: () => hostCalls,
+    importedIds: () => importedIds,
   };
 }
 
@@ -1341,3 +1359,193 @@ function segment(container: HTMLElement, value: string): HTMLButtonElement | und
     container.querySelectorAll<HTMLButtonElement>('button[role="radio"]'),
   ).find((button) => button.getAttribute('data-value') === value);
 }
+
+/**
+ * Selecting several conversations and importing them in one go.
+ *
+ * The page is a directory you pick from, so the checkboxes are always there —
+ * there is no mode to enter. What these cases pin is the accounting: a batch
+ * that reports one number for four different outcomes is worse than no batch.
+ */
+describe('ImportTasksSettingsPage batch import', () => {
+  function rows(container: HTMLElement): HTMLInputElement[] {
+    return Array.from(container.querySelectorAll<HTMLInputElement>('li input[type="checkbox"]'));
+  }
+
+  function masterBox(container: HTMLElement): HTMLInputElement {
+    const box = container.querySelector<HTMLInputElement>(
+      '.maka-import-selection-bar input[type="checkbox"]',
+    );
+    assert.ok(box, 'master checkbox renders');
+    return box;
+  }
+
+  async function tick(box: HTMLInputElement, checked: boolean): Promise<void> {
+    // React's checkbox onChange is driven by the native click, and its value
+    // tracker swallows a programmatic `.checked` write without one.
+    await act(async () => {
+      box.checked = checked;
+      box.dispatchEvent(new (globalThis.window as unknown as { Event: typeof Event }).Event('click', {
+        bubbles: true,
+        cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+  }
+
+  it('the master box marks and unmarks exactly the rows on screen', async () => {
+    const { container } = await renderPage({
+      catalog: {
+        sessions: [
+          externalSession({ id: 'a', name: 'A' }),
+          externalSession({ id: 'b', name: 'B' }),
+        ],
+        nextCursor: null,
+      },
+    });
+
+    assert.equal(rows(container).length, 2);
+    await tick(masterBox(container), true);
+    assert.deepEqual(rows(container).map((box) => box.checked), [true, true]);
+    assert.match(container.textContent ?? '', /2 \/ 2 selected/);
+
+    await tick(masterBox(container), false);
+    assert.deepEqual(rows(container).map((box) => box.checked), [false, false]);
+    assert.match(container.textContent ?? '', /0 \/ 2 selected/);
+  });
+
+  it('the master box reads indeterminate for a partial selection', async () => {
+    // The usual state during a selection, and the one a checked/unchecked pair
+    // cannot express.
+    const { container } = await renderPage({
+      catalog: {
+        sessions: [externalSession({ id: 'a' }), externalSession({ id: 'b' })],
+        nextCursor: null,
+      },
+    });
+
+    await tick(rows(container)[0]!, true);
+    assert.equal(masterBox(container).indeterminate, true);
+    await tick(rows(container)[1]!, true);
+    assert.equal(masterBox(container).indeterminate, false);
+    assert.equal(masterBox(container).checked, true);
+  });
+
+  it('imports the marked rows one at a time and counts each outcome once', async () => {
+    // Sequential on purpose: recovery re-reads the catalog window an attempt
+    // came from, so overlapping attempts would race that read, and a progress
+    // count is only true when one thing is happening.
+    const { container, importedIds } = await renderPage({
+      catalog: {
+        sessions: [
+          externalSession({ id: 'fresh', name: 'Fresh' }),
+          externalSession({
+            id: 'again',
+            name: 'Again',
+            importState: { importedCount: 1, importedSessionIds: ['prior'], isImporting: false },
+          }),
+          externalSession({ id: 'broken', name: 'Broken' }),
+        ],
+        nextCursor: null,
+      },
+      importBySource: { fresh: 'ok', again: 'ok', broken: 'throw' },
+    });
+
+    await tick(masterBox(container), true);
+    const run = buttonWithText(container, 'Import selected');
+    assert.ok(run, 'the batch button renders');
+    await act(async () => {
+      run.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.deepEqual(importedIds(), ['fresh', 'again', 'broken']);
+    const text = container.textContent ?? '';
+    // Two imported, and the summary says one of them now exists twice —
+    // re-importing is how a conversation is refreshed, but a user who marked
+    // three and reads "imported 2" deserves to know which kind they were.
+    assert.match(text, /Imported 2 conversations/);
+    assert.match(text, /1 of them had been imported before/);
+    // One rejection does not become the batch's answer for the rows after it.
+    assert.match(text, /1 more could not be imported/);
+  });
+
+  it('a Host that does not answer is not counted as a failure', async () => {
+    // Only a catalog read settles whether an unanswered conversion landed.
+    // Calling it a failure is what invites the retry that makes a second copy.
+    const { container } = await renderPage({
+      catalog: { sessions: [externalSession({ id: 'quiet' })], nextCursor: null },
+      importBySource: { quiet: 'unknown' },
+    });
+
+    await tick(masterBox(container), true);
+    const run = buttonWithText(container, 'Import selected');
+    assert.ok(run);
+    await act(async () => {
+      run.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? '';
+    assert.match(text, /No conversation was imported/);
+    assert.doesNotMatch(text, /could not be imported/);
+    // It surfaces through the unconfirmed banner, which owns the retry.
+    assert.match(text, /unconfirmed|Unconfirmed|outcome/i);
+  });
+
+  it('spins only the conversion in flight, not every queued row', async () => {
+    // A spinner claims something is happening now. Marking every selected row
+    // would put one on rows the batch has not reached, and on rows it already
+    // finished.
+    let releaseFirst: ((value: { ok: false; reason: 'commit_outcome_unknown' }) => void) | undefined;
+    const { container } = await renderPage({
+      catalog: {
+        sessions: [externalSession({ id: 'a', name: 'A' }), externalSession({ id: 'b', name: 'B' })],
+        nextCursor: null,
+      },
+      // The first conversion parks until released, so the assertion lands while
+      // exactly one row is converting and the other is queued.
+      importResult: new Promise((resolve) => {
+        releaseFirst = resolve;
+      }),
+    });
+
+    await tick(masterBox(container), true);
+    const run = buttonWithText(container, 'Import selected');
+    assert.ok(run);
+    await act(async () => {
+      run.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const spinning = Array.from(container.querySelectorAll('li')).map((row) =>
+      row.textContent?.includes('Importing') === true || !!row.querySelector('[aria-busy="true"]'),
+    );
+    assert.equal(spinning.filter(Boolean).length, 1, 'exactly one row reads as converting');
+
+    await act(async () => {
+      releaseFirst?.({ ok: false, reason: 'commit_outcome_unknown' });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  it('the batch button stays out of reach until something is marked', async () => {
+    const { container } = await renderPage({
+      catalog: { sessions: [externalSession({ id: 'a' })], nextCursor: null },
+    });
+
+    const run = buttonWithText(container, 'Import selected');
+    assert.ok(run);
+    assert.equal(run.disabled, true);
+    await tick(rows(container)[0]!, true);
+    assert.equal(buttonWithText(container, 'Import selected')?.disabled, false);
+  });
+});

--- a/apps/desktop/src/renderer/locales/external-session-import-copy.ts
+++ b/apps/desktop/src/renderer/locales/external-session-import-copy.ts
@@ -79,6 +79,18 @@ type ExternalSessionImportCopy = {
    * or paged away by the time it renders.
    */
   importOutcomeUnknownDescription: (names: readonly string[]) => string;
+  selectAllAriaLabel: string;
+  /** Marked out of listed — the source's own total is not a number this page knows. */
+  selectedCount: (selected: number, listed: number) => string;
+  selectRowAriaLabel: (name: string) => string;
+  importSelected: string;
+  /** Which one of how many the batch is on, so the count means something. */
+  batchProgress: (done: number, total: number) => string;
+  batchDoneTitle: (imported: number) => string;
+  /** Counted apart from the total: these conversations now exist twice. */
+  batchDuplicated: (count: number) => string;
+  batchFailed: (count: number) => string;
+  batchNothingImported: string;
 };
 
 const COPY = {
@@ -126,6 +138,15 @@ const COPY = {
     importNotRecordedTitle: '没有发现新任务',
     importNotRecordedDescription: '没有记录到新的任务，可以安全重试。',
     importOutcomeUnknownTitle: '需要确认导入结果',
+    selectAllAriaLabel: '全选或全不选',
+    selectedCount: (selected, listed) => `已选 ${selected} / ${listed}`,
+    selectRowAriaLabel: (name) => `选择 ${name}`,
+    importSelected: '导入所选',
+    batchProgress: (done, total) => `正在导入 ${done} / ${total}`,
+    batchDoneTitle: (imported) => `已导入 ${imported} 个对话`,
+    batchDuplicated: (count) => `其中 ${count} 个之前已导入过，现在各有两份。`,
+    batchFailed: (count) => `另有 ${count} 个没能导入。`,
+    batchNothingImported: '没有对话被导入。',
     importOutcomeUnknownDescription: (names) =>
       `以下对话的导入结果无法确认：${names.map((name) => `「${name}」`).join('、')}。请先在任务列表中查找，已经出现的不要再次导入。`,
   },
@@ -171,6 +192,16 @@ const COPY = {
     importNotRecordedTitle: 'No new task found',
     importNotRecordedDescription: 'No new task was recorded, so it is safe to retry.',
     importOutcomeUnknownTitle: 'Check the import result',
+    selectAllAriaLabel: 'Select all or none',
+    selectedCount: (selected, listed) => `${selected} / ${listed} selected`,
+    selectRowAriaLabel: (name) => `Select ${name}`,
+    importSelected: 'Import selected',
+    batchProgress: (done, total) => `Importing ${done} / ${total}`,
+    batchDoneTitle: (imported) => `Imported ${imported} conversations`,
+    batchDuplicated: (count) =>
+      `${count} of them had been imported before and now exist twice.`,
+    batchFailed: (count) => `${count} more could not be imported.`,
+    batchNothingImported: 'No conversation was imported.',
     importOutcomeUnknownDescription: (names) =>
       `Maka could not confirm the outcome of these imports: ${names.map((name) => `“${name}”`).join(', ')}. Look in the task list first, and do not import again anything that is already there.`,
   },

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -32,7 +32,16 @@ import type {
   DesktopRuntimeHostRef,
   DesktopSessionSummary,
 } from '../../preload/bridge-contract.js';
-import { Spinner, useMountedRef, useUiLocale } from '@maka/ui';
+import {
+  EMPTY_LISTED_SELECTION,
+  listedSelectionMasterState,
+  pruneListedSelection,
+  setAllListedSelected,
+  Spinner,
+  toggleListedSelection,
+  useMountedRef,
+  useUiLocale,
+} from '@maka/ui';
 import { ICON_SIZE, MessageSquare } from '@maka/ui/icons';
 import { getExternalSessionImportCopy } from '../locales/external-session-import-copy.js';
 import { localizedShellErrorMessage } from '../locales/shell-copy.js';
@@ -146,6 +155,75 @@ type ImportAttempt = {
   loadedCatalogItemCountBefore: number;
 };
 
+/**
+ * The page's import activity.
+ *
+ * `single` is one row's 导入 button; `batch` is the selection's. They are one
+ * state because they are one activity and cannot overlap — and `summary` is
+ * what the last batch left behind, which no other slot on this page can hold.
+ *
+ * A batch runs SEQUENTIALLY, and not because the Host cannot take two: it
+ * dedupes per (adapter, source id) and is happy to convert different
+ * conversations at once. The reasons are here, on this page. Recovery re-reads
+ * the whole catalog window an attempt came from, so overlapping attempts would
+ * race that read; a progress count is only true when one thing is happening;
+ * and the page has no useful answer to "which of these five failed" if they
+ * fail together.
+ */
+type ImportRun =
+  | { kind: 'idle'; summary?: ImportBatchOutcome }
+  | { kind: 'single'; attempt: ImportAttempt }
+  /** `current` is the one conversion actually in flight; the rest are queued. */
+  | { kind: 'batch'; done: number; total: number; current?: string };
+
+const IDLE_IMPORT_RUN: ImportRun = { kind: 'idle' };
+
+/** What one row of a batch did. */
+type ImportBatchDisposition = 'imported' | 'duplicated' | 'failed' | 'unknown';
+
+/**
+ * What a batch import can honestly say afterwards.
+ *
+ * `duplicated` is counted apart from `imported` because a row that already had
+ * a copy is selectable on purpose — re-importing is how one is refreshed — but
+ * a user who marked twelve and reads "imported 12" deserves to know that two of
+ * them now exist twice.
+ *
+ * `unknown` is neither a success nor a failure: the call did not answer, and
+ * only a catalog read settles whether the conversion landed. Folding it into
+ * failures is what would invite the retry that makes a second copy.
+ */
+type ImportBatchOutcome = {
+  imported: number;
+  duplicated: number;
+  failed: readonly string[];
+  unknown: readonly string[];
+};
+
+const EMPTY_IMPORT_BATCH_OUTCOME: ImportBatchOutcome = {
+  imported: 0,
+  duplicated: 0,
+  failed: [],
+  unknown: [],
+};
+
+function recordImportBatchResult(
+  outcome: ImportBatchOutcome,
+  sourceSessionId: string,
+  disposition: ImportBatchDisposition,
+): ImportBatchOutcome {
+  switch (disposition) {
+    case 'imported':
+      return { ...outcome, imported: outcome.imported + 1 };
+    case 'duplicated':
+      return { ...outcome, imported: outcome.imported + 1, duplicated: outcome.duplicated + 1 };
+    case 'failed':
+      return { ...outcome, failed: [...outcome.failed, sourceSessionId] };
+    case 'unknown':
+      return { ...outcome, unknown: [...outcome.unknown, sourceSessionId] };
+  }
+}
+
 type ImportRecovery =
   | { kind: 'landed'; attempt: ImportAttempt; importedSessionId: string }
   | { kind: 'not_recorded'; attempt: ImportAttempt };
@@ -199,17 +277,32 @@ export function ImportTasksSettingsPage(props: {
   const [searchDraft, setSearchDraft] = useState('');
   const [search, setSearch] = useState('');
   const [catalog, setCatalog] = useState<CatalogState>(EMPTY_CATALOG);
-  const [sourceLoading, setSourceLoading] = useState(false);
-  const [sourceResolved, setSourceResolved] = useState(false);
+  /**
+   * One probe, three phases — not two booleans that are always written
+   * together. `sourceLoading && sourceResolved` was never a state this page
+   * could be in, and nothing enforced that.
+   */
+  const [sourceProbe, setSourceProbe] = useState<'idle' | 'loading' | 'resolved'>('idle');
   const [catalogLoading, setCatalogLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   /**
-   * At most one import at a time. Not because two conversions would collide —
-   * Desktop Main can take both — but because the first one to succeed calls
-   * `onImported`, which closes Settings and opens the new task, orphaning any
-   * other import on a page the user can no longer see.
+   * What import work this page is doing, and what the last run said.
+   *
+   * One state, not three. A single import and a batch are the same activity —
+   * a batch is a run of conversions the user asked for at once — and the
+   * summary is what that activity leaves behind. Keeping them apart invited
+   * combinations the page can never be in (a single import in flight while a
+   * batch runs) and cost the page hook budget it does not have: the renderer
+   * debt ledger refuses this file more stateful hooks than it already carries.
+   *
+   * Still at most one at a time, and still not because two conversions would
+   * collide — Desktop Main dedupes per (adapter, source id) and takes both
+   * happily. A single import ends by calling `onImported`, which closes
+   * Settings and opens the new task; anything else running would be orphaned on
+   * a page the user can no longer see. A batch stays here and reports instead,
+   * which is why it can hold several conversions where a single one cannot.
    */
-  const [activeImport, setActiveImport] = useState<ImportAttempt | null>(null);
+  const [importRun, setImportRun] = useState<ImportRun>(IDLE_IMPORT_RUN);
   const [sourceError, setSourceError] = useState<string | null>(null);
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
@@ -223,6 +316,12 @@ export function ImportTasksSettingsPage(props: {
    * local lock and either exposes the landed task or allows a safe retry.
    */
   const [uncertainImports, setUncertainImports] = useState<readonly ImportAttempt[]>([]);
+  /**
+   * Rows marked for a batch. Always available: this page exists to pick
+   * conversations out of a directory, so there is no mode to enter.
+   */
+  const [selection, setSelection] = useState(EMPTY_LISTED_SELECTION);
+
   // Only the newest list request may write. Switching source or toggling the
   // archived filter while a page is in flight would otherwise land the old
   // source's rows under the new source's label.
@@ -263,8 +362,7 @@ export function ImportTasksSettingsPage(props: {
 
   const loadSources = useCallback(async () => {
     const generation = ++requestGeneration.current;
-    setSourceLoading(true);
-    setSourceResolved(false);
+    setSourceProbe('loading');
     setSourceError(null);
     setCatalogError(null);
     setImportError(null);
@@ -285,8 +383,7 @@ export function ImportTasksSettingsPage(props: {
       setSourceError(localizedShellErrorMessage(error, copy.loadFailedFallback, locale));
     } finally {
       if (generation === requestGeneration.current) {
-        setSourceLoading(false);
-        setSourceResolved(true);
+        setSourceProbe('resolved');
       }
     }
   }, [copy.loadFailedFallback, host, locale]);
@@ -429,7 +526,7 @@ export function ImportTasksSettingsPage(props: {
   useEffect(() => {
     if (
       adapterId === null ||
-      activeImport !== null ||
+      importRun.kind !== 'idle' ||
       catalogLoading ||
       loadingMore ||
       !hasCatalogImportInFlight
@@ -443,7 +540,7 @@ export function ImportTasksSettingsPage(props: {
     }, EXTERNAL_SESSION_IMPORT_POLL_MS);
     return () => clearTimeout(timeout);
   }, [
-    activeImport,
+    importRun.kind,
     adapterId,
     catalog.sessions.length,
     catalogPollTick,
@@ -461,6 +558,21 @@ export function ImportTasksSettingsPage(props: {
         timeStyle: 'short',
       }),
     [locale],
+  );
+
+  /**
+   * The page's only call into `externalSessions.import`.
+   *
+   * Both the row button and the batch go through here. That is a bridge-surface
+   * fact as much as a tidiness one: the renderer debt ledger counts call sites
+   * per file and forbids this page from gaining another, so a second literal
+   * call was never an option — and a single place to convert one conversation
+   * is what the two paths wanted anyway.
+   */
+  const requestImport = useCallback(
+    (adapter: string, sourceSessionId: string) =>
+      window.maka.externalSessions.import({ adapterId: adapter, sourceSessionId }, host),
+    [host],
   );
 
   const recoverUnknownImport = useCallback(
@@ -557,7 +669,7 @@ export function ImportTasksSettingsPage(props: {
 
   const importConversation = useCallback(
     async (session: DesktopExternalSessionCatalogItem) => {
-      if (adapterId === null || activeImport !== null) return;
+      if (adapterId === null || importRun.kind !== 'idle') return;
       const attempt: ImportAttempt = {
         adapterId,
         sourceSessionId: session.id,
@@ -571,14 +683,11 @@ export function ImportTasksSettingsPage(props: {
         latestImportedSessionIdBefore: session.importState.importedSessionIds[0],
         loadedCatalogItemCountBefore: catalog.sessions.length,
       };
-      setActiveImport(attempt);
+      setImportRun({ kind: 'single', attempt });
       setImportError(null);
       setImportRecovery(null);
       try {
-        const outcome = await window.maka.externalSessions.import({
-          adapterId: attempt.adapterId,
-          sourceSessionId: attempt.sourceSessionId,
-        }, host);
+        const outcome = await requestImport(attempt.adapterId, attempt.sourceSessionId);
         // Navigating away from Settings unmounts this page while the import is
         // still in Desktop Main's hands. The conversion itself completes and is
         // stored either way; what must not happen is a completion from a page
@@ -593,32 +702,147 @@ export function ImportTasksSettingsPage(props: {
         if (!mountedRef.current) return;
         setImportError(localizedShellErrorMessage(error, copy.importFailedFallback, locale));
       } finally {
-        if (mountedRef.current) setActiveImport(null);
+        if (mountedRef.current) setImportRun(IDLE_IMPORT_RUN);
       }
     },
     [
-      activeImport,
+      importRun.kind,
       adapterId,
       catalog.sessions.length,
       copy.importFailedFallback,
-      host,
       locale,
       mountedRef,
       props,
       recoverUnknownImport,
+      requestImport,
       includeArchived,
       search,
     ],
   );
 
-  const noSource = sourceResolved && !sourceLoading && !sourceError && adapterIds.length === 0;
+  const listedSourceIds = useMemo(
+    () => catalog.sessions.map((session) => session.id),
+    [catalog.sessions],
+  );
+  /**
+   * The marked rows that are still on screen — derived, not reconciled.
+   *
+   * A selection outlives the list it was made from: a search narrows, the
+   * archived filter flips, a poll replaces the window. Intersecting at read
+   * time answers that without an effect, so a stale id can never be counted,
+   * confirmed, or imported even for the render between the catalog changing and
+   * an effect catching up. It also leaves this page's hook budget alone, which
+   * the renderer debt ledger will not let grow.
+   */
+  const marked = useMemo(
+    () => pruneListedSelection(selection, listedSourceIds).selectedIds,
+    [listedSourceIds, selection],
+  );
+  const masterState = listedSelectionMasterState({ selectedIds: marked }, listedSourceIds);
+
+  const busy = importRun.kind !== 'idle';
+
+  const importSelected = useCallback(async () => {
+    if (adapterId === null || busy) return;
+    // Frozen at the press, in the catalog's own order rather than the set's
+    // insertion order, so the progress count walks the list the way the user
+    // reads it.
+    const targets = catalog.sessions.filter((session) => marked.has(session.id));
+    if (targets.length === 0) return;
+    setImportError(null);
+    setImportRecovery(null);
+    setImportRun({ kind: 'batch', done: 0, total: targets.length, current: targets[0]?.id });
+    let outcome = EMPTY_IMPORT_BATCH_OUTCOME;
+    try {
+      for (const [index, session] of targets.entries()) {
+        if (!mountedRef.current) return;
+        const attempt: ImportAttempt = {
+          adapterId,
+          sourceSessionId: session.id,
+          name: session.name,
+          includeArchived,
+          text: search,
+          importedCountBefore: session.importState.importedCount,
+          latestImportedSessionIdBefore: session.importState.importedSessionIds[0],
+          loadedCatalogItemCountBefore: catalog.sessions.length,
+        };
+        // A row that already had a copy is selectable on purpose — re-importing
+        // is how a conversation is refreshed — but the summary owes the user
+        // the fact that it now exists twice.
+        const wasImported = session.importState.importedCount > 0;
+        try {
+          const result = await requestImport(attempt.adapterId, attempt.sourceSessionId);
+          if (!mountedRef.current) return;
+          outcome = recordImportBatchResult(
+            outcome,
+            session.id,
+            // Not `failed`: the call did not answer, and only a catalog read
+            // settles whether the conversion landed. Calling it a failure is
+            // what invites the retry that makes a second copy.
+            result.ok ? (wasImported ? 'duplicated' : 'imported') : 'unknown',
+          );
+          if (!result.ok) {
+            // Recorded, not recovered. A single import recovers inline, but
+            // recovery re-reads the whole catalog window per attempt, and doing
+            // that between conversions would interleave N full reads with the
+            // batch and race the writes it is making. The unconfirmed banner
+            // names every one of these and its 重试 resolves them a press at a
+            // time, removing each as it settles.
+            setUncertainImports((current) =>
+              current.some(
+                (entry) =>
+                  entry.adapterId === attempt.adapterId &&
+                  entry.sourceSessionId === attempt.sourceSessionId,
+              )
+                ? current
+                : [...current, attempt],
+            );
+          }
+        } catch {
+          if (!mountedRef.current) return;
+          // One rejection is not the batch's answer for every row after it. The
+          // failure is recorded and the run continues; the summary names how
+          // many did not go through.
+          outcome = recordImportBatchResult(outcome, session.id, 'failed');
+        }
+        setImportRun({
+          kind: 'batch',
+          done: index + 1,
+          total: targets.length,
+          current: targets[index + 1]?.id,
+        });
+      }
+    } finally {
+      if (mountedRef.current) {
+        setImportRun({ kind: 'idle', summary: outcome });
+        // Cleared because it was answered. Leaving the rows marked after a run
+        // invites a second press that would import each of them again.
+        setSelection(EMPTY_LISTED_SELECTION);
+        // Imported rows change their own description ("已导入 N 次"), and the
+        // page has no other reason to re-read.
+        void loadCatalog(adapterId);
+      }
+    }
+  }, [
+    adapterId,
+    busy,
+    catalog.sessions,
+    includeArchived,
+    loadCatalog,
+    mountedRef,
+    requestImport,
+    search,
+    marked,
+  ]);
+
+  const noSource = sourceProbe === 'resolved' && !sourceError && adapterIds.length === 0;
   const catalogEmpty =
     adapterId !== null && !catalogLoading && !catalogError && catalog.sessions.length === 0;
   // The shared normalizer decides what counts as a filter, so the empty-state
   // copy and the matcher cannot disagree about a whitespace-only box.
   const activeSearch = normalizeExternalSessionQueryText(search);
 
-  if (sourceLoading) {
+  if (sourceProbe === 'loading') {
     return (
       <SettingsPage>
         <div role="status" aria-live="polite">
@@ -731,12 +955,51 @@ export function ImportTasksSettingsPage(props: {
               free to change while an import runs: filter it out, switch source,
               retry a failed page, and the row is gone. This is also what tells
               the user why every remaining 导入 is disabled. */}
-          {activeImport !== null && (
+          {importRun.kind === 'single' && (
             <div role="status" aria-live="polite">
               <Banner
                 status="info"
                 title={copy.importInProgressTitle}
-                description={copy.importInProgressDescription(activeImport.name)}
+                description={copy.importInProgressDescription(importRun.attempt.name)}
+              />
+            </div>
+          )}
+
+          {importRun.kind === 'batch' && (
+            <div role="status" aria-live="polite">
+              <Banner
+                status="info"
+                title={copy.importInProgressTitle}
+                description={copy.batchProgress(importRun.done, importRun.total)}
+              />
+            </div>
+          )}
+
+          {/* The batch stays on this page and reports here, rather than
+              navigating the way a single import does. There is no sensible task
+              to open after importing twelve, and leaving would strand the rows
+              that did not land. */}
+          {importRun.kind === 'idle' && importRun.summary !== undefined && (
+            <div role="status" aria-live="polite">
+              <Banner
+                status={importRun.summary.failed.length > 0 ? 'warning' : 'success'}
+                title={
+                  importRun.summary.imported > 0
+                    ? copy.batchDoneTitle(importRun.summary.imported)
+                    : copy.batchNothingImported
+                }
+                description={
+                  [
+                    importRun.summary.duplicated > 0
+                      ? copy.batchDuplicated(importRun.summary.duplicated)
+                      : null,
+                    importRun.summary.failed.length > 0
+                      ? copy.batchFailed(importRun.summary.failed.length)
+                      : null,
+                  ]
+                    .filter(Boolean)
+                    .join(' ') || undefined
+                }
               />
             </div>
           )}
@@ -816,6 +1079,37 @@ export function ImportTasksSettingsPage(props: {
           )}
 
           {catalog.sessions.length > 0 && (
+            <HStack gap={2} vAlign="center" className="maka-import-selection-bar">
+              <CheckboxInput
+                label={copy.selectAllAriaLabel}
+                isLabelHidden
+                value={masterState}
+                isDisabled={busy}
+                // Plain checkbox semantics, including from the partial state:
+                // an indeterminate box becomes ticked, which selects all. It is
+                // what the platform does and what the Session rail's own master
+                // box does, and one surface inventing a second rule for the
+                // same control is worse than either rule.
+                onChange={(checked) =>
+                  setSelection(setAllListedSelected(listedSourceIds, checked))
+                }
+              />
+              <span className="maka-import-selection-count" aria-live="polite">
+                {copy.selectedCount(marked.size, listedSourceIds.length)}
+              </span>
+              <span className="maka-import-selection-spacer" />
+              <Button
+                variant="secondary"
+                size="sm"
+                label={copy.importSelected}
+                isLoading={importRun.kind === 'batch'}
+                isDisabled={busy || marked.size === 0}
+                onClick={() => void importSelected()}
+              />
+            </HStack>
+          )}
+
+          {catalog.sessions.length > 0 && (
             <List
               density="balanced"
               hasDividers
@@ -836,7 +1130,12 @@ export function ImportTasksSettingsPage(props: {
                   .join(' · ');
                 const isImporting =
                   session.importState.isImporting ||
-                  (activeImport !== null && isSameAttempt(activeImport, adapterId, session));
+                  (importRun.kind === 'single' &&
+                    isSameAttempt(importRun.attempt, adapterId, session)) ||
+                  // Only the conversion actually in flight. Marking every
+                  // selected row would put a spinner on rows that are queued,
+                  // and a spinner claims something is happening now.
+                  (importRun.kind === 'batch' && importRun.current === session.id);
                 const latestImportedSessionId = session.importState.importedSessionIds[0];
                 const hasImported = session.importState.importedCount > 0;
                 return (
@@ -844,7 +1143,25 @@ export function ImportTasksSettingsPage(props: {
                     key={session.id}
                     label={session.name}
                     description={description.length > 0 ? description : undefined}
-                    startContent={<MessageSquare size={ICON_SIZE.control} aria-hidden="true" />}
+                    startContent={
+                      <HStack gap={2} vAlign="center">
+                        {/* The box leads, in the same column as the master box
+                            above it. The source icon stays: it says what kind of
+                            thing the row is, which selecting does not. */}
+                        <CheckboxInput
+                          label={copy.selectRowAriaLabel(session.name)}
+                          isLabelHidden
+                          value={marked.has(session.id)}
+                          isDisabled={busy || isImporting}
+                          onChange={(checked) =>
+                            setSelection((current) =>
+                              toggleListedSelection(current, session.id, checked),
+                            )
+                          }
+                        />
+                        <MessageSquare size={ICON_SIZE.control} aria-hidden="true" />
+                      </HStack>
+                    }
                     endContent={
                       <HStack gap={2} vAlign="center">
                         {latestImportedSessionId !== undefined && props.onOpenImported && (
@@ -862,7 +1179,7 @@ export function ImportTasksSettingsPage(props: {
                           isLoading={isImporting}
                           isDisabled={
                             isImporting ||
-                            activeImport !== null ||
+                            busy ||
                             uncertainImports.length > 0
                           }
                           // `onClick`, not `clickAction`. Astryx runs

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -252,3 +252,17 @@
   border-end-start-radius: var(--radius-surface);
   border-end-end-radius: var(--radius-surface);
 }
+
+/*
+ * Import · the batch selection bar.
+ *
+ * It heads the catalog List directly below it, so it carries no rule of its
+ * own: the List already draws dividers between its rows, and a second line
+ * here would read as a divider above a row that is not one.
+ *
+ * The spacer takes the leftover width so 导入所选 stays on the trailing edge
+ * whatever the locale does to the count's length.
+ */
+.maka-import-selection-spacer {
+  flex: 1 1 auto;
+}

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -6,7 +6,7 @@ Generated against `@astryxdesign/core@0.5.0` (194 component exports).
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 233 files — blocker 0, reimplementation 0, polish 1, aligned 232.
+**Totals:** 234 files — blocker 0, reimplementation 0, polish 1, aligned 233.
 
 ## Exclusions (explicit)
 

--- a/packages/ui/src/__tests__/listed-selection.test.ts
+++ b/packages/ui/src/__tests__/listed-selection.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  EMPTY_LISTED_SELECTION,
+  listedSelectionMasterState,
+  pruneListedSelection,
+  setAllListedSelected,
+  toggleListedSelection,
+  type ListedSelection,
+} from '../listed-selection.js';
+
+const LISTED = ['a', 'b', 'c'];
+
+function ids(selection: ListedSelection): string[] {
+  return [...selection.selectedIds].sort();
+}
+
+function mark(selection: ListedSelection, id: string): ListedSelection {
+  return toggleListedSelection(selection, id, true);
+}
+
+describe('toggleListedSelection', () => {
+  test('marks and unmarks one id', () => {
+    const one = mark(EMPTY_LISTED_SELECTION, 'b');
+    assert.deepEqual(ids(one), ['b']);
+    assert.deepEqual(ids(toggleListedSelection(one, 'b', false)), []);
+  });
+
+  test('a toggle that changes nothing returns the same value', () => {
+    // Identity is the render boundary for a list of rows: a fresh Set for a
+    // click that changed nothing re-renders all of them.
+    const one = mark(EMPTY_LISTED_SELECTION, 'b');
+    assert.equal(toggleListedSelection(one, 'b', true), one);
+    assert.equal(toggleListedSelection(one, 'c', false), one);
+  });
+
+  test('the input is never mutated', () => {
+    const one = mark(EMPTY_LISTED_SELECTION, 'b');
+    mark(one, 'c');
+    assert.deepEqual(ids(one), ['b']);
+  });
+});
+
+describe('setAllListedSelected', () => {
+  test('marks exactly what the surface listed', () => {
+    // A paged catalog does not know its own total and a filtered one is showing
+    // a subset on purpose, so "all" can only mean the rows under the box.
+    assert.deepEqual(ids(setAllListedSelected(LISTED, true)), ['a', 'b', 'c']);
+  });
+
+  test('unticking settles on the shared empty value', () => {
+    assert.equal(setAllListedSelected(LISTED, false), EMPTY_LISTED_SELECTION);
+  });
+});
+
+describe('listedSelectionMasterState', () => {
+  test('reads unchecked, indeterminate, then checked', () => {
+    assert.equal(listedSelectionMasterState(EMPTY_LISTED_SELECTION, LISTED), false);
+    assert.equal(listedSelectionMasterState(mark(EMPTY_LISTED_SELECTION, 'b'), LISTED), 'indeterminate');
+    assert.equal(listedSelectionMasterState(setAllListedSelected(LISTED, true), LISTED), true);
+  });
+
+  test('an empty list is unchecked, never checked', () => {
+    // `every` over an empty array is vacuously true, which would tick the box
+    // above no rows at all.
+    assert.equal(listedSelectionMasterState(setAllListedSelected([], true), []), false);
+    assert.equal(listedSelectionMasterState(mark(EMPTY_LISTED_SELECTION, 'a'), []), false);
+  });
+
+  test('a mark outside the listed ids cannot make it checked', () => {
+    const stray = mark(EMPTY_LISTED_SELECTION, 'zzz');
+    assert.equal(listedSelectionMasterState(stray, LISTED), 'indeterminate');
+  });
+});
+
+describe('pruneListedSelection', () => {
+  test('drops ids the surface no longer lists', () => {
+    const all = setAllListedSelected(LISTED, true);
+    assert.deepEqual(ids(pruneListedSelection(all, ['a', 'c'])), ['a', 'c']);
+  });
+
+  test('returns the same value when nothing was dropped', () => {
+    const one = mark(EMPTY_LISTED_SELECTION, 'a');
+    assert.equal(pruneListedSelection(one, LISTED), one);
+  });
+
+  test('an emptied result settles on the shared empty value', () => {
+    assert.equal(pruneListedSelection(mark(EMPTY_LISTED_SELECTION, 'a'), []), EMPTY_LISTED_SELECTION);
+  });
+
+  test('accepts a Set without rebuilding it', () => {
+    // The import page passes the ids it already has; re-wrapping a Set per
+    // render is work a derived read cannot afford.
+    const all = setAllListedSelected(LISTED, true);
+    assert.deepEqual(ids(pruneListedSelection(all, new Set(['b']))), ['b']);
+  });
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -43,6 +43,7 @@ export * from './tool-activity/sandbox-denial.js';
 export * from './chat-input-behavior.js';
 export * from './runtime-resume-copy.js';
 export * from './input-history.js';
+export * from './listed-selection.js';
 export * from './daily-review-helpers.js';
 export * from './locale-helpers.js';
 export * from './locale-context.js';

--- a/packages/ui/src/listed-selection.ts
+++ b/packages/ui/src/listed-selection.ts
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A marked subset of whatever a surface is currently listing.
+ *
+ * Ids only, and no opinion about what they identify: the External Session
+ * import catalog marks source conversation ids, and anything else with a
+ * checkbox column can mark its own.
+ *
+ * Every function returns the SAME value when nothing changed. Identity is the
+ * render boundary for a list of rows, and a fresh Set per keystroke or per poll
+ * re-renders all of them for no reason.
+ */
+export interface ListedSelection {
+  readonly selectedIds: ReadonlySet<string>;
+}
+
+export const EMPTY_LISTED_SELECTION: ListedSelection = Object.freeze({
+  selectedIds: Object.freeze(new Set<string>()) as ReadonlySet<string>,
+});
+
+export function toggleListedSelection(
+  selection: ListedSelection,
+  id: string,
+  selected: boolean,
+): ListedSelection {
+  if (selection.selectedIds.has(id) === selected) return selection;
+  const selectedIds = new Set(selection.selectedIds);
+  if (selected) selectedIds.add(id);
+  else selectedIds.delete(id);
+  return { selectedIds };
+}
+
+/**
+ * The master box: every listed id, or none of them.
+ *
+ * "All" is what the surface has listed and is showing. A paged catalog does not
+ * know its own total, and a filtered one is showing a subset on purpose — a box
+ * that reached past the rows beneath it would act on a number nobody saw.
+ */
+export function setAllListedSelected(
+  listedIds: readonly string[],
+  selected: boolean,
+): ListedSelection {
+  return selected ? { selectedIds: new Set(listedIds) } : EMPTY_LISTED_SELECTION;
+}
+
+/** What the master box shows: all, none, or some. */
+export function listedSelectionMasterState(
+  selection: ListedSelection,
+  listedIds: readonly string[],
+): boolean | 'indeterminate' {
+  if (selection.selectedIds.size === 0) return false;
+  // `every` over an empty array is vacuously true, which would tick the box
+  // above no rows at all.
+  if (listedIds.length === 0) return false;
+  return listedIds.every((id) => selection.selectedIds.has(id)) ? true : 'indeterminate';
+}
+
+/**
+ * Drops ids the surface no longer lists.
+ *
+ * A selection outlives the list it was made from: a search narrows, a filter
+ * flips, a poll replaces the window. Keeping an id that is gone would make a
+ * count disagree with the rows on screen, and would act on something the user
+ * can no longer see.
+ */
+export function pruneListedSelection(
+  selection: ListedSelection,
+  listedIds: Iterable<string>,
+): ListedSelection {
+  const listed = listedIds instanceof Set ? listedIds : new Set(listedIds);
+  const selectedIds = new Set<string>();
+  for (const id of selection.selectedIds) if (listed.has(id)) selectedIds.add(id);
+  if (selectedIds.size === selection.selectedIds.size) return selection;
+  return selectedIds.size === 0 ? EMPTY_LISTED_SELECTION : { selectedIds };
+}


### PR DESCRIPTION
## Summary

Settings › 导入任务 imported one conversation per press. A Claude Code directory here lists 1128 of them, so bringing over a project's worth meant finding a row, pressing 导入, waiting for the page to navigate away, coming back, and finding the next one.

Every row now carries a checkbox and a master row sits above the list:

```
[▬]  已选 15 / 16                          [ 导入所选 ]
[ ]  cyberpet      ~/CyberPet · 19:13          [ 导入 ]
[✓]  cyberpet      ~/CyberPet · 18:57          [ 导入 ]
```

There is no mode to enter: this page exists to pick conversations out of a directory, so the boxes are the page. The per-row 导入 button is untouched and still navigates to what it imported.

**A batch stays here and reports.** A single import ends by calling `onImported`, which closes Settings and opens the new task. There is no sensible task to open after importing twelve, and leaving would strand the rows that did not land. The summary counts four outcomes apart:

- **imported** — landed.
- **duplicated** — landed, and that conversation now exists twice. Re-importing is how one is refreshed, so those rows are selectable on purpose; but a user who marked twelve and reads "imported 12" deserves to know which kind they were.
- **failed** — the Host rejected it. One rejection is not the batch's answer for every row after it, so the run continues.
- **unknown** — the call did not answer. Only a catalog read settles whether the conversion landed, and folding this into failures is what would invite the retry that makes a second copy. These reach the existing unconfirmed banner, which names every one of them and resolves them a press at a time.

**Sequential, and not because the Host cannot take two.** `external-session-coordinator.ts` dedupes per `(adapterId, sourceSessionId)` and converts different conversations concurrently without complaint. The reasons are on this page: recovery re-reads the whole catalog window an attempt came from, so overlapping attempts would race that read; a progress count is only true while one thing is happening; and the page has no useful answer to "which of these five failed" if they fail together.

**"All" means the rows on screen.** The catalog is paged behind a cursor and narrowed by a search term and the archived filter, so a box that reached past the rows beneath it would start an import whose size the user never saw.

## Paying for it in a file that may not grow

`renderer-architecture.json` ratchets this page's debt against `main`: no new stateful hooks, no new bridge call sites, no new module specifiers. Three consolidations paid for the feature, and each is worth having on its own terms.

- `sourceLoading` + `sourceResolved` become one `sourceProbe`. They were always written together, and `loading && resolved` was never a state this page could be in with nothing enforcing it.
- `activeImport` plus the batch's progress and summary become one `importRun`. A single import and a batch are one activity and cannot overlap; three states invited combinations that cannot happen.
- The marked set is **intersected at read time** rather than pruned in an effect. That is not only a hook saved: an effect leaves a render in which a row the catalog just dropped is still counted, still named by the confirm, and still importable. A derived read has no such window.

Both import paths now go through one `requestImport`, which the ledger also required — and which is what two callers of the same bridge method wanted anyway.

| metric | main | here |
|---|---:|---:|
| `hookCalls` | 31 | 31 |
| `bridgePaths` | 4 | 4 |
| `dependencyPaths` | 19 | 19 |

The selection itself is `packages/ui/src/listed-selection.ts` — a marked subset of whatever a surface is listing, with no opinion about what the ids identify. Every function returns its input unchanged when nothing moved, because identity is the render boundary for a list of rows.

## Self-review

Reviewing the diff before opening this turned up three defects, all fixed here.

1. **A stale doc comment left stacked above its replacement**, describing an `activeImport` that no longer exists. Its one load-bearing fact — that the single-import limit is about navigation, not about the Host — is merged into the new comment.
2. **Every selected row spun during a batch**, including rows the run had not reached and rows it had already finished. A spinner claims something is happening *now*, so the batch state carries the id actually converting and only that row reads as busy. A test parks the first conversion and asserts exactly one row is spinning.
3. **The batch records an unanswered import without running recovery**, unlike the single path. That is deliberate — recovery re-reads the whole catalog window, and doing that between conversions would interleave N full reads with the writes the batch is making — but it was undocumented, which is how a deliberate divergence becomes a bug report.

## Verification

```
packages/ui        304 tests, 304 pass, 0 fail
apps/desktop      1851 tests, 1849 pass, 2 fail   (environmental, see below)
check:renderer-architecture --base    pass, all three metrics level with main
astryx surface inventory + its tests  pass
astryx:theme --check                  pass
knip (apps/desktop, packages/ui)      pass
lint, format:check, typecheck         pass
check:app-shell-hooks, check:asf-headers   pass
```

Driven in the running app over a real Claude Code directory of 16 conversations: master box to 16/16, untick one row to 15/16 with the master reading `indeterminate`, and back.

The two failing `app-update-attestation` cases (TUF/Sigstore in the packaged Electron runtime) fail on this machine with and without these changes.

Each behaviour fails a test when reverted:

| reverted | result |
|---|---|
| counting a re-import as `duplicated` | 29 pass / 1 fail |
| treating a rejection as an import | 29 pass / 1 fail |
| the master box's `indeterminate` state | 29 pass / 1 fail |
| spinning only the conversion in flight | 30 pass / 1 fail |

## Relationship to #4365

No file overlaps that PR. It adds multi-select to the Session rail; this adds it to the import catalog. They share the checkbox-and-master-box shape and nothing else — the rail acts on Maka's own sessions through `SessionNavigationServices`, this acts on foreign conversations through `window.maka.externalSessions`. Either can land first; whichever lands second will need `renderer-architecture.json` and the Astryx inventory regenerated, which is mechanical.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Opus 5 via Claude Code — design, implementation, tests, and this description. Reviewed and verified locally by me; the commit carries a `Generated-by` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
