### PR TITLE
fix(desktop): deflake sidebar hover-card e2e

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -565,8 +565,6 @@ export const test = base.extend<{
       e2eFixtureScenario: 'settings-bots-onboarding',
     }, use);
   },
-  // A real project with several sessions. Shown because the contract under
-  // test is native focus order across independently interactive row controls.
   // Seeded connection so the composer is ready, plus one registered Project so
   // the workspace picker under it has a second target to move to.
   newTaskTargetWindow: async ({}, use) => {
@@ -578,13 +576,16 @@ export const test = base.extend<{
       showWindow: true,
     }, use);
   },
+  // A real project with several sessions. Hidden: a shown key window receives
+  // the physical cursor's mouse-moved events, which cancel the delayed hover
+  // card mid-test. CDP input needs no visible window, and the focus-order
+  // test drives synthetic Tab that never reaches native focus either way.
   projectSidebarWindow: async ({}, use) => {
     await withE2eWindow({
       seed: false,
       readinessSelector: '[data-maka-contract="search-modal"][open]',
       e2eFixtureScenario: 'sidebar-search-modal-open',
       locale: 'zh',
-      showWindow: true,
     }, use);
   },
   parentRemovalWindow: async ({}, use) => {


### PR DESCRIPTION
`sidebar-project-row.spec.ts` hover-card tests fail intermittently on developer machines (~5-20% locally): the card never appears, or shows a different row's content.

Root cause: the fixture window is shown and key, so macOS delivers the developer's physical mouse-moved events to it alongside Playwright's CDP pointer. A real move across the sidebar fires `mouseleave` on the hovered row, cancelling the 300ms-delayed hover card — or, if the physical cursor rests over another row, opening that row's card instead. Captured with an in-page event log: the killing events carry fractional trackpad coordinates a CDP dispatch never produces.

The fix removes the interference at its source instead of retrying around it (as an earlier revision of this PR did): `projectSidebarWindow` drops its `showWindow: true` opt-in, so the fixture stays behind the existing reveal gate and the physical cursor has no window to deliver moves to. CDP input dispatch does not need a visible window. The fixture had opted into showing for its native-focus-order test, but that test drives synthetic Tab through CDP, which never reaches native focus — shown or hidden, it exercises the same DOM traversal, and it passes hidden.

Boundaries: the xvfb ~1fps compositor throttle that motivates showing fixtures is Linux-CI-only, and that lane keeps forcing shown via `isCiLinuxDisplay()` — with no physical mouse present there, the flake cannot occur. `BrowserWindow.setIgnoreMouseEvents(true)` was tried and rejected: it blocks clicks but not mouse-moved delivery (12/12 failures with the flag applied).

Before (shown window; scripted CGEvent cursor sweep during the run — the two failure shapes):

```
Error: expect(locator).toBeVisible() failed
Locator: locator('.maka-sidebar-hover-card[data-kind="session"]')
Expected: visible

Error: expect(locator).toHaveText(expected) failed
Expected: "任务 00"
  - locator resolved to <span class="maka-sidebar-hover-card-title">任务 11</span>
```

After (hidden window; same sweep, then the full spec with the cursor at rest):

```
  2 passed (7.2s)

  4 passed (13.8s)
```

# AI use
Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the revision propagation and causal overlay retirement, added regression tests, and assisted with review. All affected commits include `Generated-by: Codex` trailers.
