### PR TITLE
perf(desktop): paginate usage activity

### DIFF
--- a/apps/desktop/src/renderer/features/usage/ui/usage-settings-view.tsx
+++ b/apps/desktop/src/renderer/features/usage/ui/usage-settings-view.tsx
@@ -19,11 +19,13 @@
 
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
+  paginateData,
   SegmentedControl,
   SegmentedControlItem,
   Tab,
   TabList,
   Tooltip,
+  useTablePagination,
 } from '@astryxdesign/core';
 import { uiLocaleToIntlLocale } from '@maka/core/ui-locale';
 import { parseDesktopSessionKey } from '../../../../shared/runtime-host-identity.js';
@@ -36,12 +38,14 @@ import {
   type UsageSettingsCopy,
 } from '../../../locales/settings-usage-copy.js';
 import { MetricCard } from './metric-card.js';
-import { UsageStatsTable } from './usage-stats-table.js';
+import { UsageStatsTable, type UsageTableRow } from './usage-stats-table.js';
 import { useActionGuard } from '../controller/action-guard.js';
 import { useOptimisticSettingsDraft } from '../controller/optimistic-settings-draft.js';
 import { useUsageServices, useUsageStats } from '../services-context.js';
 
 type UsageActiveTab = UsageSettings['activeTab'];
+
+const USAGE_REQUESTS_PAGE_SIZE = 50;
 
 /**
  * The Usage settings surface (issue #4425). A disposable view: it unmounts when
@@ -69,6 +73,7 @@ export function UsageSettingsView(props: {
   // panels read `null` (loading/empty) rather than the previous range's numbers.
   const { stats, reload, targetKey } = useUsageStats(persistedUsage.range);
   const [refreshing, setRefreshing] = useState(false);
+  const [usageRefreshRevision, setUsageRefreshRevision] = useState(0);
   const usageRefreshGuard = useActionGuard<'refresh'>();
   const {
     draft: usageDraft,
@@ -127,6 +132,7 @@ export function UsageSettingsView(props: {
 
   async function refresh() {
     if (!usageRefreshGuard.begin('refresh')) return;
+    setUsageRefreshRevision((revision) => revision + 1);
     setRefreshing(true);
     try {
       await reload(usageDraftRef.current.range);
@@ -210,6 +216,7 @@ export function UsageSettingsView(props: {
         {usageDraft.activeTab === 'requests' ? (
           <div className="settingsUsageTabPanel">
             <UsageRequestsPanel
+              key={`${usageDraft.range}:${usageRefreshRevision}`}
               logs={showRequestDetails ? filteredLogs : []}
               showDetails={usageDraft.showDetails}
               modelFilter={usageDraft.modelFilter}
@@ -276,6 +283,21 @@ function UsageRequestsPanel(props: {
   onToggleDetails(showDetails: boolean): void;
   onClearFilters(): void;
 }) {
+  const [page, setPage] = useState(1);
+  const pageCount = Math.max(1, Math.ceil(props.logs.length / USAGE_REQUESTS_PAGE_SIZE));
+  const currentPage = Math.min(page, pageCount);
+  const pagination = useTablePagination<UsageTableRow>({
+    page: currentPage,
+    onPageChange: setPage,
+    totalItems: props.logs.length,
+    pageSize: USAGE_REQUESTS_PAGE_SIZE,
+    size: 'sm',
+  });
+
+  useEffect(() => {
+    setPage(1);
+  }, [props.logs]);
+
   if (!props.showDetails) {
     return (
       <Banner
@@ -290,7 +312,10 @@ function UsageRequestsPanel(props: {
         <div className="settingsUsageModelFilter">
           <TextInput
             value={props.modelFilter}
-            onChange={(value) => props.onModelFilterChange(value)}
+            onChange={(value) => {
+              setPage(1);
+              props.onModelFilterChange(value);
+            }}
             placeholder={props.copy.filterPlaceholder}
             label={props.copy.filterAria}
             isLabelHidden
@@ -308,7 +333,10 @@ function UsageRequestsPanel(props: {
             { value: 'aborted', label: props.copy.statuses[3] },
           ]}
           width={320}
-          onChange={(value) => props.onStatusChange(value as UsageSettings['status'])}
+          onChange={(value) => {
+            setPage(1);
+            props.onStatusChange(value as UsageSettings['status']);
+          }}
         />
         <div className="settingsUsageDetailToggle">
           <span>{props.copy.details}</span>
@@ -327,12 +355,22 @@ function UsageRequestsPanel(props: {
           isDisabled={!props.hasRequestFilters}
           aria-hidden={!props.hasRequestFilters ? 'true' : undefined}
           tabIndex={!props.hasRequestFilters ? -1 : undefined}
-          onClick={props.hasRequestFilters ? props.onClearFilters : undefined}
+          onClick={
+            props.hasRequestFilters
+              ? () => {
+                  setPage(1);
+                  props.onClearFilters();
+                }
+              : undefined
+          }
           label={props.copy.clearFilters}
         />
       </div>
       <UsageStatsTable
         ariaLabel={props.copy.tables.requestsAria}
+        rowIndexStart={(currentPage - 1) * USAGE_REQUESTS_PAGE_SIZE + 1}
+        rowCount={props.logs.length}
+        plugins={{ pagination }}
         columns={[
           { header: props.copy.tables.requestHeaders[0], width: 168 },
           { header: props.copy.tables.requestHeaders[1], width: 72 },
@@ -343,7 +381,7 @@ function UsageRequestsPanel(props: {
           { header: props.copy.tables.requestHeaders[6], numeric: true },
           { header: props.copy.tables.requestHeaders[7], width: 72 },
         ]}
-        rows={props.logs.map((row) => [
+        rows={paginateData(props.logs, currentPage, USAGE_REQUESTS_PAGE_SIZE).map((row) => [
           new Date(row.ts).toLocaleString(uiLocaleToIntlLocale(props.locale)),
           usageRequestKindLabel(row.kind, props.copy),
           usageRequestTarget(row),
@@ -362,7 +400,10 @@ function UsageRequestsPanel(props: {
               variant="ghost"
               size="sm"
               label={props.copy.clearFilters}
-              onClick={props.onClearFilters}
+              onClick={() => {
+                setPage(1);
+                props.onClearFilters();
+              }}
             />
           ) : undefined,
         }}

--- a/apps/desktop/src/renderer/features/usage/ui/usage-settings-view.tsx
+++ b/apps/desktop/src/renderer/features/usage/ui/usage-settings-view.tsx
@@ -46,6 +46,7 @@ import { useUsageServices, useUsageStats } from '../services-context.js';
 type UsageActiveTab = UsageSettings['activeTab'];
 
 const USAGE_REQUESTS_PAGE_SIZE = 50;
+const EMPTY_USAGE_LOGS: UsageStats['logs'] = [];
 
 /**
  * The Usage settings surface (issue #4425). A disposable view: it unmounts when
@@ -73,7 +74,6 @@ export function UsageSettingsView(props: {
   // panels read `null` (loading/empty) rather than the previous range's numbers.
   const { stats, reload, targetKey } = useUsageStats(persistedUsage.range);
   const [refreshing, setRefreshing] = useState(false);
-  const [usageRefreshRevision, setUsageRefreshRevision] = useState(0);
   const usageRefreshGuard = useActionGuard<'refresh'>();
   const {
     draft: usageDraft,
@@ -132,7 +132,6 @@ export function UsageSettingsView(props: {
 
   async function refresh() {
     if (!usageRefreshGuard.begin('refresh')) return;
-    setUsageRefreshRevision((revision) => revision + 1);
     setRefreshing(true);
     try {
       await reload(usageDraftRef.current.range);
@@ -216,8 +215,7 @@ export function UsageSettingsView(props: {
         {usageDraft.activeTab === 'requests' ? (
           <div className="settingsUsageTabPanel">
             <UsageRequestsPanel
-              key={`${usageDraft.range}:${usageRefreshRevision}`}
-              logs={showRequestDetails ? filteredLogs : []}
+              logs={showRequestDetails ? filteredLogs : EMPTY_USAGE_LOGS}
               showDetails={usageDraft.showDetails}
               modelFilter={usageDraft.modelFilter}
               status={usageDraft.status}
@@ -312,10 +310,7 @@ function UsageRequestsPanel(props: {
         <div className="settingsUsageModelFilter">
           <TextInput
             value={props.modelFilter}
-            onChange={(value) => {
-              setPage(1);
-              props.onModelFilterChange(value);
-            }}
+            onChange={props.onModelFilterChange}
             placeholder={props.copy.filterPlaceholder}
             label={props.copy.filterAria}
             isLabelHidden
@@ -334,7 +329,6 @@ function UsageRequestsPanel(props: {
           ]}
           width={320}
           onChange={(value) => {
-            setPage(1);
             props.onStatusChange(value as UsageSettings['status']);
           }}
         />
@@ -357,10 +351,7 @@ function UsageRequestsPanel(props: {
           tabIndex={!props.hasRequestFilters ? -1 : undefined}
           onClick={
             props.hasRequestFilters
-              ? () => {
-                  setPage(1);
-                  props.onClearFilters();
-                }
+              ? props.onClearFilters
               : undefined
           }
           label={props.copy.clearFilters}
@@ -400,10 +391,7 @@ function UsageRequestsPanel(props: {
               variant="ghost"
               size="sm"
               label={props.copy.clearFilters}
-              onClick={() => {
-                setPage(1);
-                props.onClearFilters();
-              }}
+              onClick={props.onClearFilters}
             />
           ) : undefined,
         }}

--- a/apps/desktop/src/renderer/features/usage/ui/usage-stats-table.tsx
+++ b/apps/desktop/src/renderer/features/usage/ui/usage-stats-table.tsx
@@ -41,7 +41,7 @@ export interface UsageColumn {
   width?: number;
 }
 
-type UsageTableRow = Record<string, unknown> & { id: number };
+export type UsageTableRow = Record<string, unknown> & { id: number };
 
 function usageCellNeedsCustomRenderer(value: ReactNode) {
   return (
@@ -81,6 +81,9 @@ export interface UsageEmpty {
 
 export function UsageStatsTable(props: {
   ariaLabel: string;
+  rowIndexStart?: number;
+  rowCount?: number;
+  plugins?: Record<string, TablePlugin<UsageTableRow>>;
   columns: UsageColumn[];
   rows: Array<Array<ReactNode>>;
   empty: UsageEmpty;
@@ -121,13 +124,17 @@ export function UsageStatsTable(props: {
     <Card className="settingsUsageTable" padding={3}>
       <Table
         aria-label={props.ariaLabel}
+        rowIndexStart={props.rowIndexStart}
+        rowCount={props.rowCount}
         data={data}
         columns={columns}
         idKey="id"
         density="compact"
         dividers="rows"
         textOverflow="truncate"
-        plugins={usageTablePlugins}
+        plugins={
+          props.plugins ? { ...usageTablePlugins, ...props.plugins } : usageTablePlugins
+        }
       />
     </Card>
   );

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -239,6 +239,8 @@ function makeUsageLog(input: {
   };
 }
 
+const USAGE_PAGINATION_SENTINEL = 'Usage pagination page two sentinel';
+
 const usageLogs: UsageStats['logs'] = [
   makeUsageLog({
     id: '1',
@@ -265,6 +267,23 @@ const usageLogs: UsageStats['logs'] = [
     turnId: undefined,
     costUsd: undefined,
   },
+  ...Array.from({ length: 47 }, (_, index) => {
+    const id = String(index + 6);
+    return makeUsageLog({
+      id,
+      kind: 'model',
+      model: 'gpt-5',
+      sessionName: `Usage pagination fixture ${id}`,
+      minutesAgo: index + 40,
+    });
+  }),
+  makeUsageLog({
+    id: '53',
+    kind: 'model',
+    model: 'gpt-5',
+    sessionName: USAGE_PAGINATION_SENTINEL,
+    minutesAgo: 90,
+  }),
 ];
 
 // Priced provenance so the fixtures' costs read as authoritative
@@ -1472,7 +1491,7 @@ function withUsageStoryBridge(
       ): Promise<UpdateAppSettingsResult> => ({
         settings: mergeSettings(settings, patch),
       }),
-      usageStats: async (): Promise<UsageStats> => stats,
+      usageStats: async (): Promise<UsageStats> => ({ ...stats, logs: [...stats.logs] }),
     },
   } satisfies Record<string, unknown>);
 }
@@ -2106,6 +2125,8 @@ export const UsageLongTail: Story = {
     if (showDetails) await userEvent.click(showDetails);
 
     const table = await canvas.findByRole('table', { name: usageCopy.tables.requestsAria });
+    expect(table.querySelectorAll('tbody tr')).toHaveLength(50);
+    expect(within(table).queryByText(USAGE_PAGINATION_SENTINEL)).not.toBeInTheDocument();
     const timeCell = table.querySelector<HTMLTableCellElement>('tbody tr td:first-child');
     expect(timeCell).not.toBeNull();
     const timeText = timeCell?.firstElementChild;
@@ -2130,6 +2151,66 @@ export const UsageLongTail: Story = {
       expect(tooltip).toHaveTextContent(longTarget);
     });
     await userEvent.unhover(targetCellText);
+
+    async function goToPageTwo() {
+      const pageTwo = canvas
+        .getAllByRole('button')
+        .find((button) => button.textContent?.trim() === '2');
+      expect(pageTwo).toBeDefined();
+      await userEvent.click(pageTwo!);
+      await waitFor(() => {
+        const secondPageTable = canvas.getByRole('table', {
+          name: usageCopy.tables.requestsAria,
+        });
+        expect(secondPageTable.querySelectorAll('tbody tr')).toHaveLength(3);
+        expect(secondPageTable).toHaveAttribute('aria-rowcount', String(usageLogs.length));
+        expect(secondPageTable.querySelector('tbody tr')).toHaveAttribute('aria-rowindex', '51');
+        expect(within(secondPageTable).getByText(USAGE_PAGINATION_SENTINEL)).toBeInTheDocument();
+      });
+    }
+
+    async function expectFirstPage(reason: string) {
+      await waitFor(() => {
+        const firstPageTable = canvas.getByRole('table', {
+          name: usageCopy.tables.requestsAria,
+        });
+        expect(firstPageTable.querySelectorAll('tbody tr'), reason).toHaveLength(50);
+        expect(within(firstPageTable).getByText(longTarget)).toBeInTheDocument();
+        expect(within(firstPageTable).queryByText(USAGE_PAGINATION_SENTINEL)).not.toBeInTheDocument();
+      });
+    }
+
+    await goToPageTwo();
+    const modelFilter = canvas.getByRole('textbox', { name: usageCopy.filterAria });
+    await userEvent.type(modelFilter, 'zai');
+    await expectFirstPage('model filter should reset pagination');
+
+    await goToPageTwo();
+    const statusFilter = canvas.getByRole('combobox', { name: usageCopy.statusAria });
+    await userEvent.click(canvas.getByRole('button', { name: usageCopy.clearFilters }));
+    await expectFirstPage('clearing filters should reset pagination');
+    expect(modelFilter).toHaveValue('');
+    expect(statusFilter).toHaveTextContent(usageCopy.statuses[0]);
+
+    await goToPageTwo();
+    await userEvent.click(statusFilter);
+    await userEvent.click(
+      await within(document.body).findByRole('option', { name: usageCopy.statuses[1] }),
+    );
+    await expectFirstPage('status filter should reset pagination');
+
+    await userEvent.click(await canvas.findByRole('button', { name: usageCopy.clearFilters }));
+    await goToPageTwo();
+    const nextRange = canvas
+      .getAllByRole('radio')
+      .find((radio) => radio.getAttribute('aria-checked') === 'false');
+    expect(nextRange).toBeDefined();
+    await userEvent.click(nextRange!);
+    await expectFirstPage('changing range should reset pagination');
+
+    await goToPageTwo();
+    await userEvent.click(canvas.getByRole('button', { name: usageCopy.refreshAria }));
+    await expectFirstPage('refreshing should reset pagination');
   },
 };
 // Real path: the same long-content Usage page at the minimum supported window width.


### PR DESCRIPTION
## Summary

The slowdown came from **Settings → Usage → Activity log** rendering every
matching record whenever the tab was opened. With hundreds of records, React
rebuilt the entire table—including per-row tooltips and actions—on every visit.

Paginate the log at 50 records per page so only the visible rows are mounted.
Searching, changing status, or clearing filters returns the table to the first
page.

Fixes #4531

## Verification

- `npm --workspace @maka/desktop run typecheck`
- `npm exec -- biome lint` on the changed TypeScript files
- `npm run format:check` (1,857 files)
- `npm run check:renderer-architecture -- --base upstream/main` (61 tests)
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run smoke:storybook` (502 renders)
- Deterministic 409-record render benchmark, 10 alternating runs per variant
  on the same build: all rows median 1,616.9 ms / p95 1,670.2 ms; 50 per page
  median 74.0 ms / p95 80.0 ms; 21.9× faster by median

The benchmark measures Activity log rendering only; it does not include
loading the usage history from the backend.

### UI

#### Before Change
<img width="975" height="838" alt="image" src="https://github.com/user-attachments/assets/c4440f6f-9abe-44f3-82de-fddad5da01ba" />

#### After Change

<img width="923" height="918" alt="image" src="https://github.com/user-attachments/assets/93297484-5dc1-41c0-a54c-ed6d15bad571" />

### Benchmark result

Save this snippet as `/tmp/maka-usage-benchmark.cjs`, then run it from a Maka
checkout with dependencies and Playwright Chromium installed.

```javascript
/* benchmark.cjs */
const { execFileSync } = require('node:child_process');
const { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } = require('node:fs');
const { tmpdir } = require('node:os');
const { join } = require('node:path');
const { pathToFileURL } = require('node:url');

const repo = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
const temp = mkdtempSync(join(tmpdir(), 'maka-usage-benchmark-'));
const env = { ...process.env, CACHE_DIR: join(temp, 'cache') };
const run = (command, args, cwd) => execFileSync(command, args, { cwd, env, stdio: 'pipe' });
const { chromium } = require(require.resolve('playwright', { paths: [repo] }));
const vite = pathToFileURL(require.resolve('vite', { paths: [repo] }));

function patch(file, before, after) {
  const source = readFileSync(file, 'utf8');
  if (!source.includes(before)) throw new Error(`Benchmark fixture is outdated: ${before}`);
  writeFileSync(file, source.replace(before, after));
}

function prepare() {
  const source = join(temp, 'source');
  const archive = join(temp, 'source.tar');
  mkdirSync(source);
  run('npm', ['--workspace', '@maka/desktop', 'run', 'build:workspace-deps'], repo);
  run('git', ['archive', `--output=${archive}`, 'HEAD'], repo);
  run('tar', ['-xf', archive, '-C', source], repo);
  symlinkSync(join(repo, 'node_modules'), join(source, 'node_modules'), 'dir');
  const nestedModules = join(source, 'apps/desktop/node_modules');
  mkdirSync(join(nestedModules, '@vitejs'), { recursive: true });
  symlinkSync(join(repo, 'apps/desktop/node_modules/@vitejs/plugin-react'),
    join(nestedModules, '@vitejs/plugin-react'), 'dir');
  patch(join(source, 'apps/desktop/src/renderer/settings/usage-settings-page.tsx'),
    'pageSize={USAGE_REQUESTS_PAGE_SIZE}',
    "pageSize={Number(Reflect.get(globalThis, '__usageBenchmarkPageSize')) || USAGE_REQUESTS_PAGE_SIZE}");
  run('npm', ['run', 'sync:model-metadata'], source);
  run('npm', ['--workspace', '@maka/desktop', 'run', 'build-storybook'], source);
  return join(source, 'apps/desktop/storybook-static');
}

function waitForTable(page, columns, rows) {
  return page.waitForFunction(({ columns, rows }) => [...document.querySelectorAll('table')].some(
    (table) => table.querySelectorAll('thead th').length === columns
      && table.querySelectorAll('tbody tr').length === rows,
  ), { columns, rows }, { timeout: 10_000 });
}

async function setup(page, url) {
  await page.goto(url, { waitUntil: 'networkidle' });
  await page.waitForFunction(() => window.maka?.settings?.usageStats);
  await page.evaluate(async () => {
    const stats = await window.maka.settings.usageStats();
    const logs = Array.from({ length: 409 }, (_, index) => ({
      id: String(index), ts: 1_800_000_000_000 - index * 60_000, kind: 'model',
      sessionId: `session-${index}`, sessionName: `Benchmark ${index}`,
      provider: 'openai', model: 'gpt-5', inputTokens: 12_400,
      outputTokens: 3_800, costUsd: 0.04, latencyMs: 1_000, status: 'success',
    }));
    window.maka.settings.usageStats = async () => ({
      ...stats, logs, summary: { ...stats.summary, totalRequests: logs.length },
    });
  });
  await page.getByRole('button', { name: 'Refresh usage' }).click();
  await page.getByRole('button', { name: /^Activity log/ }).click();
  await page.getByRole('button', { name: 'Show details' }).click();
  await page.getByRole('button', { name: /^Providers/ }).click();
  await waitForTable(page, 4, 1);
}

async function renderActivity(page, rows) {
  await page.evaluate((size) => Reflect.set(globalThis, '__usageBenchmarkPageSize', size), rows);
  const elapsed = await page.evaluate(async (expected) => {
    const button = [...document.querySelectorAll('button')]
      .find((item) => item.textContent?.trim().startsWith('Activity log'));
    const start = performance.now();
    button.click();
    while (performance.now() - start < 10_000) {
      const table = [...document.querySelectorAll('table')]
        .find((item) => item.querySelectorAll('thead th').length === 8);
      if (table?.querySelectorAll('tbody tr').length === expected) {
        void table.getBoundingClientRect();
        return performance.now() - start;
      }
      await new Promise(requestAnimationFrame);
    }
    throw new Error(`Expected ${expected} Activity Log rows.`);
  }, rows);
  await page.getByRole('button', { name: /^Providers/ }).click();
  await waitForTable(page, 4, 1);
  return elapsed;
}

function summarize(values) {
  const sorted = [...values].sort((left, right) => left - right);
  const middle = sorted.length / 2;
  return {
    median: (sorted[middle - 1] + sorted[middle]) / 2,
    p95: sorted[Math.ceil(sorted.length * 0.95) - 1],
  };
}

(async () => {
  let browser;
  let server;
  try {
    const staticDir = prepare();
    const { preview } = await import(vite);
    server = await preview({ configFile: false, root: join(staticDir, '..'),
      build: { outDir: 'storybook-static' }, logLevel: 'silent',
      preview: { host: '127.0.0.1', port: 0 } });
    const url = `http://127.0.0.1:${server.httpServer.address().port}/iframe.html?id=product-settings-pages--usage-single-provider&viewMode=story&globals=locale:en`;
    browser = await chromium.launch({ headless: true });
    const page = await browser.newPage({ viewport: { width: 1280, height: 900 }, timezoneId: 'UTC' });
    await setup(page, url);
    await renderActivity(page, 409);
    await renderActivity(page, 50);
    const all = [];
    const paginated = [];
    for (let run = 0; run < 10; run += 1) {
      const variants = run % 2 ? [[50, paginated], [409, all]] : [[409, all], [50, paginated]];
      for (const [rows, times] of variants) times.push(await renderActivity(page, rows));
    }
    const allRows = summarize(all);
    const fiftyRows = summarize(paginated);
    console.log(`All rows: median ${allRows.median.toFixed(1)} ms, p95 ${allRows.p95.toFixed(1)} ms`);
    console.log(`50/page:  median ${fiftyRows.median.toFixed(1)} ms, p95 ${fiftyRows.p95.toFixed(1)} ms`);
    console.log(`Speedup:  ${(allRows.median / fiftyRows.median).toFixed(1)}x by median`);
  } finally {
    await browser?.close();
    await server?.close();
    rmSync(temp, { recursive: true, force: true });
  }
})().catch((error) => {
  console.error(error.message);
  process.exitCode = 1;
});
```

```bash
$ cd maka-agent
$ node /tmp/maka-usage-benchmark.cjs
All rows: median 1616.9 ms, p95 1670.2 ms
50/page:  median 74.0 ms, p95 80.0 ms
Speedup:  21.9x by median
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with implementation, tests,
benchmarking, review, and verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
