### PR TITLE
ci: name the Ubuntu image instead of asking for the queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,11 @@ jobs:
   # Renaming it would leave that check unreported on every open pull request
   # until the rename merged, and nothing could merge while it was unreported.
   test:
-    runs-on: ubuntu-latest
+    # Pinned, not `ubuntu-latest`. The two resolve to the same image, but only
+    # the alias makes this required context wait at the tail, and the steps
+    # below already assume this image. `ci-workflow-policy.test.mjs` holds the
+    # rule for every lane.
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/copilot-auto-review.yml
+++ b/.github/workflows/copilot-auto-review.yml
@@ -33,7 +33,7 @@ jobs:
       github.event.pull_request.draft == false &&
       !endsWith(github.event.pull_request.user.login, '[bot]') &&
       !contains(github.event.pull_request.labels.*.name, 'copilot-skip')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -50,7 +50,7 @@ concurrency:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - name: Check out the repository

--- a/.github/workflows/gitoxide-helper-admission.yml
+++ b/.github/workflows/gitoxide-helper-admission.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-24.04
           - macos-latest
           - windows-latest
     steps:

--- a/.github/workflows/issue-pr-lifecycle.yml
+++ b/.github/workflows/issue-pr-lifecycle.yml
@@ -46,7 +46,7 @@ concurrency:
 jobs:
   lifecycle:
     if: github.repository == 'apache/maka'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/pr-effort-label.yml
+++ b/.github/workflows/pr-effort-label.yml
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   release-identity:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
       version: ${{ steps.identity.outputs.version }}
@@ -364,7 +364,7 @@ jobs:
     # One draft release carries both platforms, so it is created once, after
     # every platform has been packaged and verified.
     needs: [release-identity, desktop, cli-macos-arm64]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/runtime-host-peer-admission.yml
+++ b/.github/workflows/runtime-host-peer-admission.yml
@@ -53,7 +53,7 @@ concurrency:
 jobs:
   test:
     name: quality
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/ci-workflow-policy.test.mjs
+++ b/scripts/ci-workflow-policy.test.mjs
@@ -375,6 +375,38 @@ test('the recovery lane pairs its path filter with a nightly run and a main push
   assert.match(readWorkflow('windows-recovery.yml'), /\n {4}name: windows_recovery/u);
 });
 
+test('no lane asks for the one runner label that queues', () => {
+  // `ubuntu-latest` is the only label here whose wait for a runner is not
+  // predictable: its median is as good as any pinned label's, but its tail
+  // reaches tens of minutes, and the required context is paid at the tail
+  // rather than the median. Naming the image instead costs no coverage,
+  // because the two resolve to the same image; it costs the automatic image
+  // upgrade, which becomes a deliberate commit rather than a silent one.
+  // That is the trade this rule makes. To take it back for one lane, change
+  // this test — an exemption is worth as much as the review it passes, and
+  // no lane needs one today.
+  //
+  // The literal is banned outright rather than only where a runner is named.
+  // `runs-on` reaches a runner through matrix values, inline sequences and
+  // `include` objects, so any shape-aware matcher is a second authority that
+  // can disagree with GitHub's; under this rule the literal has no legitimate
+  // use anywhere, which makes its mere presence the honest contract.
+  const workflows = readdirSync(WORKFLOW_DIR).filter(
+    (file) => file.endsWith('.yml') || file.endsWith('.yaml'),
+  );
+
+  assert.ok(workflows.length > 0, 'no workflows found to check');
+
+  for (const name of workflows) {
+    // Comments stripped, so explaining the rule in a workflow cannot break it.
+    assert.doesNotMatch(
+      readWorkflow(name).replaceAll(/^[ \t]*#.*$/gmu, ''),
+      /\bubuntu-latest\b/u,
+      `${name}: ubuntu-latest queues for a runner; name the image instead`,
+    );
+  }
+});
+
 test('the recovery lane keeps every run kind out of one shared concurrency group', () => {
   const workflow = readWorkflow('windows-recovery.yml');
 


### PR DESCRIPTION
Nine substitutions across eight workflows move `ubuntu-latest` to `ubuntu-24.04`. Thirteen jobs in the release and packaging lanes were already pinned; these were the ones still on the alias.

### The two labels are the same machine

Read out of `Set up job` logs on the same day, one job that asked for each label:

| asked for | `Image:` | `Version:` | provisioner | runner |
|---|---|---|---|---|
| `ubuntu-latest` | `ubuntu-24.04` | `20260823.283.1` | `20260819.586` | `2.336.0` |
| `ubuntu-24.04` | `ubuntu-24.04` | `20260823.283.1` | `20260819.586` | `2.336.0` |

Same image, same build. This changes which queue a job waits in, and nothing else.

### The queues are not the same

Restricted to 07:00–15:00 UTC, when the contention happens, across 22 ASF repositories (`runner_group_name == "GitHub Actions"`, jobs that actually acquired a runner):

| label | n | median | p90 | longest |
|---|---|---|---|---|
| `ubuntu-latest` | 408 | **12.00 min** | 28.67 min | 39.23 min |
| `ubuntu-24.04` | 268 | **0.37 min** | 6.10 min | 36.42 min |

**The gain is in the median, not the tail.** Thirty-two times better in the middle; 4.7x at p90; and at the extreme the two are indistinguishable — the pinned pool has been seen at 36 minutes. This buys "almost always seconds instead of minutes", not "never waits again". Over the full day and all labels, 46% of `ubuntu-latest` jobs wait more than a minute against 36% of `ubuntu-24.04` ones, which is the same story: the alias is worse everywhere, and it is dramatically worse in the body of the distribution rather than at the edge.

`apache/flink` reaches a p90 of 105.8 minutes on the alias. Within `apache/iceberg`, the same-repository comparison is **0.43 median on `ubuntu-24.04` (n=58) against 18.78 on `ubuntu-latest` (n=3, small)**.

This repository's own figures, before the pin: `ubuntu-latest` 6.62 median / 11.12 p90 (n=11); `ubuntu-24.04` 0.29 / 1.23 (n=8). Small samples, same direction.

Note the volume: `ubuntu-24.04` carries **1053 jobs** in this sample against the alias's 2034. It is a heavily used pool that happens to be faster, not an empty one that looks fast for lack of users.

### The sharpest control is one push in this repository

One push to #4482 created **nine first-layer jobs within the same second**, none of them declaring `needs:` (verified against the YAML — the dependent jobs in that run appear correctly six minutes later):

| queue | label | job |
|---|---|---|
| **7.7 min** | `ubuntu-latest` | PR effort label / label |
| **7.68 min** | `ubuntu-latest` | Gitoxide helper admission / ubuntu-latest |
| **7.5 min** | `ubuntu-latest` | CI / test |
| 24 s | `windows-latest` | Gitoxide helper admission / windows-latest |
| 23 s | `macos-latest` | Gitoxide helper admission / macos-latest |
| 6 s | `ubuntu-24.04-arm` | CLI package validation / linux-arm64 |
| 4 s | `macos-15` | CLI package validation / darwin-arm64 |
| 3 s | `windows-2025` | CLI package validation / win32-x64 |
| **3 s** | `ubuntu-24.04` | CLI package validation / linux-x64 |

Same push, same `created_at` to the second, label the only variable.

**Confounders ruled out.** Not the `-latest` alias as such — two of the six fast jobs are aliases. Not our own `concurrency` groups — median `run_started_at - created_at` is 0.0 across 1036 runs. Not a self-hosted split — `runner_group_name` reads `GitHub Actions` on all nine. Not burst rank or repo load — `spearman(queue, rank within same-instant group)` is 0.23, and jobs that were the *only* job at their instant wait the same as those in bursts (17.68 vs 17.47 min median, n=47/96).

### `ci.yml` has a reason of its own

Its bubblewrap step disables `apparmor_restrict_unprivileged_userns` **specifically because Ubuntu 24.04 gates user namespaces that way** — the comment at `ci.yml:158` says so. The required context already assumes this image. The alias only left that assumption free to drift on GitHub's schedule, with no commit to review. Pinning is a net reduction in risk for the one check that blocks every merge.

### What this does not settle, stated plainly

- **The mechanism is unidentified.** `apache/kafka` has a 0.30 min median on `ubuntu-latest` in the same hours `apache/spark` sits at 21–37. Something is allocated per-repository that the API does not expose. "The alias pool is saturated org-wide" cannot be the whole story.
- **Censoring is one-sided.** In the local 19h window, 30 first-layer jobs were cancelled *while still queued* between 07:00–14:00 UTC; **all 30 were `ubuntu-latest`** (median 7.2 min waited before cancellation). They are excluded from every median above, which biases the alias figures *low*. The effect is larger than measured, not smaller.
- **Two figures in the first draft of this PR were overstated** and have been corrected here: CI's `created_at → first job started` is 23.0 min, not 33.4; and the gitoxide three-OS median of 15.0/0.1/0.1 was one 8-run slice, not the 46-run median of 1.58.

### Scope

| workflow | job |
|---|---|
| `ci.yml` | `test` — the required context |
| `dependency-audit.yml` | `audit` |
| `gitoxide-helper-admission.yml` | the `ubuntu-latest` matrix leg |
| `runtime-host-peer-admission.yml` | `quality` |
| `pr-effort-label.yml` | `label` |
| `issue-pr-lifecycle.yml` | `lifecycle` |
| `release.yml` | `release-identity` and `publish` |
| `copilot-auto-review.yml` | `request-review` (currently disabled; pinned so re-enabling does not reintroduce it) |

That leg in `gitoxide-helper-admission.yml` was kept on the alias in #4480 as a live control. **Removing it is deliberate**: the measurement is complete and reproducible from history and from the ten other repositories above, while keeping one lane on the alias would cost every Gitoxide pull request its tail wait indefinitely.

**`windows-latest` and `macos-latest` stay as they are**, for two different reasons.

Windows has no queue to escape and no faster label to escape to. `windows-latest` waits 0.05 min median across 98 jobs and has never been seen above 1.20; `windows-2025` is *slower* at 0.10 median (n=26), and same-instant pairs differ by +0.02 min. In this repository the two sit at 0.12 and 0.14. Pinning would be a real image change bought with nothing.

macOS does queue, just rarely: 3 of 86 jobs waited over a minute, the worst being 9.73 (apache/pulsar) and 5.98 (apache/lucene). That is a fifteenth of `ubuntu-latest`'s rate of 46%. It stays on the alias because **no named macOS label is measurably better and one is clearly worse** — `macos-14` exceeds a minute on 35% of its 37 jobs, and `macos-15` has only 8 observations. Unlike Ubuntu, where both labels resolve to one image, `macos-latest` is macOS 26 and `macos-15` is macOS 15: pinning here changes the operating system to chase a tail that the pinned labels do not demonstrably avoid.

### The rule

`ci-workflow-policy.test.mjs` now rejects the literal `ubuntu-latest` anywhere in any `.yml` or `.yaml` workflow, after stripping comments.

The first version of this test matched runner *declaration shapes*. That was both incomplete and a false authority: `runs-on` reaches a runner through matrix values, inline sequences and `include` objects, and the repository already uses `os: [windows-latest, macos-latest]` in `runtime-host-owner-platform.yml`. Adding the alias there would have passed. Verified: the current rule is red for each of `os: [.., ubuntu-latest]`, `- os: ubuntu-latest`, `runs-on: [self-hosted, ubuntu-latest]` and a trailing-space `runs-on: ubuntu-latest`, all four of which the shape matcher let through — and green as committed across all 21 workflows.

Under this rule the literal has no legitimate use anywhere, which makes its mere presence the honest contract. There is no exemption syntax: taking one back means editing this test, which is a commit someone reviews. No lane needs one today.

`ubuntu-latest` is what every tutorial writes, so without a rule this drifts back one new workflow at a time — which is how these nine got here.

### What is given up

**The automatic image upgrade.** When GitHub moves `latest`, these labels move by hand. Dependabot does not update `runs-on:`, so this obligation currently has no owner beyond the test comment. Filed as a known gap rather than solved here.

**Concentration risk.** `ubuntu-latest` carries **79.1% of this repository's Ubuntu job-minutes** (3141 of 3970 in a 19h window). This raises our demand on the pinned label **6.2x**, onto a pool whose wait was measured while it carried one sixth of that load. The evidence that it absorbs the shift is indirect: across the ASF it already carries more jobs than the alias, and during the contended hours it holds a 0.37 min median against the alias's 12.00 while both reach the high thirties at the extreme — the pinned pool is better in the body of the distribution, not immune.

**Rollback criterion:** if this repository's median wait on `ubuntu-24.04` during 07:00–15:00 UTC passes 2 minutes after this lands, revisit. The median is the criterion because the median is what this buys — both pools already reach the high thirties at the extreme, so a tail figure would trip immediately and mean nothing. With both sides finally measurable, a split becomes an arithmetic question rather than a guess.

Refs #4480

