### PR TITLE
test(cli): wait for hung settlement before the activator deadline

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-local-target-activation.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-local-target-activation.test.ts
@@ -100,7 +100,15 @@ test('a parent deadline terminates and waits for a target activator with a hung 
         },
         inheritableAuthorityLeaseFd: lease.fd,
       },
-      { settlementTimeoutMs: 50 },
+      {
+        settlementTimeoutMs: 50,
+        // Hold the 50 ms deadline until read-entered proves the child reached
+        // the hung readRecord; otherwise that budget also has to cover spawn
+        // and ESM load, which loses under CI contention (#4466).
+        beforeSettlementTimeout: async () => {
+          assert.equal(await waitForEntered(readEnteredPath), 'entered');
+        },
+      },
     );
     assert.equal(activation.kind, 'ready');
     await assert.rejects(
@@ -116,3 +124,13 @@ test('a parent deadline terminates and waits for a target activator with a hung 
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+async function waitForEntered(path: string, timeoutMs = 5_000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await readFile(path, 'utf8').catch(() => undefined);
+    if (value === 'entered') return value;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${path} to contain "entered"`);
+}

--- a/packages/cli/src/__tests__/runtime-host-local-target-activation.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-local-target-activation.test.ts
@@ -100,15 +100,10 @@ test('a parent deadline terminates and waits for a target activator with a hung 
         },
         inheritableAuthorityLeaseFd: lease.fd,
       },
-      {
-        settlementTimeoutMs: 50,
-        // Hold the 50 ms deadline until read-entered proves the child reached
-        // the hung readRecord; otherwise that budget also has to cover spawn
-        // and ESM load, which loses under CI contention (#4466).
-        beforeSettlementTimeout: async () => {
-          assert.equal(await waitForEntered(readEnteredPath), 'entered');
-        },
-      },
+      // 50 ms also covered child spawn and ESM load, so CI could SIGKILL before
+      // read-entered was written (#4466). Two seconds fits startup; the hung
+      // read still trips the settlement deadline.
+      { settlementTimeoutMs: 2_000 },
     );
     assert.equal(activation.kind, 'ready');
     await assert.rejects(
@@ -124,13 +119,3 @@ test('a parent deadline terminates and waits for a target activator with a hung 
     await rm(directory, { recursive: true, force: true });
   }
 });
-
-async function waitForEntered(path: string, timeoutMs = 5_000): Promise<string> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const value = await readFile(path, 'utf8').catch(() => undefined);
-    if (value === 'entered') return value;
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  throw new Error(`timed out waiting for ${path} to contain "entered"`);
-}

--- a/packages/cli/src/runtime-host-local-target-activation.ts
+++ b/packages/cli/src/runtime-host-local-target-activation.ts
@@ -56,15 +56,7 @@ export class RuntimeHostTargetActivationError extends Error {
  */
 export function launchRuntimeHostTargetActivator(
   input: RuntimeHostTargetActivationInput,
-  options: {
-    readonly settlementTimeoutMs?: number;
-    /**
-     * Called after settle is sent and before the deadline starts. Tests wait
-     * here so a short timeout measures a hung settlement, not child-process
-     * startup.
-     */
-    readonly beforeSettlementTimeout?: () => Promise<void>;
-  } = {},
+  options: { readonly settlementTimeoutMs?: number } = {},
 ): Promise<RuntimeHostTargetActivation> {
   const args = [
     input.staged.cliPath,
@@ -113,20 +105,6 @@ export function launchRuntimeHostTargetActivator(
       if (settled) return;
       settled = true;
       let settlementTimedOut = false;
-      if (child.connected) {
-        try {
-          child.send({ kind: 'settle' });
-        } catch {
-          // The close result below remains the only settlement evidence.
-        }
-      }
-      try {
-        await options.beforeSettlementTimeout?.();
-      } catch (error) {
-        child.kill('SIGKILL');
-        await closed;
-        throw error;
-      }
       // This parent owns the activator process and therefore the hard bound.
       // Killing and then awaiting close releases its inherited lease even when
       // an individual authority read in the child never settles.
@@ -135,6 +113,13 @@ export function launchRuntimeHostTargetActivator(
         child.kill('SIGKILL');
       }, options.settlementTimeoutMs ?? TARGET_ACTIVATOR_SETTLEMENT_TIMEOUT_MS);
       settlementTimer.unref();
+      if (child.connected) {
+        try {
+          child.send({ kind: 'settle' });
+        } catch {
+          // The close result below remains the only settlement evidence.
+        }
+      }
       try {
         const exited = await closed;
         if (settlementTimedOut) {

--- a/packages/cli/src/runtime-host-local-target-activation.ts
+++ b/packages/cli/src/runtime-host-local-target-activation.ts
@@ -56,7 +56,15 @@ export class RuntimeHostTargetActivationError extends Error {
  */
 export function launchRuntimeHostTargetActivator(
   input: RuntimeHostTargetActivationInput,
-  options: { readonly settlementTimeoutMs?: number } = {},
+  options: {
+    readonly settlementTimeoutMs?: number;
+    /**
+     * Called after settle is sent and before the deadline starts. Tests wait
+     * here so a short timeout measures a hung settlement, not child-process
+     * startup.
+     */
+    readonly beforeSettlementTimeout?: () => Promise<void>;
+  } = {},
 ): Promise<RuntimeHostTargetActivation> {
   const args = [
     input.staged.cliPath,
@@ -105,6 +113,20 @@ export function launchRuntimeHostTargetActivator(
       if (settled) return;
       settled = true;
       let settlementTimedOut = false;
+      if (child.connected) {
+        try {
+          child.send({ kind: 'settle' });
+        } catch {
+          // The close result below remains the only settlement evidence.
+        }
+      }
+      try {
+        await options.beforeSettlementTimeout?.();
+      } catch (error) {
+        child.kill('SIGKILL');
+        await closed;
+        throw error;
+      }
       // This parent owns the activator process and therefore the hard bound.
       // Killing and then awaiting close releases its inherited lease even when
       // an individual authority read in the child never settles.
@@ -113,13 +135,6 @@ export function launchRuntimeHostTargetActivator(
         child.kill('SIGKILL');
       }, options.settlementTimeoutMs ?? TARGET_ACTIVATOR_SETTLEMENT_TIMEOUT_MS);
       settlementTimer.unref();
-      if (child.connected) {
-        try {
-          child.send({ kind: 'settle' });
-        } catch {
-          // The close result below remains the only settlement evidence.
-        }
-      }
       try {
         const exited = await closed;
         if (settlementTimedOut) {


### PR DESCRIPTION
## Summary

The hung-settlement parent-deadline test gave the parent a 50 ms settlement budget while the child still had to spawn Node and load the activator ESM graph. Under CI load, the parent could SIGKILL the child before `read-entered` was fully written, producing the flaky `'' !== 'entered'` failure.

This change separates those concerns: the test now waits for `read-entered` to contain `entered`, proving the child has entered the hung `readRecord` stub, and only then starts the 50 ms settlement deadline. The original assertions are unchanged, and production callers are unaffected because the wait is provided through a test-only `beforeSettlementTimeout` hook on `launchRuntimeHostTargetActivator`.

Fixes #4466

## Verification

- `npx biome check packages/cli/src/runtime-host-local-target-activation.ts packages/cli/src/__tests__/runtime-host-local-target-activation.test.ts` — passed
- `npm --workspace maka-agent run build:workspace-deps && npm --workspace maka-agent run build` — passed
- `node --test packages/cli/dist/__tests__/runtime-host-local-target-activation.test.js` — passed 5 consecutive runs

Not run locally: full root `npm test`, `npm run lint`, `npm run format:check`, and `npm run typecheck`.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Cursor — implemented the fix for #4466, drafted this PR description, and suggested the commit message.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No