### PR TITLE
test(desktop): stabilize sidebar resize drag

### DIFF
--- a/apps/desktop/e2e/sidebar-geometry.spec.ts
+++ b/apps/desktop/e2e/sidebar-geometry.spec.ts
@@ -112,23 +112,27 @@ test('resize handle drag from its vertical centre changes the column width', asy
   expect(initialWidth).toBeGreaterThanOrEqual(SESSION_LIST_EXPANDED_MIN_WIDTH);
   expect(initialWidth).toBeLessThanOrEqual(SESSION_LIST_EXPANDED_MAX_WIDTH);
 
-  const handleBox = await handle.boundingBox();
-  if (!handleBox) throw new Error('resize handle has no visible bounds');
   // Grab the vertical centre. The Astryx hitAreaOffsetX bug leaves only the top
   // half grabbable, so the centre no-ops unless sidebar.css's `transform: none
   // !important` is applied — this point is the regression probe for that rule.
+  // Let locator actionability resolve the handle's live centre before reading
+  // its endpoint; replaying a box captured before that wait can miss a moving
+  // 16px handle under load.
+  await handle.hover();
+  const handleBox = await handle.boundingBox();
+  if (!handleBox) throw new Error('resize handle has no visible bounds');
   const grabX = handleBox.x + handleBox.width / 2;
   const grabY = handleBox.y + handleBox.height / 2;
 
-  await handle.hover();
-  await page.mouse.move(grabX, grabY);
   await page.mouse.down();
-  await page.mouse.move(grabX + 80, grabY, { steps: 20 });
 
   // Astryx flags the separator while a drag is in flight; shell-layout.css keys
   // its transition-suppression (`:has([data-resizing])`) on it, so the width
-  // tracks the pointer live rather than easing behind it.
+  // tracks the pointer live rather than easing behind it. Check the second the
+  // pointer goes down, so a missed grab fails directly instead of timing out on
+  // an unrelated width assertion.
   await expect(handle).toHaveAttribute('data-resizing', /.*/);
+  await page.mouse.move(grabX + 80, grabY, { steps: 20 });
   await expect.poll(() => wrapperWidth(wrapper)).toBeGreaterThan(initialWidth + 40);
   await page.mouse.up();
   await expect(handle).not.toHaveAttribute('data-resizing', /.*/);
@@ -139,17 +143,20 @@ test('resize handle drag from its vertical centre changes the column width', asy
 
   // Drag the other way to prove the handle also narrows the column, grabbing
   // the centre again at the handle's new right-edge position.
+  await handle.hover();
   const widenedHandleBox = await handle.boundingBox();
   if (!widenedHandleBox) throw new Error('resize handle lost its bounds after widening');
   const shrinkX = widenedHandleBox.x + widenedHandleBox.width / 2;
   const shrinkY = widenedHandleBox.y + widenedHandleBox.height / 2;
 
-  await handle.hover();
-  await page.mouse.move(shrinkX, shrinkY);
   await page.mouse.down();
-  await page.mouse.move(shrinkX - 120, shrinkY, { steps: 20 });
+  await expect(handle).toHaveAttribute('data-resizing', /.*/);
+  // Undo the 80px widening. Keeping the reverse drag symmetric means every
+  // width accepted by the precondition stays above the collapsible region.
+  await page.mouse.move(shrinkX - 80, shrinkY, { steps: 20 });
   await expect.poll(() => wrapperWidth(wrapper)).toBeLessThan(widenedWidth - 40);
   await page.mouse.up();
+  await expect(handle).not.toHaveAttribute('data-resizing', /.*/);
 
   const narrowedWidth = await wrapperWidth(wrapper);
   expect(narrowedWidth).toBeLessThan(widenedWidth - 40);


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Stabilizes the existing real-Electron sidebar resize regression test after its one-off timeout in #4523's newly parallelized E2E run.

- Lets Playwright resolve the 16px handle's live center before reading the drag endpoint, instead of moving back to a pre-actionability absolute coordinate.
- Confirms `data-resizing` immediately after both pointer-down events, so a missed grab fails at its cause rather than as a later width timeout.
- Makes the reverse drag symmetric (80px out, 80px back), keeping every width allowed by the test precondition outside the collapsible region.

This changes test timing only; production behavior is unchanged. Refs #4523.

</details>

<details>
<summary>中文</summary>

修复 #4523 新增并行 E2E 后暴露的一次真实 Electron 侧栏拖拽等待超时。

- 先让 Playwright 在 16px 拖拽柄的实时中心完成 actionability 定位，再读取拖拽终点，不再回放等待前缓存的绝对坐标。
- 两次按下后都立即确认 `data-resizing`，让漏抓直接报在起因处，而不是随后表现为宽度等待超时。
- 将反向拖拽改为对称的 80px，确保测试前置条件允许的所有宽度都不会进入可折叠区域。

本 PR 只调整测试时序，不改变产品行为。关联 #4523。

</details>

## Verification

<details open>
<summary>English</summary>

- `npm exec -- playwright test e2e/sidebar-geometry.spec.ts --config e2e/playwright.config.ts --workers=1 --repeat-each=20 --max-failures=1 --grep 'resize handle drag'` — 20/20 passed across cold Electron launches (3.3m).
- `npm exec -- biome check apps/desktop/e2e/sidebar-geometry.spec.ts` — passed.
- `git diff --check` — passed.
- Full Desktop E2E was not rerun locally; CI exercises the intended four-display topology.

</details>

<details>
<summary>中文</summary>

- 同一真实 Electron 拖拽用例在冷启动下连续运行 20 次，20/20 通过（3.3 分钟）。
- 目标文件 Biome 检查通过。
- `git diff --check` 通过。
- 本地未重复运行完整 Desktop E2E；CI 会覆盖目标的四显示器并行拓扑。

</details>

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

<details open>
<summary>English</summary>

OpenAI Codex inspected the failed CI job and local pointer diagnostics, authored the scoped test stabilization, and ran the verification above.

</details>

<details>
<summary>中文</summary>

OpenAI Codex 检查了失败的 CI job 与本地 pointer 诊断，编写了限定范围的测试稳定性修复，并执行了上述验证。

</details>

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
