### PR TITLE
ci(windows): cache Rust builds in the release-windows-check lane

### DIFF
--- a/.github/workflows/release-windows-check.yml
+++ b/.github/workflows/release-windows-check.yml
@@ -138,8 +138,43 @@ jobs:
       - name: Update stable Rust for Desktop native artifacts
         run: rustup update stable --no-self-update
 
+      - id: rustc
+        name: Resolve Rust cache version
+        run: |
+          echo "version=$(rustc --version | cut -d ' ' -f 2)" >> "$GITHUB_OUTPUT"
+          echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          {
+            echo "KACHE_CACHE_DIR=${{ runner.temp }}/kache"
+            echo "KACHE_RUNTIME_DIR=${{ runner.temp }}/kache-runtime"
+            echo "RUSTC_WRAPPER=kache"
+          } >> "$GITHUB_ENV"
+
+      - name: Install Kache
+        uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
+        with:
+          tool: kache@0.16.0
+
+      - id: kache-cache
+        name: Restore Rust build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/kache
+          key: kache-windows-release-check-v0.16.0-${{ runner.os }}-${{ runner.arch }}-rust-${{ steps.rustc.outputs.version }}-${{ steps.rustc.outputs.revision }}
+          restore-keys: |
+            kache-windows-release-check-v0.16.0-${{ runner.os }}-${{ runner.arch }}-rust-${{ steps.rustc.outputs.version }}-
+
       - name: Package the Windows installer and ZIP
         run: npm run package:windows-x64
+
+      - name: Report Rust build cache
+        run: kache report --format github >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Save Rust build cache
+        if: github.ref_name == github.event.repository.default_branch
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/kache
+          key: ${{ steps.kache-cache.outputs.cache-primary-key }}
 
       - name: Verify the Windows release
         run: npm run verify:windows-x64 -- x64

--- a/scripts/ci-workflow-policy.test.mjs
+++ b/scripts/ci-workflow-policy.test.mjs
@@ -271,7 +271,7 @@ test('Rust build caches publish immutable source generations only from the defau
     .map((name) => [name, readWorkflow(name)])
     .filter(([, workflow]) => workflow.includes('tool: kache@0.16.0'));
 
-  assert.equal(workflows.length, 5);
+  assert.equal(workflows.length, 6);
   for (const [name, workflow] of workflows) {
     assert.match(workflow, /echo "revision=\$\(git rev-parse HEAD\)"/u, name);
     const primaryKeys = [...workflow.matchAll(/^\s+key: (kache-[^\n]+)$/gmu)].map(([, key]) => key);


### PR DESCRIPTION
Add Kache install, restore, report, and save steps to the package job so the runtime-host-peer and sandbox launcher release builds reuse a warm cache on windows-2025, following the pattern already used in windows-sandbox-w0.yml.

## Summary

`Release Windows check` is the slowest PR lane in this repository and the only one that compiles Rust without a build cache. The `Package the Windows installer and ZIP` step alone averages ~10m54s, largely because it runs two cold Rust release builds on `windows-2025`:

- `npm run build:runtime-host-peer` (`native/runtime-host-peer`, `cdylib`)
- `cargo build --manifest-path experiments/windows-sandbox/launcher/Cargo.toml --release --locked` (sandbox launcher)

This PR adds Kache install, restore, report, and save steps to the `package` job in `.github/workflows/release-windows-check.yml`, following the same pattern already used in `windows-sandbox-w0.yml`:

- `kache@0.16.0` via the same pinned `taiki-e/install-action`
- `KACHE_CACHE_DIR`, `KACHE_RUNTIME_DIR`, and `RUSTC_WRAPPER=kache` injected before packaging
- cache key scoped to `windows-2025`, `rustc` version, and commit revision
- `kache report` written to the GitHub Actions step summary for warm-cache measurement
- cache saved only on the default branch

No verification logic changes. The lane still runs the same end-to-end checks, including `Verify the Windows release`, so a stale cache cannot silently pass.

Fixes #4470

## Verification

- [x] Reviewed `.github/workflows/release-windows-check.yml` against `windows-sandbox-w0.yml` and confirmed the Kache wiring matches the existing repository pattern (install pin, env vars, restore/save actions, default-branch save guard).
- [x] Confirmed `scripts/package-windows-x64.mjs` builds both Rust targets inside the cached step and inherits `process.env`, so `RUSTC_WRAPPER=kache` applies to both `build:runtime-host-peer` and the sandbox launcher `cargo build`.
- [x] Confirmed `npm run clean` only removes TypeScript `dist` outputs and does not delete Rust `target/` directories, so it does not defeat Kache.
- [ ] Full `Release Windows check` workflow on `windows-2025` — not run locally; requires CI to measure warm-cache impact against the ~10m54s baseline from the issue.

Expected CI evidence after merge:

- `kache report` appears in the workflow step summary
- `Package the Windows installer and ZIP` is faster on a warm cache than the issue baseline
- the lane still passes end to end, including `Verify the Windows release`

## Rollout

The save step only runs when `github.ref_name == github.event.repository.default_branch`, so `pull_request` runs restore the cache but do not write it. That is fine: this workflow also runs on a nightly schedule (`17 5 * * *`) and via `workflow_dispatch`, both on `main`, so the default-branch cache is populated automatically without any manual seeding after merge.

On Windows, Kache caches `runtime-host-peer` fully as a `cdylib`. The sandbox launcher is a `bin` crate, so dependency crates are cached but the final `.exe` may still be rebuilt unless `KACHE_CACHE_EXECUTABLES` is enabled later. That matches the current `windows-sandbox-w0.yml` behavior and is acceptable for this issue's scope.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Cursor (Auto) drafted the workflow change and PR description based on issue #4470 and the existing `windows-sandbox-w0.yml` reference implementation.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No