### PR TITLE
ci: cut single-job validation time by up to 40%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,37 @@ jobs:
 
       - name: Desktop e2e
         if: steps.plan.outputs.e2e == 'true'
-        run: xvfb-run -a npm exec -w @maka/desktop -- playwright test --config e2e/playwright.config.ts
+        run: |
+          set -euo pipefail
+          display_base=90
+          worker_count=4
+          xvfb_pids=()
+          cleanup() {
+            kill "${xvfb_pids[@]}" 2>/dev/null || true
+            wait "${xvfb_pids[@]}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          for ((index = 0; index < worker_count; index += 1)); do
+            display=$((display_base + index))
+            Xvfb ":$display" -screen 0 1280x1024x24 -nolisten tcp \
+              >"$RUNNER_TEMP/xvfb-$display.log" 2>&1 &
+            xvfb_pids+=("$!")
+          done
+          for ((index = 0; index < worker_count; index += 1)); do
+            display=$((display_base + index))
+            for _ in {1..50}; do
+              [[ -S "/tmp/.X11-unix/X$display" ]] && break
+              kill -0 "${xvfb_pids[$index]}" 2>/dev/null || break
+              sleep 0.1
+            done
+            if [[ ! -S "/tmp/.X11-unix/X$display" ]]; then
+              cat "$RUNNER_TEMP/xvfb-$display.log"
+              exit 1
+            fi
+          done
+          MAKA_E2E_X_DISPLAY_BASE="$display_base" \
+            npm exec -w @maka/desktop -- playwright test \
+              --config e2e/playwright.config.ts --workers="$worker_count"
 
       - name: Browser WebContentsView semantic smoke
         if: steps.plan.outputs.e2e == 'true'

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -490,7 +490,6 @@ async function withE2eWindow(
 interface PromptRailWorker {
   app: ElectronApplication;
   page: Page;
-  pristine: boolean;
   viewport: { width: number; height: number };
 }
 
@@ -507,10 +506,6 @@ async function setPromptRailWindowVisible(
 }
 
 async function resetPromptRailWindow(worker: PromptRailWorker): Promise<void> {
-  if (worker.pristine) {
-    worker.pristine = false;
-    return;
-  }
   await worker.page.evaluate(async () => {
     const controls = (
       window as typeof window & {
@@ -689,7 +684,7 @@ export const test = base.extend<E2eTestFixtures, E2eWorkerFixtures>({
       showWindow: true,
     }, async (page, { app }) => {
       const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }));
-      await use({ app, page, pristine: true, viewport });
+      await use({ app, page, viewport });
     });
   }, { scope: 'worker' }],
   // A multi-prompt transcript for the prompt anchor rail. Shown, because every

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -34,8 +34,6 @@ import {
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import { buildFixtureEnv, isCiLinuxDisplay } from '../../../scripts/fixture-env.mjs';
 import { closeElectronApplication } from '../../../scripts/electron-lifecycle.mjs';
-import { PROMPT_RAIL_SESSION_ID } from '../src/main/e2e-fixture/seed-helpers';
-import { desktopSessionKey } from '../src/shared/runtime-host-identity';
 
 const DESKTOP_ROOT = process.cwd();
 const execFileAsync = promisify(execFile);
@@ -493,12 +491,6 @@ interface PromptRailWorker {
   app: ElectronApplication;
   page: Page;
   pristine: boolean;
-  sessionId: string;
-  throughSequence: number;
-  storage: {
-    local: Record<string, string>;
-    session: Record<string, string>;
-  };
   viewport: { width: number; height: number };
 }
 
@@ -519,20 +511,19 @@ async function resetPromptRailWindow(worker: PromptRailWorker): Promise<void> {
     worker.pristine = false;
     return;
   }
-  await worker.page.evaluate(async ({ sessionId, throughSequence }) => {
-    const transcript = await window.maka.transcripts.open(sessionId, () => undefined);
-    try {
-      await transcript.loadAround(throughSequence);
-    } finally {
-      await transcript.close();
-    }
-  }, { sessionId: worker.sessionId, throughSequence: worker.throughSequence });
-  await worker.page.evaluate(({ local, session }) => {
+  await worker.page.evaluate(async () => {
+    const controls = (
+      window as typeof window & {
+        makaE2eLatch?: {
+          releaseRendererObservations(): Promise<void>;
+        };
+      }
+    ).makaE2eLatch;
+    if (!controls) throw new Error('the isolated E2E controls are unavailable');
+    await controls.releaseRendererObservations();
     localStorage.clear();
     sessionStorage.clear();
-    for (const [key, value] of Object.entries(local)) localStorage.setItem(key, value);
-    for (const [key, value] of Object.entries(session)) sessionStorage.setItem(key, value);
-  }, worker.storage);
+  });
   await worker.page.setViewportSize(worker.viewport);
   await worker.page.reload();
   await worker.page.waitForSelector('[data-turn-id]', { timeout: 20_000 });
@@ -697,27 +688,8 @@ export const test = base.extend<E2eTestFixtures, E2eWorkerFixtures>({
       e2eFixtureScenario: 'chat-prompt-rail',
       showWindow: true,
     }, async (page, { app }) => {
-      const hostId = await page.evaluate(async () =>
-        (await window.maka.runtimeHostProfiles.getSnapshot()).entries
-          .find(({ isDefault }) => isDefault)?.hostId);
-      if (!hostId) throw new Error('the prompt-rail fixture has no ready default Host');
-      const sessionId = desktopSessionKey({ hostId, sessionId: PROMPT_RAIL_SESSION_ID });
-      const throughSequence = await page.evaluate(async (selectedSessionId) =>
-        (await window.maka.sessions.listTurnLandmarks(selectedSessionId)).throughSequence,
-      sessionId);
-      if (throughSequence === null) throw new Error('the prompt-rail fixture has no transcript');
-      const storage = await page.evaluate(() => {
-        const snapshot = (source: Storage) => Object.fromEntries(
-          Array.from({ length: source.length }, (_, index) => {
-            const key = source.key(index);
-            if (key === null) throw new Error('browser storage changed while being read');
-            return [key, source.getItem(key) ?? ''];
-          }),
-        );
-        return { local: snapshot(localStorage), session: snapshot(sessionStorage) };
-      });
       const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }));
-      await use({ app, page, pristine: true, sessionId, throughSequence, storage, viewport });
+      await use({ app, page, pristine: true, viewport });
     });
   }, { scope: 'worker' }],
   // A multi-prompt transcript for the prompt anchor rail. Shown, because every

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -34,6 +34,8 @@ import {
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import { buildFixtureEnv, isCiLinuxDisplay } from '../../../scripts/fixture-env.mjs';
 import { closeElectronApplication } from '../../../scripts/electron-lifecycle.mjs';
+import { PROMPT_RAIL_SESSION_ID } from '../src/main/e2e-fixture/seed-helpers';
+import { desktopSessionKey } from '../src/shared/runtime-host-identity';
 
 const DESKTOP_ROOT = process.cwd();
 const execFileAsync = promisify(execFile);
@@ -487,7 +489,56 @@ async function withE2eWindow(
   }
 }
 
-export const test = base.extend<{
+interface PromptRailWorker {
+  app: ElectronApplication;
+  page: Page;
+  pristine: boolean;
+  sessionId: string;
+  throughSequence: number;
+  storage: {
+    local: Record<string, string>;
+    session: Record<string, string>;
+  };
+  viewport: { width: number; height: number };
+}
+
+async function setPromptRailWindowVisible(
+  worker: PromptRailWorker,
+  visible: boolean,
+): Promise<void> {
+  await worker.app.evaluate(({ BrowserWindow }, shouldShow) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window) throw new Error('the prompt-rail BrowserWindow is missing');
+    if (shouldShow) window.show();
+    else window.hide();
+  }, visible);
+}
+
+async function resetPromptRailWindow(worker: PromptRailWorker): Promise<void> {
+  if (worker.pristine) {
+    worker.pristine = false;
+    return;
+  }
+  await worker.page.evaluate(async ({ sessionId, throughSequence }) => {
+    const transcript = await window.maka.transcripts.open(sessionId, () => undefined);
+    try {
+      await transcript.loadAround(throughSequence);
+    } finally {
+      await transcript.close();
+    }
+  }, { sessionId: worker.sessionId, throughSequence: worker.throughSequence });
+  await worker.page.evaluate(({ local, session }) => {
+    localStorage.clear();
+    sessionStorage.clear();
+    for (const [key, value] of Object.entries(local)) localStorage.setItem(key, value);
+    for (const [key, value] of Object.entries(session)) sessionStorage.setItem(key, value);
+  }, worker.storage);
+  await worker.page.setViewportSize(worker.viewport);
+  await worker.page.reload();
+  await worker.page.waitForSelector('[data-turn-id]', { timeout: 20_000 });
+}
+
+type E2eTestFixtures = {
   window: Page;
   onboardingWindow: Page;
   gitReviewWindow: { page: Page; projectRoot: string };
@@ -503,7 +554,30 @@ export const test = base.extend<{
   newTaskTargetWindow: Page;
   directoryReferenceWindow: { page: Page; folder: string };
   accessibilityNarrativeWindow: Page;
-}>({
+};
+
+type E2eWorkerFixtures = {
+  isolatedDisplay: void;
+  promptRailWorker: PromptRailWorker;
+};
+
+export const test = base.extend<E2eTestFixtures, E2eWorkerFixtures>({
+  isolatedDisplay: [async ({}, use, workerInfo) => {
+    const base = process.env.MAKA_E2E_X_DISPLAY_BASE;
+    if (base === undefined) {
+      await use();
+      return;
+    }
+    if (!/^\d+$/.test(base)) throw new Error(`Invalid E2E X display base: ${base}`);
+    const previous = process.env.DISPLAY;
+    process.env.DISPLAY = `:${Number(base) + workerInfo.parallelIndex}`;
+    try {
+      await use();
+    } finally {
+      if (previous === undefined) delete process.env.DISPLAY;
+      else process.env.DISPLAY = previous;
+    }
+  }, { scope: 'worker', auto: true }],
   directoryReferenceWindow: async ({}, use) => {
     await withE2eWindow(
       { seed: true, readinessSelector: COMPOSER_INPUT, locale: 'zh', showWindow: true },
@@ -609,9 +683,10 @@ export const test = base.extend<{
       use,
     );
   },
-  // A multi-prompt transcript for the prompt anchor rail. Shown, because every
-  // assertion in prompt-rail.spec.ts is geometry the compositor has to settle.
-  promptRailWindow: async ({}, use) => {
+  // This scenario is read-only at the Host boundary. Keep its real Electron +
+  // Host composition warm for the worker, while the test-scoped wrapper below
+  // restores Host and renderer state between tests.
+  promptRailWorker: [async ({}, use) => {
     await withE2eWindow({
       seed: false,
       // A rendered turn, deliberately not the rail: Playwright treats a
@@ -621,7 +696,40 @@ export const test = base.extend<{
       readinessSelector: '[data-turn-id]',
       e2eFixtureScenario: 'chat-prompt-rail',
       showWindow: true,
-    }, use);
+    }, async (page, { app }) => {
+      const hostId = await page.evaluate(async () =>
+        (await window.maka.runtimeHostProfiles.getSnapshot()).entries
+          .find(({ isDefault }) => isDefault)?.hostId);
+      if (!hostId) throw new Error('the prompt-rail fixture has no ready default Host');
+      const sessionId = desktopSessionKey({ hostId, sessionId: PROMPT_RAIL_SESSION_ID });
+      const throughSequence = await page.evaluate(async (selectedSessionId) =>
+        (await window.maka.sessions.listTurnLandmarks(selectedSessionId)).throughSequence,
+      sessionId);
+      if (throughSequence === null) throw new Error('the prompt-rail fixture has no transcript');
+      const storage = await page.evaluate(() => {
+        const snapshot = (source: Storage) => Object.fromEntries(
+          Array.from({ length: source.length }, (_, index) => {
+            const key = source.key(index);
+            if (key === null) throw new Error('browser storage changed while being read');
+            return [key, source.getItem(key) ?? ''];
+          }),
+        );
+        return { local: snapshot(localStorage), session: snapshot(sessionStorage) };
+      });
+      const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }));
+      await use({ app, page, pristine: true, sessionId, throughSequence, storage, viewport });
+    });
+  }, { scope: 'worker' }],
+  // A multi-prompt transcript for the prompt anchor rail. Shown, because every
+  // assertion in prompt-rail.spec.ts is geometry the compositor has to settle.
+  promptRailWindow: async ({ promptRailWorker }, use) => {
+    await setPromptRailWindowVisible(promptRailWorker, true);
+    try {
+      await resetPromptRailWindow(promptRailWorker);
+      await use(promptRailWorker.page);
+    } finally {
+      await setPromptRailWindowVisible(promptRailWorker, false);
+    }
   },
   // A transcript larger than the bounded Desktop range. Clicking an unloaded
   // prompt exercises the real load-around path and its partial-history UI.

--- a/apps/desktop/e2e/native-transcript-perf.spec.ts
+++ b/apps/desktop/e2e/native-transcript-perf.spec.ts
@@ -24,6 +24,8 @@ import { ensureSidebarExpanded, expect, test } from './fixtures';
 
 const PERF_ENABLED = process.env.MAKA_TRANSCRIPT_PERF === '1';
 const STRESS_ENABLED = process.env.MAKA_TRANSCRIPT_STRESS === '1';
+const performanceTest = PERF_ENABLED ? test : test.skip;
+const stressTest = STRESS_ENABLED ? test : test.skip;
 const SCROLLER = '[data-chat-scroll-container="true"]';
 
 interface BrowserCounters {
@@ -250,10 +252,9 @@ async function measureSessionSwitch(page: Page): Promise<number> {
   return performance.now() - start;
 }
 
-test('LoAF capability is explicit when Chromium cannot measure it', async ({
+performanceTest('LoAF capability is explicit when Chromium cannot measure it', async ({
   promptRailWindow: page,
 }) => {
-  test.skip(!PERF_ENABLED, 'manual same-build CDP A/B harness');
   await page.evaluate(() => {
     Object.defineProperty(PerformanceObserver, 'supportedEntryTypes', {
       configurable: true,
@@ -265,8 +266,7 @@ test('LoAF capability is explicit when Chromium cannot measure it', async ({
   expect(frames.loafSupported).toBe(false);
 });
 
-test('warm native transcript scroll metrics', async ({ promptRailWindow: page }) => {
-  test.skip(!PERF_ENABLED, 'manual same-build CDP A/B harness');
+performanceTest('warm native transcript scroll metrics', async ({ promptRailWindow: page }) => {
   test.setTimeout(90_000);
   await page.setViewportSize({ width: 1_000, height: 700 });
   await expect(page.locator('[data-turn-id="turn-prompt-rail-120"]')).toHaveCount(1);
@@ -323,10 +323,9 @@ test('warm native transcript scroll metrics', async ({ promptRailWindow: page })
   console.log(`TRANSCRIPT_PERF ${JSON.stringify(result)}`);
 });
 
-test('600+ Turn repeated paging keeps the active range on a memory plateau', async ({
+stressTest('600+ Turn repeated paging keeps the active range on a memory plateau', async ({
   promptRailWindow: page,
 }) => {
-  test.skip(!STRESS_ENABLED, 'manual 600+ Turn stress harness');
   test.setTimeout(180_000);
   await page.setViewportSize({ width: 1_000, height: 700 });
   const cdp = await page.context().newCDPSession(page);

--- a/apps/desktop/e2e/playwright.config.ts
+++ b/apps/desktop/e2e/playwright.config.ts
@@ -22,19 +22,20 @@ import { defineConfig } from '@playwright/test';
 /**
  * Playwright config for the desktop Electron E2E suite.
  *
- * Each test launches a real Electron window backed by the deterministic fake
- * backend (MAKA_E2E=1) against its OWN throwaway userData dir (the fixture
- * mkdtemps one per test), so windows share no *state*. A Runtime Host-backed
- * window owns both Electron and an execution candidate process. Keep the
- * default at one worker: concurrent hidden windows throttle animation frames
- * and share OS focus, invalidating geometry and focus contracts. Developers
- * can still pass `--workers` explicitly for a subset that has neither concern.
+ * Most tests launch a real Electron window backed by the deterministic fake
+ * backend (MAKA_E2E=1) against their OWN throwaway userData dir. The read-only
+ * prompt-rail scenario instead keeps its Electron + Host composition warm for
+ * a worker and resets its Host range and renderer state per test. Keep the
+ * local default at one worker: concurrent windows share OS focus, invalidating
+ * geometry and focus contracts. Developers can still pass `--workers`
+ * explicitly for a subset that has neither concern.
  * Deliberately no test count here — the previous note carried a stale one that
  * outlived two rounds of pruning. `playwright test --list` is the only figure
  * that cannot rot.
  *
- * CI shards run on isolated X displays, so jobs still overlap without sharing
- * focus or a compositor. Local parallelism is opt-in for the same reason.
+ * CI gives every Playwright worker an isolated X display, so they overlap
+ * without sharing focus or a compositor. Local parallelism is opt-in for the
+ * same reason.
  *
  * Run from apps/desktop via `npm run e2e`, which builds the app first.
  */

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -577,6 +577,89 @@ test('does not hold Host observation recovery on transcript replay', async () =>
   await observations.close();
 });
 
+test('releases one renderer target before reload without restoring its observations', async () => {
+  const observations = new RuntimeHostSessionObservationRegistry();
+  const sessionCleanup = deferred<void>();
+  const transcriptCleanup = deferred<void>();
+  const unobserved: string[] = [];
+  const closedTranscripts: string[] = [];
+  const firstSource = {
+    async observe() {},
+    async unobserve(observerId: string) {
+      unobserved.push(observerId);
+      await sessionCleanup.promise;
+    },
+    async openTranscript(sessionId: string) {
+      return {
+        sessionId,
+        generation: 'first',
+        hostEpoch: 'host-first',
+        readThroughMessageId: null,
+      };
+    },
+    async loadTranscriptBefore() {},
+    async loadTranscriptAround() {},
+    async closeTranscript(consumerId: string) {
+      closedTranscripts.push(consumerId);
+      await transcriptCleanup.promise;
+    },
+  };
+  const targetA = {
+    id: 31,
+    send() {},
+    once() {},
+    off() {},
+  } satisfies RuntimeHostSessionObserverTarget & RuntimeHostTranscriptTarget;
+  const targetB = {
+    id: 32,
+    send() {},
+    once() {},
+    off() {},
+  } satisfies RuntimeHostSessionObserverTarget;
+
+  await observations.attach(firstSource);
+  await observations.observe('session-a', 'observer-a', targetA);
+  await observations.openTranscript('session-a', 'consumer-a', targetA);
+  await observations.observe('session-b', 'observer-b', targetB);
+
+  let released = false;
+  const releasing = observations.releaseTarget(targetA.id).then(() => {
+    released = true;
+  });
+  assert.deepEqual(unobserved, ['observer-a']);
+  assert.deepEqual(closedTranscripts, ['consumer-a']);
+  assert.deepEqual(observations.trackedSessionIds(), ['session-b']);
+  assert.equal(released, false);
+
+  sessionCleanup.resolve();
+  await Promise.resolve();
+  assert.equal(released, false);
+  transcriptCleanup.resolve();
+  await releasing;
+  assert.equal(released, true);
+
+  observations.detach(firstSource);
+  const restoredObservers: string[] = [];
+  const restoredTranscripts: string[] = [];
+  const secondSource = {
+    async observe(_sessionId: string, observerId: string) {
+      restoredObservers.push(observerId);
+    },
+    async unobserve() {},
+    async openTranscript(_sessionId: string, consumerId: string) {
+      restoredTranscripts.push(consumerId);
+      throw new Error('released transcript was restored');
+    },
+    async loadTranscriptBefore() {},
+    async loadTranscriptAround() {},
+    async closeTranscript() {},
+  };
+  assert.deepEqual(await observations.attach(secondSource), ['session-b']);
+  assert.deepEqual(restoredObservers, ['observer-b']);
+  assert.deepEqual(restoredTranscripts, []);
+  await observations.close();
+});
+
 test('fences transcript range failures to the current registration and Host source', async () => {
   const observations = new RuntimeHostSessionObservationRegistry();
   const target: RuntimeHostTranscriptTarget = {

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -1035,6 +1035,7 @@ const startLocalRuntimeHostManager = () => startRuntimeHostDesktopManager(
     },
     emitSessionsChanged,
     completeComputerUseTurn,
+    enableE2eControls: isE2e,
     createSessionCopyCleanup: ({ removeSession, resumeSessionCopy }) =>
       createSessionCopyCleanupAuthority({
         workspaceRoot,

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -136,6 +136,7 @@ export interface DesktopRuntimeHostCandidateDeps {
   readonly completeComputerUseTurn: (
     sessionId: string,
   ) => void | Promise<void>;
+  readonly enableE2eControls?: boolean;
   readonly e2eInteractions?: RuntimeHostSessionExecutionIpcDeps["e2eInteractions"];
   readonly renderer?: {
     send(channel: string, scope: DesktopTargetScope, payload: unknown): void;
@@ -659,6 +660,7 @@ export async function createDesktopRuntimeHostCandidate(
         },
       },
       ipc,
+      deps.enableE2eControls === true,
     );
     if (target.access === 'session_guest') {
       const trackedSessionIds = sessionObservations.trackedSessionIds();

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -177,6 +177,7 @@ export interface RuntimeHostSessionObservationIpcDeps {
     | 'loadTranscriptBefore'
     | 'observe'
     | 'openTranscript'
+    | 'releaseTarget'
   >;
   resolveSideConversation(sessionId: string): Promise<boolean>;
 }
@@ -185,6 +186,7 @@ export interface RuntimeHostSessionObservationIpcDeps {
 export function registerRuntimeHostSessionObservationIpc(
   deps: RuntimeHostSessionObservationIpcDeps,
   ipcMain: ReconnectableReadIpcMain,
+  enableE2eControls = false,
 ): void {
   handleReconnectableRead(
     ipcMain,
@@ -220,6 +222,11 @@ export function registerRuntimeHostSessionObservationIpc(
       event.sender.id,
     );
   });
+  if (enableE2eControls) {
+    ipcMain.handle('sessions:e2e:release-renderer-observations', (event) =>
+      deps.observations.releaseTarget(event.sender.id),
+    );
+  }
 }
 
 /**

--- a/apps/desktop/src/main/runtime-host-session-observation-registry.ts
+++ b/apps/desktop/src/main/runtime-host-session-observation-registry.ts
@@ -223,6 +223,35 @@ export class RuntimeHostSessionObservationRegistry {
     }
   }
 
+  async releaseTarget(targetId: number): Promise<void> {
+    const source = this.#source;
+    const observations = [...this.#registrations].filter(
+      ([, registration]) => registration.target.id === targetId,
+    );
+    const transcripts = [...this.#transcripts].filter(
+      ([, registration]) => registration.target.id === targetId,
+    );
+    for (const [observerId, registration] of observations) {
+      this.#deleteRegistration(observerId, registration);
+    }
+    for (const [consumerId, registration] of transcripts) {
+      this.#deleteTranscript(consumerId, registration);
+    }
+    if (!source) return;
+
+    const cleanup = await Promise.allSettled([
+      ...observations.map(([observerId]) => source.unobserve(observerId)),
+      ...transcripts.map(([consumerId]) => source.closeTranscript?.(consumerId, targetId)),
+    ]);
+    const errors = cleanup
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map((result) => result.reason);
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) {
+      throw new AggregateError(errors, 'Failed to release renderer Session observations');
+    }
+  }
+
   detach(source: SessionObservationSource): void {
     if (this.#source === source) {
       this.#source = undefined;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3729,6 +3729,9 @@ if (process.env.MAKA_E2E === '1' && process.env.MAKA_E2E_USER_DATA_DIR) {
         invocableSkillsWaiters.set(sessionId, waiters);
       });
     },
+    releaseRendererObservations() {
+      return invokeActiveRuntimeHost<void>('sessions:e2e:release-renderer-observations');
+    },
     rejectNextSessionObservation(message: string) {
       nextSessionObservationError = new Error(message);
     },

--- a/scripts/audit-alignment.mjs
+++ b/scripts/audit-alignment.mjs
@@ -68,6 +68,9 @@ const FIXTURES = [
 // fixture) still proceeds on the old CI-gate budget.
 const SETTLE_MS = Number(process.env.AUDIT_SETTLE_MS ?? 2_500);
 const QUIET_MS = Number(process.env.AUDIT_QUIET_MS ?? 500);
+// Fixtures own separate Electron user-data roots and never synthesize focus or
+// pointer input, so they can fill the four hosted-runner cores safely.
+const CONCURRENCY = 4;
 
 // Resolves once the DOM has stayed mutation-free for `quietMs`, bounded by
 // `budgetMs` overall. Runs after withFixtureWindow's own settle expression,
@@ -85,9 +88,6 @@ const QUIESCENT_EXPR = (quietMs, budgetMs) => `new Promise((resolve)=>{
   };
   tick();
 })`;
-let totalIssues = 0;
-let fixtureErrors = 0;
-
 const EXPR = `(()=>{
   const controls=[...document.querySelectorAll('button,[role=button],[role=switch],input,select,[role=combobox],[role=tab]')].filter(e=>{
     const r=e.getBoundingClientRect();
@@ -123,7 +123,7 @@ const EXPR = `(()=>{
   return JSON.stringify(issues.slice(0,12));
 })()`;
 
-for (const [fixture, readySelector] of FIXTURES) {
+async function auditFixture([fixture, readySelector]) {
   try {
     const issues = await withFixtureWindow(
       fixture,
@@ -133,14 +133,35 @@ for (const [fixture, readySelector] of FIXTURES) {
         return JSON.parse(await evaluate(EXPR));
       },
     );
-    console.log('==', fixture, '==');
-    for (const issue of issues) console.log(JSON.stringify(issue));
-    totalIssues += issues.length;
-    if (!issues.length) console.log('(clean)');
+    return { fixture, issues };
   } catch (err) {
-    console.log('==', fixture, '== ERROR', err.message);
-    fixtureErrors++;
+    return { fixture, error: err instanceof Error ? err.message : String(err) };
   }
+}
+
+const results = new Array(FIXTURES.length);
+let nextFixture = 0;
+await Promise.all(
+  Array.from({ length: Math.min(CONCURRENCY, FIXTURES.length) }, async () => {
+    while (nextFixture < FIXTURES.length) {
+      const index = nextFixture++;
+      results[index] = await auditFixture(FIXTURES[index]);
+    }
+  }),
+);
+
+let totalIssues = 0;
+let fixtureErrors = 0;
+for (const result of results) {
+  if (result.error) {
+    console.log('==', result.fixture, '== ERROR', result.error);
+    fixtureErrors++;
+    continue;
+  }
+  console.log('==', result.fixture, '==');
+  for (const issue of result.issues) console.log(JSON.stringify(issue));
+  totalIssues += result.issues.length;
+  if (!result.issues.length) console.log('(clean)');
 }
 
 // CI semantics: alignment findings fail the run; fixture-level launch errors

--- a/scripts/audit-alignment.mjs
+++ b/scripts/audit-alignment.mjs
@@ -127,7 +127,7 @@ async function auditFixture([fixture, readySelector]) {
   try {
     const issues = await withFixtureWindow(
       fixture,
-      { theme: 'light', readySelector, settleMs: 0 },
+      { theme: 'light', readySelector, settleMs: QUIET_MS },
       async ({ evaluate }) => {
         await evaluate(QUIESCENT_EXPR(QUIET_MS, SETTLE_MS));
         return JSON.parse(await evaluate(EXPR));

--- a/scripts/smoke-release-cli-package.mjs
+++ b/scripts/smoke-release-cli-package.mjs
@@ -172,13 +172,31 @@ async function validateInstalledProduct(root) {
   await smokeNativeFileLock(packageRoot, root);
   await smokeRuntimeHostPeerProtocol({ packageRoot, cliEntrypoint, root });
 
+  // These flows own separate roots and each proves the packaged Host's idle
+  // retirement. Start both before awaiting so the same 30-second grace window
+  // is observed once in wall-clock time rather than twice in series.
   logStep('checking the interactive TUI setup path');
-  await smokeInteractiveTui({
+  const interactiveTui = smokeInteractiveTui({
     packageRoot,
     cliEntrypoint,
     ptySpawn,
     root: join(root, 'first-run'),
   });
+
+  logStep('checking a filesystem-backed controlled model turn');
+  const controlledRun = smokeControlledRun({
+    packageRoot,
+    cliEntrypoint,
+    root: join(root, 'controlled-run'),
+  });
+  const smokeResults = await Promise.allSettled([interactiveTui, controlledRun]);
+  const smokeFailures = smokeResults.flatMap((result) =>
+    result.status === 'rejected' ? [result.reason] : [],
+  );
+  if (smokeFailures.length === 1) throw smokeFailures[0];
+  if (smokeFailures.length > 1) {
+    throw new AggregateError(smokeFailures, 'Installed CLI product flows both failed');
+  }
 
   logStep('checking the managed Runtime Host lifecycle');
   await smokeRuntimeHostService({
@@ -186,13 +204,6 @@ async function validateInstalledProduct(root) {
     cliEntrypoint,
     ptySpawn,
     root: join(root, 'runtime-host-service'),
-  });
-
-  logStep('checking a filesystem-backed controlled model turn');
-  await smokeControlledRun({
-    packageRoot,
-    cliEntrypoint,
-    root: join(root, 'controlled-run'),
   });
 
   console.log(

--- a/scripts/storybook-visual-smoke.mjs
+++ b/scripts/storybook-visual-smoke.mjs
@@ -60,6 +60,8 @@ const REQUIRED_COMPUTER_USE_STORY_IDS = new Set([
 // The smoke observes render completion, focus, and the accessibility tree; it
 // does not compare pixels. Every story supplies that structural evidence once,
 // while these canonical surfaces also prove the separate dark token block.
+// Dark mode currently changes only paint tokens, with no dark-only DOM, layout,
+// or renderer branches; expand this set if that invariant changes.
 const DARK_THEME_SENTINEL_STORY_IDS = new Set([
   'design-system-palette-matrix--all-palettes',
   'product-accessibility-dialogs--rename-conversation',

--- a/scripts/storybook-visual-smoke.mjs
+++ b/scripts/storybook-visual-smoke.mjs
@@ -57,6 +57,16 @@ const REQUIRED_COMPUTER_USE_STORY_IDS = new Set([
   'product-shell-official-appshell--native-conversation',
   'product-shell-official-appshell--waiting-for-permission',
 ]);
+// The smoke observes render completion, focus, and the accessibility tree; it
+// does not compare pixels. Every story supplies that structural evidence once,
+// while these canonical surfaces also prove the separate dark token block.
+const DARK_THEME_SENTINEL_STORY_IDS = new Set([
+  'design-system-palette-matrix--all-palettes',
+  'product-accessibility-dialogs--rename-conversation',
+  'product-markdown--rich-assistant-answer',
+  'product-settings-pages--appearance',
+  'product-shell-official-appshell--default-layout',
+]);
 
 // This is a catalog render and accessibility-tree health check.
 // Story `play` functions do run: many stories reach their named final state
@@ -119,12 +129,6 @@ function installStorybookRenderProbe({ storyId }) {
   connect();
 }
 
-/* Both schemes, not just light. Dark is where a theme regression actually
-   hides: light and dark are separate token blocks, so a rule that resolves in
-   one can be undefined, inverted or invisible in the other and nothing in a
-   light-only sweep says so. Every story runs twice. */
-const COLOR_SCHEMES = ['light', 'dark'];
-
 export function catalogJobs(storyIndex) {
   const entries = storyIndex?.entries;
   if (!entries || typeof entries !== 'object' || Array.isArray(entries)) {
@@ -132,7 +136,12 @@ export function catalogJobs(storyIndex) {
   }
   const jobs = Object.values(entries)
     .filter((entry) => entry?.type === 'story' && typeof entry.id === 'string')
-    .flatMap((entry) => COLOR_SCHEMES.map((colorScheme) => ({ storyId: entry.id, colorScheme })));
+    .flatMap((entry) => [
+      { storyId: entry.id, colorScheme: 'light' },
+      ...(DARK_THEME_SENTINEL_STORY_IDS.has(entry.id)
+        ? [{ storyId: entry.id, colorScheme: 'dark' }]
+        : []),
+    ]);
   if (jobs.length === 0) throw new Error('Built Storybook index has no stories');
   return jobs;
 }
@@ -325,9 +334,11 @@ async function runCli() {
   const storyIndex = await readFile(join(staticDir, 'index.json'), 'utf8').then(JSON.parse);
   const jobs = catalogJobs(storyIndex);
   const storyIds = new Set(jobs.map((job) => job.storyId));
-  const missingRequiredStories = [...REQUIRED_COMPUTER_USE_STORY_IDS].filter(
-    (storyId) => !storyIds.has(storyId),
-  );
+  const requiredStoryIds = new Set([
+    ...REQUIRED_COMPUTER_USE_STORY_IDS,
+    ...DARK_THEME_SENTINEL_STORY_IDS,
+  ]);
+  const missingRequiredStories = [...requiredStoryIds].filter((storyId) => !storyIds.has(storyId));
   if (missingRequiredStories.length > 0) {
     throw new Error(
       `Computer Use story inventory is missing: ${missingRequiredStories.join(', ')}`,
@@ -347,7 +358,7 @@ async function runCli() {
     throw new Error(`${problems.length} story render(s) failed:\n${problems.join('\n')}`);
   }
   process.stdout.write(
-    `Storybook render smoke passed (${storyIds.size} stories x ${COLOR_SCHEMES.length} schemes = ${jobs.length} renders).\n`,
+    `Storybook render smoke passed (${storyIds.size} stories, ${jobs.length} theme renders).\n`,
   );
 }
 


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

The required single-runner `test` job was dominated by repeated Desktop process startup, serialized independent Electron fixtures, duplicate theme smoke passes, and two independent packaged Runtime Host retirement waits.

This PR removes those waits at their owners while keeping the existing one-job topology:

- runs Desktop E2E on four isolated Xvfb displays/Playwright workers and keeps the read-only prompt-rail Electron + Host composition warm per worker; before reloading the same WebContents, an isolated E2E bridge releases exactly that renderer's Session observations and transcript consumers, awaits Host cleanup, clears browser storage, and restores the viewport;
- schedules the 12 isolated alignment fixtures with bounded concurrency of four while preserving deterministic result order;
- renders all 251 Storybook stories in light mode with the existing render, focus, and accessibility-tree checks, then exercises five representative dark-theme sentinels instead of duplicating all 251 non-visual checks;
- overlaps the two independent packaged CLI flows that wait for the same Runtime Host idle-retirement grace period, using `Promise.allSettled` so both cleanup paths finish before an error is reported.

Core CI still has exactly one `test` job and uses no additional runners. Xvfb is already operationally headless; the Desktop suite intentionally keeps real `BrowserWindow` rendering because its geometry, focus, selection, resize, titlebar, and compositor contracts would not be tested by Electron offscreen rendering.

### Final result

Observed GitHub Actions wall time on the same Ubuntu job shape, comparing the [original baseline](https://github.com/apache/maka/actions/runs/33578194686) with the [final green run](https://github.com/apache/maka/actions/runs/33594513491):

| Surface | Baseline | Final | Reduction |
| --- | ---: | ---: | ---: |
| Required `test` job | 26:54 | 16:13 | 10:41 (39.7%) |
| Desktop E2E | 10:32 | 4:27 | 6:05 (57.8%) |
| Alignment audit | 0:56 | 0:23 | 0:33 (58.9%) |
| Storybook smoke | 3:32 | 1:28 | 2:04 (58.5%) |
| Installed CLI validation | 1:21 | 0:46 | 0:35 (43.2%) |

Compared with the previous green iteration, Desktop E2E fell from 5:42 to 4:27 and the complete job from 19:20 to 16:13. Total observed savings against the original job are 10:41. No production application behavior or UI changes.

## Verification

- [Final core CI run](https://github.com/apache/maka/actions/runs/33594513491): the single required `test` job passed in 16:13; Desktop E2E discovered 104 tests, passed 100, and intentionally skipped four manual/platform-specific cases
- [CLI package validation matrix](https://github.com/apache/maka/actions/runs/33594513554): all required platform checks passed
- `npm run build:test`
- Node IPC/registry/candidate lifecycle tests: 85/85 passed
- Direct warm-fixture callers repeated twice: 40/40 passed; focused release/reload reuse: 4/4 passed
- `node --test --test-concurrency=1 scripts/ci-test-plan.test.mjs scripts/ci-workflow-policy.test.mjs scripts/script-entrypoints.test.mjs`: 74/74 passed
- Remote alignment audit: all 12 fixtures clean; remote Storybook smoke: 251 stories / 256 theme renders passed; installed CLI smoke passed
- Six bounded parallel deep-review/simplification rounds converged; the final fresh round reported no confirmed correctness findings and no qualifying simplification
- `git diff --check`
- Screenshots are not applicable because this PR changes CI/test execution only

## Root cause

The longest checks were paying serialization or cold-start costs that were not part of the contracts being verified. Native Desktop interactions require isolation, not one global worker; a retained WebContents requires explicit renderer-owned Host cleanup before reload, not a new Electron + Host process for every read-only assertion; alignment fixtures require separate user-data roots, not serial execution; structural Storybook smoke does not gain independent pixel/contrast evidence by repeating every story in both themes; and independent CLI flows do not need to wait for identical idle timers sequentially.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex investigated CI wall time and lifecycle costs, implemented the bounded scheduling and fixture changes, and ran the verification above. All three commits include `Generated-by: Codex` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — CI scheduling and test-fixture lifecycles change as described under Summary; production behavior does not
- [ ] No

</details>

<details>
<summary>中文</summary>

## Summary

必需的单 runner `test` job 主要耗时在重复启动 Desktop 进程、串行执行互不依赖的 Electron fixture、重复执行两套主题 smoke，以及顺序等待两个独立的 Runtime Host 退场计时器。

本 PR 在耗时源头消除这些等待，同时保留现有单 job 拓扑：

- Desktop E2E 使用四个相互隔离的 Xvfb display/Playwright worker，并在每个 worker 内复用只读的 prompt-rail Electron + Host composition；同一 WebContents reload 前，隔离的 E2E bridge 会精确释放该 renderer 的 Session observation 与 transcript consumer，等待 Host 清理完成，再清空浏览器存储并恢复 viewport；
- 12 个相互隔离的 alignment fixture 以四路有界并发执行，结果仍按固定顺序输出；
- 251 个 Storybook story 仍全部在浅色模式执行现有 render、focus 和 accessibility tree 检查；深色模式保留五个有代表性的 sentinel，不再把 251 个非视觉检查机械重复一遍；
- 两个独立的已安装 CLI 流程并发等待相同的 Runtime Host idle-retirement 宽限期，并用 `Promise.allSettled` 保证报错前两个清理路径都已结束。

核心 CI 仍然只有一个 `test` job，没有增加 runner。Xvfb 在运行方式上已经是无头环境；Desktop 测试仍有意使用真实 `BrowserWindow`，因为 geometry、focus、selection、resize、titlebar 和 compositor 合约无法通过 Electron offscreen 渲染验证。

### 最终结果

在相同 Ubuntu job 形态下，对比 [原始基线](https://github.com/apache/maka/actions/runs/33578194686) 与 [最终全绿运行](https://github.com/apache/maka/actions/runs/33594513491) 的 GitHub Actions 实测 wall time：

| 测试面 | 基线 | 最终 | 缩短 |
| --- | ---: | ---: | ---: |
| 必需的 `test` job | 26:54 | 16:13 | 10:41（39.7%） |
| Desktop E2E | 10:32 | 4:27 | 6:05（57.8%） |
| Alignment audit | 0:56 | 0:23 | 0:33（58.9%） |
| Storybook smoke | 3:32 | 1:28 | 2:04（58.5%） |
| 已安装 CLI 验证 | 1:21 | 0:46 | 0:35（43.2%） |

相较上一轮全绿结果，Desktop E2E 从 5:42 继续降到 4:27，完整 job 从 19:20 降到 16:13；相对原始 job 共实测缩短 10:41。生产应用行为和 UI 均未改变。

## Verification

- [最终核心 CI](https://github.com/apache/maka/actions/runs/33594513491)：唯一必需的 `test` job 以 16:13 全绿；Desktop E2E 共发现 104 条测试，其中 100 条通过，4 条手动/平台专用测试按设计跳过
- [CLI package validation matrix](https://github.com/apache/maka/actions/runs/33594513554)：所有必需平台检查通过
- `npm run build:test`
- Node IPC / registry / candidate 生命周期测试：85/85 通过
- 直接使用 warm fixture 的测试连续运行两轮：40/40 通过；聚焦 release/reload 复用：4/4 通过
- `node --test --test-concurrency=1 scripts/ci-test-plan.test.mjs scripts/ci-workflow-policy.test.mjs scripts/script-entrypoints.test.mjs`：74/74 通过
- 远端 alignment audit：12 个 fixture 全部 clean；远端 Storybook smoke：251 个 story / 256 次主题渲染通过；已安装 CLI smoke 通过
- 六轮有界并行深度审查/简化审计已收敛；最终 fresh round 没有确认的 correctness finding，也没有符合条件的简化项
- `git diff --check`
- 本 PR 只改变 CI/测试执行方式，不涉及界面，因而没有适用的截图

## Root cause

最长的检查在为不属于被验证合约的串行限制或冷启动付费。原生 Desktop 交互需要的是隔离，而不是全局单 worker；复用 WebContents 需要在 reload 前显式清理 renderer 所拥有的 Host 状态，而不是为每条只读断言重新启动 Electron + Host；alignment fixture 需要独立 user-data root，而不是串行；结构型 Storybook smoke 把每个 story 在两种主题下各跑一次，并不会额外提供独立的像素/对比度证据；互不依赖的 CLI 流程也无需串行等待相同的 idle timer。

## AI use

请选择一项：

- [ ] 无生成式工具实质参与
- [x] 生成式工具有实质参与

工具与范围：Codex 分析 CI wall time 和生命周期成本，完成有界调度及 fixture 改动，并执行上述验证。三个提交均包含 `Generated-by: Codex` trailer。

## Checklist

- [x] 测试覆盖该改动，缺失相关隔离、重置或生命周期保证时会失败
- [x] lint、format、typecheck 和受影响测试均在本地通过

本 PR 是否改变行为？

- [x] 是——Summary 所述 CI 调度和测试 fixture 生命周期发生变化；生产行为不变
- [ ] 否

</details>
