### PR TITLE
fix(runtime): keep every placeholder when bounding a multi-result tool message

### DIFF
--- a/packages/runtime/src/__tests__/history-compact-input-fit.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-input-fit.test.ts
@@ -75,6 +75,60 @@ describe('history compaction input fitting', () => {
     );
   });
 
+  test('bounds every oversized result in a multi-result tool message', () => {
+    const oversizedOutput = 'raw-tool-output-'.repeat(1_024);
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'call-1', toolName: 'shell', input: { command: 'a' } },
+          { type: 'tool-call', toolCallId: 'call-2', toolName: 'shell', input: { command: 'b' } },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'shell',
+            output: { type: 'text', value: oversizedOutput },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-2',
+            toolName: 'shell',
+            output: { type: 'text', value: oversizedOutput },
+          },
+        ],
+      },
+      { role: 'assistant', content: [{ type: 'text', text: 'Both inspections completed.' }] },
+    ];
+
+    const bounded = fitHistoryCompactMessages(messages, {
+      maxInputEstimatedTokens: 1_000,
+      charsPerToken: 1,
+    });
+
+    assert.ok(stableJsonLength(bounded) <= 1_000);
+    assert.equal(JSON.stringify(bounded).includes(oversizedOutput), false);
+    assert.deepEqual(
+      bounded.flatMap((message) =>
+        typeof message.content === 'string'
+          ? []
+          : message.content
+              .filter((part) => part.type === 'tool-call' || part.type === 'tool-result')
+              .map((part) => ({ type: part.type, toolCallId: part.toolCallId })),
+      ),
+      [
+        { type: 'tool-call', toolCallId: 'call-1' },
+        { type: 'tool-call', toolCallId: 'call-2' },
+        { type: 'tool-result', toolCallId: 'call-1' },
+        { type: 'tool-result', toolCallId: 'call-2' },
+      ],
+    );
+  });
+
   test('fails before dispatch when non-tool history cannot fit', () => {
     assert.throws(
       () =>

--- a/packages/runtime/src/history-compact-input-fit.ts
+++ b/packages/runtime/src/history-compact-input-fit.ts
@@ -48,6 +48,12 @@ export function fitHistoryCompactMessages(
   for (let messageIndex = 0; messageIndex < bounded.length; messageIndex += 1) {
     const message = bounded[messageIndex]!;
     if (message.role !== 'tool') continue;
+    // Accumulate replacements across the parts of this one tool message. A
+    // message that batches several tool results (one per parallel tool call)
+    // must keep every earlier placeholder, not just the last one — otherwise
+    // the returned history still carries full-size payloads even though the
+    // budget accounting already credited their removal.
+    let content = message.content;
     for (let partIndex = 0; partIndex < message.content.length; partIndex += 1) {
       const part = message.content[partIndex]!;
       if (part.type !== 'tool-result') continue;
@@ -62,7 +68,7 @@ export function fitHistoryCompactMessages(
       const originalChars = stableJsonLength(part);
       const replacementChars = stableJsonLength(replacement);
       if (replacementChars >= originalChars) continue;
-      const content = [...message.content];
+      content = [...content];
       content[partIndex] = replacement;
       bounded = [...bounded];
       bounded[messageIndex] = { ...message, content };


### PR DESCRIPTION
## Summary

`fitHistoryCompactMessages` bounds a compaction request by replacing old, oversized `tool-result` payloads with a placeholder. Each replacement copied from the **original** `message.content`, so a single `tool` message that batches several results (one per parallel tool call) kept only the **last** placeholder while every earlier payload stayed at full size — even though the budget accounting (`estimatedChars`) had already credited their removal. The helper could therefore return a history that still exceeds `maxInputEstimatedTokens` yet treat it as "fit" (or, at other sizes, throw `input_too_large` for input that would actually fit), failing at exactly the case it exists to handle.

The fix accumulates replacements across a message's parts, matching the pattern already used in `active-tool-result-prune.ts`.

Fixes #4454

## Verification

- `npm --workspace @maka/runtime run typecheck` — clean
- `node --test dist/__tests__/history-compact-input-fit.test.js` — the new `bounds every oversized result in a multi-result tool message` case fails on `main` (returns 16974 chars for a 1000-char budget, one full payload surviving) and passes with this change; the three existing cases still pass
- `npx biome check` on both changed files — clean

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: **Claude Code** — diagnosis, the fix, and the test, under human review of record. A `Generated-by: Claude Code` trailer is on the commit.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
