### PR TITLE
fix(desktop): show platform-correct shortcut labels on Windows and Linux

### DIFF
--- a/apps/desktop/src/main/__tests__/command-palette-retired.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-retired.test.ts
@@ -84,3 +84,33 @@ test('a stale in-memory default pointing at a retired connection is not testable
   const ids = commandIds([retired, connection()], retired.slug);
   assert.ok(!ids.includes('diag:test-default'));
 });
+
+for (const locale of ['en', 'zh'] as const) {
+  test(`${locale} static shortcut hints preserve both platform variants`, () => {
+    const commands = buildCommandList({
+      locale,
+      activeSessionId: 'session-1',
+      themePref: 'auto',
+      connections: [],
+      defaultSlug: null,
+      onNewChat: () => {},
+      onOpenSideChat: () => {},
+      onOpenSettings: () => {},
+      onOpenSettingsSection: () => {},
+      onOpenShortcuts: () => {},
+      onSetTheme: () => {},
+      onCopyDiagnostics: () => {},
+    });
+    const byId = new Map(commands.map((command) => [command.id, command]));
+    assert.deepEqual(byId.get('action:side-chat')?.platformHint, {
+      apple: '⌥⌘S',
+      other: 'Ctrl+Alt+S',
+    });
+    assert.deepEqual(byId.get('action:open-settings')?.platformHint, {
+      apple: '⌘,',
+      other: 'Ctrl+,',
+    });
+    assert.equal(byId.get('diag:copy-diagnostics')?.platformHint?.other, 'Ctrl+Shift+D · ' +
+      (locale === 'zh' ? '脱敏日志 · 仅写入剪贴板' : 'Redacted logs · clipboard only'));
+  });
+}

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -37,6 +37,7 @@ import {
   AstryxLocaleProvider,
   type SearchSource,
   type SearchableItem,
+  PlatformShortcutText,
   useUiLocale,
 } from '@maka/ui';
 import { Kbd } from '@astryxdesign/core/Kbd';
@@ -139,6 +140,13 @@ export function CommandPalette(props: {
           if (!command) return false;
           if (fuzzy(normalized, command.label)) return true;
           if (command.hint && fuzzy(normalized, command.hint)) return true;
+          if (
+            command.platformHint &&
+            (fuzzy(normalized, command.platformHint.apple) ||
+              fuzzy(normalized, command.platformHint.other))
+          ) {
+            return true;
+          }
           return command.keywords?.some((keyword) =>
             fuzzy(normalized, keyword),
           ) ?? false;
@@ -191,9 +199,14 @@ export function CommandPalette(props: {
                 <command.Icon size={ICON_SIZE.chrome} />
               </span>
               <span className="maka-palette-label">{command.label}</span>
-              {command.hint ? (
+              {command.hint || command.platformHint ? (
                 <span className="maka-palette-hint">
-                  {command.hint}
+                  {command.hint ?? (
+                    <PlatformShortcutText
+                      apple={command.platformHint!.apple}
+                      other={command.platformHint!.other}
+                    />
+                  )}
                   <ChevronRight size={ICON_SIZE.meta} aria-hidden="true" />
                 </span>
               ) : (

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -29,19 +29,6 @@ import { type SlashCommandIdForSurface } from '@maka/core/slash-command-catalog'
 
 import { type ThinkingLevel } from '@maka/core/model-thinking';
 import { type GoalStatus } from '@maka/core/goal';
-import { isAppleShortcutPlatform } from '@maka/ui';
-
-// Palette hints are plain strings rendered verbatim by the command palette,
-// not Kbd tokens, so they detect the platform themselves (#3876). The
-// keyboardHelp `keys` arrays below stay as ⌘/⇧ glyphs on purpose: they are
-// parsed through keyboard-help's ASTRYX_KEY_TOKENS into Kbd's platform-aware
-// `mod` token, which renders the right label per platform.
-const APPLE_HINTS = isAppleShortcutPlatform(
-  typeof navigator === 'undefined' ? '' : navigator.platform,
-);
-function platformHint(apple: string, other: string): string {
-  return APPLE_HINTS ? apple : other;
-}
 
 export const STATIC_COMMAND_IDS = [
   'action:new-chat',
@@ -77,6 +64,10 @@ type CommandCopy = {
   label: string;
   group: string;
   hint?: string;
+  platformHint?: {
+    apple: string;
+    other: string;
+  };
 };
 
 const STATIC_COMMAND_KEYWORDS: Record<StaticCommandId, readonly string[]> = {
@@ -570,7 +561,7 @@ const ZH_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   'action:new-chat': { label: '新建任务', hint: '开始新的任务', group: '操作' },
   'action:side-chat': {
     label: '打开侧边对话',
-    hint: platformHint('⌥⌘S', 'Ctrl+Alt+S'),
+    platformHint: { apple: '⌥⌘S', other: 'Ctrl+Alt+S' },
     group: '操作',
   },
   'action:new-deep-research': {
@@ -583,7 +574,11 @@ const ZH_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
     hint: '打开定时任务表单',
     group: '操作',
   },
-  'action:open-settings': { label: '打开设置', hint: platformHint('⌘,', 'Ctrl+,'), group: '操作' },
+  'action:open-settings': {
+    label: '打开设置',
+    platformHint: { apple: '⌘,', other: 'Ctrl+,' },
+    group: '操作',
+  },
   'action:keyboard-help': { label: '查看键盘快捷键', hint: '?', group: '操作' },
   'theme:light': { label: '主题 · 浅色', group: '主题' },
   'theme:dark': { label: '主题 · 深色', group: '主题' },
@@ -635,7 +630,10 @@ const ZH_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   },
   'diag:copy-diagnostics': {
     label: '复制诊断信息',
-    hint: platformHint('⇧⌘D · 脱敏日志 · 仅写入剪贴板', 'Ctrl+Shift+D · 脱敏日志 · 仅写入剪贴板'),
+    platformHint: {
+      apple: '⇧⌘D · 脱敏日志 · 仅写入剪贴板',
+      other: 'Ctrl+Shift+D · 脱敏日志 · 仅写入剪贴板',
+    },
     group: '诊断',
   },
   'diag:test-network-proxy': {
@@ -658,7 +656,7 @@ const EN_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   },
   'action:side-chat': {
     label: 'Open side chat',
-    hint: platformHint('⌥⌘S', 'Ctrl+Alt+S'),
+    platformHint: { apple: '⌥⌘S', other: 'Ctrl+Alt+S' },
     group: 'Actions',
   },
   'action:new-deep-research': {
@@ -673,7 +671,7 @@ const EN_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   },
   'action:open-settings': {
     label: 'Open Settings',
-    hint: platformHint('⌘,', 'Ctrl+,'),
+    platformHint: { apple: '⌘,', other: 'Ctrl+,' },
     group: 'Actions',
   },
   'action:keyboard-help': {
@@ -731,7 +729,10 @@ const EN_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   },
   'diag:copy-diagnostics': {
     label: 'Copy diagnostics',
-    hint: platformHint('⇧⌘D · Redacted logs · clipboard only', 'Ctrl+Shift+D · Redacted logs · clipboard only'),
+    platformHint: {
+      apple: '⇧⌘D · Redacted logs · clipboard only',
+      other: 'Ctrl+Shift+D · Redacted logs · clipboard only',
+    },
     group: 'Diagnostics',
   },
   'diag:test-network-proxy': {

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -29,6 +29,19 @@ import { type SlashCommandIdForSurface } from '@maka/core/slash-command-catalog'
 
 import { type ThinkingLevel } from '@maka/core/model-thinking';
 import { type GoalStatus } from '@maka/core/goal';
+import { isAppleShortcutPlatform } from '@maka/ui';
+
+// Palette hints are plain strings rendered verbatim by the command palette,
+// not Kbd tokens, so they detect the platform themselves (#3876). The
+// keyboardHelp `keys` arrays below stay as ⌘/⇧ glyphs on purpose: they are
+// parsed through keyboard-help's ASTRYX_KEY_TOKENS into Kbd's platform-aware
+// `mod` token, which renders the right label per platform.
+const APPLE_HINTS = isAppleShortcutPlatform(
+  typeof navigator === 'undefined' ? '' : navigator.platform,
+);
+function platformHint(apple: string, other: string): string {
+  return APPLE_HINTS ? apple : other;
+}
 
 export const STATIC_COMMAND_IDS = [
   'action:new-chat',
@@ -557,7 +570,7 @@ const ZH_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   'action:new-chat': { label: '新建任务', hint: '开始新的任务', group: '操作' },
   'action:side-chat': {
     label: '打开侧边对话',
-    hint: '⌥⌘S',
+    hint: platformHint('⌥⌘S', 'Ctrl+Alt+S'),
     group: '操作',
   },
   'action:new-deep-research': {
@@ -570,7 +583,7 @@ const ZH_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
     hint: '打开定时任务表单',
     group: '操作',
   },
-  'action:open-settings': { label: '打开设置', hint: '⌘,', group: '操作' },
+  'action:open-settings': { label: '打开设置', hint: platformHint('⌘,', 'Ctrl+,'), group: '操作' },
   'action:keyboard-help': { label: '查看键盘快捷键', hint: '?', group: '操作' },
   'theme:light': { label: '主题 · 浅色', group: '主题' },
   'theme:dark': { label: '主题 · 深色', group: '主题' },
@@ -622,7 +635,7 @@ const ZH_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   },
   'diag:copy-diagnostics': {
     label: '复制诊断信息',
-    hint: '⇧⌘D · 脱敏日志 · 仅写入剪贴板',
+    hint: platformHint('⇧⌘D · 脱敏日志 · 仅写入剪贴板', 'Ctrl+Shift+D · 脱敏日志 · 仅写入剪贴板'),
     group: '诊断',
   },
   'diag:test-network-proxy': {
@@ -645,7 +658,7 @@ const EN_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   },
   'action:side-chat': {
     label: 'Open side chat',
-    hint: '⌥⌘S',
+    hint: platformHint('⌥⌘S', 'Ctrl+Alt+S'),
     group: 'Actions',
   },
   'action:new-deep-research': {
@@ -660,7 +673,7 @@ const EN_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   },
   'action:open-settings': {
     label: 'Open Settings',
-    hint: '⌘,',
+    hint: platformHint('⌘,', 'Ctrl+,'),
     group: 'Actions',
   },
   'action:keyboard-help': {
@@ -718,7 +731,7 @@ const EN_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
   },
   'diag:copy-diagnostics': {
     label: 'Copy diagnostics',
-    hint: '⇧⌘D · Redacted logs · clipboard only',
+    hint: platformHint('⇧⌘D · Redacted logs · clipboard only', 'Ctrl+Shift+D · Redacted logs · clipboard only'),
     group: 'Diagnostics',
   },
   'diag:test-network-proxy': {

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -6,7 +6,7 @@ Generated against `@astryxdesign/core@0.5.2` (194 component exports).
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 236 files — blocker 0, reimplementation 0, polish 1, aligned 235.
+**Totals:** 237 files — blocker 0, reimplementation 0, polish 1, aligned 236.
 
 ## Exclusions (explicit)
 
@@ -230,6 +230,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `packages/ui/src/module-hub-selector.tsx` | ui-composition | Tab, TabList | aligned — uses Astryx (Tab, TabList) | aligned |
 | `packages/ui/src/module-pages.tsx` | ui-composition | EmptyState, Spinner | aligned — uses Astryx (EmptyState, Spinner) | aligned |
 | `packages/ui/src/permission-mode-menu.tsx` | ui-composition | DropdownMenu, DropdownMenuRadioGroup, DropdownMenuRadioItem, Selector, SelectorOption | aligned — uses Astryx (DropdownMenu, DropdownMenuRadioGroup, DropdownMenuRadioItem, Selector, SelectorOption) | aligned |
+| `packages/ui/src/platform-shortcut-text.tsx` | ui-composition | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `packages/ui/src/primitives/chat.tsx` | primitive | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `packages/ui/src/primitives/module-page.tsx` | primitive | Dialog, DialogHeader, HStack, Heading, Layout, LayoutContent, LayoutHeader, LayoutPanel, ResizeHandle, StackItem, Text, VStack | aligned — uses Astryx (Dialog, DialogHeader, HStack, Heading, Layout, LayoutContent, LayoutHeader, LayoutPanel) | aligned |
 | `packages/ui/src/primitives/page-header.tsx` | primitive | none | aligned — no raw controls; no Astryx JSX usage | aligned |

--- a/docs/astryx-surface-file-inventory.paths
+++ b/docs/astryx-surface-file-inventory.paths
@@ -201,6 +201,7 @@ packages/ui/src/model-picker.tsx
 packages/ui/src/module-hub-selector.tsx
 packages/ui/src/module-pages.tsx
 packages/ui/src/permission-mode-menu.tsx
+packages/ui/src/platform-shortcut-text.tsx
 packages/ui/src/primitives/chat.tsx
 packages/ui/src/primitives/module-page.tsx
 packages/ui/src/primitives/page-header.tsx

--- a/packages/ui/src/__tests__/utils.test.ts
+++ b/packages/ui/src/__tests__/utils.test.ts
@@ -17,19 +17,21 @@
  * under the License.
  */
 
-import { clsx, type ClassValue } from 'clsx';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { isAppleShortcutPlatform } from '../utils.js';
 
-export function cn(...inputs: ClassValue[]): string {
-  return clsx(inputs);
-}
+test('detects Apple platforms from navigator.platform values', () => {
+  assert.equal(isAppleShortcutPlatform('MacIntel'), true);
+  assert.equal(isAppleShortcutPlatform('Macintosh'), true);
+  assert.equal(isAppleShortcutPlatform('iPhone'), true);
+  assert.equal(isAppleShortcutPlatform('iPad'), true);
+});
 
-/**
- * Plain shortcut display strings cannot lean on the design-system Kbd,
- * whose `mod` token is already platform-aware (⌘ on Apple platforms, Ctrl
- * elsewhere). Detect Apple platforms with the same navigator.platform
- * fallback Kbd uses so hand-built hint strings agree with Kbd output
- * rendered beside them.
- */
-export function isAppleShortcutPlatform(platform: string | null | undefined): boolean {
-  return /Mac|iPhone|iPad|iPod/.test(platform ?? '');
-}
+test('rejects non-Apple platforms and unknown input (#3876)', () => {
+  assert.equal(isAppleShortcutPlatform('Win32'), false);
+  assert.equal(isAppleShortcutPlatform('Linux x86_64'), false);
+  assert.equal(isAppleShortcutPlatform(''), false);
+  assert.equal(isAppleShortcutPlatform(null), false);
+  assert.equal(isAppleShortcutPlatform(undefined), false);
+});

--- a/packages/ui/src/__tests__/utils.test.ts
+++ b/packages/ui/src/__tests__/utils.test.ts
@@ -19,11 +19,12 @@
 
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { isAppleShortcutPlatform } from '../utils.js';
+import { isAppleShortcutPlatform, preferredShortcutPlatform } from '../utils.js';
 
 test('detects Apple platforms from navigator.platform values', () => {
   assert.equal(isAppleShortcutPlatform('MacIntel'), true);
   assert.equal(isAppleShortcutPlatform('Macintosh'), true);
+  assert.equal(isAppleShortcutPlatform('macOS'), true);
   assert.equal(isAppleShortcutPlatform('iPhone'), true);
   assert.equal(isAppleShortcutPlatform('iPad'), true);
 });
@@ -34,4 +35,12 @@ test('rejects non-Apple platforms and unknown input (#3876)', () => {
   assert.equal(isAppleShortcutPlatform(''), false);
   assert.equal(isAppleShortcutPlatform(null), false);
   assert.equal(isAppleShortcutPlatform(undefined), false);
+});
+
+test('prefers userAgentData.platform and falls back only when it is blank', () => {
+  assert.equal(preferredShortcutPlatform('macOS', 'Win32'), 'macOS');
+  assert.equal(preferredShortcutPlatform('Windows', 'MacIntel'), 'Windows');
+  assert.equal(preferredShortcutPlatform('  ', 'MacIntel'), 'MacIntel');
+  assert.equal(preferredShortcutPlatform(undefined, 'Linux x86_64'), 'Linux x86_64');
+  assert.equal(preferredShortcutPlatform(undefined, undefined), '');
 });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -64,6 +64,7 @@ export * from './toast.js';
 export * from './tool-output-stream.js';
 export * from './ui.js';
 export * from './utils.js';
+export * from './platform-shortcut-text.js';
 
 // Maka-owned product assets and compositions remain public only where they do
 // not duplicate a published Astryx component authority.

--- a/packages/ui/src/platform-shortcut-text.tsx
+++ b/packages/ui/src/platform-shortcut-text.tsx
@@ -17,27 +17,21 @@
  * under the License.
  */
 
-/**
- * Shared types for the Command Palette. Pulled out of
- * `command-palette.tsx` so non-JSX consumers can import them under the
- * main-process tsconfig that does not compile JSX.
- */
+import { isAppleShortcutPlatform, preferredShortcutPlatform } from './utils.js';
 
-import type { LucideIcon } from '@maka/ui/icons';
-
-export type CommandKind = 'action' | 'session';
-
-export interface Command {
-  id: string;
-  kind: CommandKind;
-  label: string;
-  hint?: string;
-  platformHint?: {
-    apple: string;
-    other: string;
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: {
+    platform?: string;
   };
-  group: string;
-  Icon: LucideIcon;
-  keywords?: string[];
-  run(): void | Promise<void>;
+};
+
+export function PlatformShortcutText(props: { apple: string; other: string }) {
+  const browserNavigator = typeof navigator === 'undefined'
+    ? undefined
+    : navigator as NavigatorWithUserAgentData;
+  const platform = preferredShortcutPlatform(
+    browserNavigator?.userAgentData?.platform,
+    browserNavigator?.platform,
+  );
+  return <>{isAppleShortcutPlatform(platform) ? props.apple : props.other}</>;
 }

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -21,10 +21,19 @@ import { AlertCircle, Blocks, Download, Network, Settings, SquarePen, Timer } fr
 import { useSessionRailChrome } from './session-rail-context.js';
 import { useUiLocale } from './locale-context.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
+import { isAppleShortcutPlatform } from './utils.js';
 import { Icon } from '@astryxdesign/core/Icon';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { SideNavItem, SideNavSection } from '@astryxdesign/core/SideNav';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
+
+// The kbd is a plain display string outside the design-system Kbd, so it
+// cannot lean on that component's platform-aware `mod` token (#3876).
+const NEW_TASK_KEYS = isAppleShortcutPlatform(
+  typeof navigator === 'undefined' ? '' : navigator.platform,
+)
+  ? '⌘ N'
+  : 'Ctrl N';
 
 export function SessionSidebarNav() {
   const props = useSessionRailChrome();
@@ -55,7 +64,7 @@ export function SessionSidebarNav() {
         icon={SquarePen}
         size="md"
         onClick={props.onNew}
-        endContent={<kbd className="maka-nav-kbd" aria-hidden="true">⌘ N</kbd>}
+        endContent={<kbd className="maka-nav-kbd" aria-hidden="true">{NEW_TASK_KEYS}</kbd>}
       />
       {props.workHubEntry ? (
         <SideNavItem

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -21,19 +21,11 @@ import { AlertCircle, Blocks, Download, Network, Settings, SquarePen, Timer } fr
 import { useSessionRailChrome } from './session-rail-context.js';
 import { useUiLocale } from './locale-context.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
-import { isAppleShortcutPlatform } from './utils.js';
+import { PlatformShortcutText } from './platform-shortcut-text.js';
 import { Icon } from '@astryxdesign/core/Icon';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { SideNavItem, SideNavSection } from '@astryxdesign/core/SideNav';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
-
-// The kbd is a plain display string outside the design-system Kbd, so it
-// cannot lean on that component's platform-aware `mod` token (#3876).
-const NEW_TASK_KEYS = isAppleShortcutPlatform(
-  typeof navigator === 'undefined' ? '' : navigator.platform,
-)
-  ? '⌘ N'
-  : 'Ctrl N';
 
 export function SessionSidebarNav() {
   const props = useSessionRailChrome();
@@ -64,7 +56,11 @@ export function SessionSidebarNav() {
         icon={SquarePen}
         size="md"
         onClick={props.onNew}
-        endContent={<kbd className="maka-nav-kbd" aria-hidden="true">{NEW_TASK_KEYS}</kbd>}
+        endContent={(
+          <kbd className="maka-nav-kbd" aria-hidden="true">
+            <PlatformShortcutText apple="⌘ N" other="Ctrl N" />
+          </kbd>
+        )}
       />
       {props.workHubEntry ? (
         <SideNavItem

--- a/packages/ui/src/utils.ts
+++ b/packages/ui/src/utils.ts
@@ -31,5 +31,14 @@ export function cn(...inputs: ClassValue[]): string {
  * rendered beside them.
  */
 export function isAppleShortcutPlatform(platform: string | null | undefined): boolean {
-  return /Mac|iPhone|iPad|iPod/.test(platform ?? '');
+  return /mac|iphone|ipad|ipod/i.test(platform ?? '');
+}
+
+/** Prefer Chromium's current platform authority, falling back for older engines. */
+export function preferredShortcutPlatform(
+  userAgentDataPlatform: string | null | undefined,
+  legacyPlatform: string | null | undefined,
+): string {
+  const modern = userAgentDataPlatform?.trim();
+  return modern || legacyPlatform?.trim() || '';
 }


### PR DESCRIPTION
## Summary

Shortcut display strings were hard-coded to macOS glyphs in the two places that bypass the design-system `Kbd` component:

- the sidebar New Task hint rendered a literal `⌘ N`;
- command-palette hints for side chat (`⌥⌘S`), Settings (`⌘,`), and copy diagnostics (`⇧⌘D · …`) rendered `⌘`/`⌥`/`⇧` on every platform, in both locales.

The shortcut behavior was already correct everywhere (`mod` resolves to Ctrl off macOS), so this change is display-only. Windows and Linux now show `Ctrl N`, `Ctrl+Alt+S`, `Ctrl+,`, and `Ctrl+Shift+D · …`; macOS output is unchanged.

The renderer owns platform detection. It prefers `navigator.userAgentData.platform` and falls back to `navigator.platform`, matching Chromium's current and legacy platform authorities. The locale catalog remains pure data and carries both display variants, so command-palette search can match either spelling without depending on browser globals. The sidebar and palette share one `PlatformShortcutText` renderer from `@maka/ui`.

The `keyboardHelp` key arrays deliberately keep their `⌘`/`⇧` glyphs: they are parsed through `ASTRYX_KEY_TOKENS` into the design-system `Kbd` component's platform-aware `mod` token, so changing those source tokens would affect shortcut registration rather than fix these raw display strings.

Fixes #3876

## Verification

| Check | Result |
|---|---|
| Renderer architecture ledger (`npm run check:renderer-architecture`) | 61/61 checks passed |
| `@maka/ui` test suite | 307/307 passed |
| Desktop renderer typecheck | Passed |
| Desktop main-process test suite | 1,877/1,877 passed |
| Biome on all changed files | Passed |
| Astryx surface inventory | Current at 237 files against `@astryxdesign/core@0.5.2`; 0 blockers and 0 reimplementations |
| `git diff --check` | Passed |

Coverage includes case-insensitive Apple platform detection, `userAgentData.platform` precedence with legacy fallback, and propagation of both localized platform variants into the command-palette model.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

- GLM-5.3-Flash via ZCode traced the original display path, implemented the initial platform-aware labels, and added the initial tests.
- OpenAI Codex independently reviewed the change, found that the locale module's renderer dependency and direct browser-capability read violated the renderer architecture gate, moved platform detection to a shared renderer component, preserved both variants for search, added regression coverage, refreshed the generated Astryx inventory, and ran the verification above.

The commits carry matching `Generated-by` trailers.

## Checklist

- [x] Tests cover the changed platform-selection and command-model behavior
- [x] Format, typecheck, architecture, and affected test suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — Windows/Linux shortcut labels now use Ctrl/Alt/Shift spellings; macOS output is unchanged

**Automated review notice:** This comment was posted by an automated review agent operated by WAWQAQ. It is not an independent human review and does not replace one.
