### PR TITLE
docs(ui): stop describing the fade's blur layer as density-sized

### DIFF
--- a/packages/ui/src/chat-surface-layout.tsx
+++ b/packages/ui/src/chat-surface-layout.tsx
@@ -57,12 +57,13 @@ export type ChatSurfaceLayoutProps = Omit<ComponentProps<typeof ChatLayout>, 'au
  * (`balanced`) stand. Compact spends spacing-2 on the dock's gutters — 8px
  * between the composer card's rounded bottom edge and the window edge, at every
  * window height — and the card read as pushed against the frame rather than
- * resting above it. Balanced spends spacing-3 there and lengthens the fade over
- * the transcript to match (blur layer 80px → 100px, mask ramp 24px → 36px). The
- * message-area and dock-inner styles resolve to literally the same StyleX atoms
- * in both tiers, so this moves the dock and nothing else. It stays written out
- * rather than dropped entirely so an upstream default change cannot silently
- * retune the composer's gutters.
+ * resting above it. Balanced spends spacing-3 there and lengthens the fade's
+ * mask ramp to match (24px → 36px); the blur layer itself fills the dock at
+ * every tier, so density tunes only the ramp. The message-area and dock-inner
+ * styles resolve to literally the same StyleX atoms in both tiers, so this
+ * moves the dock and nothing else. It stays written out rather than dropped
+ * entirely so an upstream default change cannot silently retune the composer's
+ * gutters.
  */
 export function ChatSurfaceLayout({
   className,


### PR DESCRIPTION
## Summary

Follow-up from @liuxiaocs7's review of #4472. Since that change the blur layer fills the dock at every density tier and only the mask ramp is density-tuned (24px → 36px); the `ChatSurfaceLayout` doc comment still said the layer grows 80px → 100px. Comment-only.

The other follow-up — trailing whitespace at `patches/@astryxdesign+core+0.5.2.patch:696` — is a unified-diff context line for a blank line (a single space), which is the format itself; the same lines exist elsewhere in that patch (73, 127, 339, …) and stripping them would break `patch-package`'s context match. Left as is.

## Verification

Comment-only change; `git diff --check` clean.