### PR TITLE
refactor(desktop): move Task Entry controller below AppShell

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -297,6 +297,13 @@
       "owner": "src/renderer/features/module-hub/ui/module-hub-provider.tsx",
       "ownerSymbol": "ModuleHubProvider",
       "count": 1
+    },
+    {
+      "implementation": "src/renderer/features/task-entry/controller/use-task-entry-controller.ts",
+      "symbol": "useTaskEntryController",
+      "owner": "src/renderer/features/task-entry/ui/task-entry-provider.tsx",
+      "ownerSymbol": "TaskEntryRoot",
+      "count": 1
     }
   ],
   "legacyAppShell": {
@@ -795,7 +802,6 @@
           "useStableActions": 6,
           "useState": 17,
           "useSystemUiLocale": 1,
-          "useTaskEntryController": 1,
           "useTaskSubmissionReadiness": 1,
           "useToast": 1,
           "useTurnActionRegistry": 1,
@@ -899,7 +905,7 @@
           "react": 1
         },
         "importSpecifiers": 124,
-        "nonTriviaTokens": 15563
+        "nonTriviaTokens": 15543
       },
       "src/renderer/use-app-shell-composer-quotes.ts": {
         "importDeclarations": 2,

--- a/apps/desktop/src/main/__tests__/task-entry-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/task-entry-boundary.test.ts
@@ -83,6 +83,39 @@ describe('Task Entry feature boundary', () => {
     const productionEntry = readFileSync(join(featureRoot, 'index.ts'), 'utf8');
     assert.equal(productionEntry.includes('createFakeTaskEntryServices'), false);
     assert.equal(productionEntry.includes("from './testing"), false);
+    assert.equal(productionEntry.includes('useTaskEntryController'), false);
+    assert.equal(productionEntry.includes('TaskEntryProvider,'), false);
+    assert.equal(productionEntry.includes('useTaskEntryOwnership'), false);
+  });
+
+  it('keeps the controller owned by TaskEntryProvider and out of renderer roots', () => {
+    const controllerOwner = join(featureRoot, 'ui', 'task-entry-provider.tsx');
+    const consumers: string[] = [];
+    for (const path of sourceFiles(join(desktopRoot, 'src', 'renderer'))) {
+      if (!/\.tsx?$/.test(path) || path.endsWith('use-task-entry-controller.ts')) continue;
+      const source = readFileSync(path, 'utf8');
+      if (/\buseTaskEntryController\s*\(/.test(source)) {
+        consumers.push(relative(desktopRoot, path));
+      }
+    }
+    assert.deepEqual(consumers, [relative(desktopRoot, controllerOwner)]);
+  });
+
+  it('keeps the controller module behind TaskEntryProvider and the testing entry', () => {
+    const importers: string[] = [];
+    for (const path of sourceFiles(featureRoot)) {
+      if (!/\.tsx?$/.test(path)) continue;
+      const source = readFileSync(path, 'utf8');
+      for (const match of source.matchAll(/from\s+['"]([^'"]+)['"]/g)) {
+        if (match[1]?.includes('controller/use-task-entry-controller')) {
+          importers.push(relative(desktopRoot, path));
+        }
+      }
+    }
+    assert.deepEqual(importers.sort(), [
+      'src/renderer/features/task-entry/testing.ts',
+      'src/renderer/features/task-entry/ui/task-entry-provider.tsx',
+    ]);
   });
 
   it('keeps Task Entry catalog, picker, and directory handoff ownership out of AppShell', () => {
@@ -96,10 +129,21 @@ describe('Task Entry feature boundary', () => {
       'newTaskDraftKey(',
       'RemoteProjectDirectoryDialog',
       'const workspacePicker: WorkspacePickerModel',
+      'useTaskEntryController',
+      'useTaskEntryShellProjection',
+      'taskEntry.host',
+      'taskEntry.owner',
+      '<TaskEntryHost model=',
+      '<TaskEntry.TaskEntryHost model=',
     ]) {
       assert.equal(appShell.includes(forbidden), false, forbidden);
     }
-    assert.equal(appShell.includes('const taskEntry = useTaskEntryController({'), true);
-    assert.equal(appShell.includes('<TaskEntryHost model={taskEntry.host} />'), true);
+    for (const required of [
+      '<TaskEntry.TaskEntryRoot>',
+      '<TaskEntry.TaskEntryWorkspacePickerConsumer manageProjects=',
+      '<TaskEntry.TaskEntryHost />',
+    ]) {
+      assert.equal(appShell.includes(required), true, required);
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/task-entry-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/task-entry-boundary.test.ts
@@ -83,40 +83,10 @@ describe('Task Entry feature boundary', () => {
     const productionEntry = readFileSync(join(featureRoot, 'index.ts'), 'utf8');
     assert.equal(productionEntry.includes('createFakeTaskEntryServices'), false);
     assert.equal(productionEntry.includes("from './testing"), false);
-    assert.equal(productionEntry.includes('useTaskEntryController'), false);
-    assert.equal(productionEntry.includes('TaskEntryProvider,'), false);
     assert.equal(productionEntry.includes('useTaskEntryOwnership'), false);
   });
 
-  it('keeps the controller owned by TaskEntryProvider and out of renderer roots', () => {
-    const controllerOwner = join(featureRoot, 'ui', 'task-entry-provider.tsx');
-    const consumers: string[] = [];
-    for (const path of sourceFiles(join(desktopRoot, 'src', 'renderer'))) {
-      if (!/\.tsx?$/.test(path) || path.endsWith('use-task-entry-controller.ts')) continue;
-      const source = readFileSync(path, 'utf8');
-      if (/\buseTaskEntryController\s*\(/.test(source)) {
-        consumers.push(relative(desktopRoot, path));
-      }
-    }
-    assert.deepEqual(consumers, [relative(desktopRoot, controllerOwner)]);
-  });
 
-  it('keeps the controller module behind TaskEntryProvider and the testing entry', () => {
-    const importers: string[] = [];
-    for (const path of sourceFiles(featureRoot)) {
-      if (!/\.tsx?$/.test(path)) continue;
-      const source = readFileSync(path, 'utf8');
-      for (const match of source.matchAll(/from\s+['"]([^'"]+)['"]/g)) {
-        if (match[1]?.includes('controller/use-task-entry-controller')) {
-          importers.push(relative(desktopRoot, path));
-        }
-      }
-    }
-    assert.deepEqual(importers.sort(), [
-      'src/renderer/features/task-entry/testing.ts',
-      'src/renderer/features/task-entry/ui/task-entry-provider.tsx',
-    ]);
-  });
 
   it('keeps Task Entry catalog, picker, and directory handoff ownership out of AppShell', () => {
     const appShell = readFileSync(

--- a/apps/desktop/src/main/__tests__/task-entry-provider-scope.test.ts
+++ b/apps/desktop/src/main/__tests__/task-entry-provider-scope.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { act, createElement, Fragment } from 'react';
+import { LocaleProvider, ToastProvider } from '@maka/ui';
+import { cleanupFakeDom, installReactRenderer } from './fake-dom.js';
+import {
+  createFakeTaskEntryServices,
+  TaskEntryRoot,
+  TaskEntryServicesProvider,
+  TaskEntryWorkspacePickerConsumer,
+  useTaskEntryHostModel,
+  type TaskEntryCatalog,
+  type TaskEntryHost,
+  type TaskEntryShellProjection,
+  type TaskEntryServices,
+} from '../../renderer/features/task-entry/testing.js';
+
+let shellRenders = 0;
+let frameRenders = 0;
+let workspaceRenders = 0;
+let hostRenders = 0;
+let latestTaskEntry: TaskEntryShellProjection | undefined;
+let latestDirectoryHostId: string | undefined;
+let latestWorkspaceGroupCount = 0;
+
+function project(id: string) {
+  return {
+    id,
+    name: id,
+    locations: [{ path: `/tmp/${id}`, isWorktree: false }],
+    available: true,
+    preferredPath: `/tmp/${id}`,
+  };
+}
+
+function remoteHost(): Extract<TaskEntryHost, { state: 'available' }> {
+  return {
+    profile: { id: 'remote', name: 'Remote', kind: 'remote' },
+    hostId: 'host-remote',
+    readiness: 'ready',
+    state: 'available',
+    projects: [project('project-a')],
+    capabilities: {
+      chooseClientDirectory: false,
+      chooseHostDirectory: true,
+      selectNoProject: false,
+    },
+    selectedProjectId: 'project-a',
+    chatDefaults: { permissionMode: 'ask', thinkingLevel: 'high' },
+  };
+}
+
+function catalog(): TaskEntryCatalog {
+  return { defaultProfileId: 'remote', hosts: [remoteHost()] };
+}
+
+function WorkspaceProbe() {
+  return createElement(TaskEntryWorkspacePickerConsumer, {
+    manageProjects() {},
+    children: (workspacePicker) => {
+      workspaceRenders += 1;
+      latestWorkspaceGroupCount = workspacePicker.groups.length;
+      return null;
+    },
+  });
+}
+
+function HostProbe() {
+  const host = useTaskEntryHostModel();
+  hostRenders += 1;
+  latestDirectoryHostId = host.directoryHost?.hostId;
+  return null;
+}
+
+function FrameProbe() {
+  frameRenders += 1;
+  return createElement(Fragment, null, createElement(WorkspaceProbe), createElement(HostProbe));
+}
+
+function ShellProbe() {
+  return createElement(TaskEntryRoot, {
+    children: (taskEntry) => {
+      shellRenders += 1;
+      latestTaskEntry = taskEntry;
+      return createElement(FrameProbe);
+    },
+  });
+}
+
+function renderProvider(
+  root: ReturnType<typeof installReactRenderer>['root'],
+  services: TaskEntryServices,
+) {
+  root.render(
+    createElement(LocaleProvider, {
+      locale: 'en',
+      children: createElement(
+        ToastProvider,
+        null,
+        createElement(
+          TaskEntryServicesProvider,
+          { services },
+          createElement(ShellProbe),
+        ),
+      ),
+    }),
+  );
+}
+
+afterEach(() => {
+  shellRenders = 0;
+  frameRenders = 0;
+  workspaceRenders = 0;
+  hostRenders = 0;
+  latestTaskEntry = undefined;
+  latestDirectoryHostId = undefined;
+  latestWorkspaceGroupCount = 0;
+  cleanupFakeDom();
+});
+
+describe('TaskEntryProvider render scope', () => {
+  it('keeps a controller-only directory handoff below the shell frame', async () => {
+    const { root } = installReactRenderer();
+    const services = createFakeTaskEntryServices({
+      catalog: {
+        ...createFakeTaskEntryServices().catalog,
+        getCatalog: async () => catalog(),
+      },
+    });
+
+    await act(async () => renderProvider(root, services));
+    assert.equal(latestTaskEntry?.selectors.target?.hostId, 'host-remote');
+    assert.equal(latestWorkspaceGroupCount, 1);
+
+    const shellBefore = shellRenders;
+    const frameBefore = frameRenders;
+    const workspaceBefore = workspaceRenders;
+    const hostBefore = hostRenders;
+    await act(async () => latestTaskEntry?.commands.addProject());
+
+    assert.equal(latestDirectoryHostId, 'host-remote');
+    assert.equal(shellRenders, shellBefore);
+    assert.equal(frameRenders, frameBefore);
+    assert.equal(workspaceRenders, workspaceBefore);
+    assert.equal(hostRenders, hostBefore + 1);
+
+    await act(async () => root.unmount());
+  });
+
+  it('retains the shell projection across an equivalent catalog refresh', async () => {
+    const { root } = installReactRenderer();
+    const services = createFakeTaskEntryServices({
+      catalog: {
+        ...createFakeTaskEntryServices().catalog,
+        getCatalog: async () => catalog(),
+      },
+    });
+
+    await act(async () => renderProvider(root, services));
+    const shellBefore = shellRenders;
+    const frameBefore = frameRenders;
+    await act(async () => latestTaskEntry?.commands.refresh());
+
+    assert.equal(shellRenders, shellBefore);
+    assert.equal(frameRenders, frameBefore);
+    assert.equal(latestTaskEntry?.selectors.target?.projectId, 'project-a');
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/desktop/src/main/__tests__/task-entry-provider-scope.test.ts
+++ b/apps/desktop/src/main/__tests__/task-entry-provider-scope.test.ts
@@ -137,7 +137,7 @@ afterEach(() => {
   cleanupFakeDom();
 });
 
-describe('TaskEntryProvider render scope', () => {
+describe('TaskEntryRoot render scope', () => {
   it('keeps a controller-only directory handoff below the shell frame', async () => {
     const { root } = installReactRenderer();
     const services = createFakeTaskEntryServices({

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -100,7 +100,7 @@ import {
   type SessionNavigationPorts,
   type SessionNavigationRowActions,
 } from './features/session-navigation';
-import { TaskEntryHost, useTaskEntryController } from './features/task-entry';
+import * as TaskEntry from './features/task-entry';
 import { useNewTaskChoice } from './use-new-task-choice';
 import { SessionCollaborationDialog } from './session-collaboration-dialog';
 import * as SessionCollaboration from './features/session-collaboration';
@@ -258,6 +258,10 @@ type AppShellProps = {
   initialOnboardingSnapshot?: OnboardingSnapshot | null;
 };
 
+type TaskEntryShellProjection = Parameters<
+  ComponentProps<typeof TaskEntry.TaskEntryRoot>['children']
+>[0];
+
 export function AppShell({ initialOnboardingSnapshot = null }: AppShellProps = {}) {
   const [uiLocalePreference, setUiLocalePreference] = useState<UiLocalePreference>('auto');
   const [uiLocaleOverride, setUiLocaleOverride] = useState<UiLocale | null>(null);
@@ -288,13 +292,18 @@ export function AppShell({ initialOnboardingSnapshot = null }: AppShellProps = {
       <AstryxLocaleProvider>
         <ToastProvider errorAction={errorToastAction}>
           <ErrorBoundary locale={uiLocale}>
-            <AppShellContent
-              initialOnboardingSnapshot={initialOnboardingSnapshot}
-              uiLocale={uiLocale}
-              uiLocaleOverride={uiLocaleOverride}
-              setUiLocaleOverride={setUiLocaleOverride}
-              setUiLocalePreference={setUiLocalePreference}
-            />
+            <TaskEntry.TaskEntryRoot>
+              {(taskEntry) => (
+                <AppShellContent
+                  initialOnboardingSnapshot={initialOnboardingSnapshot}
+                  taskEntry={taskEntry}
+                  uiLocale={uiLocale}
+                  uiLocaleOverride={uiLocaleOverride}
+                  setUiLocaleOverride={setUiLocaleOverride}
+                  setUiLocalePreference={setUiLocalePreference}
+                />
+              )}
+            </TaskEntry.TaskEntryRoot>
           </ErrorBoundary>
         </ToastProvider>
       </AstryxLocaleProvider>
@@ -315,12 +324,14 @@ const SESSION_RAIL = <SessionListPanel />;
 
 function AppShellContent({
   initialOnboardingSnapshot = null,
+  taskEntry,
   uiLocale,
   uiLocaleOverride,
   setUiLocaleOverride,
   setUiLocalePreference,
 }: {
   initialOnboardingSnapshot?: OnboardingSnapshot | null;
+  taskEntry: TaskEntryShellProjection;
   uiLocale: UiLocale;
   uiLocaleOverride: UiLocale | null;
   setUiLocaleOverride: Dispatch<SetStateAction<UiLocale | null>>;
@@ -385,21 +396,8 @@ function AppShellContent({
   } = useSettingsModal();
 
   const onboarding = useOnboardingSnapshot(initialOnboardingSnapshot);
-  const reportTaskEntryError = useCallback<
-    Parameters<typeof useTaskEntryController>[0]['reportError']
-  >(
-    ({ title, description, profileId }) => {
-      toastApi.error(title, description, undefined, { profileId });
-    },
-    [toastApi],
-  );
-  const taskEntry = useTaskEntryController({
-    reportError: reportTaskEntryError,
-    manageProjects: openProjectSettings,
-  });
-  // Named on its own because the rail depends on it: `taskEntry.commands` is a
-  // fresh object every render, so depending on the bag rather than the command
-  // would rebuild the rail's Project rows on every AppShell commit (#4109).
+  // The owner bridge keeps commands stable while TaskEntryProvider swaps the
+  // current feature-owned implementation below the shell.
   const { selectLocalProject } = taskEntry.commands;
   const currentNewTaskDraftKey = taskEntry.selectors.draftKey;
   // Staged files and quotes do NOT take the target-scoped key: they belong to
@@ -1449,7 +1447,6 @@ function AppShellContent({
   // Where a NEW chat starts. Built unconditionally and handed to the composer,
   // which renders it only while no session owns it — the project is fixed once
   // the first message creates one, so there is nothing to pick after that.
-  const workspacePicker = taskEntry.selectors.workspacePicker;
   const taskReadinessWorkspace = activeSession?.cwd ?? taskEntry.selectors.projectPath;
   const taskReadinessRequest = {
     ...resolveTaskReadinessModelTarget(activeSession, activeSessionSendOutcome, newChatModel),
@@ -2619,9 +2616,12 @@ function AppShellContent({
         : 'im_hub';
 
   return (
-    // Goal state and Module Hub ownership both live below the shell. Composer
-    // mentions still wrap the frame so one projection serves every composer,
-    // including side-chat panels, without rebuilding the frame on catalog moves.
+    // Feature controllers live below the shell. Task Entry publishes a stable
+    // shell projection plus reader-local Host/Workspace Picker projections;
+    // Goal state and Module Hub ownership likewise wake only their narrow
+    // readers. Composer mentions still wrap the frame so one projection serves
+    // every composer, including side-chat panels, without rebuilding the frame
+    // on catalog moves.
     <Goals.GoalProvider
       activeSessionId={ownerActiveId}
       canOpenDialog={activeBoundarySurface.localInteractionAvailable}
@@ -2879,7 +2879,9 @@ function AppShellContent({
                         sessionId={activeId}
                       />
                     ) : (
-                    <ChatComposerRegion
+                      <TaskEntry.TaskEntryWorkspacePickerConsumer manageProjects={openProjectSettings}>
+                        {(workspacePicker) => (
+                          <ChatComposerRegion
                   workspacePicker={workspacePicker}
                   composerRef={composerRef}
                   active={navSelection.section === 'sessions'}
@@ -3031,7 +3033,9 @@ function AppShellContent({
                       ? shellCopy.goalTurnActive
                       : undefined
                   }
-                    />
+                          />
+                        )}
+                      </TaskEntry.TaskEntryWorkspacePickerConsumer>
                     )}
                   </>
                 }
@@ -3220,7 +3224,7 @@ function AppShellContent({
         />
       )}
       <Goals.GoalHost />
-      <TaskEntryHost model={taskEntry.host} />
+      <TaskEntry.TaskEntryHost />
       <RuntimeHostSshTerminalDialog />
       <SessionCollaborationDialog
         target={sharedSessionDialog.target}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -25,7 +25,6 @@ import {
   useRef,
   useState,
   type CSSProperties,
-  type ComponentProps,
   type Dispatch,
   type SetStateAction,
 } from 'react';
@@ -101,6 +100,7 @@ import {
   type SessionNavigationRowActions,
 } from './features/session-navigation';
 import * as TaskEntry from './features/task-entry';
+import type { TaskEntryShellProjection } from './features/task-entry';
 import { useNewTaskChoice } from './use-new-task-choice';
 import { SessionCollaborationDialog } from './session-collaboration-dialog';
 import * as SessionCollaboration from './features/session-collaboration';
@@ -258,10 +258,6 @@ type AppShellProps = {
   initialOnboardingSnapshot?: OnboardingSnapshot | null;
 };
 
-type TaskEntryShellProjection = Parameters<
-  ComponentProps<typeof TaskEntry.TaskEntryRoot>['children']
->[0];
-
 export function AppShell({ initialOnboardingSnapshot = null }: AppShellProps = {}) {
   const [uiLocalePreference, setUiLocalePreference] = useState<UiLocalePreference>('auto');
   const [uiLocaleOverride, setUiLocaleOverride] = useState<UiLocale | null>(null);
@@ -396,7 +392,7 @@ function AppShellContent({
   } = useSettingsModal();
 
   const onboarding = useOnboardingSnapshot(initialOnboardingSnapshot);
-  // The owner bridge keeps commands stable while TaskEntryProvider swaps the
+  // The owner bridge keeps commands stable while TaskEntryRoot swaps the
   // current feature-owned implementation below the shell.
   const { selectLocalProject } = taskEntry.commands;
   const currentNewTaskDraftKey = taskEntry.selectors.draftKey;

--- a/apps/desktop/src/renderer/features/task-entry/README.md
+++ b/apps/desktop/src/renderer/features/task-entry/README.md
@@ -28,7 +28,7 @@ add/relink plus remote-directory handoff lifecycles.
 
 - Consumers import production APIs from `features/task-entry`.
 - Tests and stories may additionally import `features/task-entry/testing`.
-- `TaskEntryRoot` / `TaskEntryProvider` are the only production owners of the
+- `TaskEntryRoot` is the only production owner of the
   controller hook. Renderer roots receive a stable semantic projection rather
   than catalog lifecycle state or the controller itself.
 - Task Entry may use shared renderer copy, shared project UI, core/runtime-host

--- a/apps/desktop/src/renderer/features/task-entry/README.md
+++ b/apps/desktop/src/renderer/features/task-entry/README.md
@@ -28,13 +28,18 @@ add/relink plus remote-directory handoff lifecycles.
 
 - Consumers import production APIs from `features/task-entry`.
 - Tests and stories may additionally import `features/task-entry/testing`.
+- `TaskEntryRoot` / `TaskEntryProvider` are the only production owners of the
+  controller hook. Renderer roots receive a stable semantic projection rather
+  than catalog lifecycle state or the controller itself.
 - Task Entry may use shared renderer copy, shared project UI, core/runtime-host
   types, and Maka UI.
 - Task Entry must not import `AppShell`, preload, or the main process.
 - Desktop catalog I/O enters through `TaskEntryServices`; feature code never
   reads the Desktop global bridge directly.
-- `AppShell` supplies explicit navigation/error intents and consumes only the
-  target, Host defaults, project path, draft identity, and Workspace Picker.
+- `AppShell` consumes only the target, Host defaults, project path, draft
+  identity, and stable commands. Host and Workspace Picker updates are read at
+  their local UI boundaries; Project Settings remains an injected navigation
+  intent.
 
 ## Lifecycle invariants
 

--- a/apps/desktop/src/renderer/features/task-entry/controller/use-task-entry-controller.ts
+++ b/apps/desktop/src/renderer/features/task-entry/controller/use-task-entry-controller.ts
@@ -47,18 +47,13 @@ import {
 } from '../model/task-entry-selection.js';
 import type {
   TaskEntryCatalog,
+  TaskEntryError,
   TaskEntryHostRef,
   TaskEntryProjectMutationResult,
   TaskEntryTarget,
 } from '../ports.js';
 import { useTaskEntryServices } from '../services-context.js';
 import type { TaskEntryHostModel } from '../ui/task-entry-host.js';
-
-export interface TaskEntryError {
-  readonly title: string;
-  readonly description?: string;
-  readonly profileId: string;
-}
 
 export interface UseTaskEntryControllerInput {
   reportError(error: TaskEntryError): void;

--- a/apps/desktop/src/renderer/features/task-entry/index.ts
+++ b/apps/desktop/src/renderer/features/task-entry/index.ts
@@ -18,6 +18,9 @@
  */
 
 export { TaskEntryHost } from './ui/task-entry-host.js';
+export {
+  TaskEntryRoot,
+  TaskEntryWorkspacePickerConsumer,
+} from './ui/task-entry-provider.js';
 export { TaskEntryServicesProvider } from './services-context.js';
-export { useTaskEntryController } from './controller/use-task-entry-controller.js';
 export type { TaskEntryServices } from './ports.js';

--- a/apps/desktop/src/renderer/features/task-entry/index.ts
+++ b/apps/desktop/src/renderer/features/task-entry/index.ts
@@ -22,5 +22,6 @@ export {
   TaskEntryRoot,
   TaskEntryWorkspacePickerConsumer,
 } from './ui/task-entry-provider.js';
+export type { TaskEntryShellProjection } from './ui/task-entry-provider.js';
 export { TaskEntryServicesProvider } from './services-context.js';
 export type { TaskEntryServices } from './ports.js';

--- a/apps/desktop/src/renderer/features/task-entry/ports.ts
+++ b/apps/desktop/src/renderer/features/task-entry/ports.ts
@@ -28,6 +28,12 @@ export interface TaskEntryHostRef {
   readonly hostId: string;
 }
 
+export interface TaskEntryError {
+  readonly title: string;
+  readonly description?: string;
+  readonly profileId: string;
+}
+
 export interface TaskEntryTarget extends TaskEntryHostRef {
   readonly projectId: string | null;
 }

--- a/apps/desktop/src/renderer/features/task-entry/testing.ts
+++ b/apps/desktop/src/renderer/features/task-entry/testing.ts
@@ -21,6 +21,12 @@ import type { TaskEntryServices } from './ports.js';
 
 export { TaskEntryServicesProvider } from './services-context.js';
 export {
+  TaskEntryRoot,
+  TaskEntryWorkspacePickerConsumer,
+  useTaskEntryHostModel,
+} from './ui/task-entry-provider.js';
+export type { TaskEntryShellProjection } from './ui/task-entry-provider.js';
+export {
   useTaskEntryController,
   type TaskEntryController,
 } from './controller/use-task-entry-controller.js';

--- a/apps/desktop/src/renderer/features/task-entry/ui/task-entry-host.tsx
+++ b/apps/desktop/src/renderer/features/task-entry/ui/task-entry-host.tsx
@@ -20,6 +20,7 @@
 import type { ProjectRecord } from '@maka/core/project';
 import { RemoteProjectDirectoryDialog } from '../../../remote-project-directory-dialog.js';
 import type { TaskEntryHostRef } from '../ports.js';
+import { useTaskEntryHostModel } from './task-entry-provider.js';
 
 export interface TaskEntryHostModel {
   directoryHost?: TaskEntryHostRef & { readonly name?: string };
@@ -31,7 +32,11 @@ export interface TaskEntryHostModel {
   ): Promise<void>;
 }
 
-export function TaskEntryHost({ model }: { model: TaskEntryHostModel }) {
+export function TaskEntryHost() {
+  return <TaskEntryHostView model={useTaskEntryHostModel()} />;
+}
+
+export function TaskEntryHostView({ model }: { model: TaskEntryHostModel }) {
   return (
     <RemoteProjectDirectoryDialog
       host={model.directoryHost}

--- a/apps/desktop/src/renderer/features/task-entry/ui/task-entry-provider.tsx
+++ b/apps/desktop/src/renderer/features/task-entry/ui/task-entry-provider.tsx
@@ -50,11 +50,6 @@ export interface TaskEntryShellProjection {
   readonly selectors: Omit<TaskEntryControllerSelectors, 'workspacePicker'>;
 }
 
-interface TaskEntryProviderProps {
-  readonly owner: TaskEntryOwner;
-  readonly children?: ReactNode;
-}
-
 export interface TaskEntryRootProps {
   readonly children: (taskEntry: TaskEntryShellProjection) => ReactNode;
 }
@@ -206,9 +201,9 @@ function sameHost(previous: TaskEntryHostModel, next: TaskEntryHostModel): boole
 }
 
 /**
- * Creates the stable bridge AppShell reads without owning the Task Entry controller.
- * Controller-only updates keep the same shell projection identity and therefore
- * stop at the provider or the matching leaf reader.
+ * Creates the stable bridge AppShell reads. Controller-only updates keep the
+ * same shell projection identity and therefore stop at the owner or the
+ * matching leaf reader.
  */
 function useTaskEntryOwnership(): TaskEntryShellProjection & { readonly owner: TaskEntryOwner } {
   const owner = useMemo(createTaskEntryOwner, []);
@@ -219,12 +214,19 @@ function useTaskEntryOwnership(): TaskEntryShellProjection & { readonly owner: T
   );
 }
 
-/** Owns Task Entry catalog/selection lifecycle below AppShell. */
-export function TaskEntryProvider({
-  owner: ownerInput,
-  children,
-}: TaskEntryProviderProps) {
-  const owner = ownerInput as ReturnType<typeof createTaskEntryOwner>;
+/**
+ * Owns the Task Entry controller below AppShell and hands only its stable
+ * shell projection outward.
+ *
+ * The render prop is memoized on that projection, so a controller-only update
+ * re-renders this one fiber and reuses the frame element it built last time;
+ * React bails out of the frame, and only the Host and Workspace Picker readers
+ * whose selection changed wake through the owner store. The shell's own reads
+ * arrive as `taskEntry`, whose identity moves only on a semantic change.
+ */
+export function TaskEntryRoot({ children }: TaskEntryRootProps) {
+  const ownership = useTaskEntryOwnership();
+  const owner = ownership.owner as ReturnType<typeof createTaskEntryOwner>;
   const toastApi = useToast();
   const reportError = useCallback(
     ({ title, description, profileId }: TaskEntryError) => {
@@ -234,31 +236,21 @@ export function TaskEntryProvider({
   );
   const controller = useTaskEntryController({ reportError, manageProjects: ignoreManageProjects });
   useLayoutEffect(() => owner.publish(controller), [controller, owner]);
-
-  return (
-    <TaskEntryOwnerContext.Provider value={owner}>
-      {children}
-    </TaskEntryOwnerContext.Provider>
-  );
-}
-
-/** Mounts the controller owner and hands only its stable shell projection outward. */
-export function TaskEntryRoot({ children }: TaskEntryRootProps) {
-  const ownership = useTaskEntryOwnership();
   const taskEntry = useMemo<TaskEntryShellProjection>(
     () => ({ commands: ownership.commands, selectors: ownership.selectors }),
     [ownership.commands, ownership.selectors],
   );
+  const frame = useMemo(() => children(taskEntry), [children, taskEntry]);
   return (
-    <TaskEntryProvider owner={ownership.owner}>
-      {children(taskEntry)}
-    </TaskEntryProvider>
+    <TaskEntryOwnerContext.Provider value={owner}>
+      {frame}
+    </TaskEntryOwnerContext.Provider>
   );
 }
 
 function useTaskEntryOwner(): TaskEntryOwner {
   const owner = useContext(TaskEntryOwnerContext);
-  if (!owner) throw new Error('TaskEntryProvider is missing');
+  if (!owner) throw new Error('TaskEntryRoot is missing');
   return owner;
 }
 

--- a/apps/desktop/src/renderer/features/task-entry/ui/task-entry-provider.tsx
+++ b/apps/desktop/src/renderer/features/task-entry/ui/task-entry-provider.tsx
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react';
+import { useToast, type WorkspacePickerModel } from '@maka/ui';
+import {
+  useTaskEntryController,
+  type TaskEntryController,
+  type TaskEntryControllerCommands,
+  type TaskEntryControllerSelectors,
+} from '../controller/use-task-entry-controller.js';
+import { taskEntryDraftKey } from '../model/task-entry-selection.js';
+import type { TaskEntryError } from '../ports.js';
+import type { TaskEntryHostModel } from './task-entry-host.js';
+
+type Listener = () => void;
+
+interface TaskEntryOwner {
+  getState(): TaskEntryController;
+  subscribe(listener: Listener): () => void;
+  readonly commands: TaskEntryControllerCommands;
+}
+
+export interface TaskEntryShellProjection {
+  readonly commands: TaskEntryControllerCommands;
+  readonly selectors: Omit<TaskEntryControllerSelectors, 'workspacePicker'>;
+}
+
+interface TaskEntryProviderProps {
+  readonly owner: TaskEntryOwner;
+  readonly children?: ReactNode;
+}
+
+export interface TaskEntryRootProps {
+  readonly children: (taskEntry: TaskEntryShellProjection) => ReactNode;
+}
+
+const EMPTY_WORKSPACE_PICKER: WorkspacePickerModel = {
+  pending: true,
+  groups: [],
+};
+
+const EMPTY_CONTROLLER: TaskEntryController = {
+  host: {
+    closeDirectoryPicker() {},
+    async acceptRegisteredProject() {},
+  },
+  commands: {
+    async refresh() {},
+    selectLocalProject: () => false,
+    addProject() {},
+    async chooseProjectForProfile() {},
+  },
+  selectors: {
+    draftKey: taskEntryDraftKey(undefined),
+    defaultProfileId: 'local',
+    usesDefaultHost: true,
+    workspacePicker: EMPTY_WORKSPACE_PICKER,
+    canAddProject: false,
+  },
+};
+
+const TaskEntryOwnerContext = createContext<TaskEntryOwner | null>(null);
+
+function ignoreManageProjects(): void {}
+
+function createTaskEntryOwner(): TaskEntryOwner & {
+  publish(controller: TaskEntryController): void;
+} {
+  let current = EMPTY_CONTROLLER;
+  const listeners = new Set<Listener>();
+  const owner = {
+    getState: () => current,
+    subscribe(listener: Listener): () => void {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    commands: {
+      refresh: () => current.commands.refresh(),
+      selectLocalProject: (projectId: string) =>
+        current.commands.selectLocalProject(projectId),
+      addProject: () => current.commands.addProject(),
+      chooseProjectForProfile: (profileId: string) =>
+        current.commands.chooseProjectForProfile(profileId),
+    },
+    publish(controller: TaskEntryController): void {
+      if (current === controller) return;
+      current = controller;
+      for (const listener of [...listeners]) listener();
+    },
+  };
+  return owner;
+}
+
+function useTaskEntrySelection<T>(
+  owner: TaskEntryOwner,
+  select: (controller: TaskEntryController) => T,
+  isEqual: (previous: T, next: T) => boolean = Object.is,
+): T {
+  const getSnapshot = useMemo(() => {
+    let cachedController: TaskEntryController | undefined;
+    let cachedSelection: T | undefined;
+    return (): T => {
+      const controller = owner.getState();
+      if (controller === cachedController) return cachedSelection as T;
+      const next = select(controller);
+      if (cachedController === undefined || !isEqual(cachedSelection as T, next)) {
+        cachedSelection = next;
+      }
+      cachedController = controller;
+      return cachedSelection as T;
+    };
+  }, [isEqual, owner, select]);
+  return useSyncExternalStore(owner.subscribe, getSnapshot, getSnapshot);
+}
+
+function sameTarget(
+  previous: TaskEntryControllerSelectors['target'],
+  next: TaskEntryControllerSelectors['target'],
+): boolean {
+  return previous === next || Boolean(
+    previous &&
+      next &&
+      previous.profileId === next.profileId &&
+      previous.hostId === next.hostId &&
+      previous.projectId === next.projectId,
+  );
+}
+
+function sameSelectedHost(
+  previous: TaskEntryControllerSelectors['selectedHost'],
+  next: TaskEntryControllerSelectors['selectedHost'],
+): boolean {
+  return previous === next || Boolean(
+    previous &&
+      next &&
+      previous.profileId === next.profileId &&
+      previous.hostId === next.hostId &&
+      previous.name === next.name &&
+      previous.kind === next.kind &&
+      previous.chatDefaults.permissionMode === next.chatDefaults.permissionMode &&
+      previous.chatDefaults.thinkingLevel === next.chatDefaults.thinkingLevel,
+  );
+}
+
+const selectShellSelectors = (
+  controller: TaskEntryController,
+): Omit<TaskEntryControllerSelectors, 'workspacePicker'> => {
+  const { workspacePicker: _workspacePicker, ...selectors } = controller.selectors;
+  return selectors;
+};
+
+function sameShellSelectors(
+  previous: Omit<TaskEntryControllerSelectors, 'workspacePicker'>,
+  next: Omit<TaskEntryControllerSelectors, 'workspacePicker'>,
+): boolean {
+  return (
+    sameTarget(previous.target, next.target) &&
+    previous.draftKey === next.draftKey &&
+    previous.projectPath === next.projectPath &&
+    sameSelectedHost(previous.selectedHost, next.selectedHost) &&
+    previous.selectedProfileId === next.selectedProfileId &&
+    previous.defaultProfileId === next.defaultProfileId &&
+    previous.usesDefaultHost === next.usesDefaultHost &&
+    previous.canAddProject === next.canAddProject
+  );
+}
+
+const selectWorkspacePicker = (controller: TaskEntryController): WorkspacePickerModel =>
+  controller.selectors.workspacePicker;
+const selectHost = (controller: TaskEntryController): TaskEntryHostModel => controller.host;
+
+function sameHost(previous: TaskEntryHostModel, next: TaskEntryHostModel): boolean {
+  return (
+    previous.directoryHost?.profileId === next.directoryHost?.profileId &&
+    previous.directoryHost?.hostId === next.directoryHost?.hostId &&
+    previous.directoryHost?.name === next.directoryHost?.name &&
+    previous.directoryOpener === next.directoryOpener &&
+    previous.closeDirectoryPicker === next.closeDirectoryPicker &&
+    previous.acceptRegisteredProject === next.acceptRegisteredProject
+  );
+}
+
+/**
+ * Creates the stable bridge AppShell reads without owning the Task Entry controller.
+ * Controller-only updates keep the same shell projection identity and therefore
+ * stop at the provider or the matching leaf reader.
+ */
+function useTaskEntryOwnership(): TaskEntryShellProjection & { readonly owner: TaskEntryOwner } {
+  const owner = useMemo(createTaskEntryOwner, []);
+  const selectors = useTaskEntrySelection(owner, selectShellSelectors, sameShellSelectors);
+  return useMemo(
+    () => ({ owner, commands: owner.commands, selectors }),
+    [owner, selectors],
+  );
+}
+
+/** Owns Task Entry catalog/selection lifecycle below AppShell. */
+export function TaskEntryProvider({
+  owner: ownerInput,
+  children,
+}: TaskEntryProviderProps) {
+  const owner = ownerInput as ReturnType<typeof createTaskEntryOwner>;
+  const toastApi = useToast();
+  const reportError = useCallback(
+    ({ title, description, profileId }: TaskEntryError) => {
+      toastApi.error(title, description, undefined, { profileId });
+    },
+    [toastApi],
+  );
+  const controller = useTaskEntryController({ reportError, manageProjects: ignoreManageProjects });
+  useLayoutEffect(() => owner.publish(controller), [controller, owner]);
+
+  return (
+    <TaskEntryOwnerContext.Provider value={owner}>
+      {children}
+    </TaskEntryOwnerContext.Provider>
+  );
+}
+
+/** Mounts the controller owner and hands only its stable shell projection outward. */
+export function TaskEntryRoot({ children }: TaskEntryRootProps) {
+  const ownership = useTaskEntryOwnership();
+  const taskEntry = useMemo<TaskEntryShellProjection>(
+    () => ({ commands: ownership.commands, selectors: ownership.selectors }),
+    [ownership.commands, ownership.selectors],
+  );
+  return (
+    <TaskEntryProvider owner={ownership.owner}>
+      {children(taskEntry)}
+    </TaskEntryProvider>
+  );
+}
+
+function useTaskEntryOwner(): TaskEntryOwner {
+  const owner = useContext(TaskEntryOwnerContext);
+  if (!owner) throw new Error('TaskEntryProvider is missing');
+  return owner;
+}
+
+export function TaskEntryWorkspacePickerConsumer({
+  manageProjects,
+  children,
+}: {
+  readonly manageProjects: (profileId: string) => void;
+  readonly children: (workspacePicker: WorkspacePickerModel) => ReactNode;
+}) {
+  const owner = useTaskEntryOwner();
+  const controllerPicker = useTaskEntrySelection(owner, selectWorkspacePicker);
+  const workspacePicker = useMemo<WorkspacePickerModel>(
+    () => ({
+      ...controllerPicker,
+      groups: controllerPicker.groups.map((group) =>
+        group.onManage
+          ? { ...group, onManage: () => manageProjects(group.id) }
+          : group),
+    }),
+    [controllerPicker, manageProjects],
+  );
+  return children(workspacePicker);
+}
+
+export function useTaskEntryHostModel(): TaskEntryHostModel {
+  return useTaskEntrySelection(useTaskEntryOwner(), selectHost, sameHost);
+}

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -6,7 +6,7 @@ Generated against `@astryxdesign/core@0.5.2` (194 component exports).
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 247 files — blocker 0, reimplementation 0, polish 1, aligned 246.
+**Totals:** 248 files — blocker 0, reimplementation 0, polish 1, aligned 247.
 
 ## Exclusions (explicit)
 
@@ -72,6 +72,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/features/session-settings/services-context.tsx` | shell-chrome-or-panel | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/task-entry/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/task-entry/ui/task-entry-host.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
+| `apps/desktop/src/renderer/features/task-entry/ui/task-entry-provider.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/usage/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/usage/ui/metric-card.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/usage/ui/usage-settings-view.tsx` | other | Banner, Button, SegmentedControl, SegmentedControlItem, Selector, Switch, Tab, TabList, TextInput, Tooltip | aligned — uses Astryx (Banner, Button, SegmentedControl, SegmentedControlItem, Selector, Switch, Tab, TabList) | aligned |

--- a/docs/astryx-surface-file-inventory.paths
+++ b/docs/astryx-surface-file-inventory.paths
@@ -43,6 +43,7 @@ apps/desktop/src/renderer/features/session-navigation/ui/session-navigation-prov
 apps/desktop/src/renderer/features/session-settings/services-context.tsx
 apps/desktop/src/renderer/features/task-entry/services-context.tsx
 apps/desktop/src/renderer/features/task-entry/ui/task-entry-host.tsx
+apps/desktop/src/renderer/features/task-entry/ui/task-entry-provider.tsx
 apps/desktop/src/renderer/features/usage/services-context.tsx
 apps/desktop/src/renderer/features/usage/ui/metric-card.tsx
 apps/desktop/src/renderer/features/usage/ui/usage-settings-view.tsx

--- a/scripts/check-app-shell-hooks.mjs
+++ b/scripts/check-app-shell-hooks.mjs
@@ -148,7 +148,6 @@ export const ALLOWED = {
     useShellSearch: 1,
     useStableActions: 6,
     useState: 15,
-    useTaskEntryController: 1,
     useTaskSubmissionReadiness: 1,
     useToast: 1,
     // The last of the three `useKeyedPendingRegistry` call sites this entry


### PR DESCRIPTION
## Summary

- make `TaskEntryRoot` / `TaskEntryProvider` the sole production owner of `useTaskEntryController`
- expose a stable semantic projection to AppShell while Host and Workspace Picker subscribe at their actual render boundaries
- remove the raw controller from the production feature entry and keep it behind the testing seam
- add render-scope and exact ownership/import provenance tests so controller ownership cannot silently flow back into AppShell
- preserve routing, UI, IPC/storage contracts, catalog fencing, focus restoration, and draft identity behavior

This is the controller-scope follow-up to the Task Entry feature slice from #3723.

Refs #4582 (supersedes #3439)
## Performance evidence

I measured the pure controller-only remote-directory handoff that previously re-rendered the AppShell-owned frame. This is a same-process alternating A/B benchmark with a synthetic 2,000-leaf shell frame, 20 warmups, and 120 paired trials per run. The table reports each run's median:

| Run | Rendered fibers, AppShell owner | Rendered fibers, scoped owner | React `actualDuration` | Scoped | Synchronous JS wall | Scoped |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 2,003 | 1 | 3.315 ms | 0.248 ms | 4.022 ms | 0.313 ms |
| 2 | 2,003 | 1 | 3.258 ms | 0.171 ms | 3.989 ms | 0.304 ms |
| 3 | 2,003 | 1 | 3.473 ms | 0.206 ms | 4.271 ms | 0.289 ms |
| Median of run medians | 2,003 | 1 | 3.315 ms | 0.206 ms | 4.022 ms | 0.304 ms |

That is 99.95% fewer rendered fibers, 93.8% lower React render duration, and 92.4% lower synchronous JS wall time for this isolated update. All 360 paired trials favored the scoped owner.

This does **not** measure the full create-task/pause/IPC/Runtime Host chain and is not a claim that the entire application is 92% faster. The percentages come from a synthetic 2,000-leaf frame in a same-process harness, not from a running Maka instance, so they demonstrate the scope mechanism rather than an in-app gain; the deterministic render-scope test is the contract. The benchmark scaffold was temporary and is not included in the production diff. The permanent deterministic test proves the scope boundary without timing: the same real controller handoff leaves the shell and unrelated frame at zero renders and wakes only the Host reader.

## Review focus

The generic `controllerOwners` registry is still under review in #4315, so this branch does not duplicate that checker. Against current `main`, exact Task Entry tests pin the sole controller call site, the only deep importers, the public/testing split, and the absence of controller/Host/Workspace ownership in AppShell. If #4315 lands first, this PR should be rebased and Task Entry registered in that generic policy.

The latest rebase resolves AppShell, Task Entry public-entry, and generated architecture-ledger conflicts against `main@b714a3921`. Task Entry now uses one namespace public-entry import, so the updated root ratchet improves rather than grows: AppShell import specifiers `186 → 185`, and the obsolete `useTaskEntryController: 1` hook inventory entry is retired.

## Verification

Exact head: `8a59de8fd5ac7d230513ce1a993ccd141e95765c`

- `npm run rebuild` — full production build, including renderer entry and third-party notice checks
- `npm --workspace @maka/desktop run test:dist` — 1,969/1,969 passed
- `npm run check:renderer-architecture -- --base upstream/main` — 71/71 checker fixtures and real checkout passed
- `npm run check:app-shell-hooks` — 41 hooks / 77 call sites passed
- `npm run astryx:surface-inventory` — 244 files, 1 exclusion
- `npm run astryx:surface-inventory:test` — 15/15 passed
- `npx knip --workspace apps/desktop`
- `npm run typecheck --workspace @maka/desktop -- --pretty false`
- `npm run lint`
- `npm run format:check`
- `git diff --check upstream/main...HEAD`
- `git merge-tree --write-tree upstream/main HEAD`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex designed and implemented the controller ownership boundary, added the architecture/render-scope tests, built and ran the temporary benchmark, resolved the current-main conflicts, audited remote overlap, and prepared this PR. The commit includes a `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — Task Entry controller-only updates no longer re-render AppShell-wide consumers; there is no intended user-visible UI change
- [ ] No


