### PR TITLE
fix(desktop): hide raw renderer exceptions

### DIFF
--- a/apps/desktop/src/main/__tests__/native-diagnostic-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/native-diagnostic-dialog.test.ts
@@ -23,8 +23,10 @@ import type { MessageBoxOptions, MessageBoxReturnValue } from 'electron';
 import {
   copyDesktopDiagnosticReport,
   createDesktopMainRendererDiagnosticInput,
+  createDesktopStartupDiagnosticInput,
 } from '../main-process-diagnostics.js';
 import {
+  defaultRuntimeHostRecoveryDialog,
   showFatalStartupError,
   showMainRendererProcessGoneDialog,
   showMessageBoxWithDiagnostics,
@@ -80,6 +82,40 @@ test('copies diagnostics as an auxiliary native-dialog action', async () => {
   assert.match(shown[1]?.detail ?? '', /Diagnostics copied/);
 });
 
+test('keeps Default Runtime Host errors in diagnostics instead of dialog copy', async () => {
+  const error = new Error('Authorization: Bearer very-secret-token');
+  const recovery = defaultRuntimeHostRecoveryDialog({
+    locale: 'en',
+    profileName: 'Shared Host',
+    error,
+  });
+
+  assert.doesNotMatch(JSON.stringify(recovery.options), /very-secret-token/u);
+  assert.match(recovery.options.detail ?? '', /Copy diagnostics/u);
+  assert.match(recovery.diagnosticDetails, /very-secret-token/u);
+
+  let report = '';
+  await copyDesktopDiagnosticReport(
+    {
+      environment: diagnosticEnvironment,
+      mainLogs: () => [],
+      runtimeHostProcessLogs: () => [],
+      resolveActiveRuntimeHost: () => undefined,
+      resolveRuntimeHost: () => undefined,
+      writeClipboard: (value) => {
+        report = value;
+      },
+    },
+    createDesktopStartupDiagnosticInput({
+      title: recovery.options.title ?? '',
+      description: recovery.options.message,
+      details: recovery.diagnosticDetails,
+    }),
+  );
+  assert.match(report, /Error: Authorization/u);
+  assert.doesNotMatch(report, /very-secret-token/u);
+});
+
 test('fatal startup errors remain copyable without a renderer or BrowserWindow', async () => {
   const shown: MessageBoxOptions[] = [];
   const responses = [1, 0];
@@ -100,6 +136,11 @@ test('fatal startup errors remain copyable without a renderer or BrowserWindow',
 
   assert.deepEqual(shown[0]?.buttons, ['Exit', 'Copy Diagnostics']);
   assert.deepEqual(shown[1]?.buttons, ['Exit', 'Copy Again']);
+  assert.equal(
+    shown[0]?.detail,
+    'An unexpected startup error occurred. Copy diagnostics to inspect the details.',
+  );
+  assert.doesNotMatch(shown[0]?.detail ?? '', /very-secret-token/);
   assert.match(shown[1]?.detail ?? '', /Diagnostics copied/);
   assert.match(clipboard, /Surface: startup/);
   assert.match(clipboard, /Recent main-process logs \(1\)/);
@@ -178,5 +219,6 @@ test('managed Host recovery preserves the workspace and confirms active-work int
   assert.match(shown?.detail ?? '', /workspace, Host identity, credentials, and settings/);
   assert.match(shown?.detail ?? '', /automatic update compatibility cannot be confirmed/);
   assert.match(shown?.detail ?? '', /interrupt that work/);
-  assert.match(shown?.detail ?? '', /service update failed/);
+  assert.match(shown?.detail ?? '', /Copy diagnostics to inspect the details/);
+  assert.doesNotMatch(shown?.detail ?? '', /service update failed/);
 });

--- a/apps/desktop/src/main/__tests__/renderer-error-report.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-error-report.test.ts
@@ -19,7 +19,13 @@
 
 import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
-import { formatRendererErrorReport, RENDERER_ERROR_REPORT_MAX_BYTES } from '../../renderer/error-boundary.js';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  ErrorBoundaryFallback,
+  formatRendererErrorReport,
+  RENDERER_ERROR_REPORT_MAX_BYTES,
+} from '../../renderer/error-boundary.js';
 
 const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
 
@@ -54,4 +60,23 @@ test('bounds and redacts the browser-only renderer error report', () => {
   assert.match(report, /(?:<redacted>|\[redacted\])/);
   assert.doesNotMatch(report, /sk-(?:location|message|stack)secret123/);
   assert.match(report, /^Maka renderer error report/);
+});
+
+test('keeps raw exceptions out of the localized crash surface', () => {
+  for (const [locale, title] of [
+    ['zh', 'Maka 渲染层崩溃了'],
+    ['en', 'The Maka renderer crashed'],
+  ] as const) {
+    const markup = renderToStaticMarkup(
+      createElement(ErrorBoundaryFallback, {
+        copyState: 'idle',
+        locale,
+        onCopyReport() {},
+        onReset() {},
+        onReload() {},
+      }),
+    );
+    assert.match(markup, new RegExp(title));
+    assert.doesNotMatch(markup, /maka-error-stack|Error details|错误详情|component stack/i);
+  }
 });

--- a/apps/desktop/src/main/native-diagnostic-dialog-copy.ts
+++ b/apps/desktop/src/main/native-diagnostic-dialog-copy.ts
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
+
+interface NativeDiagnosticDialogCopy {
+  readonly dialog: {
+    readonly copy: string;
+    readonly copyAgain: string;
+    readonly copied: string;
+    readonly copyFailed: string;
+  };
+  readonly fatalStartup: {
+    readonly title: string;
+    readonly message: string;
+    readonly detail: string;
+    readonly exit: string;
+  };
+  readonly rendererGone: {
+    readonly title: string;
+    readonly message: string;
+    readonly detail: string;
+    readonly relaunch: string;
+    readonly exit: string;
+  };
+  readonly runtimeHostRecovery: {
+    readonly title: string;
+    readonly message: string;
+    readonly detail: string;
+    readonly activeTasks: string;
+    readonly repairFailed: string;
+    readonly repair: string;
+    readonly repairAndRestart: string;
+    readonly exit: string;
+  };
+  readonly defaultRuntimeHostRecovery: {
+    readonly title: string;
+    connectFailed(profileName: string): string;
+    readonly detail: string;
+    readonly retry: string;
+    readonly useLocal: string;
+    readonly keepOffline: string;
+  };
+  readonly storageRootRepair: {
+    readonly title: string;
+    readonly message: string;
+    detail(workspaceRoot: string): string;
+    readonly repair: string;
+    readonly exit: string;
+  };
+}
+
+const COPY = {
+  en: {
+    dialog: {
+      copy: 'Copy Diagnostics',
+      copyAgain: 'Copy Again',
+      copied: 'Diagnostics copied. You can paste them into an issue report.',
+      copyFailed: 'Could not copy diagnostics.',
+    },
+    fatalStartup: {
+      title: 'Maka failed to start',
+      message: 'Maka could not finish starting.',
+      detail: 'An unexpected startup error occurred. Copy diagnostics to inspect the details.',
+      exit: 'Exit',
+    },
+    rendererGone: {
+      title: 'Maka needs to recover',
+      message: "Maka's interface stopped unexpectedly.",
+      detail: 'Relaunch Maka to continue, or exit and reopen it later.',
+      relaunch: 'Relaunch',
+      exit: 'Exit',
+    },
+    runtimeHostRecovery: {
+      title: 'Maka needs to repair Runtime Host',
+      message: 'The Runtime Host for this workspace could not start.',
+      detail:
+        'Maka can repair the managed Runtime Host selected by this Desktop. Your workspace, Host identity, credentials, and settings will be preserved. Repair may replace the installed Host with the version selected for this Desktop even when automatic update compatibility cannot be confirmed.',
+      activeTasks:
+        'The Host may still own active work. Continuing can interrupt that work before the Host restarts.',
+      repairFailed: 'The previous repair attempt did not finish. Copy diagnostics to inspect the details.',
+      repair: 'Repair Runtime Host',
+      repairAndRestart: 'Repair and Restart Host',
+      exit: 'Exit',
+    },
+    defaultRuntimeHostRecovery: {
+      title: 'Default Runtime Host is unavailable',
+      connectFailed: (profileName) => `Could not connect to ${profileName}`,
+      detail:
+        'Retry, use Local as the default Host, or keep the current selection and resolve it later in Settings. Copy diagnostics to inspect the connection failure.',
+      retry: 'Retry',
+      useLocal: 'Use Local',
+      keepOffline: 'Keep Offline',
+    },
+    storageRootRepair: {
+      title: 'Maka workspace needs repair',
+      message: 'Maka cannot verify this workspace.',
+      detail: (workspaceRoot) =>
+        `The disk identity may have changed. Repair only if this is the original Maka workspace on this computer, not a copied workspace.\n\n${workspaceRoot}`,
+      repair: 'Repair Workspace',
+      exit: 'Exit',
+    },
+  },
+  zh: {
+    dialog: {
+      copy: '复制诊断信息',
+      copyAgain: '再次复制',
+      copied: '诊断信息已复制，可直接粘贴到问题报告中。',
+      copyFailed: '无法复制诊断信息。',
+    },
+    fatalStartup: {
+      title: 'Maka 启动失败',
+      message: 'Maka 无法完成启动。',
+      detail: '启动时发生意外错误。复制诊断信息可查看详情。',
+      exit: '退出',
+    },
+    rendererGone: {
+      title: 'Maka 需要恢复',
+      message: 'Maka 界面意外停止运行。',
+      detail: '重新启动 Maka 以继续，或退出后稍后再打开。',
+      relaunch: '重新启动',
+      exit: '退出',
+    },
+    runtimeHostRecovery: {
+      title: 'Maka 需要修复 Runtime Host',
+      message: '管理此工作区的 Runtime Host 无法启动。',
+      detail:
+        'Maka 可以修复此 Desktop 选择的托管 Runtime Host。工作区、Host 身份、凭证和设置都会保留。即使无法确认自动更新兼容性，修复也可能使用此 Desktop 选择的版本替换当前 Host。',
+      activeTasks: 'Host 可能仍有正在运行的任务。继续会先中断这些任务，再重启 Host。',
+      repairFailed: '上一次修复未能完成。复制诊断信息可查看详情。',
+      repair: '修复 Runtime Host',
+      repairAndRestart: '修复并重启 Host',
+      exit: '退出',
+    },
+    defaultRuntimeHostRecovery: {
+      title: '默认 Runtime Host 无法连接',
+      connectFailed: (profileName) => `无法连接 ${profileName}`,
+      detail:
+        '你可以重试、改用 Local 作为默认 Host，或保持当前选择并稍后在设置中处理。复制诊断信息可查看连接失败详情。',
+      retry: '重试',
+      useLocal: '改用 Local',
+      keepOffline: '保持离线',
+    },
+    storageRootRepair: {
+      title: 'Maka 工作区需要修复',
+      message: 'Maka 无法验证这个工作区。',
+      detail: (workspaceRoot) =>
+        `系统中的磁盘标识可能发生了变化。仅当这是本机原来的 Maka 工作区、而不是复制出的工作区时，才选择修复。\n\n${workspaceRoot}`,
+      repair: '修复工作区',
+      exit: '退出',
+    },
+  },
+} satisfies UiCatalog<NativeDiagnosticDialogCopy>;
+
+export function getNativeDiagnosticDialogCopy(locale: UiLocale): NativeDiagnosticDialogCopy {
+  return COPY[locale];
+}

--- a/apps/desktop/src/main/native-diagnostic-dialog.ts
+++ b/apps/desktop/src/main/native-diagnostic-dialog.ts
@@ -27,6 +27,7 @@ import {
   formatDesktopDiagnosticReport,
   type DesktopDiagnosticEnvironment,
 } from './main-process-diagnostics.js';
+import { getNativeDiagnosticDialogCopy } from './native-diagnostic-dialog-copy.js';
 import { whileAwaitingPerson } from './startup-step.js';
 
 interface DiagnosticDialogDeps {
@@ -49,6 +50,27 @@ export interface RuntimeHostStartupRecoveryDialogInput {
   readonly activeTasks: boolean;
 }
 
+export function defaultRuntimeHostRecoveryDialog(input: {
+  readonly locale: UiLocale;
+  readonly profileName: string;
+  readonly error: Error;
+}): { readonly options: MessageBoxOptions; readonly diagnosticDetails: string } {
+  const copy = getNativeDiagnosticDialogCopy(input.locale).defaultRuntimeHostRecovery;
+  return {
+    options: {
+      type: 'warning',
+      title: copy.title,
+      message: copy.connectFailed(input.profileName),
+      detail: copy.detail,
+      buttons: [copy.retry, copy.useLocal, copy.keepOffline],
+      defaultId: 0,
+      cancelId: 2,
+      noLink: true,
+    },
+    diagnosticDetails: input.error.stack ?? `${input.error.name}: ${input.error.message}`,
+  };
+}
+
 export async function showMessageBoxWithDiagnostics(
   options: MessageBoxOptions,
   deps: DiagnosticDialogDeps,
@@ -66,9 +88,10 @@ export async function showFatalStartupError(
   error: unknown,
   deps: FatalStartupDiagnosticDialogDeps,
 ): Promise<void> {
-  const copy = FATAL_STARTUP_COPY[deps.locale];
+  const copy = getNativeDiagnosticDialogCopy(deps.locale).fatalStartup;
   const message = error instanceof Error ? error.message : String(error);
   const input = createDesktopStartupDiagnosticInput({
+    // The diagnostic report is machine-facing and stays English regardless of locale.
     title: 'Maka failed to start',
     description: message || 'Unknown startup error',
     ...(error instanceof Error && error.stack ? { details: error.stack } : {}),
@@ -78,7 +101,7 @@ export async function showFatalStartupError(
       type: 'error',
       title: copy.title,
       message: copy.message,
-      detail: message || copy.unknownError,
+      detail: copy.detail,
       buttons: [copy.exit],
       defaultId: 0,
       cancelId: 0,
@@ -103,7 +126,7 @@ export async function showFatalStartupError(
 export async function showMainRendererProcessGoneDialog(
   deps: DiagnosticDialogDeps,
 ): Promise<'relaunch' | 'exit'> {
-  const copy = MAIN_RENDERER_GONE_COPY[deps.locale];
+  const copy = getNativeDiagnosticDialogCopy(deps.locale).rendererGone;
   const result = await showMessageBoxWithDiagnostics(
     {
       type: 'error',
@@ -124,13 +147,11 @@ export async function showRuntimeHostStartupRecoveryDialog(
   input: RuntimeHostStartupRecoveryDialogInput,
   deps: DiagnosticDialogDeps,
 ): Promise<'repair' | 'exit'> {
-  const copy = RUNTIME_HOST_STARTUP_RECOVERY_COPY[deps.locale];
+  const copy = getNativeDiagnosticDialogCopy(deps.locale).runtimeHostRecovery;
   const detail = [
     copy.detail,
     input.activeTasks ? copy.activeTasks : undefined,
-    input.repairError
-      ? `${copy.repairFailed}\n${input.repairError.message}`
-      : undefined,
+    input.repairError ? copy.repairFailed : undefined,
   ]
     .filter(Boolean)
     .join('\n\n');
@@ -156,10 +177,10 @@ async function copyDiagnostics(
 ): Promise<string> {
   try {
     await copy();
-    return DIALOG_COPY[locale].copied;
+    return getNativeDiagnosticDialogCopy(locale).dialog.copied;
   } catch (error) {
     console.error('[diagnostics] native clipboard write failed:', error);
-    return DIALOG_COPY[locale].copyFailed;
+    return getNativeDiagnosticDialogCopy(locale).dialog.copyFailed;
   }
 }
 
@@ -172,7 +193,7 @@ function diagnosticDialogOptions(
   if (!buttons || buttons.length === 0) {
     throw new TypeError('A diagnostic dialog requires at least one decision button');
   }
-  const copy = DIALOG_COPY[locale];
+  const copy = getNativeDiagnosticDialogCopy(locale).dialog;
   return {
     options: {
       ...options,
@@ -184,76 +205,3 @@ function diagnosticDialogOptions(
     copyId: buttons.length,
   };
 }
-
-const DIALOG_COPY = {
-  en: {
-    copy: 'Copy Diagnostics',
-    copyAgain: 'Copy Again',
-    copied: 'Diagnostics copied. You can paste them into an issue report.',
-    copyFailed: 'Could not copy diagnostics.',
-  },
-  zh: {
-    copy: '复制诊断信息',
-    copyAgain: '再次复制',
-    copied: '诊断信息已复制，可直接粘贴到问题报告中。',
-    copyFailed: '无法复制诊断信息。',
-  },
-} as const;
-
-const FATAL_STARTUP_COPY = {
-  en: {
-    title: 'Maka failed to start',
-    message: 'Maka could not finish starting.',
-    unknownError: 'An unknown startup error occurred.',
-    exit: 'Exit',
-  },
-  zh: {
-    title: 'Maka 启动失败',
-    message: 'Maka 无法完成启动。',
-    unknownError: '启动时发生未知错误。',
-    exit: '退出',
-  },
-} as const;
-
-const MAIN_RENDERER_GONE_COPY = {
-  en: {
-    title: 'Maka needs to recover',
-    message: "Maka's interface stopped unexpectedly.",
-    detail: 'Relaunch Maka to continue, or exit and reopen it later.',
-    relaunch: 'Relaunch',
-    exit: 'Exit',
-  },
-  zh: {
-    title: 'Maka 需要恢复',
-    message: 'Maka 界面意外停止运行。',
-    detail: '重新启动 Maka 以继续，或退出后稍后再打开。',
-    relaunch: '重新启动',
-    exit: '退出',
-  },
-} as const;
-
-const RUNTIME_HOST_STARTUP_RECOVERY_COPY = {
-  en: {
-    title: 'Maka needs to repair Runtime Host',
-    message: 'The Runtime Host for this workspace could not start.',
-    detail:
-      'Maka can repair the managed Runtime Host selected by this Desktop. Your workspace, Host identity, credentials, and settings will be preserved. Repair may replace the installed Host with the version selected for this Desktop even when automatic update compatibility cannot be confirmed.',
-    activeTasks:
-      'The Host may still own active work. Continuing can interrupt that work before the Host restarts.',
-    repairFailed: 'The previous repair attempt did not finish:',
-    repair: 'Repair Runtime Host',
-    repairAndRestart: 'Repair and Restart Host',
-    exit: 'Exit',
-  },
-  zh: {
-    title: 'Maka 需要修复 Runtime Host',
-    message: '管理此工作区的 Runtime Host 无法启动。',
-    detail:
-      'Maka 可以修复此 Desktop 选择的托管 Runtime Host。工作区、Host 身份、凭证和设置都会保留。即使无法确认自动更新兼容性，修复也可能使用此 Desktop 选择的版本替换当前 Host。',
-    activeTasks: 'Host 可能仍有正在运行的任务。继续会先中断这些任务，再重启 Host。',
-    repairFailed: '上一次修复未能完成：',
-    repair: '修复 Runtime Host',
-    repairAndRestart: '修复并重启 Host',
-    exit: '退出',
-  },
-} as const;

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -115,10 +115,12 @@ import {
   type DesktopDiagnosticsDeps,
 } from "./main-process-diagnostics.js";
 import {
+  defaultRuntimeHostRecoveryDialog,
   showMainRendererProcessGoneDialog,
   showMessageBoxWithDiagnostics,
   showRuntimeHostStartupRecoveryDialog,
 } from "./native-diagnostic-dialog.js";
+import { getNativeDiagnosticDialogCopy } from "./native-diagnostic-dialog-copy.js";
 import {
   resolveDesktopSessionWorkspace,
 } from "./new-session-project.js";
@@ -334,6 +336,7 @@ const desktopDiagnostics: DesktopDiagnosticsDeps = {
 function showStartupDiagnosticDialog(
   options: MessageBoxOptions,
   locale: ReturnType<typeof resolveSystemUiLocale>,
+  diagnosticDetails = options.detail,
 ): Promise<MessageBoxReturnValue> {
   return showMessageBoxWithDiagnostics(options, {
     locale,
@@ -344,7 +347,7 @@ function showStartupDiagnosticDialog(
         createDesktopStartupDiagnosticInput({
           title: options.title || options.message,
           description: options.message,
-          ...(options.detail ? { details: options.detail } : {}),
+          ...(diagnosticDetails ? { details: diagnosticDetails } : {}),
         }),
       ),
   });
@@ -1909,26 +1912,20 @@ async function confirmDesktopStorageRootRepair(
   console.log(
     "[storage-root] root-identity conflict; parking at repair dialog",
   );
-  const isChinese =
-    resolveSystemUiLocale(app.getPreferredSystemLanguages()) === "zh";
+  const locale = resolveSystemUiLocale(app.getPreferredSystemLanguages());
+  const copy = getNativeDiagnosticDialogCopy(locale).storageRootRepair;
   const { response } = await showStartupDiagnosticDialog(
     {
       type: "warning",
-      title: isChinese ? "Maka 工作区需要修复" : "Maka workspace needs repair",
-      message: isChinese
-        ? "Maka 无法验证这个工作区。"
-        : "Maka cannot verify this workspace.",
-      detail: isChinese
-        ? `系统中的磁盘标识可能发生了变化。仅当这是本机原来的 Maka 工作区、而不是复制出的工作区时，才选择修复。\n\n${workspaceRoot}`
-        : `The disk identity may have changed. Repair only if this is the original Maka workspace on this computer, not a copied workspace.\n\n${workspaceRoot}`,
-      buttons: isChinese
-        ? ["修复工作区", "退出"]
-        : ["Repair Workspace", "Exit"],
+      title: copy.title,
+      message: copy.message,
+      detail: copy.detail(workspaceRoot),
+      buttons: [copy.repair, copy.exit],
       defaultId: 1,
       cancelId: 1,
       noLink: true,
     },
-    isChinese ? "zh" : "en",
+    locale,
   );
   return response === 0;
 }
@@ -1937,28 +1934,12 @@ async function promptForDefaultRuntimeHostRecovery(input: {
   readonly profileName: string;
   readonly error: Error;
 }): Promise<"retry" | "use_local" | "keep_offline"> {
-  const isChinese =
-    resolveSystemUiLocale(app.getPreferredSystemLanguages()) === "zh";
+  const locale = resolveSystemUiLocale(app.getPreferredSystemLanguages());
+  const dialogInput = defaultRuntimeHostRecoveryDialog({ ...input, locale });
   const { response } = await showStartupDiagnosticDialog(
-    {
-      type: "warning",
-      title: isChinese
-        ? "默认 Runtime Host 无法连接"
-        : "Default Runtime Host is unavailable",
-      message: isChinese
-        ? `无法连接 ${input.profileName}`
-        : `Could not connect to ${input.profileName}`,
-      detail: isChinese
-        ? `${input.error.message}\n\n你可以重试、改用 Local 作为默认 Host，或保持当前选择并稍后在设置中处理。`
-        : `${input.error.message}\n\nRetry, use Local as the default Host, or keep the current selection and resolve it later in Settings.`,
-      buttons: isChinese
-        ? ["重试", "改用 Local", "保持离线"]
-        : ["Retry", "Use Local", "Keep Offline"],
-      defaultId: 0,
-      cancelId: 2,
-      noLink: true,
-    },
-    isChinese ? "zh" : "en",
+    dialogInput.options,
+    locale,
+    dialogInput.diagnosticDetails,
   );
   return response === 0 ? "retry" : response === 1 ? "use_local" : "keep_offline";
 }

--- a/apps/desktop/src/renderer/error-boundary.tsx
+++ b/apps/desktop/src/renderer/error-boundary.tsx
@@ -17,14 +17,6 @@
  * under the License.
  */
 
-// apps/desktop/src/renderer/error-boundary.tsx
-//
-// Top-level React error boundary. If anything in the renderer throws during
-// render or in a lifecycle method, the boundary catches it and shows a
-// friendly fallback with stack details and a "Try again" button instead of a
-// blank white window (the old behavior — a Vite/Electron renderer that
-// crashed early just left the user staring at an empty viewport).
-
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { truncateUtf8 } from '@maka/core/diagnostic-log';
 import type { UiLocale } from '@maka/core/ui-locale';
@@ -135,12 +127,10 @@ export class ErrorBoundary extends Component<{ children: ReactNode; locale: UiLo
   };
 
   render(): ReactNode {
-    const { error, errorInfo, copyState } = this.state;
+    const { error, copyState } = this.state;
     if (!error) return this.props.children;
     return (
       <ErrorBoundaryFallback
-        error={error}
-        errorInfo={errorInfo}
         copyState={copyState}
         locale={this.props.locale}
         onCopyReport={this.handleCopyReport}
@@ -151,29 +141,19 @@ export class ErrorBoundary extends Component<{ children: ReactNode; locale: UiLo
   }
 }
 
-// The fallback face, split out of the class so its four `copyState` values can
-// be rendered directly in Storybook — the crash surface is otherwise reachable
-// only by actually crashing the renderer (and the failed-copy state only by
-// additionally failing the clipboard bridge).
-// The class owns all state and side effects; this component only paints.
 export function ErrorBoundaryFallback({
-  error,
-  errorInfo,
   copyState,
   locale,
   onCopyReport,
   onReset,
   onReload,
 }: {
-  error: Error;
-  errorInfo?: ErrorInfo | null;
   copyState: ErrorBoundaryCopyState;
   locale: UiLocale;
   onCopyReport: () => void;
   onReset: () => void;
   onReload: () => void;
 }): ReactNode {
-  const safeStack = redactSecrets(`${error.name}: ${error.message}${error.stack ? `\n\n${error.stack}` : ''}`);
   const copyPending = copyState === 'pending';
   const copy = getShellCopy(locale).errorBoundary;
   const copyLabel = copyPending
@@ -196,18 +176,7 @@ export function ErrorBoundaryFallback({
         </span>
         <div className="maka-error-copy">
           <h2>{copy.title}</h2>
-          <p>
-            {copy.descriptionBeforeRetry} <strong>{copy.retry}</strong> {copy.descriptionBeforeReload}{' '}
-            <strong>{copy.reload}</strong> {copy.descriptionAfterReload}
-          </p>
-          <pre className="maka-error-stack" role="group" aria-label={copy.errorDetails}>
-            {safeStack}
-          </pre>
-          {errorInfo?.componentStack && (
-            <pre className="maka-error-stack" role="group" aria-label={copy.componentStack}>
-              {redactSecrets(errorInfo.componentStack.trim())}
-            </pre>
-          )}
+          <p>{copy.description}</p>
           <div className="maka-error-actions">
             <UiButton
               variant="secondary"

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -401,13 +401,9 @@ type ShellCopy = {
     copyFailed: string;
     copyReport: string;
     title: string;
-    descriptionBeforeRetry: string;
+    description: string;
     retry: string;
-    descriptionBeforeReload: string;
     reload: string;
-    descriptionAfterReload: string;
-    errorDetails: string;
-    componentStack: string;
     clipboardFailure: string;
   };
   commandPalette: {
@@ -1099,14 +1095,11 @@ const SHELL_COPY_BY_LOCALE = {
       copyFailed: '复制失败',
       copyReport: '复制诊断信息',
       title: 'Maka 渲染层崩溃了',
-      descriptionBeforeRetry: '已捕获一次未处理的 React 异常。下面是错误摘要；点',
+      description:
+        '已捕获一次未处理的 React 异常。可以重试以清除这次崩溃，或重新加载整个窗口。需要交接时先复制诊断信息。',
       retry: '重试',
-      descriptionBeforeReload: '清掉这次崩溃，',
       reload: '重新加载',
-      descriptionAfterReload: '会刷新整个窗口。需要交接时先复制诊断信息。',
-      errorDetails: '错误详情',
-      componentStack: '组件栈',
-      clipboardFailure: '剪贴板不可用或被系统拒绝；可以手动选择上面的错误摘要。',
+      clipboardFailure: '剪贴板不可用或被系统拒绝，请稍后重试。',
     },
     commandPalette: {
       label: '命令面板',
@@ -1647,14 +1640,11 @@ const SHELL_COPY_BY_LOCALE = {
       copyFailed: 'Copy failed',
       copyReport: 'Copy diagnostics',
       title: 'The Maka renderer crashed',
-      descriptionBeforeRetry: 'An unhandled React error was caught. The summary is below. Choose',
+      description:
+        'An unhandled React error was caught. Try again to clear this crash, or reload to refresh the entire window. Copy the diagnostics before handing off the issue.',
       retry: 'Try again',
-      descriptionBeforeReload: 'to clear this crash, or',
       reload: 'Reload',
-      descriptionAfterReload: 'to refresh the entire window. Copy the diagnostics before handing off the issue.',
-      errorDetails: 'Error details',
-      componentStack: 'Component stack',
-      clipboardFailure: 'The clipboard is unavailable or was denied. You can select the error summary above manually.',
+      clipboardFailure: 'The clipboard is unavailable or was denied. Try again later.',
     },
     commandPalette: {
       label: 'Command palette',

--- a/apps/desktop/src/renderer/styles/error.css
+++ b/apps/desktop/src/renderer/styles/error.css
@@ -76,20 +76,6 @@
     max-width: 56ch;
   }
 
-.maka-error-stack {
-    font: var(--maka-text-supporting);
-    margin: var(--space-1) 0 0;
-    max-height: 220px;
-    padding: var(--space-2-5) var(--space-3);
-    border: var(--border-width-hairline) solid var(--border);
-    border-radius: var(--radius-surface);
-    background: var(--foreground-3);
-    color: var(--foreground-secondary);
-    overflow: auto;
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
 .maka-error-actions {
     display: flex;
     align-items: center;

--- a/apps/desktop/stories/error-boundary.stories.tsx
+++ b/apps/desktop/stories/error-boundary.stories.tsx
@@ -19,7 +19,6 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
-import type { ErrorInfo } from 'react';
 import {
   ErrorBoundaryFallback,
   type ErrorBoundaryCopyState,
@@ -39,42 +38,11 @@ const onCopyReport = fn();
 const onReset = fn();
 const onReload = fn();
 
-// Explicitly synthetic diagnostics used only to exercise the fallback layout.
-// The generic fixture names do not represent a Maka product call chain.
-function buildRendererError(name: string, message: string, frames: string[]): Error {
-  const error = new Error(message);
-  error.name = name;
-  error.stack = [`${name}: ${message}`, ...frames.map((frame) => `    at ${frame}`)].join('\n');
-  return error;
-}
-
-const syntheticError = buildRendererError(
-  'TypeError',
-  "Cannot read properties of undefined (reading 'messages')",
-  [
-    'SyntheticCrashFixture (<synthetic-storybook-fixture>:42:7)',
-    'renderWithHooks (react-dom.development.js:15486:18)',
-    'mountIndeterminateComponent (react-dom.development.js:20103:13)',
-    'beginWork (react-dom.development.js:21626:16)',
-  ],
-);
-
-const syntheticComponentStack: ErrorInfo = {
-  componentStack: [
-    '',
-    '    at SyntheticCrashFixture (<synthetic-storybook-fixture>:42:7)',
-    '    at SyntheticParentFixture (<synthetic-storybook-fixture>:18:3)',
-    '    at ErrorBoundary',
-  ].join('\n'),
-};
-
 const resolveLocale = (globals: Record<string, unknown>) => (globals.locale === 'en' ? 'en' : 'zh');
 
-function fallback(copyState: ErrorBoundaryCopyState, error: Error, errorInfo: ErrorInfo) {
+function fallback(copyState: ErrorBoundaryCopyState) {
   return (_args: unknown, { globals }: { globals: Record<string, unknown> }) => (
     <ErrorBoundaryFallback
-      error={error}
-      errorInfo={errorInfo}
       copyState={copyState}
       locale={resolveLocale(globals)}
       onCopyReport={onCopyReport}
@@ -84,23 +52,21 @@ function fallback(copyState: ErrorBoundaryCopyState, error: Error, errorInfo: Er
   );
 }
 
-// Visual snapshot of the fallback's idle state. In production, ErrorBoundary supplies
-// this Error/ErrorInfo shape after catching a renderer crash.
 export const DefaultFallback: Story = {
-  render: fallback('idle', syntheticError, syntheticComponentStack),
+  render: fallback('idle'),
 };
 
 // Visual snapshot of the fallback's pending state; it does not exercise the copy transition.
 export const CopyPending: Story = {
-  render: fallback('pending', syntheticError, syntheticComponentStack),
+  render: fallback('pending'),
 };
 
 // Visual snapshot of the fallback's copied state; it does not exercise the copy transition.
 export const Copied: Story = {
-  render: fallback('copied', syntheticError, syntheticComponentStack),
+  render: fallback('copied'),
 };
 
 // Visual snapshot of the fallback's failed state; it does not exercise the copy transition.
 export const CopyFailed: Story = {
-  render: fallback('failed', syntheticError, syntheticComponentStack),
+  render: fallback('failed'),
 };


### PR DESCRIPTION
Part of #2672

## Summary

Unexpected renderer and startup failures show raw exception text as product copy: the crash surface renders the exception and component stack into the window, and native startup dialogs interpolate `error.message` into their detail text — unlocalized, unstable, and occasionally containing content that belongs only in a diagnostic report.

Raw exceptions are diagnostic data, not stable product copy. The crash surface and the native diagnostic dialogs now show fixed localized recovery guidance from typed catalogs (the reshaped `errorBoundary` group in `shell-copy.ts`, and a new main-process `native-diagnostic-dialog-copy.ts`), while the raw details keep flowing through the existing diagnostics channel — the copyable report still carries the full redacted stack. The last `locale ===` ternary block in `runtime-host-boot.ts` moves into the catalog with the rest. The renderer copy deliberately stays in `shell-copy.ts`: the renderer architecture ratchet forbids new files in the AppShell closure, so the diff's renderer debt footprint is identical to `main`.

Scope note: this covers the generic surfaces only; expected-error localization by error code is a sibling PR, and the copy-boundary gate expansion for these files lands with the CLI ratchet PR.

## Verification

```text
Before (dialog detail carries the raw exception; fallback renders the stack)
runtime-host-boot.ts:  detail: isChinese ? `${input.error.message}\n\n你可以重试…` : `${input.error.message}\n\nRetry…`
error-boundary.tsx:    <pre className="maka-error-stack">{safeStack}</pre>

After (fixed localized guidance; raw error only in the diagnostic report)
native-diagnostic-dialog.test.js:
✔ keeps Default Runtime Host errors in diagnostics instead of dialog copy
    assert.doesNotMatch(JSON.stringify(recovery.options), /very-secret-token/u)
    assert.match(report, /Error: Authorization/u)
renderer-error-report.test.js:
✔ keeps raw exceptions out of the localized crash surface
ℹ tests 7  ℹ pass 7  ℹ fail 0
```

Workspace build, the touched suites, renderer/storybook typecheck, and Biome pass locally.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code implemented the migration, reviewed it for simplification (dead `shell-copy` group, catalog placement), and ran the listed checks.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

