### PR TITLE
fix(cli): exit 1 when a denied sandbox boundary is never retried

### DIFF
--- a/packages/cli/src/__tests__/activation-command.test.ts
+++ b/packages/cli/src/__tests__/activation-command.test.ts
@@ -462,10 +462,12 @@ describe('maka activate JSONL protocol', () => {
   });
 
   test('blocks a completed invocation whose stream carried a boundary failure', async () => {
-    // Before #4506 the classifier cleared `sandboxBoundary` when a later tool
-    // succeeded, so this activation completed with exit 0. The stream event is
-    // the hard fact; the outcome shape here (`completed`, boundary `none`) is
-    // exactly what that clearing produced.
+    // Guards the current contract: a completed invocation whose stream carried
+    // a boundary failure reports `blocked` / `permission_required` with exit 3.
+    // The `maka activate` transition itself (main completed with exit 0 when
+    // the classifier cleared `recovered`) is not regression-coverable after
+    // the deletion: `recovered` no longer exists in the outcome type, so an
+    // injected `MakaRunOutcome` cannot express the old shape.
     const lines: string[] = [];
     const boundaryFailure = {
       kind: 'text',

--- a/packages/cli/src/__tests__/activation-command.test.ts
+++ b/packages/cli/src/__tests__/activation-command.test.ts
@@ -461,6 +461,57 @@ describe('maka activate JSONL protocol', () => {
     });
   });
 
+  test('blocks a completed invocation whose stream carried a boundary failure', async () => {
+    // Before #4506 the classifier cleared `sandboxBoundary` when a later tool
+    // succeeded, so this activation completed with exit 0. The stream event is
+    // the hard fact; the outcome shape here (`completed`, boundary `none`) is
+    // exactly what that clearing produced.
+    const lines: string[] = [];
+    const boundaryFailure = {
+      kind: 'text',
+      text: 'Write requires an approved session sandbox boundary expansion.',
+      sandboxFailure: {
+        reason: 'sandbox_boundary_required',
+        requiredExpansion: {
+          filesystem: {
+            entries: [{ path: '/tmp/output', access: 'write', scope: 'subtree' }],
+          },
+        },
+      },
+    } as const;
+    const result = await runMakaActivationCli(
+      [
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+      ],
+      {
+        ...fakeDeps({
+          result: completedResult(),
+          events: [
+            {
+              type: 'tool_result',
+              id: 'event-boundary-result',
+              turnId: 'turn-1',
+              ts: 1,
+              toolUseId: 'tool-boundary',
+              isError: true,
+              content: boundaryFailure,
+            },
+          ],
+        }),
+        writeStdout: (text) => lines.push(text.trim()),
+      },
+    );
+
+    assert.equal(result, 3);
+    assert.equal(JSON.parse(lines.at(-1)!).status, 'blocked');
+    assert.equal(JSON.parse(lines.at(-1)!).reason, 'permission_required');
+  });
+
   test('retries non-permission blocked sessions instead of requesting permission', async () => {
     for (const blockedReason of ['auth', 'tool_failed'] as const) {
       const lines: string[] = [];

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -321,8 +321,6 @@ describe('Runtime Host maka run adapter', () => {
         'step-2',
         'Partial answer',
         'Read',
-        { path: '/workspace/README.md' },
-        { path: '/outside/secret.txt' },
       ),
     });
 
@@ -334,37 +332,13 @@ describe('Runtime Host maka run adapter', () => {
   test('returns exit code 1 when a same-named tool retries a different target (durable)', async () => {
     const fixture = runFixture({
       graph: true,
-      finalMessages: sandboxBoundaryMessages(
-        'step-1',
-        'step-2',
-        'Read',
-        { path: '/workspace/README.md' },
-        { path: '/outside/secret.txt' },
-      ),
+      finalMessages: sandboxBoundaryMessages('step-1', 'step-2', 'Read'),
     });
 
     const exitCode = await runFixtureCommand(fixture, [
       'accept durable same-name different target',
       '--graph',
     ]);
-
-    assert.equal(exitCode, 1);
-  });
-
-  test('keeps a same-target retry unresolved because the boundary cannot move (live)', async () => {
-    const fixture = runFixture({
-      turnEvents: sandboxBoundaryEvents(
-        'turn-1',
-        'step-1',
-        'step-2',
-        'Recovered answer',
-        'Read',
-        { path: '/workspace/README.md' },
-        { path: '/workspace/README.md' },
-      ),
-    });
-
-    const exitCode = await runFixtureCommand(fixture, ['accept same-target retry']);
 
     assert.equal(exitCode, 1);
   });
@@ -1497,22 +1471,20 @@ function sandboxBoundaryMessages(
   failureStepId: string | undefined,
   successStepId: string | undefined,
   successToolName = 'Read',
-  successArgs: unknown = {},
-  failureArgs: unknown = {},
 ): StoredMessage[] {
   const sameStep = failureStepId !== undefined && failureStepId === successStepId;
   return [
     ...graphMessages(false),
     ...(failureStepId === undefined
       ? []
-      : [storedToolCall('turn-2', 'tool-1', failureStepId, 5, 'Read', failureArgs)]),
+      : [storedToolCall('turn-2', 'tool-1', failureStepId, 5, 'Read')]),
     ...(sameStep
-      ? [storedToolCall('turn-2', 'tool-2', successStepId, 6, successToolName, successArgs)]
+      ? [storedToolCall('turn-2', 'tool-2', successStepId, 6, successToolName)]
       : []),
     sandboxFailureToolResult('turn-2', 7),
     ...(successStepId === undefined || sameStep
       ? []
-      : [storedToolCall('turn-2', 'tool-2', successStepId, 8, successToolName, successArgs)]),
+      : [storedToolCall('turn-2', 'tool-2', successStepId, 8, successToolName)]),
     successfulToolResult('turn-2', 9),
     {
       type: 'turn_state',
@@ -1650,19 +1622,17 @@ async function* sandboxBoundaryEvents(
   successStepId: string | undefined,
   text: string,
   successToolName = 'Read',
-  successArgs: unknown = {},
-  failureArgs: unknown = {},
 ): AsyncIterable<SessionEvent> {
   const sameStep = failureStepId !== undefined && failureStepId === successStepId;
   if (failureStepId !== undefined) {
-    yield toolStart(turnId, 'tool-1', failureStepId, 1, 'Read', failureArgs);
+    yield toolStart(turnId, 'tool-1', failureStepId, 1, 'Read');
   }
   if (sameStep) {
-    yield toolStart(turnId, 'tool-2', successStepId, 2, successToolName, successArgs);
+    yield toolStart(turnId, 'tool-2', successStepId, 2, successToolName);
   }
   yield sandboxFailureToolResult(turnId, 3);
   if (successStepId !== undefined && !sameStep) {
-    yield toolStart(turnId, 'tool-2', successStepId, 4, successToolName, successArgs);
+    yield toolStart(turnId, 'tool-2', successStepId, 4, successToolName);
   }
   yield successfulToolResult(turnId, 5);
   yield* eventsFor(turnId, text, 6);

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -313,15 +313,9 @@ describe('Runtime Host maka run adapter', () => {
     );
   });
 
-  test('returns exit code 1 when a same-named tool retries a different target (live)', async () => {
+  test('keeps the boundary unresolved when a later same-named call succeeds (live)', async () => {
     const fixture = runFixture({
-      turnEvents: sandboxBoundaryEvents(
-        'turn-1',
-        'step-1',
-        'step-2',
-        'Partial answer',
-        'Read',
-      ),
+      turnEvents: sandboxBoundaryEvents('turn-1', 'step-1', 'step-2', 'Partial answer', 'Read'),
     });
 
     const exitCode = await runFixtureCommand(fixture, ['accept same-name different target']);
@@ -329,7 +323,7 @@ describe('Runtime Host maka run adapter', () => {
     assert.equal(exitCode, 1);
   });
 
-  test('returns exit code 1 when a same-named tool retries a different target (durable)', async () => {
+  test('keeps the boundary unresolved when a later same-named call succeeds (durable)', async () => {
     const fixture = runFixture({
       graph: true,
       finalMessages: sandboxBoundaryMessages('step-1', 'step-2', 'Read'),
@@ -1475,12 +1469,8 @@ function sandboxBoundaryMessages(
   const sameStep = failureStepId !== undefined && failureStepId === successStepId;
   return [
     ...graphMessages(false),
-    ...(failureStepId === undefined
-      ? []
-      : [storedToolCall('turn-2', 'tool-1', failureStepId, 5, 'Read')]),
-    ...(sameStep
-      ? [storedToolCall('turn-2', 'tool-2', successStepId, 6, successToolName)]
-      : []),
+    ...(failureStepId === undefined ? [] : [storedToolCall('turn-2', 'tool-1', failureStepId, 5)]),
+    ...(sameStep ? [storedToolCall('turn-2', 'tool-2', successStepId, 6, successToolName)] : []),
     sandboxFailureToolResult('turn-2', 7),
     ...(successStepId === undefined || sameStep
       ? []
@@ -1625,7 +1615,7 @@ async function* sandboxBoundaryEvents(
 ): AsyncIterable<SessionEvent> {
   const sameStep = failureStepId !== undefined && failureStepId === successStepId;
   if (failureStepId !== undefined) {
-    yield toolStart(turnId, 'tool-1', failureStepId, 1, 'Read');
+    yield toolStart(turnId, 'tool-1', failureStepId, 1);
   }
   if (sameStep) {
     yield toolStart(turnId, 'tool-2', successStepId, 2, successToolName);
@@ -1639,11 +1629,11 @@ async function* sandboxBoundaryEvents(
 }
 
 async function* deniedWideningEvents(turnId: string): AsyncIterable<SessionEvent> {
-  yield toolStart(turnId, 'tool-1', 'step-1', 1, 'Read', { path: '/outside/secret.txt' });
+  yield toolStart(turnId, 'tool-1', 'step-1', 1);
   yield sandboxFailureToolResult(turnId, 2);
   yield toolStart(turnId, 'tool-2', 'step-2', 3, 'request_sandbox_boundary');
   yield successfulToolResult(turnId, 4, 'tool-2');
-  yield toolStart(turnId, 'tool-3', 'step-3', 5, 'Read', { path: '/workspace/README.md' });
+  yield toolStart(turnId, 'tool-3', 'step-3', 5);
   yield successfulToolResult(turnId, 6, 'tool-3');
   yield* eventsFor(turnId, 'Recovered answer', 7);
 }
@@ -1791,7 +1781,6 @@ function toolStart(
   stepId: string,
   ts: number,
   toolName = 'Read',
-  args: unknown = {},
 ): Extract<SessionEvent, { type: 'tool_start' }> {
   return {
     type: 'tool_start',
@@ -1800,7 +1789,7 @@ function toolStart(
     ts,
     toolUseId,
     toolName,
-    args,
+    args: {},
     stepId,
   };
 }
@@ -1811,7 +1800,6 @@ function storedToolCall(
   stepId: string,
   ts: number,
   toolName = 'Read',
-  args: unknown = {},
 ): Extract<StoredMessage, { type: 'tool_call' }> {
   return {
     type: 'tool_call',
@@ -1819,7 +1807,7 @@ function storedToolCall(
     turnId,
     ts,
     toolName,
-    args,
+    args: {},
     stepId,
   };
 }

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -313,6 +313,82 @@ describe('Runtime Host maka run adapter', () => {
     );
   });
 
+  test('returns exit code 1 when a same-named tool retries a different target (live)', async () => {
+    const fixture = runFixture({
+      turnEvents: sandboxBoundaryEvents(
+        'turn-1',
+        'step-1',
+        'step-2',
+        'Partial answer',
+        'Read',
+        { path: '/workspace/README.md' },
+        { path: '/outside/secret.txt' },
+      ),
+    });
+
+    const exitCode = await runFixtureCommand(fixture, ['accept same-name different target']);
+
+    assert.equal(exitCode, 1);
+  });
+
+  test('returns exit code 1 when a same-named tool retries a different target (durable)', async () => {
+    const fixture = runFixture({
+      graph: true,
+      finalMessages: sandboxBoundaryMessages(
+        'step-1',
+        'step-2',
+        'Read',
+        { path: '/workspace/README.md' },
+        { path: '/outside/secret.txt' },
+      ),
+    });
+
+    const exitCode = await runFixtureCommand(fixture, [
+      'accept durable same-name different target',
+      '--graph',
+    ]);
+
+    assert.equal(exitCode, 1);
+  });
+
+  test('keeps a same-target retry unresolved because the boundary cannot move (live)', async () => {
+    const fixture = runFixture({
+      turnEvents: sandboxBoundaryEvents(
+        'turn-1',
+        'step-1',
+        'step-2',
+        'Recovered answer',
+        'Read',
+        { path: '/workspace/README.md' },
+        { path: '/workspace/README.md' },
+      ),
+    });
+
+    const exitCode = await runFixtureCommand(fixture, ['accept same-target retry']);
+
+    assert.equal(exitCode, 1);
+  });
+
+  test('returns exit code 1 when a denied widening precedes any later tool success', async () => {
+    const stderr: string[] = [];
+    const fixture = runFixture({
+      turnEvents: deniedWideningEvents('turn-1'),
+    });
+
+    const exitCode = await runFixtureCommand(
+      fixture,
+      ['accept post-denial success'],
+      () => {},
+      (text) => stderr.push(text),
+    );
+
+    assert.equal(exitCode, 1);
+    assert.equal(
+      stderr.join(''),
+      'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
+    );
+  });
+
   test('returns exit code 1 when reconnect restores a missed sandbox failure', async () => {
     let publishReplacement = () => {};
     const fixture = runFixture({
@@ -351,18 +427,26 @@ describe('Runtime Host maka run adapter', () => {
     assert.equal(stdout.join(''), 'Final graph answer\n');
   });
 
-  test('returns exit code 0 when a root Graph boundary failure recovers', async () => {
+  test('keeps a root Graph boundary failure unresolved even when a later same-named call succeeds', async () => {
     const stdout: string[] = [];
+    const stderr: string[] = [];
     const fixture = runFixture({
       graph: true,
       turnEvents: sandboxBoundaryEvents('turn-1', 'step-1', 'step-2', 'Recovered answer'),
     });
-    const exitCode = await runFixtureCommand(fixture, ['recover once', '--graph'], (text) =>
-      stdout.push(text),
+    const exitCode = await runFixtureCommand(
+      fixture,
+      ['recover once', '--graph'],
+      (text) => stdout.push(text),
+      (text) => stderr.push(text),
     );
 
-    assert.equal(exitCode, 0);
-    assert.equal(stdout.join(''), 'Final graph answer\n');
+    assert.equal(exitCode, 1);
+    assert.equal(stdout.join(''), '');
+    assert.equal(
+      stderr.join(''),
+      'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
+    );
   });
 
   test('returns exit code 1 when a same-step Graph sibling succeeds after a sandbox failure', async () => {
@@ -465,7 +549,7 @@ describe('Runtime Host maka run adapter', () => {
     assert.equal(observed.at(-1)?.finalOutput, 'Final graph answer');
   });
 
-  test('reports a recovered sandbox boundary from live and durable Turns', async () => {
+  test('keeps the sandbox boundary unresolved across live and durable Turns', async () => {
     const live = await observeFixtureOutcome({
       turnEvents: sandboxBoundaryEvents('turn-1', 'step-1', 'step-2', 'Recovered answer'),
     });
@@ -474,8 +558,8 @@ describe('Runtime Host maka run adapter', () => {
       finalMessages: sandboxBoundaryMessages('step-1', 'step-2'),
     });
 
-    assert.equal(live.sandboxBoundary, 'recovered');
-    assert.equal(durable.sandboxBoundary, 'recovered');
+    assert.equal(live.sandboxBoundary, 'unresolved');
+    assert.equal(durable.sandboxBoundary, 'unresolved');
   });
 
   test('leaves sandbox failures unresolved when their provider steps are unavailable', async () => {
@@ -491,7 +575,7 @@ describe('Runtime Host maka run adapter', () => {
     assert.equal(durable.sandboxBoundary, 'unresolved');
   });
 
-  test('returns a recovered boundary to unresolved after a later sandbox failure', async () => {
+  test('keeps the boundary unresolved across interleaved successes and a later sandbox failure', async () => {
     const outcome = await observeFixtureOutcome({
       turnEvents: sandboxFailureAfterRecoveryEvents('turn-1'),
     });
@@ -1413,16 +1497,22 @@ function sandboxBoundaryMessages(
   failureStepId: string | undefined,
   successStepId: string | undefined,
   successToolName = 'Read',
+  successArgs: unknown = {},
+  failureArgs: unknown = {},
 ): StoredMessage[] {
   const sameStep = failureStepId !== undefined && failureStepId === successStepId;
   return [
     ...graphMessages(false),
-    ...(failureStepId === undefined ? [] : [storedToolCall('turn-2', 'tool-1', failureStepId, 5)]),
-    ...(sameStep ? [storedToolCall('turn-2', 'tool-2', successStepId, 6, successToolName)] : []),
+    ...(failureStepId === undefined
+      ? []
+      : [storedToolCall('turn-2', 'tool-1', failureStepId, 5, 'Read', failureArgs)]),
+    ...(sameStep
+      ? [storedToolCall('turn-2', 'tool-2', successStepId, 6, successToolName, successArgs)]
+      : []),
     sandboxFailureToolResult('turn-2', 7),
     ...(successStepId === undefined || sameStep
       ? []
-      : [storedToolCall('turn-2', 'tool-2', successStepId, 8, successToolName)]),
+      : [storedToolCall('turn-2', 'tool-2', successStepId, 8, successToolName, successArgs)]),
     successfulToolResult('turn-2', 9),
     {
       type: 'turn_state',
@@ -1560,16 +1650,32 @@ async function* sandboxBoundaryEvents(
   successStepId: string | undefined,
   text: string,
   successToolName = 'Read',
+  successArgs: unknown = {},
+  failureArgs: unknown = {},
 ): AsyncIterable<SessionEvent> {
   const sameStep = failureStepId !== undefined && failureStepId === successStepId;
-  if (failureStepId !== undefined) yield toolStart(turnId, 'tool-1', failureStepId, 1);
-  if (sameStep) yield toolStart(turnId, 'tool-2', successStepId, 2, successToolName);
+  if (failureStepId !== undefined) {
+    yield toolStart(turnId, 'tool-1', failureStepId, 1, 'Read', failureArgs);
+  }
+  if (sameStep) {
+    yield toolStart(turnId, 'tool-2', successStepId, 2, successToolName, successArgs);
+  }
   yield sandboxFailureToolResult(turnId, 3);
   if (successStepId !== undefined && !sameStep) {
-    yield toolStart(turnId, 'tool-2', successStepId, 4, successToolName);
+    yield toolStart(turnId, 'tool-2', successStepId, 4, successToolName, successArgs);
   }
   yield successfulToolResult(turnId, 5);
   yield* eventsFor(turnId, text, 6);
+}
+
+async function* deniedWideningEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield toolStart(turnId, 'tool-1', 'step-1', 1, 'Read', { path: '/outside/secret.txt' });
+  yield sandboxFailureToolResult(turnId, 2);
+  yield toolStart(turnId, 'tool-2', 'step-2', 3, 'request_sandbox_boundary');
+  yield successfulToolResult(turnId, 4, 'tool-2');
+  yield toolStart(turnId, 'tool-3', 'step-3', 5, 'Read', { path: '/workspace/README.md' });
+  yield successfulToolResult(turnId, 6, 'tool-3');
+  yield* eventsFor(turnId, 'Recovered answer', 7);
 }
 
 async function* projectedSameStepSandboxFailureEvents(turnId: string): AsyncIterable<SessionEvent> {
@@ -1715,6 +1821,7 @@ function toolStart(
   stepId: string,
   ts: number,
   toolName = 'Read',
+  args: unknown = {},
 ): Extract<SessionEvent, { type: 'tool_start' }> {
   return {
     type: 'tool_start',
@@ -1723,7 +1830,7 @@ function toolStart(
     ts,
     toolUseId,
     toolName,
-    args: {},
+    args,
     stepId,
   };
 }
@@ -1734,6 +1841,7 @@ function storedToolCall(
   stepId: string,
   ts: number,
   toolName = 'Read',
+  args: unknown = {},
 ): Extract<StoredMessage, { type: 'tool_call' }> {
   return {
     type: 'tool_call',
@@ -1741,7 +1849,7 @@ function storedToolCall(
     turnId,
     ts,
     toolName,
-    args: {},
+    args,
     stepId,
   };
 }

--- a/packages/cli/src/activation-command.ts
+++ b/packages/cli/src/activation-command.ts
@@ -588,10 +588,7 @@ export async function runMakaActivationCli(
   if (invocation?.failure?.class === 'permission_denied') {
     return finish('blocked', 'permission_denied', undefined, 'grant_permission');
   }
-  if (
-    (streamBoundaryFailure && invocation?.sandboxBoundary !== 'recovered') ||
-    invocation?.sandboxBoundary === 'unresolved'
-  ) {
+  if (streamBoundaryFailure || invocation?.sandboxBoundary === 'unresolved') {
     return finish('blocked', 'permission_required', undefined, 'grant_permission');
   }
   if (!invocation) return finish('fatal_failure', 'missing_invocation');

--- a/packages/cli/src/run-command-core.ts
+++ b/packages/cli/src/run-command-core.ts
@@ -280,8 +280,7 @@ export async function runMakaTextCliCore(
   }
 
   let outcome: MakaRunOutcome | undefined;
-  let unclassifiedBoundaryFailure = false;
-  const boundaryFailureInvocationIds = new Set<string>();
+  let boundaryFailure = false;
   let context: MakaRunContext;
   try {
     context = await deps.createContext({
@@ -311,10 +310,7 @@ export async function runMakaTextCliCore(
       ...(parsed.options.hostProfileId ? { hostProfileId: parsed.options.hostProfileId } : {}),
       ...(parsed.options.projectId ? { projectId: parsed.options.projectId } : {}),
       runOutcomeObserver: (result) => {
-        if (result.sandboxBoundary === 'unresolved') {
-          boundaryFailureInvocationIds.add(result.outcomeId);
-          unclassifiedBoundaryFailure = false;
-        }
+        if (result.sandboxBoundary === 'unresolved') boundaryFailure = true;
         outcome = result;
       },
     });
@@ -400,7 +396,7 @@ export async function runMakaTextCliCore(
         : {}),
     })) {
       if (event.type === 'sandbox_boundary_request') {
-        unclassifiedBoundaryFailure = true;
+        boundaryFailure = true;
         deps.writeStderr(
           'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
         );
@@ -411,7 +407,7 @@ export async function runMakaTextCliCore(
       }
       const sandboxFailureReason = sessionEventSandboxBoundaryFailureReason(event);
       if (sandboxFailureReason) {
-        unclassifiedBoundaryFailure = true;
+        boundaryFailure = true;
         deps.writeStderr(
           sandboxFailureReason === 'requires_bypass'
             ? 'maka run: sandbox bypass requires an explicit --yolo\n'
@@ -443,9 +439,7 @@ export async function runMakaTextCliCore(
     return 1;
   }
   if (streamFailed) return 1;
-  if (unclassifiedBoundaryFailure || boundaryFailureInvocationIds.size > 0) {
-    return 1;
-  }
+  if (boundaryFailure) return 1;
   if (!outcome) {
     deps.writeStderr('maka run: runtime produced no outcome\n');
     return 1;

--- a/packages/cli/src/run-command-core.ts
+++ b/packages/cli/src/run-command-core.ts
@@ -82,7 +82,7 @@ export interface MakaRunOutcome {
   status: 'completed' | 'failed';
   finalOutput?: string;
   failure?: { class: string; message?: string };
-  sandboxBoundary: 'none' | 'unresolved' | 'recovered';
+  sandboxBoundary: 'none' | 'unresolved';
 }
 
 export interface MakaRunContextInput {
@@ -311,10 +311,7 @@ export async function runMakaTextCliCore(
       ...(parsed.options.hostProfileId ? { hostProfileId: parsed.options.hostProfileId } : {}),
       ...(parsed.options.projectId ? { projectId: parsed.options.projectId } : {}),
       runOutcomeObserver: (result) => {
-        if (result.sandboxBoundary === 'recovered') {
-          boundaryFailureInvocationIds.delete(result.outcomeId);
-          unclassifiedBoundaryFailure = false;
-        } else if (result.sandboxBoundary === 'unresolved') {
+        if (result.sandboxBoundary === 'unresolved') {
           boundaryFailureInvocationIds.add(result.outcomeId);
           unclassifiedBoundaryFailure = false;
         }

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -575,12 +575,6 @@ type TurnOutcomeObservation =
       readonly failure: NonNullable<MakaRunOutcome['failure']>;
     }
   | {
-      readonly kind: 'tool_call';
-      readonly toolUseId: string;
-      readonly stepId: string | undefined;
-      readonly toolName: string;
-    }
-  | {
       readonly kind: 'tool_result';
       readonly toolUseId: string;
       readonly outcome: 'sandbox_failure' | 'success';
@@ -590,14 +584,7 @@ type TerminalOutcomeObservation = Extract<TurnOutcomeObservation, { kind: 'termi
 
 class TurnOutcomeClassifier {
   readonly #outcomeId: string;
-  readonly #callByToolUseId = new Map<
-    string,
-    { readonly stepId: string | undefined; readonly toolName: string }
-  >();
-  readonly #unresolvedSandboxFailures = new Map<
-    string,
-    { readonly failedStepId: string | undefined; readonly failedToolName: string | undefined }
-  >();
+  readonly #unresolvedSandboxFailures = new Set<string>();
   #finalOutput: string | undefined;
   #terminal: TerminalOutcomeObservation | undefined;
 
@@ -617,19 +604,9 @@ class TurnOutcomeClassifier {
           this.#terminal = observation;
         }
         return;
-      case 'tool_call':
-        this.#callByToolUseId.set(observation.toolUseId, {
-          stepId: observation.stepId,
-          toolName: observation.toolName,
-        });
-        return;
       case 'tool_result': {
         if (observation.outcome === 'sandbox_failure') {
-          const call = this.#callByToolUseId.get(observation.toolUseId);
-          this.#unresolvedSandboxFailures.set(observation.toolUseId, {
-            failedStepId: call?.stepId,
-            failedToolName: call?.toolName,
-          });
+          this.#unresolvedSandboxFailures.add(observation.toolUseId);
         }
         // No clearing path: `maka run` denies every widening request, so the
         // boundary cannot move mid-Turn and a later success cannot prove that
@@ -686,14 +663,6 @@ function observationFromSessionEvent(event: SessionEvent): TurnOutcomeObservatio
   if (event.type === 'complete') {
     return observationFromCompleteEvent(event);
   }
-  if (event.type === 'tool_start') {
-    return {
-      kind: 'tool_call',
-      toolUseId: event.toolUseId,
-      stepId: event.stepId,
-      toolName: event.toolName,
-    };
-  }
   return event.type === 'tool_result' ? observationFromToolResult(event) : undefined;
 }
 
@@ -721,14 +690,6 @@ function observationFromStoredMessage(message: StoredMessage): TurnOutcomeObserv
         class: message.errorClass ?? 'runtime_error',
         message: 'Agent Graph final Turn failed',
       },
-    };
-  }
-  if (message.type === 'tool_call') {
-    return {
-      kind: 'tool_call',
-      toolUseId: message.id,
-      stepId: message.stepId,
-      toolName: message.toolName,
     };
   }
   return message.type === 'tool_result' ? observationFromToolResult(message) : undefined;

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -596,14 +596,10 @@ class TurnOutcomeClassifier {
   >();
   readonly #unresolvedSandboxFailures = new Map<
     string,
-    {
-      readonly failedStepId: string | undefined;
-      readonly failedToolName: string | undefined;
-    }
+    { readonly failedStepId: string | undefined; readonly failedToolName: string | undefined }
   >();
   #finalOutput: string | undefined;
   #terminal: TerminalOutcomeObservation | undefined;
-  #sandboxBoundaryRecovered = false;
 
   constructor(outcomeId: string) {
     this.#outcomeId = outcomeId;
@@ -628,29 +624,16 @@ class TurnOutcomeClassifier {
         });
         return;
       case 'tool_result': {
-        const call = this.#callByToolUseId.get(observation.toolUseId);
         if (observation.outcome === 'sandbox_failure') {
+          const call = this.#callByToolUseId.get(observation.toolUseId);
           this.#unresolvedSandboxFailures.set(observation.toolUseId, {
             failedStepId: call?.stepId,
             failedToolName: call?.toolName,
           });
-          return;
         }
-        const unresolved = [...this.#unresolvedSandboxFailures.values()];
-        // The wire has no retry identity. A later success can only prove recovery
-        // when there is exactly one unresolved candidate.
-        if (
-          observation.outcome === 'success' &&
-          call?.toolName !== 'request_sandbox_boundary' &&
-          unresolved.length === 1 &&
-          call?.stepId !== undefined &&
-          unresolved[0]?.failedStepId !== undefined &&
-          call.stepId !== unresolved[0].failedStepId &&
-          call.toolName === unresolved[0].failedToolName
-        ) {
-          this.#unresolvedSandboxFailures.clear();
-          this.#sandboxBoundaryRecovered = true;
-        }
+        // No clearing path: `maka run` denies every widening request, so the
+        // boundary cannot move mid-Turn and a later success cannot prove that
+        // a blocked call recovered. The failure stays unresolved to the end.
         return;
       }
     }
@@ -662,12 +645,7 @@ class TurnOutcomeClassifier {
     const terminal = this.#terminal;
     if (!terminal && incomplete === 'pending') return undefined;
     const completed = terminal?.status === 'completed';
-    const sandboxBoundary =
-      this.#unresolvedSandboxFailures.size > 0
-        ? 'unresolved'
-        : this.#sandboxBoundaryRecovered
-          ? 'recovered'
-          : 'none';
+    const sandboxBoundary = this.#unresolvedSandboxFailures.size > 0 ? 'unresolved' : 'none';
     const failure =
       terminal?.status === 'failed'
         ? terminal.failure


### PR DESCRIPTION
## Summary
- Scope update after Astro-Han's second review: the branch is now a **net deletion**, and it is a deliberate **tightening**, not a behavior-preserving refactor. The `recovered` state is unreachable on every path `maka run` can take: non-interactive runs deny every widening request, so the boundary cannot move mid-Turn and a blocked call cannot later succeed — and the condition main used to clear the failure (same tool name, different step) compared information that could never establish recovery in the first place.
- `sandboxBoundary` collapses to `none | unresolved`: a sandbox failure stays unresolved for the rest of the Turn on both the live and durable paths. `stableArgsJson`, the args plumbing, the widening pin, and the `recovered` clauses in `run-command-core` / `activation-command` are all removed. The classifier's bookkeeping collapses with them: which step and which tool failed participated in no decision, so the map is now a set of tool-use ids and the `tool_call` observation variant is gone.

## Compatibility impact

This is the point of the PR, stated explicitly:

- **`maka run` exit codes change on reachable paths.** A Turn whose boundary request was denied now exits `1` with the boundary diagnostic on stderr even when a later same-named (or any later) tool call succeeded — main clears `recovered` on exactly that shape today, and the flipped fixture (`keeps a root Graph boundary failure unresolved even when a later same-named call succeeds`) pins the transition from `exit 0` + stdout to `exit 1` + empty stdout. The runtime asks the model for a closing explanation after a denial; on an unresolved exit that text is suppressed, so callers doing `maka run ... > out.txt` get an empty file. That suppression predates this PR but is now the common path; writing the explanation out while keeping exit `1` is the named follow-up if review wants it settled here.
- **`maka activate` changes**: an activation whose stream carried a sandbox boundary failure while the invocation completed now returns `blocked` / `permission_required` / exit `3` instead of `completed` / exit `0` (`activation-command.ts` drops the `!== 'recovered'` escape). The fixture guards the current contract rather than pinning the transition, since `recovered` no longer exists in the outcome type and an injected `MakaRunOutcome` cannot express the old shape; the transition itself is not regression-coverable after the deletion.
- Regressions kept: live and durable same-name/different-target fixtures exit `1`; a denied widening followed by an unrelated successful read exits `1` with the diagnostic on stderr; the boundary stays unresolved across live and durable Turns.

Named follow-ups (agreed with review, not in this PR): the `sandbox_boundary_request` branch in `run-command-core` now has no production caller and should be removed with its fixture scenario reworked; and surfacing the suppressed final message on unresolved exits.

## Verification

| Claim | Command | Result |
| --- | --- | --- |
| Suite green after P2/P3 changes | `node --test dist/__tests__/runtime-host-run-command.test.js` (packages/cli) | 39 tests, 39 pass, 0 fail |
| `maka activate` fixture guards contract | `node --test dist/__tests__/activation-command.test.js` (packages/cli) | 12 tests, 12 pass, 0 fail |
| Repo format | `npm run format:check` | Checked 1916 files, no issues |
| ASF headers | `npm run check:asf-headers` | Every source file carries the ASF header or a reviewed exclusion |
| Full cli suite on this Windows machine | `node --test "dist/**/*.test.js"` | 725 tests: 681 pass, 41 fail, 3 skipped |
| The 41 failures are pre-existing platform gaps, not this change | Stashed the change, rebuilt, re-ran two representative failing files, compared with the change applied | Identical both ways: 9 tests / 5 pass / 4 fail. Failures are macOS LaunchAgent plist path assertions, systemd deployment suites, and SIGINT/SIGTERM exit-code tests; none of those files import the changed module |
| Red-on-base scope | The earlier round measured 2 of the then-present cases red on `main@6e6af952a` (pre-#4389). The base has since moved to `9d4002b38`, which already includes #4389's name-based fix, so per-case red counts against the current base were not re-measured | Stated for completeness; the surviving cases pin the tightening rather than target discrimination |

## AI use
Analysis, patch, and tests were produced with GLM-5.3-Flash (ZCode) under the contributor's direction; the contributor reviewed and is the human contributor of record.

## Checklist
- [x] Tests and checks pass locally (see Verification)
- [x] Behavior change: **Yes** — `maka run` unresolved exits (exit `1`, empty stdout) are now the pinned common path, and `maka activate` returns `blocked` / exit `3` where it previously completed with exit `0`.
