### PR TITLE
fix(cli): report MCP server failures in provider readiness

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-capability-provider-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-capability-provider-command.test.ts
@@ -23,7 +23,10 @@ import { test } from 'node:test';
 import type { McpToolBinding } from '@maka/core/mcp';
 import type { McpClientManager } from '@maka/mcp';
 import { createMcpCapabilityProvider as createPureMcpCapabilityProvider } from '../mcp-capability-provider.js';
-import { createMcpCapabilityProvider } from '../runtime-host-capability-provider-command.js';
+import {
+  createMcpCapabilityProvider,
+  formatRuntimeHostCapabilityProviderReadyMessage,
+} from '../runtime-host-capability-provider-command.js';
 
 test('TUI MCP control keeps its capability provider on the pure import boundary', async () => {
   const [tuiSource, providerSource] = await Promise.all([
@@ -35,6 +38,42 @@ test('TUI MCP control keeps its capability provider on the pure import boundary'
   assert.match(tuiSource, /from ['"]\.\/mcp-capability-provider\.js['"]/u);
   assert.doesNotMatch(tuiSource, /@maka\/runtime-host\/server/u);
   assert.doesNotMatch(providerSource, /@maka\/runtime-host\/server/u);
+});
+
+test('provider readiness reports a failed MCP server with its sanitized diagnostic', () => {
+  const manager = {
+    toolSnapshot: () => ({ revision: 1, tools: new Array(24).fill({}) }),
+    statuses: () => [
+      {
+        serverId: 'xcodebuildmcp',
+        state: 'connected' as const,
+        toolCount: 24,
+        tools: [],
+        updatedAt: 1,
+      },
+      {
+        serverId: 'missing-command',
+        state: 'error' as const,
+        toolCount: 0,
+        tools: [],
+        error:
+          'MCP server "missing-command" connection failed: spawn command-does-not-exist ENOENT',
+        updatedAt: 1,
+      },
+      {
+        serverId: 'remote-oauth',
+        state: 'needs-auth' as const,
+        toolCount: 0,
+        tools: [],
+        updatedAt: 1,
+      },
+    ],
+  } as unknown as Pick<McpClientManager, 'statuses' | 'toolSnapshot'>;
+
+  assert.equal(
+    formatRuntimeHostCapabilityProviderReadyMessage(manager),
+    'Runtime Host capability provider is connected (24 MCP tools; 2 servers failed: missing-command — MCP server "missing-command" connection failed: spawn command-does-not-exist ENOENT; remote-oauth — needs-auth)\n',
+  );
 });
 
 test('MCP capability publication freezes an accepted callable tool snapshot', async () => {

--- a/packages/cli/src/__tests__/runtime-host-capability-provider-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-capability-provider-command.test.ts
@@ -76,6 +76,29 @@ test('provider readiness reports a failed MCP server with its sanitized diagnost
   );
 });
 
+test('provider readiness sanitizes failed MCP server ids into one line', () => {
+  const manager = {
+    toolSnapshot: () => ({ revision: 1, tools: [] }),
+    statuses: () => [
+      {
+        serverId: 'bad\u2028Runtime Host capability provider is connected (999 MCP tools)\u202e',
+        state: 'error' as const,
+        toolCount: 0,
+        tools: [],
+        error: 'ordinary diagnostic',
+        updatedAt: 1,
+      },
+    ],
+  } as unknown as Pick<McpClientManager, 'statuses' | 'toolSnapshot'>;
+
+  const message = formatRuntimeHostCapabilityProviderReadyMessage(manager);
+  assert.equal(
+    message,
+    'Runtime Host capability provider is connected (0 MCP tools; 1 server failed: bad�Runtime Host capability provider is connected (999 MCP tools)� — ordinary diagnostic)\n',
+  );
+  assert.equal(message.split('\n').length, 2);
+});
+
 test('MCP capability publication freezes an accepted callable tool snapshot', async () => {
   let accepted = false;
   const binding = 'binding-1' as McpToolBinding;

--- a/packages/cli/src/runtime-host-capability-provider-command.ts
+++ b/packages/cli/src/runtime-host-capability-provider-command.ts
@@ -21,7 +21,11 @@ import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { createCredentialMcpOAuthStorage, McpClientManager } from '@maka/mcp';
+import {
+  createCredentialMcpOAuthStorage,
+  formatMcpDiagnosticText,
+  McpClientManager,
+} from '@maka/mcp';
 import { createFileCredentialStore } from '@maka/storage/credential-store';
 import { normalizeMcpConfig } from '@maka/storage/mcp-config-store';
 import {
@@ -204,7 +208,10 @@ export function formatRuntimeHostCapabilityProviderReadyMessage(
     failures.length === 0
       ? ''
       : `; ${failures.length} ${failures.length === 1 ? 'server' : 'servers'} failed: ${failures
-          .map((status) => `${status.serverId} — ${status.error ?? status.state}`)
+          .map(
+            (status) =>
+              `${formatMcpDiagnosticText(status.serverId)} — ${status.error ?? status.state}`,
+          )
           .join('; ')}`;
   return `Runtime Host capability provider is connected (${manager.toolSnapshot().tools.length} MCP tools${failureSummary})\n`;
 }

--- a/packages/cli/src/runtime-host-capability-provider-command.ts
+++ b/packages/cli/src/runtime-host-capability-provider-command.ts
@@ -123,9 +123,7 @@ export async function runRuntimeHostCapabilityProviderCli(
     });
     await runRuntimeHostProcessLifecycle(service, {
       onReady: () => {
-        process.stdout.write(
-          `Runtime Host capability provider is connected (${manager.toolSnapshot().tools.length} MCP tools)\n`,
-        );
+        process.stdout.write(formatRuntimeHostCapabilityProviderReadyMessage(manager));
       },
     });
     return 0;
@@ -189,6 +187,27 @@ async function connectRemoteCapabilityProvider(input: {
 }
 
 export { createMcpCapabilityProvider } from './mcp-capability-provider.js';
+
+export function formatRuntimeHostCapabilityProviderReadyMessage(
+  manager: Pick<McpClientManager, 'statuses' | 'toolSnapshot'>,
+): string {
+  const failures = manager
+    .statuses()
+    .filter(
+      (status) =>
+        status.state === 'error' ||
+        status.state === 'disconnected' ||
+        status.state === 'needs-auth',
+    )
+    .sort((left, right) => left.serverId.localeCompare(right.serverId));
+  const failureSummary =
+    failures.length === 0
+      ? ''
+      : `; ${failures.length} ${failures.length === 1 ? 'server' : 'servers'} failed: ${failures
+          .map((status) => `${status.serverId} — ${status.error ?? status.state}`)
+          .join('; ')}`;
+  return `Runtime Host capability provider is connected (${manager.toolSnapshot().tools.length} MCP tools${failureSummary})\n`;
+}
 
 function reportRefreshFailure(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -90,6 +90,7 @@ import {
   type McpOAuthStorage,
 } from './oauth.js';
 
+export { formatMcpDiagnosticText } from './diagnostic-text.js';
 export { McpToolCallError } from './tool-call-error.js';
 export {
   createCredentialMcpOAuthStorage,


### PR DESCRIPTION

## Summary

Include MCP servers in `error`, `disconnected`, or `needs-auth` state in the Runtime Host capability-provider readiness line. The output keeps the healthy tool count and uses the manager's sanitized status diagnostic for each failed server. The existing stdout readiness channel remains unchanged.

Fixes #4536

## Verification

```text
mise exec node@24.19.0 -- npx -y npm@11.19.0 run build
mise exec node@24.19.0 -- node --test packages/cli/dist/__tests__/runtime-host-capability-provider-command.test.js
Before fix: 0 pass, 1 fail, exit 1
After fix: 4 pass, 0 fail, exit 0
```

The failing test showed that the readiness formatter was absent. The passing test fixes the output contract for 24 healthy tools and one failed server.

A live provider run published 24 tools and reported one failed `missing-command` server with an `ENOENT` diagnostic.

```text
mise exec node@24.19.0 -- npx -y npm@11.19.0 run format: exit 0
mise exec node@24.19.0 -- npx -y npm@11.19.0 run typecheck: exit 0
mise exec node@24.19.0 -- npx -y npm@11.19.0 run lint: exit 0
mise exec node@24.19.0 -- npx -y npm@11.19.0 run format:check: exit 0
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (gpt-5.6-sol), human-reviewed

## Checklist

- [x] Tests cover the change, with a red test recorded before the fix
- [x] Lint, format, typecheck and the affected suite pass locally

Does this PR entail a change in behavior?

- [x] Yes, described under Summary above
- [ ] No
