### PR TITLE
fix(desktop): use config-relative glob so desktop stories load on Windows

### DIFF
--- a/apps/desktop/.storybook/main.ts
+++ b/apps/desktop/.storybook/main.ts
@@ -33,7 +33,11 @@ const STORYBOOK_NODE_CRYPTO_BOUNDARY = resolve(
 const config: StorybookConfig = {
   stories: [
     '../../../packages/ui/stories/**/*.stories.@(ts|tsx)',
-    resolve(REPO_ROOT, 'apps/desktop/stories/**/*.stories.@(ts|tsx)'),
+    // Config-relative glob (forward slashes) like the UI entry above. A
+    // `resolve(REPO_ROOT, ...)` absolute path produces backslashes on Windows,
+    // which glob matchers treat as escape characters, so no desktop story ever
+    // matches there.
+    '../stories/**/*.stories.@(ts|tsx)',
   ],
   framework: {
     name: '@storybook/react-vite',


### PR DESCRIPTION
## Summary

On Windows, Storybook run from `apps/desktop` never indexes the desktop story
files: `index.json` reports 53 entries (only the `packages/ui` stories) and
none of the desktop stories appear in the sidebar. The desktop stories glob was
built with `resolve(REPO_ROOT, 'apps/desktop/stories/**/*.stories.@(ts|tsx)')`,
which produces a backslash absolute path on Windows. Glob matchers treat
backslashes as escape characters, so the pattern matches nothing and the entry
is silently dropped. The neighboring `packages/ui` entry is a forward-slash,
config-relative glob — which is why exactly the UI stories kept working, and
why CI (Linux) never caught it: a resolved absolute POSIX path still globs
correctly.

Switch the desktop entry to the same config-relative, forward-slash form
(`'../stories/**/*.stories.@(ts|tsx)'`) so the glob matches on all platforms.

Fixes #4516

## Verification

Verified the glob behavior directly with `fast-glob` (the matcher Storybook
uses) against a clean checkout:

- The new config-relative glob `../stories/**/*.stories.@(ts|tsx)` resolves
  from `apps/desktop/.storybook/` and matches all **15** desktop story files
  (including the `settings/` and `subagent-sessions` entries).
- The old entry as an absolute POSIX path matches the same 15 — which is why
  CI (Linux) never caught the bug.
- The old entry rendered with Windows-style backslashes (`E:\...\stories\**`)
  matches **0** files, reproducing the reported Windows failure.

Not run: a full Storybook launch on Windows (no Windows machine here), and the
repo's lint/typecheck/test suites (a full `npm ci` could not complete from this
network). The glob-level reproduction above demonstrates both the bug and the
fix; a reviewer on Windows can confirm end-to-end with `npm run storybook` in
`apps/desktop` and check http://localhost:6006/index.json (expected: 251
entries, all desktop stories present).

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — identified the fix, edited
`apps/desktop/.storybook/main.ts`, and authored the commit. The commit carries
a `Generated-by: Claude (Claude Code)` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
