### PR TITLE
refactor(desktop): centralize session navigation ports

### DIFF
--- a/apps/desktop/src/renderer/features/session-navigation/README.md
+++ b/apps/desktop/src/renderer/features/session-navigation/README.md
@@ -33,6 +33,8 @@ owns:
 
 - Consumers import production APIs from `features/session-navigation`.
 - Tests may additionally import `features/session-navigation/testing`.
+- Contract types the shell fulfills for this feature live in `ports.ts`;
+  controller files export only what they implement.
 - Desktop Sessions bridge calls go through `SessionNavigationServices`; only
   `platform/desktop/create-session-navigation-services.ts` reads that bridge.
 - Session Navigation may use shared renderer storage/copy, core types, and Maka

--- a/apps/desktop/src/renderer/features/session-navigation/controller/session-row-actions.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/controller/session-row-actions.ts
@@ -21,39 +21,12 @@ import type { SessionSummary } from '@maka/core/session';
 import type { UiLocale } from '@maka/core/ui-locale';
 import { getShellCopy, localizedShellErrorMessage } from '../../../locales/shell-copy.js';
 import { revisionFamilySessionIds } from '@maka/core/session-revisions';
-import type { SessionNavigationSessionService } from '../ports.js';
-
-type RefBox<T> = { current: T };
-
-/** What `sessions.remove` settled on. `restored` means the task is still there. */
-type SessionRemoveDisposition = 'removed' | 'restored';
-
-/**
- * How a delete settled together with the count the Host actually archived.
- * `archivedSubtaskCount` is the Host's executed number — 0 when the delete was
- * called off (`restored`) — so the toast reports a fact, not a renderer guess.
- */
-type SessionRemoveOutcome = {
-  disposition: SessionRemoveDisposition;
-  archivedSubtaskCount: number;
-};
-
-type ToastApi = {
-  success(title: string, description?: string): void;
-  error(
-    title: string,
-    description?: string,
-    diagnosticDetails?: string,
-    diagnosticTarget?: { sessionId: string },
-  ): void;
-  confirm(options: {
-    title: string;
-    description: string;
-    confirmLabel: string;
-    cancelLabel: string;
-    destructive?: boolean;
-  }): Promise<boolean>;
-};
+import type {
+  SessionNavigationRef,
+  SessionNavigationRemoveOutcome,
+  SessionNavigationSessionService,
+  SessionNavigationToastApi,
+} from '../ports.js';
 
 /**
  * What a sweep can honestly say afterwards. `verified: false` means the catalog
@@ -116,15 +89,15 @@ export interface SessionNavigationRowActions {
 
 export function createSessionNavigationRowActions(deps: {
   uiLocale: UiLocale;
-  activeIdRef: RefBox<string | undefined>;
+  activeIdRef: SessionNavigationRef<string | undefined>;
   clearActiveMessages: () => void;
   clearSessionRendererState: (sessionId: string) => void;
-  pendingSessionRowActionsRef: RefBox<Set<string>>;
+  pendingSessionRowActionsRef: SessionNavigationRef<Set<string>>;
   refreshSessions: () => Promise<ReadonlyArray<SessionSummary>>;
   service: SessionNavigationSessionService;
-  sessionsRef: RefBox<ReadonlyArray<SessionSummary>>;
+  sessionsRef: SessionNavigationRef<ReadonlyArray<SessionSummary>>;
   setActiveId: (sessionId: string | undefined) => void;
-  toastApi: ToastApi;
+  toastApi: SessionNavigationToastApi;
 }): SessionNavigationRowActions {
   const {
     uiLocale,
@@ -258,7 +231,7 @@ export function createSessionNavigationRowActions(deps: {
   async function removeSessionFamily(
     sessionId: string,
     options: { requireArchived: boolean },
-  ): Promise<SessionRemoveOutcome> {
+  ): Promise<SessionNavigationRemoveOutcome> {
     // Read before the write: the family comes off the live catalog, which no
     // longer lists it afterwards.
     const familyIds = revisionFamilySessionIds(sessionsRef.current, sessionId);

--- a/apps/desktop/src/renderer/features/session-navigation/controller/session-row-actions.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/controller/session-row-actions.ts
@@ -21,8 +21,8 @@ import type { SessionSummary } from '@maka/core/session';
 import type { UiLocale } from '@maka/core/ui-locale';
 import { getShellCopy, localizedShellErrorMessage } from '../../../locales/shell-copy.js';
 import { revisionFamilySessionIds } from '@maka/core/session-revisions';
+import type { RefObject } from 'react';
 import type {
-  SessionNavigationRef,
   SessionNavigationRemoveOutcome,
   SessionNavigationSessionService,
   SessionNavigationToastApi,
@@ -89,13 +89,13 @@ export interface SessionNavigationRowActions {
 
 export function createSessionNavigationRowActions(deps: {
   uiLocale: UiLocale;
-  activeIdRef: SessionNavigationRef<string | undefined>;
+  activeIdRef: RefObject<string | undefined>;
   clearActiveMessages: () => void;
   clearSessionRendererState: (sessionId: string) => void;
-  pendingSessionRowActionsRef: SessionNavigationRef<Set<string>>;
+  pendingSessionRowActionsRef: RefObject<Set<string>>;
   refreshSessions: () => Promise<ReadonlyArray<SessionSummary>>;
   service: SessionNavigationSessionService;
-  sessionsRef: SessionNavigationRef<ReadonlyArray<SessionSummary>>;
+  sessionsRef: RefObject<ReadonlyArray<SessionSummary>>;
   setActiveId: (sessionId: string | undefined) => void;
   toastApi: SessionNavigationToastApi;
 }): SessionNavigationRowActions {

--- a/apps/desktop/src/renderer/features/session-navigation/controller/use-session-navigation-controller.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/controller/use-session-navigation-controller.ts
@@ -35,53 +35,13 @@ import {
   sessionRailLayoutStore,
   type SessionRailLayoutState,
 } from '../model/session-rail-layout-store.js';
-import type { SessionNavigationSession } from '../ports.js';
+import type { SessionNavigationPorts, SessionNavigationSession } from '../ports.js';
 import { useSessionNavigationServices } from '../services-context.js';
 import {
   createSessionNavigationRowActions,
   type SessionNavigationRowActions,
 } from './session-row-actions.js';
 import { useSessionSelection } from './use-session-selection.js';
-
-export type SessionNavigationToastApi = {
-  success(title: string, description?: string): void;
-  error(
-    title: string,
-    description?: string,
-    diagnosticDetails?: string,
-    diagnosticTarget?: { sessionId: string },
-  ): void;
-  confirm(options: {
-    title: string;
-    description: string;
-    confirmLabel: string;
-    cancelLabel: string;
-    destructive?: boolean;
-  }): Promise<boolean>;
-};
-
-type RefBox<T> = { current: T };
-
-/**
- * What the rail asks of the rest of the shell, named one by one.
- *
- * Switching a session also clears the active messages and leaves the Work Hub.
- * Those are commands the shell issues, and they stay commands: the rail calls
- * them, it does not subscribe to them. Nothing here has to be identity-stable —
- * the controller reads them through a ref published on commit — so the shell
- * may build this object inline, and no ordinary `function` declaration upstream
- * can quietly put the rail back on every AppShell render (#4109).
- */
-export interface SessionNavigationPorts {
-  activeIdRef: RefBox<string | undefined>;
-  sessionsRef: RefBox<ReadonlyArray<SessionSummary>>;
-  pendingSessionRowActionsRef: RefBox<Set<string>>;
-  activateSession(sessionId: string | undefined): void;
-  clearActiveMessages(): void;
-  clearSessionRendererState(sessionId: string): void;
-  refreshSessions(): Promise<ReadonlyArray<SessionSummary>>;
-  toastApi: SessionNavigationToastApi;
-}
 
 export interface UseSessionNavigationControllerInput {
   /**

--- a/apps/desktop/src/renderer/features/session-navigation/index.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/index.ts
@@ -30,5 +30,4 @@ export type {
 export type {
   SessionNavigationPorts,
   SessionNavigationServices,
-  SessionNavigationToastApi,
 } from './ports.js';

--- a/apps/desktop/src/renderer/features/session-navigation/index.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/index.ts
@@ -21,11 +21,10 @@ export { SessionNavigationServicesProvider } from './services-context.js';
 export { SessionNavigationProvider } from './ui/session-navigation-provider.js';
 export { createSessionOpenCommand } from './controller/session-open-command.js';
 export { useSessionNavigationReads } from './controller/use-session-navigation-reads.js';
-export type { SessionNavigationPorts } from './controller/use-session-navigation-controller.js';
 export { deriveSessionRail } from './model/session-rail.js';
 export { sessionRailLayoutStore } from './model/session-rail-layout-store.js';
 export type {
   SessionNavigationRowActions,
   SessionPurgeOutcome,
 } from './controller/session-row-actions.js';
-export type { SessionNavigationServices } from './ports.js';
+export type { SessionNavigationPorts, SessionNavigationServices } from './ports.js';

--- a/apps/desktop/src/renderer/features/session-navigation/index.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/index.ts
@@ -27,4 +27,8 @@ export type {
   SessionNavigationRowActions,
   SessionPurgeOutcome,
 } from './controller/session-row-actions.js';
-export type { SessionNavigationPorts, SessionNavigationServices } from './ports.js';
+export type {
+  SessionNavigationPorts,
+  SessionNavigationServices,
+  SessionNavigationToastApi,
+} from './ports.js';

--- a/apps/desktop/src/renderer/features/session-navigation/ports.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/ports.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import type { RefObject } from 'react';
 import type { SessionSummary } from '@maka/core/session';
 import type { RuntimeHostProfileKind } from '@maka/runtime-host/profile-kind';
 
@@ -32,8 +33,10 @@ export interface SessionNavigationRemoveOutcome {
   readonly archivedSubtaskCount: number;
 }
 
-export type SessionNavigationRef<T> = { current: T };
-
+/**
+ * The slice of the shell toast surface the rail uses. Structural typing checks
+ * it against the real `ToastApi` where the shell wires it in.
+ */
 export type SessionNavigationToastApi = {
   success(title: string, description?: string): void;
   error(
@@ -99,15 +102,17 @@ export interface SessionNavigationServices {
  *
  * Switching a session also clears the active messages and leaves the Work Hub.
  * Those are commands the shell issues, and they stay commands: the rail calls
- * them, it does not subscribe to them. Nothing here has to be identity-stable —
- * the controller reads them through a ref published on commit — so the shell
- * may build this object inline, and no ordinary `function` declaration upstream
- * can quietly put the rail back on every AppShell render (#4109).
+ * them, it does not subscribe to them. The function fields need no identity
+ * stability — the controller reads them through a ref published on commit — so
+ * the shell may rebuild this object inline, and no ordinary `function`
+ * declaration upstream can quietly put the rail back on every AppShell render
+ * (#4109). The ref boxes themselves must be stable (`useRef` results): row
+ * actions capture them once and dereference at call time.
  */
 export interface SessionNavigationPorts {
-  activeIdRef: SessionNavigationRef<string | undefined>;
-  sessionsRef: SessionNavigationRef<ReadonlyArray<SessionSummary>>;
-  pendingSessionRowActionsRef: SessionNavigationRef<Set<string>>;
+  activeIdRef: RefObject<string | undefined>;
+  sessionsRef: RefObject<ReadonlyArray<SessionSummary>>;
+  pendingSessionRowActionsRef: RefObject<Set<string>>;
   activateSession(sessionId: string | undefined): void;
   clearActiveMessages(): void;
   clearSessionRendererState(sessionId: string): void;

--- a/apps/desktop/src/renderer/features/session-navigation/ports.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/ports.ts
@@ -32,6 +32,25 @@ export interface SessionNavigationRemoveOutcome {
   readonly archivedSubtaskCount: number;
 }
 
+export type SessionNavigationRef<T> = { current: T };
+
+export type SessionNavigationToastApi = {
+  success(title: string, description?: string): void;
+  error(
+    title: string,
+    description?: string,
+    diagnosticDetails?: string,
+    diagnosticTarget?: { sessionId: string },
+  ): void;
+  confirm(options: {
+    title: string;
+    description: string;
+    confirmLabel: string;
+    cancelLabel: string;
+    destructive?: boolean;
+  }): Promise<boolean>;
+};
+
 export interface SessionNavigationSession extends SessionSummary {
   readonly profileId: string;
   readonly profileName: string;
@@ -73,4 +92,25 @@ export interface SessionNavigationSessionService {
 
 export interface SessionNavigationServices {
   readonly sessions: SessionNavigationSessionService;
+}
+
+/**
+ * What the rail asks of the rest of the shell, named one by one.
+ *
+ * Switching a session also clears the active messages and leaves the Work Hub.
+ * Those are commands the shell issues, and they stay commands: the rail calls
+ * them, it does not subscribe to them. Nothing here has to be identity-stable —
+ * the controller reads them through a ref published on commit — so the shell
+ * may build this object inline, and no ordinary `function` declaration upstream
+ * can quietly put the rail back on every AppShell render (#4109).
+ */
+export interface SessionNavigationPorts {
+  activeIdRef: SessionNavigationRef<string | undefined>;
+  sessionsRef: SessionNavigationRef<ReadonlyArray<SessionSummary>>;
+  pendingSessionRowActionsRef: SessionNavigationRef<Set<string>>;
+  activateSession(sessionId: string | undefined): void;
+  clearActiveMessages(): void;
+  clearSessionRendererState(sessionId: string): void;
+  refreshSessions(): Promise<ReadonlyArray<SessionSummary>>;
+  toastApi: SessionNavigationToastApi;
 }

--- a/apps/desktop/src/renderer/features/session-navigation/testing.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/testing.ts
@@ -20,6 +20,7 @@
 import type { SessionNavigationServices } from './ports.js';
 
 export type {
+  SessionNavigationPorts,
   SessionNavigationServices,
   SessionNavigationSession,
   SessionNavigationSessionService,
@@ -33,7 +34,6 @@ export { createSessionOpenCommand } from './controller/session-open-command.js';
 export {
   useSessionNavigationController,
   type SessionNavigationController,
-  type SessionNavigationPorts,
   type UseSessionNavigationControllerInput,
 } from './controller/use-session-navigation-controller.js';
 export { useSessionSelection } from './controller/use-session-selection.js';

--- a/apps/desktop/src/renderer/features/session-navigation/testing.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/testing.ts
@@ -24,7 +24,6 @@ export type {
   SessionNavigationServices,
   SessionNavigationSession,
   SessionNavigationSessionService,
-  SessionNavigationToastApi,
 } from './ports.js';
 
 export { SessionNavigationServicesProvider } from './services-context.js';

--- a/apps/desktop/src/renderer/features/session-navigation/testing.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/testing.ts
@@ -24,6 +24,7 @@ export type {
   SessionNavigationServices,
   SessionNavigationSession,
   SessionNavigationSessionService,
+  SessionNavigationToastApi,
 } from './ports.js';
 
 export { SessionNavigationServicesProvider } from './services-context.js';

--- a/apps/desktop/src/renderer/features/session-navigation/ui/session-navigation-provider.tsx
+++ b/apps/desktop/src/renderer/features/session-navigation/ui/session-navigation-provider.tsx
@@ -36,10 +36,7 @@ import {
   type SessionRowActions,
   type SidebarUpdateReminder,
 } from '@maka/ui';
-import {
-  useSessionNavigationController,
-  type SessionNavigationPorts,
-} from '../controller/use-session-navigation-controller.js';
+import { useSessionNavigationController } from '../controller/use-session-navigation-controller.js';
 import type { SessionNavigationRowActions } from '../controller/session-row-actions.js';
 import {
   SESSION_LIST_EXPANDED_MAX_WIDTH,
@@ -47,7 +44,7 @@ import {
 } from '../model/session-list-layout.js';
 import type { SessionRailProjection } from '../model/session-rail.js';
 import { sessionRailLayoutStore } from '../model/session-rail-layout-store.js';
-import type { SessionNavigationSession } from '../ports.js';
+import type { SessionNavigationPorts, SessionNavigationSession } from '../ports.js';
 
 /** The chrome the shell owns and the rail only displays. */
 export interface SessionNavigationChromeInput {


### PR DESCRIPTION
Refs #4395

## Summary

Session Navigation row actions redeclare the remove outcome, toast API, and ref holder already owned by the feature boundary, so those contracts can drift without a type error at their consumers.

The feature now declares its shell ports and supporting contracts once in `ports.ts`, with ref holders typed as React's `RefObject`. Row actions consume the canonical remove outcome instead of restating the Host result, while the public and testing entry points continue exporting `SessionNavigationPorts` under the same name. The toast port stays a hand-written narrow slice rather than a `Pick` of `@maka/ui`'s `ToastApi`: structural typing already checks it against the real implementation where the shell wires it in.

This is type-only. The main-process Runtime Host translation remains separate, and ref holders outside Session Navigation are deliberately unchanged.

## Verification

```text
Before
controller/session-row-actions.ts:26:type RefBox<T> = { current: T };
controller/session-row-actions.ts:36:type SessionRemoveOutcome = {
controller/session-row-actions.ts:41:type ToastApi = {
controller/use-session-navigation-controller.ts:47:export type SessionNavigationToastApi = {
controller/use-session-navigation-controller.ts:64:type RefBox<T> = { current: T };

After
ports.ts:31:export interface SessionNavigationRemoveOutcome {
ports.ts:40:export type SessionNavigationToastApi = {
ports.ts:112:export interface SessionNavigationPorts {
ports.ts:113:  activeIdRef: RefObject<string | undefined>;
```

`npm --workspace @maka/desktop run build:main` passed. The six Session Navigation suites passed 46 tests, and the renderer architecture check passed 60 tests. Renderer typecheck, Biome lint, and formatting also passed.

The complete Desktop typecheck still reaches three unrelated `@maka/ui` errors already present on `main`: removed `autoScroll`, `settledText`, and `trailingAction` props. This PR does not change those files.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex identified the duplicate feature contracts, implemented the type-only consolidation, and ran the listed checks.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

No new tests: this is a type-only consolidation with no runtime behavior to
exercise. The existing Session Navigation suites cover the consumers and were
run. Full Desktop typecheck was not clean — see the three pre-existing
`@maka/ui` errors noted under Verification.

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No


