### PR TITLE
fix(i18n): make resume-park and connection-error copy locale-aware

### DIFF
--- a/apps/desktop/src/renderer/use-shell-resume.ts
+++ b/apps/desktop/src/renderer/use-shell-resume.ts
@@ -64,7 +64,7 @@ export function useShellResume(options: {
     try {
       const result = await window.maka.sessions.resumeLatest(sessionId);
       if (result.disposition === 'park') {
-        const parkCopy = resumeParkToastCopy(result.rejectionReasons);
+        const parkCopy = resumeParkToastCopy(result.rejectionReasons, uiLocale);
         setResumeParkDescriptionBySession((current) => ({
           ...current,
           [sessionId]: parkCopy.description,

--- a/packages/core/src/connection-error-copy.ts
+++ b/packages/core/src/connection-error-copy.ts
@@ -18,67 +18,49 @@
  */
 
 /**
- * Human-readable copy for a not-ready chat connection: maps each
- * `NO_REAL_CONNECTION:<reason>` code to one fix sentence so a first-run / CLI
- * surface does not hand-roll its own table.
+ * Canonical parser for `NO_REAL_CONNECTION:<reason>` failures.
  *
- * Pure & sync. `describeChatConfigurationReason` turns a reason into a Chinese
- * sentence naming what is missing and where to fix it (设置 · 模型);
- * `parseNoRealConnectionError` reports whether an error is a NO_REAL_CONNECTION
- * failure and recovers its reason, tolerating both the bare CLI form and the
- * `NO_REAL_CONNECTION:<reason>: <message>` form that IPC wrapping produces.
+ * The `NO_REAL_CONNECTION` code, its reason tokens, and the
+ * `NO_REAL_CONNECTION:<reason>: <message>` wire shape that IPC wrapping
+ * produces are locale-independent protocol values. Presentation copy is a
+ * surface concern: the Desktop resolves its own localized table from the
+ * parsed reason, and the CLI renders its own line, so this module owns
+ * parsing only — producers stay free to word the embedded message in their
+ * own language because consumers never display it.
  *
- * This module is the canonical parser and copy table for both CLI and desktop;
- * surfaces adapt their local event shape here instead of duplicating the rules.
+ * Pure & sync.
  */
 
 import type { ChatConfigurationReason } from './connection-readiness.js';
 
 export const NO_REAL_CONNECTION_CODE = 'NO_REAL_CONNECTION';
 
-const GENERIC_FIX_COPY = '模型连接暂时无法用于发送，请到 设置 · 模型 检查后重试。';
-
 /**
- * The one hand-maintained table: reason → fix copy. Typed as
- * `Record<ChatConfigurationReason, string>`, so adding a reason to the union
- * fails the build until its copy is added here — completeness and copy live in
- * one place. `CHAT_CONFIGURATION_REASONS` and the parser's known-token set are
- * derived from its keys, so neither can drift from it.
+ * Every reason, mirroring the canonical union in `connection-readiness`.
+ * `satisfies` rejects tokens that are not in the union, and the
+ * `AssertNever` alias below fails the build when the union gains a reason
+ * this list is missing, so the parser's known-token set cannot silently
+ * drift from the taxonomy.
  */
-const REASON_FIX_COPY: Record<ChatConfigurationReason, string> = {
-  missing_default_connection: '等待配置默认模型。请到 设置 · 模型 添加一个可用模型连接后再发送。',
-  connection_missing: '该任务依赖的模型连接已删除，请到 设置 · 模型 重新选择或重建连接。',
-  connection_disabled: '当前模型连接已禁用。请到 设置 · 模型 启用或选择其他默认模型。',
-  missing_api_key: '当前模型连接还没有可用凭据。请到 设置 · 模型 补齐 API key 或重新登录后再发送。',
-  missing_model: '当前模型连接还没有可用模型。请到 设置 · 模型 选择默认模型后再发送。',
-  empty_model_list: '当前模型连接没有启用模型。请到 设置 · 模型 添加或启用模型后再发送。',
-  model_not_enabled: '当前任务选择的模型未启用。请到 设置 · 模型 重新选择可用模型后再发送。',
-  model_not_chat_capable:
-    '当前任务选择的模型不能用于聊天。请到 设置 · 模型 重新选择支持聊天的模型后再发送。',
-  fake_backend: '当前任务来自旧的本地模拟连接。请到 设置 · 模型 添加真实模型后新建任务。',
-  provider_retired:
-    '当前模型连接的登录方式已从 Maka 移除，无法用于发送。请到 设置 · 模型 改用其他连接后再发送。',
-};
+export const CHAT_CONFIGURATION_REASONS = [
+  'missing_default_connection',
+  'connection_missing',
+  'connection_disabled',
+  'missing_api_key',
+  'missing_model',
+  'empty_model_list',
+  'model_not_enabled',
+  'model_not_chat_capable',
+  'fake_backend',
+  'provider_retired',
+] as const satisfies readonly ChatConfigurationReason[];
 
-/**
- * Every reason, derived from the copy table so test coverage and the parser's
- * known-token set track the union automatically. Module-scoped (the package
- * index does not re-export it) — only the parser and the tests read it.
- */
-export const CHAT_CONFIGURATION_REASONS = Object.keys(REASON_FIX_COPY) as ChatConfigurationReason[];
+type AssertNever<T extends never> = T;
+type MissingChatConfigurationReasons = AssertNever<
+  Exclude<ChatConfigurationReason, (typeof CHAT_CONFIGURATION_REASONS)[number]>
+>;
 
 const KNOWN_CHAT_CONFIGURATION_REASONS: ReadonlySet<string> = new Set(CHAT_CONFIGURATION_REASONS);
-
-/**
- * Fix instructions for a not-ready connection. `undefined` (a missing or
- * unrecognized reason) returns the generic fallback; every known reason has its
- * own line, guaranteed present by the `Record` type above.
- */
-export function describeChatConfigurationReason(reason: string | undefined): string {
-  return reason !== undefined && KNOWN_CHAT_CONFIGURATION_REASONS.has(reason)
-    ? REASON_FIX_COPY[reason as ChatConfigurationReason]
-    : GENERIC_FIX_COPY;
-}
 
 // `\bNO_REAL_CONNECTION\b` pins the whole code: the trailing boundary stops it
 // matching a longer word like `NO_REAL_CONNECTIONS` (the reason group is

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -21,10 +21,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { MAX_READ_IMAGE_BYTES } from '@maka/core/attachments';
 import type { ContextOffloadLimits } from '@maka/core/context-offload';
 import { messageContentDigest, normalizeMessageContent } from '@maka/core/events';
-import {
-  describeChatConfigurationReason,
-  NO_REAL_CONNECTION_CODE,
-} from '@maka/core/connection-error-copy';
+import { NO_REAL_CONNECTION_CODE } from '@maka/core/connection-error-copy';
 import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import { emptyPlanSessionState } from '@maka/core/plan';
@@ -309,7 +306,7 @@ export async function createExecutionRuntimeHostComposition(
     // local simulation, configure a real model and start a new one.
     backends.register('fake', () => {
       throw new Error(
-        `${NO_REAL_CONNECTION_CODE}:fake_backend: ${describeChatConfigurationReason('fake_backend')}`,
+        `${NO_REAL_CONNECTION_CODE}:fake_backend: Runtime Host cannot send on a retired local-simulation connection; configure a real model and start a new task`,
       );
     });
     const runtimePolicyActivation = new RuntimePolicyActivationGate();

--- a/packages/ui/src/__tests__/runtime-resume-copy.test.ts
+++ b/packages/ui/src/__tests__/runtime-resume-copy.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { resumeParkToastCopy } from '../runtime-resume-copy.js';
+
+const CJK = /[\u3400-\u9fff]/u;
+
+test('resolves English park copy for every known reason with no Chinese (#4489)', () => {
+  const reasons = [
+    'dangling_tool_state',
+    'pending_permission',
+    'workspace_identity_mismatch',
+    'tool_catalog_mismatch',
+    'provider_replay_unsupported',
+    'runtime_lineage_claim_mismatch',
+    'continuation_started_indeterminate',
+    'resume_feature_disabled',
+  ];
+  const copy = resumeParkToastCopy(reasons, 'en');
+  const fallback = resumeParkToastCopy([], 'en').description;
+
+  assert.equal(copy.title, 'This round cannot be resumed yet');
+  assert.equal(CJK.test(copy.title), false);
+  assert.equal(CJK.test(copy.description), false);
+  for (const reason of reasons) {
+    const single = resumeParkToastCopy([reason], 'en');
+    assert.notEqual(single.description, fallback, reason);
+    assert.equal(CJK.test(single.description), false, reason);
+  }
+});
+
+test('keeps the Chinese copy for zh', () => {
+  const copy = resumeParkToastCopy(['pending_permission'], 'zh');
+
+  assert.equal(copy.title, '暂时无法继续这一轮');
+  assert.equal(copy.description, '上次执行仍在等待权限确认。');
+});
+
+test('resolves the missing-candidate special case per locale', () => {
+  assert.deepEqual(resumeParkToastCopy(['resume_candidate_missing'], 'en'), {
+    title: 'Nothing to resume',
+    description: 'This task is already up to date.',
+  });
+  assert.deepEqual(resumeParkToastCopy(['resume_candidate_missing'], 'zh'), {
+    title: '没有可恢复的任务',
+    description: '任务已是最新状态。',
+  });
+});
+
+test('falls back to the generic description for unknown reasons and dedupes repeats', () => {
+  const unknown = resumeParkToastCopy(['not_a_known_reason'], 'en');
+  assert.equal(unknown.title, 'This round cannot be resumed yet');
+  assert.equal(unknown.description, 'This task does not currently meet the conditions to continue.');
+
+  const deduped = resumeParkToastCopy(['pending_permission', 'pending_permission'], 'zh');
+  assert.equal(deduped.description, '上次执行仍在等待权限确认。');
+});

--- a/packages/ui/src/runtime-resume-copy.ts
+++ b/packages/ui/src/runtime-resume-copy.ts
@@ -17,61 +17,160 @@
  * under the License.
  */
 
+import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
+
 export interface ResumeParkToastCopy {
   title: string;
   description: string;
 }
 
-const RESUME_PARK_REASON_COPY: Readonly<Record<string, string>> = {
-  dangling_tool_state: '上次工具执行中断，记录已保留，暂时不能自动继续。',
-  pending_permission: '上次执行仍在等待权限确认。',
-  background_operation_pending: '仍有后台操作没有结束，暂时不能继续。',
-  workspace_identity_mismatch: '当前工作区与中断时不一致。',
-  workspace_identity_missing: '无法确认中断时的工作区。',
-  workspace_cwd_mismatch: '当前工作目录与中断时不一致。',
-  workspace_ref_missing: '中断时的工作区已不可用。',
-  tool_catalog_mismatch: '可用工具已发生变化，无法安全继续。',
-  checkpoint_restore_failed: '工作区检查点恢复失败。',
-  source_run_unreadable: '上次运行记录无法完整读取。',
-  runtime_ledger_unreadable: '上次运行账本无法完整读取。',
-  runtime_ledger_empty: '上次运行没有可回放的记录。',
-  terminal_repair_failed: '上次运行记录修复失败。',
-  provider_resume_head_unsupported: '当前模型不支持这个恢复起点。',
-  provider_resume_boundary_unsupported: '当前模型不支持这个恢复边界。',
-  provider_replay_non_suffix_gap: '上次模型输出的中断位置无法安全裁剪。',
-  provider_replay_unsupported: '上次运行历史无法按当前模型协议安全回放。',
-  runtime_lineage_cycle: '续跑链存在循环引用，已停止恢复。',
-  runtime_lineage_depth_exceeded: '续跑链过长，已停止自动恢复。',
-  runtime_lineage_missing: '续跑链缺少必要的历史记录。',
-  runtime_lineage_start_mismatch: '续跑链的起点记录不一致，已停止恢复。',
-  runtime_lineage_replay_mismatch: '续跑链记录的模型上下文与当前重建结果不一致。',
-  runtime_lineage_claim_mismatch: '续跑链缺少匹配的恢复所有权记录，已停止恢复。',
-  source_prefix_digest_mismatch: '上次运行的不可变边界已发生变化。',
-  continuation_already_exists: '该中断任务已经创建过续跑。',
-  continuation_claim_repair_required: '恢复所有权已保留，但续跑记录需要先修复。',
-  continuation_started_indeterminate: '续跑已经开始，但尚未形成可证明的终态。',
-  continuation_authority_unavailable: '当前存储不支持安全的续跑所有权。',
-  resume_feature_disabled: '继续中断任务的功能尚未启用。',
-};
+/**
+ * Park reasons are locale-independent wire tokens; this record only supplies
+ * their presentation copy. `resume_candidate_missing` is not a parked-reason
+ * entry — it takes its own title/description pair below.
+ */
+interface ResumeParkReasonCopy {
+  dangling_tool_state: string;
+  pending_permission: string;
+  background_operation_pending: string;
+  workspace_identity_mismatch: string;
+  workspace_identity_missing: string;
+  workspace_cwd_mismatch: string;
+  workspace_ref_missing: string;
+  tool_catalog_mismatch: string;
+  checkpoint_restore_failed: string;
+  source_run_unreadable: string;
+  runtime_ledger_unreadable: string;
+  runtime_ledger_empty: string;
+  terminal_repair_failed: string;
+  provider_resume_head_unsupported: string;
+  provider_resume_boundary_unsupported: string;
+  provider_replay_non_suffix_gap: string;
+  provider_replay_unsupported: string;
+  runtime_lineage_cycle: string;
+  runtime_lineage_depth_exceeded: string;
+  runtime_lineage_missing: string;
+  runtime_lineage_start_mismatch: string;
+  runtime_lineage_replay_mismatch: string;
+  runtime_lineage_claim_mismatch: string;
+  source_prefix_digest_mismatch: string;
+  continuation_already_exists: string;
+  continuation_claim_repair_required: string;
+  continuation_started_indeterminate: string;
+  continuation_authority_unavailable: string;
+  resume_feature_disabled: string;
+}
 
-export function resumeParkToastCopy(reasons: readonly string[]): ResumeParkToastCopy {
+interface ResumeParkCopy {
+  title: string;
+  fallbackDescription: string;
+  missingCandidateTitle: string;
+  missingCandidateDescription: string;
+  reasons: ResumeParkReasonCopy;
+}
+
+const RESUME_PARK_COPY = {
+  zh: {
+    title: '暂时无法继续这一轮',
+    fallbackDescription: '当前任务不满足继续的条件。',
+    missingCandidateTitle: '没有可恢复的任务',
+    missingCandidateDescription: '任务已是最新状态。',
+    reasons: {
+      dangling_tool_state: '上次工具执行中断，记录已保留，暂时不能自动继续。',
+      pending_permission: '上次执行仍在等待权限确认。',
+      background_operation_pending: '仍有后台操作没有结束，暂时不能继续。',
+      workspace_identity_mismatch: '当前工作区与中断时不一致。',
+      workspace_identity_missing: '无法确认中断时的工作区。',
+      workspace_cwd_mismatch: '当前工作目录与中断时不一致。',
+      workspace_ref_missing: '中断时的工作区已不可用。',
+      tool_catalog_mismatch: '可用工具已发生变化，无法安全继续。',
+      checkpoint_restore_failed: '工作区检查点恢复失败。',
+      source_run_unreadable: '上次运行记录无法完整读取。',
+      runtime_ledger_unreadable: '上次运行账本无法完整读取。',
+      runtime_ledger_empty: '上次运行没有可回放的记录。',
+      terminal_repair_failed: '上次运行记录修复失败。',
+      provider_resume_head_unsupported: '当前模型不支持这个恢复起点。',
+      provider_resume_boundary_unsupported: '当前模型不支持这个恢复边界。',
+      provider_replay_non_suffix_gap: '上次模型输出的中断位置无法安全裁剪。',
+      provider_replay_unsupported: '上次运行历史无法按当前模型协议安全回放。',
+      runtime_lineage_cycle: '续跑链存在循环引用，已停止恢复。',
+      runtime_lineage_depth_exceeded: '续跑链过长，已停止自动恢复。',
+      runtime_lineage_missing: '续跑链缺少必要的历史记录。',
+      runtime_lineage_start_mismatch: '续跑链的起点记录不一致，已停止恢复。',
+      runtime_lineage_replay_mismatch: '续跑链记录的模型上下文与当前重建结果不一致。',
+      runtime_lineage_claim_mismatch: '续跑链缺少匹配的恢复所有权记录，已停止恢复。',
+      source_prefix_digest_mismatch: '上次运行的不可变边界已发生变化。',
+      continuation_already_exists: '该中断任务已经创建过续跑。',
+      continuation_claim_repair_required: '恢复所有权已保留，但续跑记录需要先修复。',
+      continuation_started_indeterminate: '续跑已经开始，但尚未形成可证明的终态。',
+      continuation_authority_unavailable: '当前存储不支持安全的续跑所有权。',
+      resume_feature_disabled: '继续中断任务的功能尚未启用。',
+    },
+  },
+  en: {
+    title: 'This round cannot be resumed yet',
+    fallbackDescription: 'This task does not currently meet the conditions to continue.',
+    missingCandidateTitle: 'Nothing to resume',
+    missingCandidateDescription: 'This task is already up to date.',
+    reasons: {
+      dangling_tool_state:
+        'The previous tool run was interrupted; its records are preserved, so it cannot continue automatically yet.',
+      pending_permission: 'The previous run is still waiting for a permission approval.',
+      background_operation_pending: 'Background operations are still running, so this round cannot continue yet.',
+      workspace_identity_mismatch: 'The current workspace does not match the one from the interrupted run.',
+      workspace_identity_missing: 'The workspace from the interrupted run could not be identified.',
+      workspace_cwd_mismatch: 'The current working directory does not match the one from the interrupted run.',
+      workspace_ref_missing: 'The workspace from the interrupted run is no longer available.',
+      tool_catalog_mismatch: 'The available tools have changed, so it is not safe to continue.',
+      checkpoint_restore_failed: 'Restoring the workspace checkpoint failed.',
+      source_run_unreadable: "The previous run's record could not be read in full.",
+      runtime_ledger_unreadable: "The previous run's ledger could not be read in full.",
+      runtime_ledger_empty: 'The previous run has no records to replay.',
+      terminal_repair_failed: "Repairing the previous run's record failed.",
+      provider_resume_head_unsupported: 'The current model does not support this resume point.',
+      provider_resume_boundary_unsupported: 'The current model does not support this resume boundary.',
+      provider_replay_non_suffix_gap: 'The interruption point in the previous model output cannot be trimmed safely.',
+      provider_replay_unsupported:
+        "The previous run's history cannot be replayed safely under the current model protocol.",
+      runtime_lineage_cycle: 'The resume chain contains a cycle; resuming was stopped.',
+      runtime_lineage_depth_exceeded: 'The resume chain is too long; automatic resuming was stopped.',
+      runtime_lineage_missing: 'The resume chain is missing required history records.',
+      runtime_lineage_start_mismatch: "The resume chain's starting record is inconsistent; resuming was stopped.",
+      runtime_lineage_replay_mismatch:
+        "The resume chain's recorded model context does not match what was rebuilt here.",
+      runtime_lineage_claim_mismatch:
+        'The resume chain lacks a matching resume-ownership record; resuming was stopped.',
+      source_prefix_digest_mismatch: "The previous run's immutable boundary has changed.",
+      continuation_already_exists: 'A continuation for this interrupted task already exists.',
+      continuation_claim_repair_required:
+        'Resume ownership was preserved, but the continuation record needs repair first.',
+      continuation_started_indeterminate:
+        'The continuation already started, but has not reached a provable terminal state.',
+      continuation_authority_unavailable: 'The current storage does not support safe resume ownership.',
+      resume_feature_disabled: 'Resuming interrupted tasks is not enabled.',
+    },
+  },
+} satisfies UiCatalog<ResumeParkCopy>;
+
+export function resumeParkToastCopy(reasons: readonly string[], locale: UiLocale): ResumeParkToastCopy {
+  const copy = RESUME_PARK_COPY[locale];
   if (reasons.length === 1 && reasons[0] === 'resume_candidate_missing') {
     return {
-      title: '没有可恢复的任务',
-      description: '任务已是最新状态。',
+      title: copy.missingCandidateTitle,
+      description: copy.missingCandidateDescription,
     };
   }
 
   const descriptions = [...new Set(
     reasons
-      .map((reason) => RESUME_PARK_REASON_COPY[reason])
+      .map((reason) => copy.reasons[reason as keyof ResumeParkReasonCopy])
       .filter((description): description is string => description !== undefined),
   )];
 
   return {
-    title: '暂时无法继续这一轮',
+    title: copy.title,
     description: descriptions.length > 0
       ? descriptions.join(' ')
-      : '当前任务不满足继续的条件。',
+      : copy.fallbackDescription,
   };
 }


### PR DESCRIPTION
## Summary
- `resumeParkToastCopy` rendered its park toast from a Chinese-only table with no locale parameter, so an English-locale Desktop saw `暂时无法继续这一轮` in the toast title, description, and the inline resume detail (#4489). It now resolves through a `UiCatalog<ResumeParkCopy>` (`zh` keeps the current strings verbatim; `en` is new) and takes the `UiLocale` that `use-shell-resume` already destructures but was only using on adjacent branches.
- `connection-error-copy.ts` claimed to be "the canonical parser and copy table for both CLI and desktop", but its Chinese fix-copy table has no remaining readers: the Desktop resolves `getDesktopConversationCopy(locale).model.configurationReason[reason]` from the parsed token, and the CLI renders its own English line for the same code. The module now owns parsing only: the copy table is dropped, `CHAT_CONFIGURATION_REASONS` becomes an explicit list mirror-checked against the `ChatConfigurationReason` union at compile time (`satisfies` rejects unknown tokens, an `AssertNever` alias rejects a union member missing from the list), and the one remaining embedded message (the retired `fake` backend refusal) uses the same plain-English convention as the CLI producer - consumers never display that message, they parse the reason token.
- Reason tokens, the `NO_REAL_CONNECTION` code, and the wire shape stay locale-independent; only presentation changed.

## Verification

| Claim | Command | Result |
| --- | --- | --- |
| New park-copy tests green | `node --test dist/__tests__/runtime-resume-copy.test.js` (packages/ui) | 4 tests, 4 pass, 0 fail. Same 4 tests fail against the unpatched module (verified via stash + stale-dist run: old code renders Chinese for `en`, 3 of 4 assertions fail) |
| Retired fake-backend refusal still classifies | `node --test --test-name-pattern="legacy fake-backend session" dist/__tests__/execution-composition.test.js` (packages/runtime-host) | 1 test, 1 pass |
| CLI parser consumers unaffected | `node --test dist/__tests__/tui-session-status.test.js` (packages/cli) | 3 tests, 3 pass |
| Repo format | `npm run format:check` | Checked 1854 files, no issues |
| ASF headers | `npm run check:asf-headers` | Every source file carries the ASF header or a reviewed exclusion |
| ui suite | `node --test "dist/**/*.test.js"` (packages/ui) | 313 tests: 290 pass / 23 fail with this change; identical 23 failures with the change stashed - all in the streaming/Markdown-math area |
| Known pre-existing breakage on current main | `npm run build` in packages/ui | Typecheck fails on main for reasons unrelated to this PR: merged #4207 uses `settledText`/`autoScroll`, which the `@astryxdesign/core@0.5.2` pinned in package-lock does not declare (4 files: streaming-text.test.tsx, chat-surface-layout.tsx, markdown-body.tsx, session-history-list.tsx). tsc still emits, so the suite runs; desktop typecheck is blocked by the same pre-existing errors. The changed renderer line matches the signature proven by the new ui tests |

## AI use
Analysis, patch, and tests were produced with GLM-5.3-Flash (ZCode) under the contributor's direction; the contributor reviewed and is the human contributor of record.

## Checklist
- [x] Tests and checks pass locally (pre-existing ui typecheck breakage on main documented and evidenced above)
- [ ] Behavior change: **Yes** - English locale no longer shows Chinese in the resume-park toast/detail; zh copy is unchanged