### PR TITLE
test(cli): compare State Root locations with the platform separator

### DIFF
--- a/scripts/qualify-released-cli-state-root.test.mjs
+++ b/scripts/qualify-released-cli-state-root.test.mjs
@@ -20,7 +20,7 @@
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { isAbsolute, join, resolve } from 'node:path';
+import { isAbsolute, join, resolve, sep } from 'node:path';
 import test from 'node:test';
 import {
   assertExpectedEpochRelation,
@@ -199,14 +199,14 @@ test('durable state covers the control namespace, not only the State Root', () =
   // transition it proved was never the one a user performs.
   const locations = durableStateLocations('/qualification-scope');
   assert.ok(locations.length >= 2);
-  assert.ok(locations.some(({ live }) => live === '/qualification-scope/state-root'));
+  assert.ok(locations.some(({ live }) => live === join('/qualification-scope', 'state-root')));
   assert.ok(
     locations.some(({ live }) => live.endsWith(join('.cache', 'maka', 'runtime-hosts'))),
     'the account-local control namespace must be captured and restored',
   );
   for (const { live, golden } of locations) {
     assert.ok(isAbsolute(live) && isAbsolute(golden));
-    assert.ok(!golden.startsWith(`${live}/`), 'a golden copy must not nest inside its live path');
+    assert.ok(!golden.startsWith(live + sep), 'a golden copy must not nest inside its live path');
   }
 });
 


### PR DESCRIPTION
## Summary

`durable state covers the control namespace, not only the State Root` compared `durableStateLocations()` output against POSIX string literals while the function itself builds paths with `path.join`. On Windows those disagree — `join('/qualification-scope', 'state-root')` is `\qualification-scope\state-root` — so the equality assertion was always false, `npm run check:release` failed, and with it the Windows packaging job that runs it.

The nesting guard in the same block carried the same assumption: on Windows no golden path can start with `` `${live}/` ``, so it passed vacuously and proved nothing. Both now use the platform's own separator.

The defect stayed latent on `main` because `Release Windows check` only runs when a pull request touches the release packaging inputs, and this test file is not one of them. It surfaced on https://github.com/apache/maka/pull/4468, which does touch them.

Refs #4427

## Verification

- `node --test --test-concurrency=1 scripts/qualify-released-cli-state-root.test.mjs` — 8/8 pass.
- `biome check scripts/qualify-released-cli-state-root.test.mjs` — clean.
- Windows itself is not reachable locally; the failing signal is the job log on https://github.com/apache/maka/pull/4468 (`scripts\qualify-released-cli-state-root.test.mjs:195`, `actual: false`), and `path.win32.join('/qualification-scope', 'state-root')` returning `\qualification-scope\state-root` is what makes that assertion false. This PR does not trip `Release Windows check` either, so the end-to-end confirmation comes from rebasing https://github.com/apache/maka/pull/4468 onto it.

## Root cause

A test asserted on path syntax instead of on the path constructor the code under test uses.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code isolated the failure from the CI log and wrote the change. The contributor reviewed the diff and the reasoning.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
