### PR TITLE
ci: pin the model metadata upkeep runner

### DIFF
--- a/.github/workflows/model-metadata-upkeep.yml
+++ b/.github/workflows/model-metadata-upkeep.yml
@@ -38,7 +38,7 @@ jobs:
     # A fork inherits the schedule but owns neither the branch this pushes nor
     # the pull request it opens.
     if: github.repository == 'apache/maka'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: write


### PR DESCRIPTION
**Main is red and this unblocks it.** `test` is the only required context in `.asf.yaml`, so nothing can merge until this lands.

#4460 added `model-metadata-upkeep.yml` on `ubuntu-latest` at 16:26Z. #4483 added the rule banning that label at 17:01Z. Each was green against the tree it was tested on; the collision only exists on main.

One line, `ubuntu-latest` → `ubuntu-24.04`. Same image (`ubuntu-24.04` / `20260823.283.1` in both cases, read from `Set up job` logs), different queue.

This is also the rule working as intended on its first day: `ubuntu-latest` is what every tutorial writes, so without a check it returns one new workflow at a time. It returned within the hour.

Verification: `node --test scripts/ci-workflow-policy.test.mjs` — 36 pass, 0 fail.

Refs #4480