### PR TITLE
fix(ci): restore main validation after concurrent merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
         run: npm ci
 
       - name: Check localized TUI copy boundaries
-        if: needs.plan.outputs.code == 'true'
+        if: steps.plan.outputs.code == 'true'
         run: |
           npm run check:tui-copy
           node --test scripts/check-tui-copy.test.mjs

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -3313,7 +3313,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           state.entries.push({
             kind: 'notice',
             level: 'error',
-            text: 'Usage: /copy [all]',
+            text: copyCopy.usage,
           });
           requestRender();
           return;

--- a/packages/cli/src/tui-copy-catalog.ts
+++ b/packages/cli/src/tui-copy-catalog.ts
@@ -27,6 +27,7 @@ export const TUI_COPY_RESOURCES = {
       tooLarge:
         'Too large to copy over OSC 52 · {bytes} bytes exceeds the {limit}-byte limit; a larger payload is silently dropped by the terminal.',
       nothingToCopy: 'Nothing to copy yet.',
+      usage: 'Usage: /copy [all]',
       roleUser: 'You:',
       roleAssistant: 'Maka:',
       roleGoalContinuation: 'Goal continuation (autonomous):',
@@ -40,6 +41,7 @@ export const TUI_COPY_RESOURCES = {
       tooLarge:
         '内容过大，无法复制 · {bytes} 字节超过 {limit} 字节上限；更大的内容会被终端静默丢弃。',
       nothingToCopy: '暂无可复制的内容。',
+      usage: '用法：/copy [all]',
       roleUser: '你：',
       roleAssistant: 'Maka：',
       roleGoalContinuation: '目标续跑（自主）：',

--- a/packages/cli/src/tui-copy-command.ts
+++ b/packages/cli/src/tui-copy-command.ts
@@ -42,6 +42,8 @@ export interface TuiCopyCopy {
   readonly tooLarge: string;
   /** Shown when there is nothing to copy yet. */
   readonly nothingToCopy: string;
+  /** Shown when `/copy` receives an unsupported argument. */
+  readonly usage: string;
   /** Role label for user turns in `/copy all`. */
   readonly roleUser: string;
   /** Role label for assistant turns in `/copy all`. */

--- a/scripts/check-tui-copy.mjs
+++ b/scripts/check-tui-copy.mjs
@@ -37,6 +37,7 @@ export const COVERED_FILES = [
   'packages/cli/src/runtime-host-onboarding.ts',
   'packages/cli/src/runtime-host-tui-command.ts',
   'packages/cli/src/tui-attention.ts',
+  'packages/cli/src/tui-copy-command.ts',
   'packages/cli/src/tui-shortcut-copy.ts',
   'packages/cli/src/pi-tui-layout.ts',
 ];
@@ -46,6 +47,7 @@ export const EXCLUDED_TUI_FILES = [
   'packages/cli/src/runtime-host-tui-context.ts',
   'packages/cli/src/tui-ansi.ts',
   'packages/cli/src/tui-autocomplete-layout.ts',
+  'packages/cli/src/tui-clipboard.ts',
   'packages/cli/src/tui-copy-catalog.ts',
   'packages/cli/src/tui-diff.ts',
   'packages/cli/src/tui-mcp-control.ts',


### PR DESCRIPTION
## Summary

Restore the required `test` workflow after the single-job planner refactor and the localized TUI copy gate landed concurrently.

The TUI copy step now reads the in-job planner through `steps.plan.outputs.code`. The copy boundary inventory also classifies the `/copy` command and its clipboard infrastructure, and the remaining `/copy` usage notice is served by the typed English/Chinese locale catalog instead of a hard-coded English literal.

Fixes #4503

## Verification

- `node --test --test-concurrency=1 scripts/ci-test-plan.test.mjs scripts/ci-workflow-policy.test.mjs scripts/verify-windows-harness.test.mjs` — 115/115 passed
- `npm run check:tui-copy` — 14 covered files passed
- TUI copy boundary/catalog tests — 23/23 passed
- `/copy` runner tests — 3/3 passed
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`

The full `npm test` run was also attempted locally. Unrelated local-environment/concurrency failures remained: Python 3.9 cannot parse the repository's `X | None` annotations, some Runtime Host timing tests exceeded their deadlines under parallel load, and Node's SQLite experimental warning was treated as unexpected stderr. The affected Node tests passed in isolation, and the storage test passed with warnings suppressed.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the failing GitHub Actions run, implemented the workflow and TUI locale-boundary fixes, ran verification, and drafted the issue and PR text. The human contributor reviewed the changes and chose to submit them. The commit retains a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
