### PR TITLE
fix(cli): abbreviate home-relative Windows paths in the status line

### DIFF
--- a/docs/windows-test-inventory.md
+++ b/docs/windows-test-inventory.md
@@ -16,10 +16,10 @@ Locations intentionally omit line numbers so unrelated edits do not invalidate t
 | Classification | Count |
 |---|---:|
 | windows-backend-gap | 27 |
-| portable-candidate | 12 |
+| portable-candidate | 14 |
 | platform-contract | 31 |
 
-Total Windows-excluded declarations: **70**
+Total Windows-excluded declarations: **72**
 
 ## Inventory
 
@@ -30,6 +30,8 @@ Total Windows-excluded declarations: **70**
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` keeps the inherited PATH and does not log shell stderr when capture fails | `process.platform === 'win32'` |
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` kills login-shell descendants when capture times out | `process.platform === 'win32'` |
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` bounds shell output instead of buffering until the global timeout | `process.platform === 'win32'` |
+| portable-candidate | `packages/cli/src/__tests__/pi-transcript.test.ts` shortens POSIX paths under the home directory | `process.platform === 'win32'` |
+| portable-candidate | `packages/cli/src/__tests__/pi-transcript.test.ts` keeps POSIX paths outside the home directory absolute | `process.platform === 'win32'` |
 | portable-candidate | `packages/cli/src/__tests__/runtime-host-setup.test.ts` managed operator binds its Client Data Root and routes deployment cleanup | `process.platform === 'win32'` |
 | portable-candidate | `packages/eval/src/__tests__/install-preflight.test.ts` rejects an unusable trials root before invoking external prerequisites | `process.platform === 'win32' \|\| process.geteuid?.() === 0` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/connection-effect-coordinator.test.ts` leaves canonical onboarding state unchanged when the durable intent cannot be published | `process.platform === 'win32'` |

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -5148,6 +5148,7 @@ describe('shortenCwd', () => {
     skip: process.platform === 'win32',
   }, () => {
     assert.equal(shortenCwd('/Users/alice/work/project', '/Users/alice'), '~/work/project');
+    assert.equal(shortenCwd('/Users/alice/..\\notes', '/Users/alice'), '~/..\\notes');
     assert.equal(shortenCwd('/Users/alice', '/Users/alice'), '~');
   });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -42,6 +42,7 @@ import {
   makaPiToolPresentationStatus,
   retireCancelledTransientMessages,
   replaceTranscriptWithStoredMessages,
+  shortenCwd,
   submitCompactToTranscript,
   toggleAllThinkingExpansion,
   toggleAllToolExpansion,
@@ -5141,3 +5142,45 @@ function subagentResult(
 function stripAnsi(text: string): string {
   return text.replace(/\x1b\[[0-9;]*m/g, '');
 }
+
+describe('shortenCwd', () => {
+  test('shortens POSIX paths under the home directory', {
+    skip: process.platform === 'win32',
+  }, () => {
+    assert.equal(shortenCwd('/Users/alice/work/project', '/Users/alice'), '~/work/project');
+    assert.equal(shortenCwd('/Users/alice', '/Users/alice'), '~');
+  });
+
+  test('keeps POSIX paths outside the home directory absolute', {
+    skip: process.platform === 'win32',
+  }, () => {
+    assert.equal(shortenCwd('/Users/alice-shared', '/Users/alice'), '/Users/alice-shared');
+    assert.equal(shortenCwd('/Users', '/Users/alice'), '/Users');
+    assert.equal(shortenCwd('/tmp/project', '/Users/alice'), '/tmp/project');
+  });
+
+  test('shortens Windows profile paths (#3825)', { skip: process.platform !== 'win32' }, () => {
+    assert.equal(shortenCwd('C:\\Users\\alice\\Videos', 'C:\\Users\\alice'), '~/Videos');
+    assert.equal(
+      shortenCwd('C:\\Users\\alice\\Videos\\Clips', 'C:\\Users\\alice'),
+      '~/Videos\\Clips',
+    );
+    assert.equal(shortenCwd('C:\\Users\\alice', 'C:\\Users\\alice'), '~');
+  });
+
+  test('shortens Windows profile paths with case-only differences (#3825)', {
+    skip: process.platform !== 'win32',
+  }, () => {
+    assert.equal(shortenCwd('c:\\users\\alice\\videos', 'C:\\Users\\alice'), '~/videos');
+  });
+
+  test('keeps Windows paths outside the profile directory absolute (#3825)', {
+    skip: process.platform !== 'win32',
+  }, () => {
+    assert.equal(
+      shortenCwd('C:\\Users\\alice-shared', 'C:\\Users\\alice'),
+      'C:\\Users\\alice-shared',
+    );
+    assert.equal(shortenCwd('D:\\data\\project', 'C:\\Users\\alice'), 'D:\\data\\project');
+  });
+});

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -53,7 +53,7 @@ import {
 } from '@maka/core/tool-result-status';
 import { type ShellRunUpdate } from '@maka/core/events';
 import { homedir } from 'node:os';
-import { basename, isAbsolute, relative } from 'node:path';
+import { basename, isAbsolute, relative, sep } from 'node:path';
 import type { MakaSessionDriver, MakaSideConversationParentStatus } from './session-driver.js';
 import { BoundedChunkBuffer } from './bounded-chunk-buffer.js';
 import { ansi } from './tui-ansi.js';
@@ -1947,7 +1947,7 @@ export function shortenCwd(cwd: string, homeDir?: string): string {
   if (!home) return cwd;
   const rel = relative(home, cwd);
   if (rel === '') return '~';
-  if (isAbsolute(rel) || rel === '..' || rel.startsWith('../') || rel.startsWith('..\\')) {
+  if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
     return cwd;
   }
   return `~/${rel}`;

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -53,7 +53,7 @@ import {
 } from '@maka/core/tool-result-status';
 import { type ShellRunUpdate } from '@maka/core/events';
 import { homedir } from 'node:os';
-import { basename } from 'node:path';
+import { basename, isAbsolute, relative } from 'node:path';
 import type { MakaSessionDriver, MakaSideConversationParentStatus } from './session-driver.js';
 import { BoundedChunkBuffer } from './bounded-chunk-buffer.js';
 import { ansi } from './tui-ansi.js';
@@ -1938,12 +1938,19 @@ function firstLinePreview(text: string): string {
  * Shorten an absolute path to a `~`-relative form for the statusline.
  * `/Users/alice/workspace/project` → `~/workspace/project`.
  * Falls back to the original path if it is not under the home directory.
+ * Comparison runs through `path.relative`, so Windows profile paths and
+ * case-only differences shorten as well; the remainder keeps its native
+ * separators (`~/Videos\Clips` on Windows).
  */
-function shortenCwd(cwd: string, homeDir?: string): string {
+export function shortenCwd(cwd: string, homeDir?: string): string {
   const home = homeDir ?? homedir();
-  if (home && cwd.startsWith(home + '/')) return `~${cwd.slice(home.length)}`;
-  if (home && cwd === home) return '~';
-  return cwd;
+  if (!home) return cwd;
+  const rel = relative(home, cwd);
+  if (rel === '') return '~';
+  if (isAbsolute(rel) || rel === '..' || rel.startsWith('../') || rel.startsWith('..\\')) {
+    return cwd;
+  }
+  return `~/${rel}`;
 }
 
 function formatCost(costUsd: number): string {


### PR DESCRIPTION
## Summary

The TUI status line never shortened home-relative paths on Windows: `shortenCwd` compared `cwd` against `home + '/'`, which can never match a Windows profile path (`C:\Users\<name>\Videos\...`). Only the exact home directory shortened; every subdirectory rendered as a full absolute path.

This change compares through `path.relative` instead, which handles drive letters and case-only differences via the platform module, rejects native parent-traversal and absolute results (siblings, parent traversal, and other drives keep their absolute form), and emits `~/<rest>` with the remainder's native separators. A review follow-up keeps POSIX directory names whose first segment literally contains a backslash eligible for shortening.

`shortenCwd` is exported so the contract has focused coverage.

Fixes #3825

## Verification

| Check | Command | Result |
|---|---|---|
| Target suite | `node --test dist/__tests__/pi-transcript.test.js` in packages/cli | 110 pass, 0 fail, 2 skip on Windows — the three #3825 Windows cases pass; the two POSIX-only cases skip there and run on POSIX hosts |
| Full CLI suite after review fix | `npm --workspace maka-agent test` | 667 pass, 0 fail, 3 Windows-only skip on macOS |
| Format | `npm run format:check` | Checked 1780 files, no fixes applied |
| Changed-file format | `npx biome check packages/cli/src/pi-transcript.ts packages/cli/src/__tests__/pi-transcript.test.ts` | 2 files clean after the review fix |
| Windows skip inventory | `npm run windows:inventory` | Current at 72 declarations after recording the two POSIX-only path contracts on current `main` |
| ASF headers | `npm run check:asf-headers` | 3146 files audited, every source file carries the ASF header |

Note: the full `@maka/cli` suite on the original Windows checkout reports one failure unrelated to this change — `runtime-host-update-reconciliation.test.js` hits `EPERM: operation not permitted, fsync` on a directory, the Windows directory-sync gap tracked by #3898. The failing module does not import `pi-transcript`. The `check:asf-source` release-legal script tests also fail on that checkout for spawn-environment reasons; the header audit that governs source files passes.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: GLM-5.3-Flash via ZCode traced the root cause, implemented the original fix and tests, and ran the original verification table. OpenAI Codex corrected the cross-platform parent-separator guard, added the POSIX `..\notes` regression, and refreshed the repository's Windows skip inventory during review. All affected commits carry `Generated-by` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — the Windows status line now renders `~/`-relative paths instead of full absolute paths; macOS/Linux behavior is unchanged

> **Automated review notice:** This comment was posted by an automated review agent operated by WAWQAQ. It is not an independent human review and does not replace one.
