### PR TITLE
fix(ui): remove project task-count badges

### DIFF
--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -181,6 +181,7 @@ test('project and task rows show contextual hover details', async ({
     `[data-project-id="project:${LONG_SIDEBAR_PROJECT_ID}"]`,
   );
   const projectNavigation = projectRow.locator(':scope > div > .astryx-side-nav-item');
+  await expect(projectNavigation.locator('.astryx-badge')).toHaveCount(0);
   await expect(projectNavigation).toHaveAccessibleDescription(/3 个任务.*目录可用/);
   await projectNavigation.hover();
 
@@ -193,7 +194,9 @@ test('project and task rows show contextual hover details', async ({
   await expect(projectCard.locator('.maka-sidebar-hover-card-meta')).toContainText('目录可用');
 
   const ungroupedRow = sidebar.locator('[data-project-id="__ungrouped__"]');
-  await ungroupedRow.locator(':scope > div > .astryx-side-nav-item').focus();
+  const ungroupedNavigation = ungroupedRow.locator(':scope > div > .astryx-side-nav-item');
+  await expect(ungroupedNavigation.locator('.astryx-badge')).toHaveCount(0);
+  await ungroupedNavigation.focus();
   await expect(
     page.getByRole('dialog', { name: '未归属项目 分组详情', exact: true }),
   ).toBeVisible();

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -65,11 +65,10 @@
  * stay in step and an upgrade that restructures the header keeps working.
  *
  * Bound on the header, NOT on the section root. SideNavSection wraps the whole
- * list body — every row, badge, and timestamp — in the same element as its title
+ * list body — every row and timestamp — in the same element as its title
  * (session-history-list.tsx), and custom properties inherit, so a rebind on the
- * root reaches all of it: measured live, the project session-count Badge went
- * 12px → 14px. The header is SideNavSection's first child and holds exactly the
- * title and subtitle.
+ * root would also resize the task content. The header is SideNavSection's first
+ * child and holds exactly the title and subtitle.
  *
  * Both halves of the tier move together. Size alone would leave the supporting
  * leading multiplier on a larger font and land the line box at 23.33px, off the

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -289,7 +289,8 @@ test('renders collapsible project navigation and row actions as sibling controls
   assert.ok(controlledGroup);
   assert.equal(navigation.contains(metadata), true);
   assert.equal(navigation.contains(action), false);
-  assert.equal(metadata.textContent, '1');
+  assert.equal(metadata.textContent, '');
+  assert.equal(navigation.textContent, 'Maka', 'project navigation omits the task-count badge');
   assert.equal(controlledGroup.getAttribute('aria-hidden'), 'false');
   const projectButtons = [...projectRow.querySelectorAll('button')];
   assert.equal(

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -407,6 +407,7 @@ function ProjectNavRow(props: {
   // still truthy children for Astryx (!!children) and fabricates a disclosure.
   const hasSessions = props.sessions.length > 0;
   const hasActions = props.project !== undefined && props.projectActions !== undefined;
+  const hasMeta = (props.project !== undefined && !props.project.available) || hasActions;
   return (
     <div ref={containerRef} data-project-id={props.groupKey} className="maka-project-row">
       <SideNavItem
@@ -415,13 +416,12 @@ function ProjectNavRow(props: {
         aria-describedby={hoverDescriptionId}
         icon={FolderOpen}
         collapsible={hasSessions ? { defaultIsCollapsed: false } : undefined}
-        endContent={
+        endContent={hasMeta ? (
           <ProjectItemMeta
             project={props.project}
-            sessionCount={props.sessions.length}
             reserveAction={hasActions}
           />
-        }
+        ) : undefined}
         trailingAction={
           props.project && props.projectActions ? (
             <ProjectItemActions
@@ -869,7 +869,6 @@ function preferredProjectPath(project: ProjectRecord | undefined): string | unde
 
 function ProjectItemMeta(props: {
   project?: ProjectRecord;
-  sessionCount: number;
   reserveAction: boolean;
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
@@ -878,7 +877,6 @@ function ProjectItemMeta(props: {
       {props.project && !props.project.available && (
         <AlertTriangle size={ICON_SIZE.meta} aria-label={copy.projectUnavailable} />
       )}
-      <Badge variant="neutral" label={props.sessionCount} />
       {props.reserveAction ? (
         <span className="maka-session-row-trailing" aria-hidden="true" />
       ) : null}

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -389,7 +389,7 @@ export const PinnedAndRecentSections: Story = {
 };
 
 // Real path: group-by-project — collapsible project rows, sessions nested 8px
-// under the project so titles share one x, worktree mark + count badge.
+// under the project so titles share one x, worktree mark + project actions.
 export const ProjectGroups: Story = {
   render: () => {
     const maka = makeProject({


### PR DESCRIPTION
## Summary

Remove task-count badges from Project and No project headers. The badges duplicate task totals already available in hover and focus details, and their notification-like shape can be mistaken for unread or pending items.

Task totals remain available in the contextual details. Project actions, availability warnings, and expand or collapse behavior are unchanged.

Fixes #4448

## Verification

- `npm run build:test`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm --workspace @maka/desktop run typecheck:stories`
- `node --test packages/ui/dist/__tests__/session-history-row-actions.test.js` — 9 passed
- `npm --workspace @maka/desktop run e2e -- e2e/sidebar-project-row.spec.ts` — 4 passed
- Storybook `ProjectGroups` in dark mode confirmed that project headers render no badges while action and disclosure alignment remains intact:

  ```text
  { projectBadgeCount: 0, titleTexts: [ 'maka-agent', '产品文档', '旧版桌面端' ] }
  ```

Not run: the full `npm test` suite. The changed paths are covered by the focused UI and desktop E2E suites above.

### Before Change
<img width="1232" height="432" alt="image" src="https://github.com/user-attachments/assets/f029306d-b555-4858-af62-874c648b96e8" />


### After Change
<img width="648" height="268" alt="image" src="https://github.com/user-attachments/assets/4ca34696-8031-4639-8614-6c9b451ff970" />


## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex GPT 5.6 sol implemented the UI change and regression coverage, then ran local verification under human direction and review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
