### PR TITLE
docs(architecture): audit Recovery and resume group against implementation

### DIFF
--- a/docs/architecture/runtime-recovery-resolver-adr.zh-CN.md
+++ b/docs/architecture/runtime-recovery-resolver-adr.zh-CN.md
@@ -92,12 +92,13 @@ Planner、CLI、UI 和未来 reconciler 不得各自组合事实。它们只消�
 | response 存在但对应 call 不存在 | corruption |
 | dispatch/response 的 operation、tool call、tool name 或执行身份冲突 | corruption |
 | 同一 operation 出现多个不一致 dispatch 或 response | corruption |
+| call（含 dispatch 后无 response）且 operation 已带 recovery decision fact | 以 recovery bundle 结算：disposition 为 completed 则 completed（reason `recovery_bundle_completed`），否则 parked 并沿用 fact 的 reasonCode；fact 本身损坏按 corruption 处理 |
 
 Resolver 必须 fail-closed：未知组合不能退化成自动重试。Phase 3 恢复写入者经原子 recovery bundle 事务提交 `actions.toolRecovery` decision fact（`maka.tool.recovery_decision`，protocol `tool_recovery_v1`）；后续 reconcile 结果同样追加事件，不回写历史事实。
 
 ### 5. Journal 是可重建投影，不是第二份账本
 
-Phase 2.5 保留现有表以降低查询成本，状态缩窄为写入路径可达的集合（现为 `prepared | outcome_committed | recovery_completed | recovery_parked`）。未来新状态若需要查询表示，先定义对应 RuntimeEvent，再扩展 projector。
+Phase 2.5 保留现有表以降低查询成本，状态缩窄为写入路径可达的集合（现为 `prepared | reconcile_observed | outcome_committed | recovery_completed | recovery_parked`，与 `ToolJournalState` 联合一致，其中 `reconcile_observed` 由 reconcile 追加事件写入）。未来新状态若需要查询表示，先定义对应 RuntimeEvent，再扩展 projector。
 
 新协议的重建验收标准：清空 `tool_journal_events` 与 `tool_operations` 后，从 RuntimeEvent 投影得到相同 operation identity、dispatch/result event refs、recovery mode 与 current state。
 

--- a/docs/architecture/runtime-recovery-resolver-adr.zh-CN.md
+++ b/docs/architecture/runtime-recovery-resolver-adr.zh-CN.md
@@ -85,7 +85,7 @@ Planner、CLI、UI 和未来 reconciler 不得各自组合事实。它们只消�
 |---|---|
 | call + matching response，无 dispatch | completed；表示 T1 前合成结果，legacy 下 response 本身也是完成证据 |
 | call + dispatch + matching response | completed |
-| call + dispatch，无 response | indeterminate / reconcile_required |
+| call + dispatch，无 response | indeterminate，Resolver 置 `requiresReconciliation`，reason 记 `dispatch_without_response` |
 | call，无 dispatch、无 response，首事件声明新协议 | definitely_not_dispatched |
 | call，无 dispatch、无 response，legacy/unknown protocol | indeterminate |
 | dispatch 存在但对应 call 不存在 | corruption |
@@ -93,11 +93,11 @@ Planner、CLI、UI 和未来 reconciler 不得各自组合事实。它们只消�
 | dispatch/response 的 operation、tool call、tool name 或执行身份冲突 | corruption |
 | 同一 operation 出现多个不一致 dispatch 或 response | corruption |
 
-Resolver 必须 fail-closed：未知组合不能退化成自动重试。Phase 3 首个恢复写入者应追加 `tool_recovery_decided` RuntimeEvent；后续 reconcile 结果同样追加事件，不回写历史事实。
+Resolver 必须 fail-closed：未知组合不能退化成自动重试。Phase 3 恢复写入者经原子 recovery bundle 事务提交 `actions.toolRecovery` decision fact（`maka.tool.recovery_decision`，protocol `tool_recovery_v1`）；后续 reconcile 结果同样追加事件，不回写历史事实。
 
 ### 5. Journal 是可重建投影，不是第二份账本
 
-Phase 2.5 保留现有表以降低查询成本，但状态缩窄为当前确有写入路径的 `prepared | outcome_committed`。未来 `indeterminate`、`reconciled`、`parked` 若需要查询状态，先定义对应 RuntimeEvent，再扩展 projector。
+Phase 2.5 保留现有表以降低查询成本，状态缩窄为写入路径可达的集合（现为 `prepared | outcome_committed | recovery_completed | recovery_parked`）。未来新状态若需要查询表示，先定义对应 RuntimeEvent，再扩展 projector。
 
 新协议的重建验收标准：清空 `tool_journal_events` 与 `tool_operations` 后，从 RuntimeEvent 投影得到相同 operation identity、dispatch/result event refs、recovery mode 与 current state。
 
@@ -139,7 +139,7 @@ Phase 2.5 保留现有表以降低查询成本，但状态缩窄为当前确有�
 1. Phase 2.5：增加 dispatch RuntimeEvent 和运行时 protocol marker；Journal 改为其同步投影。
 2. Phase 2.5：实现稳定 revalidation error code，清理无生产调用的旧接口与虚设状态。
 3. Phase 3：实现纯 RecoveryResolver 与完整决策表。
-4. Phase 3：提交 `tool_recovery_decided`，先支持 park/reconcile_required，不直接自动重跑有副作用工具。
+4. Phase 3：经 recovery bundle 提交 terminal decision fact（disposition `parked` / `completed`），先支持 park/reconcile，不直接自动重跑有副作用工具。
 5. Phase 3：加入 replay manifest、全 source digest revalidation 与投影重建工具。
 
 ## 验收不变量

--- a/docs/architecture/runtime-resume-architecture.md
+++ b/docs/architecture/runtime-resume-architecture.md
@@ -7,7 +7,7 @@ counterpart: ./runtime-resume-architecture.zh-CN.md
 implementation_status: phase_0_2_and_phase_3a_authority_current
 document_status: current
 translation_status: synced
-last_verified: 2026-08-29
+last_verified: 2026-09-02
 owners:
   - maka-backend
 ---
@@ -608,7 +608,7 @@ Write/Edit recovery first needs durable evidence bound to:
 | Observation | Action |
 |---|---|
 | `matches_expected_state` | Cleanup/finalize only; synthesize outcome and commit completed bundle |
-| `matches_prior_state` | Park with `redo_disabled_pending_cas` |
+| `matches_prior_state` | Park with `reconcile_matches_prior_state` |
 | `diverged` | Park; do not overwrite outside changes |
 | `unreadable` | Park; do not guess |
 
@@ -619,7 +619,7 @@ flowchart TD
   Expected -->|"Yes"| Finalize["Finalize only<br/>do not write the file again"]
   Finalize --> Completed["Commit recovered outcome<br/>+ completed decision"]
   Expected -->|"No"| Prior{"current == before?"}
-  Prior -->|"Yes"| ParkPrior["Park<br/>redo_disabled_pending_cas"]
+  Prior -->|"Yes"| ParkPrior["Park<br/>reconcile_matches_prior_state"]
   Prior -->|"No, content diverged"| ParkDiverged["Park<br/>protect outside writes"]
   Prior -->|"Unreadable"| ParkUnreadable["Park<br/>do not guess"]
 ```

--- a/docs/architecture/runtime-resume-architecture.zh-CN.md
+++ b/docs/architecture/runtime-resume-architecture.zh-CN.md
@@ -7,7 +7,7 @@ counterpart: ./runtime-resume-architecture.md
 implementation_status: phase_0_2_and_phase_3a_authority_current
 document_status: current
 translation_status: synced
-last_verified: 2026-08-29
+last_verified: 2026-09-02
 owners:
   - maka-backend
 ---
@@ -627,7 +627,7 @@ Writer、projection rebuild 和 `RecoveryResolver` 共享同一个 scanner/inter
 | observation | 动作 |
 |---|---|
 | `matches_expected_state` | 只做 cleanup/finalize，合成 outcome，提交 completed bundle |
-| `matches_prior_state` | park，`redo_disabled_pending_cas` |
+| `matches_prior_state` | park，`reconcile_matches_prior_state` |
 | `diverged` | park，不覆盖外部写入 |
 | `unreadable` | park，不猜测 |
 
@@ -638,7 +638,7 @@ flowchart TD
   Expected -->|"是"| Finalize["Finalize only<br/>不再次写文件"]
   Finalize --> Completed["提交 recovered outcome<br/>+ completed decision"]
   Expected -->|"否"| Prior{"current == before?"}
-  Prior -->|"是"| ParkPrior["Park<br/>redo_disabled_pending_cas"]
+  Prior -->|"是"| ParkPrior["Park<br/>reconcile_matches_prior_state"]
   Prior -->|"否，内容分叉"| ParkDiverged["Park<br/>保护外部写入"]
   Prior -->|"无法读取"| ParkUnreadable["Park<br/>不猜测"]
 ```

--- a/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
+++ b/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
@@ -304,7 +304,7 @@ B3（typed retry/reattach branch）仍然 defer，不进入本 PR。
 | 文件 | PR B 职责 |
 |---|---|
 | `continuation-replay.ts` | 每个 lineage segment 的唯一 provider replay materializer |
-| `model-history.ts` | 冻结 `PROVIDER_REPLAY_PROJECTION_VERSION = 1` |
+| `model-history.ts` | 冻结 `PROVIDER_REPLAY_PROJECTION_VERSION`（PR B 时为 1；#4286 起为 2） |
 | `runtime-resume.ts` | immutable lineage planner、V2 replay-edge 与历史 claim authority 校验、exact claim/start/terminal 分类 |
 | `runtime-kernel.ts` | immediate-source latest 重验、exact tool equality、原子 claim、provider T1 顺序 |
 | `agent-run.ts` | Run create 与 backend reservation 之间提交 continuation-start |

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -167,7 +167,7 @@ composite replay 存在时，它是 tool-state 与 provider suffix 的唯一 gat
 
 最终同时冻结：
 
-- `providerProjectionVersion = 1`；
+- `providerProjectionVersion`（PR B 时冻结为 1；#4286 起为 2）；
 - composite `providerReplayDigest`；
 - segment boundary manifest。
 

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -453,7 +453,7 @@ authority、同一 ledger transaction domain。lease 要携带 epoch/fencing tok
 | observation | 动作 |
 |---|---|
 | `matches_expected_state` | cleanup/finalize，合成 outcome，提交 PR A bundle |
-| `matches_prior_state` | park，reason=`redo_disabled_pending_cas` |
+| `matches_prior_state` | park，reason=`reconcile_matches_prior_state` |
 | `diverged` | park，不覆盖外部写入 |
 | `unreadable` | park，不猜测 |
 
@@ -474,8 +474,8 @@ authority、同一 ledger transaction domain。lease 要携带 epoch/fencing tok
 sandbox、one-call grant 和 abort boundary 的执行所有权。
 
 PR C 沿用 PR A 的 durable vocabulary：`matches_expected_state` 可 finalize；
-`matches_prior_state`、`diverged`、`unreadable` 均提交 terminal parked decision。UI 可以把
-`matches_prior_state` 映射为 `redo_disabled_pending_cas`，但不新增第二套 durable fact 名称。
+`matches_prior_state`、`diverged`、`unreadable` 均提交 terminal parked decision。UI 直接展示
+durable reason code（如 `reconcile_matches_prior_state`），不维护第二套展示层状态名。
 
 ### PR D — Host owner lifecycle
 


### PR DESCRIPTION
## Summary
- Audit of the **Recovery and resume** group (7 documents) from the documentation audit tracker #3522, read against current `main`. Five documents needed corrections; two (the phase0 and phase1 contracts) were verified accurate as written and are listed below with what was checked.
- Corrections:
  - **Recovery-resolver ADR**: the Phase 3 decision fact is implemented as the `actions.toolRecovery` envelope (`maka.tool.recovery_decision`, protocol `tool_recovery_v1`) committed through the atomic recovery-bundle transaction - not a `tool_recovery_decided` RuntimeEvent (no such event exists anywhere in the repo). The call+dispatch-without-response row resolves to `indeterminate` with a resolution-level `requiresReconciliation`; reconciled operations settle as terminal `parked` with `reconcile_*` reasons - there is no `reconcile_required` status. The journal states reachable by write paths are `prepared | reconcile_observed | outcome_committed | recovery_completed | recovery_parked` (the full `ToolJournalState` union; `reconcile_observed` is written by reconcile event appends).
  - **Extraction ledger + Phase 3-4 design**: `PROVIDER_REPLAY_PROJECTION_VERSION` was frozen at 1 by PR B and advanced to 2 by #4286 (cross-model reasoning replay gating).
  - **Resume architecture (en + zh-CN)**: the prior-state recovery park reason is the durable `reconcile_matches_prior_state` (`ToolRecoveryParkReason` in `packages/core/src/tool-recovery-fact.ts`); `redo_disabled_pending_cas` never became a durable code - the Phase 3-4 design previously kept it as a UI mapping note; that note now uses the durable code as well.
- Verified accurate with no changes:
  - **phase0 crash contract**: `RUNTIME_RESUME_FAILPOINTS` P0-P11 table matches `packages/runtime/src/runtime-resume.ts:234` field by field; `safe_replay`/`blocked`, `dangling_tool_state`, `runtime_offset_mismatch` all exist; the twelve-failpoint harness exists (`runtime-resume-crash.test.ts`).
  - **phase1 safe-boundary contract**: `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME`, `RuntimeContinuationPlanner`, `continuationSource`/`continuation_already_exists`, the `plan_approved`/`plan_parked`/`execution_started`/`execution_completed`/`execution_failed` lifecycle union (`session-manager.ts`), `sessions:resumeLatest`, and the CLI `/resume` route all exist as described.
  - **Extraction ledger** (beyond the one fix): all 14 listed PR A/PR B file paths resolve; `runtime_recovery_authority@1`, `runtime_continuation_authority@1`, `continuation_start_v2`, `continuation_source_v2`, `PROVIDER_REPLAY_PROJECTION_VERSION`, and the workspace-authority file inventory all match.
  - **Phase 3-4 design** (beyond the one fix): `runtime_continuation_claims`, `runtime_partial_snapshots`, `commitContinuationStart`/`commitContinuationRepairStart`, the 64-segment lineage cap (`runtime-resume.ts:696`), `retriedFromRunId`, `continuation_abandoned_before_provider_dispatch`, `branch_runtime_fact_rewrite_unsupported`, PR C observation vocabulary (`matches_expected_state`/`matches_prior_state`/`diverged`/`unreadable`), and the linked managed-mutation-lifecycle document all resolve.
- The paired resume-architecture documents move together and both carry `last_verified: 2026-09-02`; `translation_status: synced` is preserved. The tracking issue's drift greps (`run.json`, `events.jsonl`, `PermissionEngine`, `tasks.json`, `task-events.jsonl`) return zero hits across the group.

Review fixes (per Astro-Han's and me2seeks's reviews): the ADR journal-state list now matches the five-member `ToolJournalState` union (adds `reconcile_observed`), the ADR decision table gains a row for operations already carrying a recovery decision fact (settled from the recovery bundle), and the Phase 3-4 design's park-reason table and UI note now use `reconcile_matches_prior_state` (the `redo_disabled_pending_cas` mapping note is removed).

## Verification

| Claim | Command / method | Result |
| --- | --- | --- |
| Named symbols exist | `git grep` per symbol against `packages/` (list above) | all resolve; removed names (`tool_recovery_decided`, `reconcile_required`, `redo_disabled_pending_cas`) confirmed absent |
| Cited paths resolve | filesystem check for every path cited in the group | all resolve |
| Drift greps from #3522 | grep over the 7 documents | 0 hits |
| Bilingual sync | `translation_status` / `last_verified` fields of the paired docs | both `synced` / `2026-09-02` |
| Repo format | `npm run format:check` | Checked 1854 files, no issues |
| ASF headers | `npm run check:asf-headers` | Every source file carries the ASF header or a reviewed exclusion |

## AI use
Audit, cross-checking, and edits were produced with GLM-5.3-Flash (ZCode) under the contributor's direction; the contributor reviewed and is the human contributor of record.

## Checklist
- [x] Documentation-only change; no code behavior affected
- [ ] Behavioral change: **No**

