### PR TITLE
fix(desktop): load desktop stories on Windows with a config-relative glob

### DIFF
--- a/apps/desktop/.storybook/main.ts
+++ b/apps/desktop/.storybook/main.ts
@@ -33,7 +33,7 @@ const STORYBOOK_NODE_CRYPTO_BOUNDARY = resolve(
 const config: StorybookConfig = {
   stories: [
     '../../../packages/ui/stories/**/*.stories.@(ts|tsx)',
-    resolve(REPO_ROOT, 'apps/desktop/stories/**/*.stories.@(ts|tsx)'),
+    '../stories/**/*.stories.@(ts|tsx)',
   ],
   framework: {
     name: '@storybook/react-vite',


### PR DESCRIPTION
## Summary
- On Windows, Storybook in `apps/desktop` silently indexed only `packages/ui/stories` (53 entries, zero desktop story files): the desktop stories glob was built with `resolve(REPO_ROOT, ...)`, handing the globber a backslash absolute path, and glob matchers treat backslashes as escape characters (#4516).
- The desktop glob now uses the same forward-slash config-relative form the neighboring `packages/ui` entry already uses (`'../stories/**/*.stories.@(ts|tsx)'`), so it resolves against the config dir on every platform.

## Verification

| Claim | Command | Result |
| --- | --- | --- |
| Desktop stories load on Windows | `npm run storybook` (apps/desktop), then fetch `http://localhost:6006/index.json` | Before: 53 entries, no `product-agent-graph--*` / `product-onboarding-*` / etc. After: 251 entries including all 11 desktop story files; the Product/Agent Graph stories render and play |
| Linux behavior unchanged | - | Relative globs resolve against the config dir on both platforms; the packages/ui entry has always used this form |
| Repo format | `npm run format:check` | Checked 1854 files, no issues |
| ASF headers | `npm run check:asf-headers` | Every source file carries the ASF header or a reviewed exclusion |

## AI use
Analysis and the fix were produced with GLM-5.3-Flash (ZCode) under the contributor's direction; the contributor reviewed and is the human contributor of record.

## Checklist
- [x] Tests and checks pass locally (see Verification)
- [ ] Behavior change: **No** - config-only fix; Storybook story discovery on Linux is unchanged, on Windows it goes from broken to working