### PR TITLE
test(eval): bound fragmented-handshake recv by the handshake deadline

### DIFF
--- a/packages/eval/harbor/test_egress_filter_live.py
+++ b/packages/eval/harbor/test_egress_filter_live.py
@@ -165,6 +165,23 @@ def docker_image_present(image: str) -> bool:
 
 def finish_memory_bio_handshake(tls, incoming, outgoing, sock, timeout_s: float) -> str:
     deadline = time.monotonic() + timeout_s
+
+    def recv_within_deadline() -> bytes:
+        # One slow segment must not run on the socket's own timeout clock.
+        # Under CI load a recv that outlives the caller's settimeout() fails
+        # even when the handshake deadline still has budget, which is what
+        # made the fragmented handshake flaky (#4240). Wait at most until
+        # the deadline, then restore whatever the caller configured.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError("fragmented TLS handshake did not complete")
+        previous = sock.gettimeout()
+        sock.settimeout(remaining)
+        try:
+            return sock.recv(16 * 1024)
+        finally:
+            sock.settimeout(previous)
+
     while time.monotonic() < deadline:
         try:
             tls.do_handshake()
@@ -175,7 +192,7 @@ def finish_memory_bio_handshake(tls, incoming, outgoing, sock, timeout_s: float)
             pending = outgoing.read()
             if pending:
                 sock.sendall(pending)
-            response = sock.recv(16 * 1024)
+            response = recv_within_deadline()
             if not response:
                 raise AssertionError("proxy closed during the fragmented TLS handshake")
             incoming.write(response)
@@ -217,6 +234,12 @@ class MemoryBioHandshakeDriverTest(unittest.TestCase):
                 return "TLSv1.3"
 
         class FakeSocket:
+            def gettimeout(self):
+                return 10.0
+
+            def settimeout(self, _value):
+                pass
+
             def sendall(self, data):
                 events.append(("send", data))
 
@@ -237,6 +260,55 @@ class MemoryBioHandshakeDriverTest(unittest.TestCase):
                 ("write", b"server-finished"),
             ],
         )
+
+    def test_recv_waits_until_the_deadline_not_an_independent_socket_clock(self) -> None:
+        timeouts = []
+
+        class FakeTls:
+            calls = 0
+
+            def do_handshake(self):
+                self.calls += 1
+                if self.calls <= 2:
+                    raise ssl.SSLWantReadError()
+
+            def version(self):
+                return "TLSv1.3"
+
+        class FakeIncoming:
+            def write(self, _data):
+                pass
+
+        class FakeOutgoing:
+            def read(self):
+                return b""
+
+        class FakeSocket:
+            def gettimeout(self):
+                return 10.0
+
+            def settimeout(self, value):
+                timeouts.append(value)
+
+            def recv(self, _size):
+                return b"segment"
+
+        result = finish_memory_bio_handshake(
+            FakeTls(), FakeIncoming(), FakeOutgoing(), FakeSocket(), timeout_s=20
+        )
+
+        self.assertEqual(result, "TLSv1.3")
+        # Two fragmented reads happened; each was bounded by the remaining
+        # handshake deadline rather than the caller's 10s socket timeout,
+        # and the caller's timeout was restored after every recv.
+        bounded = timeouts[0::2]
+        restores = timeouts[1::2]
+        self.assertEqual(len(bounded), 2)
+        self.assertEqual(restores, [10.0, 10.0])
+        for value in bounded:
+            self.assertGreater(value, 0)
+            self.assertLessEqual(value, 20)
+        self.assertLessEqual(bounded[1], bounded[0])
 
 
 @unittest.skipUnless(


### PR DESCRIPTION
## Summary

The live Eval egress proxy test failed intermittently with `TimeoutError: timed out` from `sock.recv` inside `finish_memory_bio_handshake` (subtest `first_fragment_size=2`, CI run 33291789451) while the other six live cases passed. The triggering PR touched neither Eval nor the proxy.

Two conflicting clocks were in play: the caller configured the socket with `settimeout(10)` and passed `timeout_s=20` as the handshake deadline. Under CI load a single server segment can take longer than the per-recv 10s while the 20s handshake contract still has budget, so one slow recv aborted a handshake that would have completed. More fragments means more recv rounds, and each round rolled a fresh independent 10s dice — which is why the flake was intermittent and subtest-specific.

This change binds each recv to the remaining handshake deadline: wait at most `deadline - now`, restore the caller's configured timeout afterwards. The overall contract stays 20s — no retry is added, no deadline is weakened; the per-operation clock simply stops contradicting the deadline it exists to serve.

Fixes #4240

## Verification

| Check | Command | Result |
|---|---|---|
| Handshake driver unit tests | `python -m unittest test_egress_filter_live -v` (packages/eval/harbor) | 8 tests: both `MemoryBioHandshakeDriverTest` cases pass — the existing flight-flush contract on the updated `FakeSocket`, plus the new deadline-bounding case; the six live cases skip without `MAKA_EVAL_EGRESS_PROXY_TEST=1` |
| New contract test | `test_recv_waits_until_the_deadline_not_an_independent_socket_clock` | pins that every recv waits at most the remaining deadline (positive, ≤ `timeout_s`, non-increasing across rounds) and the caller's 10s timeout is restored after each recv |
| Format | `npm run format:check` | Checked 1780 files, no fixes applied |
| ASF headers | `npm run check:asf-headers` | Every source file carries the ASF header |

Not run locally: the live mitmproxy suite (`test:egress-proxy:live`) requires the Docker build and is gated behind `MAKA_EVAL_EGRESS_PROXY_TEST=1`; CI runs it in its Linux container. The change is platform-neutral Python (stdlib `socket`/`time` only) and the live path's diff is the recv-bounding helper alone.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: GLM-5.3-Flash via ZCode — diagnosed the two-clock contract conflict from the CI trace, implemented the deadline-bounded recv and the contract-pinning unit test, and ran the verification table above. The commit carries a `Generated-by` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — test-only: a single slow segment now consumes remaining handshake budget instead of failing at an independent 10s per-recv timeout; production code is untouched
