### PR TITLE
fix(runtime-host): avoid false Guest reconnects

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -37,6 +37,7 @@ import type { DesktopRuntimeHostSession } from "../runtime-host-client.js";
 import {
   DESKTOP_TRANSCRIPT_FRAGMENT_MAX_BYTES,
   type DesktopTranscriptBatch,
+  type DesktopTranscriptOpenResult,
 } from '../../preload/transcript-contract.js';
 import { RuntimeHostSessionObservationRegistry } from "../runtime-host-session-observation-registry.js";
 import {
@@ -482,6 +483,73 @@ test('restores transcript consumers across Host replacement', async () => {
     ['first', 'second', 'third'],
   );
   assert.deepEqual(scopes, ['first', 'second', 'third']);
+  await observations.close();
+});
+
+test('does not hold Host observation recovery on transcript replay', async () => {
+  const observations = new RuntimeHostSessionObservationRegistry();
+  const target = eventTarget(18);
+  const transcriptTarget: RuntimeHostTranscriptTarget = {
+    id: 19,
+    send() {},
+    once() {},
+    off() {},
+  };
+  const transcriptResult = (generation: string) => ({
+    sessionId: 'session-1',
+    generation,
+    hostEpoch: `host-${generation}`,
+    readThroughMessageId: null,
+  });
+  const source = (generation: string) => ({
+    async observe() {},
+    async unobserve() {},
+    async openTranscript() {
+      return transcriptResult(generation);
+    },
+    async loadTranscriptBefore() {},
+    async loadTranscriptAround() {},
+    async closeTranscript() {},
+  });
+  const first = source('first');
+  await observations.attach(first);
+  await observations.observe('session-1', 'observer-1', target);
+  await observations.openTranscript('session-1', 'consumer-1', transcriptTarget);
+  observations.detach(first);
+
+  const observationSeed = deferred<void>();
+  const transcriptReplay = deferred<DesktopTranscriptOpenResult>();
+  let transcriptReplayStarted = false;
+  let transcriptReplayCompleted = false;
+  const replacement = {
+    async observe() {
+      await observationSeed.promise;
+    },
+    async unobserve() {},
+    async openTranscript() {
+      transcriptReplayStarted = true;
+      const result = await transcriptReplay.promise;
+      transcriptReplayCompleted = true;
+      return result;
+    },
+    async loadTranscriptBefore() {},
+    async loadTranscriptAround() {},
+    async closeTranscript() {},
+  };
+  const attaching = observations.attach(replacement);
+  let attached = false;
+  void attaching.then(() => {
+    attached = true;
+  });
+  await waitFor(() => transcriptReplayStarted);
+  assert.equal(attached, false);
+
+  observationSeed.resolve();
+  assert.deepEqual(await attaching, ['session-1']);
+  assert.equal(attached, true);
+
+  transcriptReplay.resolve(transcriptResult('second'));
+  await waitFor(() => transcriptReplayCompleted);
   await observations.close();
 });
 

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -521,6 +521,8 @@ test('does not hold Host observation recovery on transcript replay', async () =>
   const transcriptReplay = deferred<DesktopTranscriptOpenResult>();
   let transcriptReplayStarted = false;
   let transcriptReplayCompleted = false;
+  let transcriptRangeStarted = false;
+  let transcriptAcknowledged = false;
   const replacement = {
     async observe() {
       await observationSeed.promise;
@@ -532,8 +534,13 @@ test('does not hold Host observation recovery on transcript replay', async () =>
       transcriptReplayCompleted = true;
       return result;
     },
-    async loadTranscriptBefore() {},
+    async loadTranscriptBefore() {
+      transcriptRangeStarted = true;
+    },
     async loadTranscriptAround() {},
+    acknowledgeTranscript() {
+      transcriptAcknowledged = true;
+    },
     async closeTranscript() {},
   };
   const attaching = observations.attach(replacement);
@@ -548,7 +555,24 @@ test('does not hold Host observation recovery on transcript replay', async () =>
   assert.deepEqual(await attaching, ['session-1']);
   assert.equal(attached, true);
 
+  const range = observations.loadTranscriptBefore(
+    {
+      consumerId: 'consumer-1',
+      sessionId: 'session-1',
+      hostEpoch: 'host-second',
+      anchorSequence: null,
+      maxBytes: DESKTOP_TRANSCRIPT_FRAGMENT_MAX_BYTES,
+    },
+    transcriptTarget.id,
+  );
+  observations.acknowledgeTranscript('consumer-1', 'second', 1, transcriptTarget.id);
+  await Promise.resolve();
+  assert.equal(transcriptRangeStarted, false);
+  assert.equal(transcriptAcknowledged, true);
+
   transcriptReplay.resolve(transcriptResult('second'));
+  await range;
+  assert.equal(transcriptRangeStarted, true);
   await waitFor(() => transcriptReplayCompleted);
   await observations.close();
 });

--- a/apps/desktop/src/main/runtime-host-session-observation-registry.ts
+++ b/apps/desktop/src/main/runtime-host-session-observation-registry.ts
@@ -88,13 +88,8 @@ interface TranscriptRegistration {
   readonly target: RuntimeHostTranscriptTarget;
   readonly destroyedListener: () => void;
   readonly ready: TranscriptReadiness;
-  restore: TranscriptRestore | undefined;
+  restore: ObservationReadiness | undefined;
   lifecycle: 'pending' | 'active';
-}
-
-interface TranscriptRestore {
-  readonly source: SessionObservationSource;
-  readonly ready: ObservationReadiness;
 }
 
 interface TranscriptReadiness {
@@ -233,9 +228,7 @@ export class RuntimeHostSessionObservationRegistry {
       this.#source = undefined;
       this.#bindTarget = (target) => target;
       for (const registration of this.#transcripts.values()) {
-        if (registration.restore?.source === source) {
-          registration.restore.ready.resolve();
-        }
+        registration.restore?.resolve();
       }
     }
   }
@@ -418,16 +411,14 @@ export class RuntimeHostSessionObservationRegistry {
     const registrations = [...this.#registrations];
     const transcripts = [...this.#transcripts];
     this.#registrations.clear();
-    this.#transcripts.clear();
     for (const [, registration] of registrations) {
       registration.target.off("destroyed", registration.destroyedListener);
       registration.ready.reject(
         new Error("Session observation ended before it became ready"),
       );
     }
-    for (const [, registration] of transcripts) {
-      registration.target.off('destroyed', registration.destroyedListener);
-      registration.ready.reject(new Error('Transcript observation ended before it became ready'));
+    for (const [consumerId, registration] of transcripts) {
+      this.#deleteTranscript(consumerId, registration);
     }
     if (source) {
       await Promise.allSettled([
@@ -467,7 +458,7 @@ export class RuntimeHostSessionObservationRegistry {
     const source = requireTranscriptSource(this.#source);
     try {
       const restore = registration.restore;
-      if (restore?.source === source) await restore.ready.promise;
+      if (restore) await restore.promise;
       if (
         this.#source !== source ||
         this.#transcripts.get(consumerId) !== registration
@@ -490,12 +481,9 @@ export class RuntimeHostSessionObservationRegistry {
 
   #restoreTranscripts(source: SessionObservationSource): void {
     for (const [consumerId, registration] of this.#transcripts) {
-      registration.restore?.ready.resolve();
-      const restore: TranscriptRestore = {
-        source,
-        ready: observationReadiness(),
-      };
-      void restore.ready.promise.catch(() => undefined);
+      registration.restore?.resolve();
+      const restore = observationReadiness();
+      void restore.promise.catch(() => undefined);
       registration.restore = restore;
       void this.#restoreTranscript(source, consumerId, registration, restore);
     }
@@ -505,7 +493,7 @@ export class RuntimeHostSessionObservationRegistry {
     source: SessionObservationSource,
     consumerId: string,
     registration: TranscriptRegistration,
-    restore: TranscriptRestore,
+    restore: ObservationReadiness,
   ): Promise<void> {
     try {
       const transcriptSource = requireTranscriptSource(source);
@@ -522,9 +510,9 @@ export class RuntimeHostSessionObservationRegistry {
         registration.lifecycle = 'active';
         registration.ready.resolve(result);
         registration.restore = undefined;
-        restore.ready.resolve();
+        restore.resolve();
       } else {
-        restore.ready.resolve();
+        restore.resolve();
         await transcriptSource.closeTranscript(consumerId);
       }
     } catch (error) {
@@ -536,11 +524,11 @@ export class RuntimeHostSessionObservationRegistry {
         if (registration.lifecycle === 'pending') {
           this.#deleteTranscript(consumerId, registration);
         } else {
-          restore.ready.reject(error instanceof Error ? error : new Error(String(error)));
+          restore.reject(error instanceof Error ? error : new Error(String(error)));
         }
         this.#onError(error);
       } else {
-        restore.ready.resolve();
+        restore.resolve();
       }
     }
   }
@@ -548,7 +536,7 @@ export class RuntimeHostSessionObservationRegistry {
   #deleteTranscript(consumerId: string, registration: TranscriptRegistration): void {
     if (this.#transcripts.get(consumerId) !== registration) return;
     this.#transcripts.delete(consumerId);
-    registration.restore?.ready.resolve();
+    registration.restore?.resolve();
     registration.target.off('destroyed', registration.destroyedListener);
     registration.ready.reject(new Error('Transcript observation ended before it became ready'));
   }

--- a/apps/desktop/src/main/runtime-host-session-observation-registry.ts
+++ b/apps/desktop/src/main/runtime-host-session-observation-registry.ts
@@ -145,6 +145,13 @@ export class RuntimeHostSessionObservationRegistry {
     }
     this.#source = source;
     this.#bindTarget = bindTarget;
+    // Transcript replay is a recoverable renderer read replica, not part of
+    // the Runtime Host availability boundary. Start it alongside Session
+    // observation seeding, but do not keep the whole Host in `reconnecting`
+    // while a large transcript is replayed and acknowledged. The existing
+    // consumer remains registered and receives its replacement generation as
+    // soon as replay completes.
+    this.#restoreTranscripts(source);
     const restored = await Promise.all(
       [...this.#registrations].map(async ([observerId, registration]) => {
         try {
@@ -174,31 +181,6 @@ export class RuntimeHostSessionObservationRegistry {
             this.#onError(error);
           }
           return undefined;
-        }
-      }),
-    );
-    await Promise.all(
-      [...this.#transcripts].map(async ([consumerId, registration]) => {
-        try {
-          const transcriptSource = requireTranscriptSource(source);
-          const result = await transcriptSource.openTranscript(
-            registration.sessionId,
-            consumerId,
-            this.#bindTranscriptTarget(registration.target),
-          );
-          if (this.#source === source && this.#transcripts.get(consumerId) === registration) {
-            registration.lifecycle = 'active';
-            registration.ready.resolve(result);
-          } else {
-            await transcriptSource.closeTranscript(consumerId);
-          }
-        } catch (error) {
-          if (this.#source === source && this.#transcripts.get(consumerId) === registration) {
-            if (registration.lifecycle === 'pending') {
-              this.#deleteTranscript(consumerId, registration);
-            }
-            this.#onError(error);
-          }
         }
       }),
     );
@@ -483,6 +465,40 @@ export class RuntimeHostSessionObservationRegistry {
         return;
       }
       throw error;
+    }
+  }
+
+  #restoreTranscripts(source: SessionObservationSource): void {
+    for (const [consumerId, registration] of this.#transcripts) {
+      void this.#restoreTranscript(source, consumerId, registration);
+    }
+  }
+
+  async #restoreTranscript(
+    source: SessionObservationSource,
+    consumerId: string,
+    registration: TranscriptRegistration,
+  ): Promise<void> {
+    try {
+      const transcriptSource = requireTranscriptSource(source);
+      const result = await transcriptSource.openTranscript(
+        registration.sessionId,
+        consumerId,
+        this.#bindTranscriptTarget(registration.target),
+      );
+      if (this.#source === source && this.#transcripts.get(consumerId) === registration) {
+        registration.lifecycle = 'active';
+        registration.ready.resolve(result);
+      } else {
+        await transcriptSource.closeTranscript(consumerId);
+      }
+    } catch (error) {
+      if (this.#source === source && this.#transcripts.get(consumerId) === registration) {
+        if (registration.lifecycle === 'pending') {
+          this.#deleteTranscript(consumerId, registration);
+        }
+        this.#onError(error);
+      }
     }
   }
 

--- a/apps/desktop/src/main/runtime-host-session-observation-registry.ts
+++ b/apps/desktop/src/main/runtime-host-session-observation-registry.ts
@@ -88,7 +88,13 @@ interface TranscriptRegistration {
   readonly target: RuntimeHostTranscriptTarget;
   readonly destroyedListener: () => void;
   readonly ready: TranscriptReadiness;
+  restore: TranscriptRestore | undefined;
   lifecycle: 'pending' | 'active';
+}
+
+interface TranscriptRestore {
+  readonly source: SessionObservationSource;
+  readonly ready: ObservationReadiness;
 }
 
 interface TranscriptReadiness {
@@ -226,6 +232,11 @@ export class RuntimeHostSessionObservationRegistry {
     if (this.#source === source) {
       this.#source = undefined;
       this.#bindTarget = (target) => target;
+      for (const registration of this.#transcripts.values()) {
+        if (registration.restore?.source === source) {
+          registration.restore.ready.resolve();
+        }
+      }
     }
   }
 
@@ -316,6 +327,7 @@ export class RuntimeHostSessionObservationRegistry {
       target,
       destroyedListener,
       ready,
+      restore: undefined,
       lifecycle: 'pending',
     };
     this.#transcripts.set(consumerId, registration);
@@ -454,6 +466,14 @@ export class RuntimeHostSessionObservationRegistry {
     }
     const source = requireTranscriptSource(this.#source);
     try {
+      const restore = registration.restore;
+      if (restore?.source === source) await restore.ready.promise;
+      if (
+        this.#source !== source ||
+        this.#transcripts.get(consumerId) !== registration
+      ) {
+        return;
+      }
       await operation(source);
     } catch (error) {
       // Once either owner changes, this rejection belongs to stale work and
@@ -470,7 +490,14 @@ export class RuntimeHostSessionObservationRegistry {
 
   #restoreTranscripts(source: SessionObservationSource): void {
     for (const [consumerId, registration] of this.#transcripts) {
-      void this.#restoreTranscript(source, consumerId, registration);
+      registration.restore?.ready.resolve();
+      const restore: TranscriptRestore = {
+        source,
+        ready: observationReadiness(),
+      };
+      void restore.ready.promise.catch(() => undefined);
+      registration.restore = restore;
+      void this.#restoreTranscript(source, consumerId, registration, restore);
     }
   }
 
@@ -478,6 +505,7 @@ export class RuntimeHostSessionObservationRegistry {
     source: SessionObservationSource,
     consumerId: string,
     registration: TranscriptRegistration,
+    restore: TranscriptRestore,
   ): Promise<void> {
     try {
       const transcriptSource = requireTranscriptSource(source);
@@ -486,18 +514,33 @@ export class RuntimeHostSessionObservationRegistry {
         consumerId,
         this.#bindTranscriptTarget(registration.target),
       );
-      if (this.#source === source && this.#transcripts.get(consumerId) === registration) {
+      if (
+        this.#source === source &&
+        this.#transcripts.get(consumerId) === registration &&
+        registration.restore === restore
+      ) {
         registration.lifecycle = 'active';
         registration.ready.resolve(result);
+        registration.restore = undefined;
+        restore.ready.resolve();
       } else {
+        restore.ready.resolve();
         await transcriptSource.closeTranscript(consumerId);
       }
     } catch (error) {
-      if (this.#source === source && this.#transcripts.get(consumerId) === registration) {
+      if (
+        this.#source === source &&
+        this.#transcripts.get(consumerId) === registration &&
+        registration.restore === restore
+      ) {
         if (registration.lifecycle === 'pending') {
           this.#deleteTranscript(consumerId, registration);
+        } else {
+          restore.ready.reject(error instanceof Error ? error : new Error(String(error)));
         }
         this.#onError(error);
+      } else {
+        restore.ready.resolve();
       }
     }
   }
@@ -505,6 +548,7 @@ export class RuntimeHostSessionObservationRegistry {
   #deleteTranscript(consumerId: string, registration: TranscriptRegistration): void {
     if (this.#transcripts.get(consumerId) !== registration) return;
     this.#transcripts.delete(consumerId);
+    registration.restore?.ready.resolve();
     registration.target.off('destroyed', registration.destroyedListener);
     registration.ready.reject(new Error('Transcript observation ended before it became ready'));
   }

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -25,7 +25,7 @@ import { createServer, type Server } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { setImmediate as delayImmediate } from 'node:timers/promises';
+import { setImmediate as delayImmediate, setTimeout as delay } from 'node:timers/promises';
 import {
   prepareStorageRootControlDirectory,
   resolveStorageRoot,
@@ -1310,6 +1310,58 @@ test('probes an otherwise idle accepted Runtime Host connection', { timeout: 2_0
   );
 });
 
+test('accepts Session traffic as liveness while a route status observation is delayed', {
+  timeout: 5_000,
+}, async () => {
+  const observed = deferred<HostStatusResult>();
+  await withProtocolPeer(
+    async (transport, hostEpoch, rootId) => {
+      const hello = decodeClientFrame(await transport.read(1_000));
+      assert.ok('kind' in hello && hello.kind === 'hello');
+      await writeProtocolFrame(transport, {
+        kind: 'accepted',
+        rootId,
+        hostEpoch,
+        connectionId: 'connection-active-liveness',
+        selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+        compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+        compositionId: 'maka.interactive',
+        compositionRevision: '1',
+        state: 'ready',
+      });
+      const probe = decodeClientFrame(await transport.read(1_000));
+      assert.ok(!('kind' in probe));
+      assert.equal(probe.operation, 'host.status');
+
+      // Keep the status request pending past its original two-second deadline.
+      // A valid Session frame in between proves the same authenticated
+      // transport is alive and must extend that deadline.
+      await delay(1_100);
+      await writeProtocolFrame(transport, {
+        kind: 'session.catalog.changed',
+        revision: 1,
+        sessionId: 'shared-session',
+      });
+      await delay(1_100);
+      await writeProtocolFrame(transport, {
+        requestId: probe.requestId,
+        operation: 'host.status',
+        ok: true,
+        result: hostStatus(hostEpoch),
+      });
+      await answerStatus(transport, hostEpoch);
+    },
+    async (connection) => {
+      await observed.promise;
+      assert.equal((await connection.status()).hostEpoch, connection.hostEpoch);
+    },
+    {
+      livenessIntervalMs: 20,
+      onHostStatus: observed.resolve,
+    },
+  );
+});
+
 async function withProtocolPeer(
   serve: (transport: FramedTransport, hostEpoch: string, rootId: string) => Promise<void>,
   run: (connection: RuntimeHostConnection) => Promise<void>,
@@ -1426,16 +1478,20 @@ async function answerStatus(transport: FramedTransport, hostEpoch: string): Prom
     requestId: request.requestId,
     operation: 'host.status',
     ok: true,
-    result: {
-      hostEpoch,
-      compositionId: 'maka.interactive',
-      compositionRevision: '1',
-      state: 'ready',
-      connections: 1,
-      activeOperations: 1,
-      activeResidencies: 0,
-    },
+    result: hostStatus(hostEpoch),
   });
+}
+
+function hostStatus(hostEpoch: string): HostStatusResult {
+  return {
+    hostEpoch,
+    compositionId: 'maka.interactive',
+    compositionRevision: '1',
+    state: 'ready',
+    connections: 1,
+    activeOperations: 1,
+    activeResidencies: 0,
+  };
 }
 
 function openResult(

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -100,7 +100,10 @@ export interface ConnectRuntimeHostInput {
   handshakeTimeoutMs?: number;
   /**
    * Maximum quiet interval before an end-to-end Host liveness probe.
-   * Any valid inbound frame restarts the interval. Injectable so tests can
+   * Any valid inbound frame restarts the quiet interval. A Host status
+   * observer additionally uses this as its periodic observation cadence;
+   * inbound traffic then extends an outstanding probe's progress deadline
+   * without suppressing future status observations. Injectable so tests can
    * exercise the cadence without waiting the real default (2s).
    */
   livenessIntervalMs?: number;
@@ -355,6 +358,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   readonly #sessionCatalogChangeListeners = new Set<(frame: SessionCatalogChangedFrame) => void>();
   readonly #scheduledTaskChangeListeners = new Set<(frame: ScheduledTaskChangedFrame) => void>();
   #livenessTimer: NodeJS.Timeout | undefined;
+  #livenessProbeDeadline: NodeJS.Timeout | undefined;
   #livenessProbePending = false;
   #inFlightDomainRequests = 0;
   #terminalError: Error | undefined;
@@ -824,6 +828,9 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   }
 
   #resetLivenessCheck(): void {
+    // Any authenticated Host frame proves the transport is still making
+    // progress, even when a periodic status observation is slow.
+    this.#resetLivenessProbeDeadline();
     // A status observer needs periodic route observations even while other
     // Session traffic keeps the connection active.
     if (this.#onHostStatus) return;
@@ -845,10 +852,11 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   #startLivenessProbe(): void {
     if (this.#terminalError || this.#livenessProbePending) return;
     this.#livenessProbePending = true;
+    this.#resetLivenessProbeDeadline();
     void this.#requestOperation(
       'host.status',
       {},
-      DEFAULT_LIVENESS_TIMEOUT_MS,
+      undefined,
       (status) => {
         this.#validateHostStatusIdentity(status);
         try {
@@ -858,13 +866,24 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
           // connection it is watching.
         }
       },
-      'connection',
+      'request',
     )
       .catch((error: unknown) => this.#fail(asError(error)))
       .finally(() => {
+        if (this.#livenessProbeDeadline) clearTimeout(this.#livenessProbeDeadline);
+        this.#livenessProbeDeadline = undefined;
         this.#livenessProbePending = false;
         this.#scheduleLivenessCheck();
       });
+  }
+
+  #resetLivenessProbeDeadline(): void {
+    if (!this.#livenessProbePending || this.#terminalError) return;
+    if (this.#livenessProbeDeadline) clearTimeout(this.#livenessProbeDeadline);
+    this.#livenessProbeDeadline = setTimeout(() => {
+      this.#livenessProbeDeadline = undefined;
+      this.#fail(requestTimeoutError('host.status'));
+    }, DEFAULT_LIVENESS_TIMEOUT_MS);
   }
 
   #acceptSubscriptionFrame(frame: SubscriptionFrame): void {
@@ -931,6 +950,8 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.#terminalError = error;
     if (this.#livenessTimer) clearTimeout(this.#livenessTimer);
     this.#livenessTimer = undefined;
+    if (this.#livenessProbeDeadline) clearTimeout(this.#livenessProbeDeadline);
+    this.#livenessProbeDeadline = undefined;
     this.#queuedDomainFrames.length = 0;
     this.#inFlightDomainRequests = 0;
     for (const pending of this.#pendingRequests.values()) {


### PR DESCRIPTION
## Summary

- treat any authenticated Host frame as forward progress while a periodic route-status probe is outstanding
- keep real transport silence connection-fatal after the existing bounded deadline
- restore transcript read replicas asynchronously so a large renderer replay cannot hold the Runtime Host in reconnecting
- gate transcript range reads on the replacement consumer while keeping ACK and close available during replay
- preserve Session observation seeding as the candidate consistency gate

## Root cause

Periodic route-status observations used a fixed connection-fatal timeout even when valid Session frames continued arriving. After replacement, candidate readiness also waited for every transcript consumer to replay and acknowledge its range. Switching Sessions closed that consumer, which explains why switching away and back appeared to reconnect immediately.

## Verification

- npm run lint
- npm run build:test
- Runtime Host subscription client suite: 26 passed
- true-silence liveness regression: 1 passed
- Desktop Session observation suite: 38 passed
- Desktop candidate suite: 21 passed

The repository-wide typecheck reaches the unchanged Desktop preload workspace and stops on the existing DesktopSessionSummary.id errors in runtime-host-session-catalog.ts; both changed workspaces and Desktop main typecheck pass.