### PR TITLE
fix(desktop): keep shared session join progress continuous

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-collaboration-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-collaboration-ipc-main.test.ts
@@ -19,6 +19,7 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { RuntimeHostOperationError } from '@maka/runtime-host/client';
 import {
   decodeCollaborationInvitationCode,
   encodeCollaborationInvitationCode,
@@ -147,5 +148,39 @@ test('requires plaintext confirmation and reports the issued invitation routes',
   assert.deepEqual(
     (peerResult as { invitation: { connectivity: unknown } }).invitation.connectivity,
     { kind: 'peer', coordinationRelayCount: 1 },
+  );
+});
+
+test('treats an unavailable collaboration authority as an empty background inbox', async () => {
+  const handlers = new Map<string, IpcHandler>();
+  registerRuntimeHostCollaborationIpc(
+    {
+      async queryCollaborationTurnRequests() {
+        throw new RuntimeHostOperationError(
+          'collaboration.turn-request.query',
+          'operation_unavailable',
+          'Runtime Host collaboration authority is unavailable',
+        );
+      },
+    } as unknown as Parameters<typeof registerRuntimeHostCollaborationIpc>[0],
+    {
+      handle(channel, listener) {
+        handlers.set(channel, listener);
+      },
+    },
+    async () => {
+      throw new Error('not used');
+    },
+  );
+  const query = handlers.get('session-collaboration:turn-request:query');
+  assert.ok(query);
+
+  assert.deepEqual(await query({} as Parameters<IpcHandler>[0]), {
+    canRequestTurns: false,
+    requests: [],
+  });
+  await assert.rejects(
+    query({} as Parameters<IpcHandler>[0], 'session-1'),
+    RuntimeHostOperationError,
   );
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -710,6 +710,50 @@ test('reconnects after a pairing candidate becomes bound to this Client', async 
   await manager.close();
 });
 
+test('activates Guest access on a fresh stream without replaying route progress', async () => {
+  const local = candidateHarness({ hostId: 'host-a' });
+  const remoteHostId = 'a'.repeat(64);
+  const pending = candidateHarness({
+    hostId: remoteHostId,
+    finalizeReconnectRequired: true,
+  });
+  const active = candidateHarness({ hostId: remoteHostId });
+  const queue = [local.candidate, pending.candidate, active.candidate];
+  const phases: string[] = [];
+  const routeRefreshes: Array<boolean | undefined> = [];
+  const manager = await startRuntimeHostDesktopManager(
+    {} as DesktopRuntimeHostCandidateStartInput,
+    {
+      startCandidate: async (input) => {
+        if (input.profileTarget) {
+          routeRefreshes.push(input.refreshPeerRoutes);
+          input.onConnectionPhase?.('discovering');
+          input.onConnectionPhase?.('connecting');
+        }
+        return ready(queue.shift()!);
+      },
+      reconnectBackoff: { minMs: 0, maxMs: 0 },
+    },
+  );
+  await manager.mountGuest(
+    peerGuestTarget('shared-session'),
+    undefined,
+    (phase) => phases.push(phase),
+  );
+  let activations = 0;
+
+  await manager.finalizeGuestAccess('shared-session', undefined, () => {
+    activations += 1;
+  });
+
+  assert.deepEqual(phases, ['discovering', 'connecting']);
+  assert.deepEqual(routeRefreshes, [undefined, false]);
+  assert.equal(activations, 1);
+  assert.equal(pending.closeCalls, 1);
+  assert.equal(manager.current('shared-session')?.candidate, active.candidate);
+  await manager.close();
+});
+
 for (const dispatch of ['not_dispatched', 'dispatched'] as const) {
   test(`replays ${dispatch} pairing finalization after connection loss`, async () => {
     const local = candidateHarness({ hostId: 'host-a' });
@@ -1633,5 +1677,26 @@ function remoteTarget(
       ...(access ? { access } : {}),
     },
     credential: `credential-${target}`,
+  };
+}
+
+function peerGuestTarget(
+  id: string,
+): NonNullable<DesktopRuntimeHostCandidateStartInput['profileTarget']> {
+  return {
+    profile: {
+      id,
+      name: id,
+      kind: 'remote',
+      transport: {
+        kind: 'libp2p-direct',
+        peerId: '12D3KooWpeer',
+        routeHints: ['/ip4/192.0.2.1/udp/41000/quic-v1'],
+        coordinationRelays: [],
+      },
+      rootId: 'a'.repeat(64),
+      access: 'session_guest',
+    },
+    credential: 'credential-peer',
   };
 }

--- a/apps/desktop/src/main/__tests__/runtime-host-guest-session-mounts.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-guest-session-mounts.test.ts
@@ -61,6 +61,42 @@ test('retains a successful Guest mount and rehydrates the same authority after r
   await second!.close();
 });
 
+test('presents Guest import as one connection followed by access activation', async () => {
+  const progress: string[] = [];
+  const mounts = service(memoryStore(), {
+    mount: async (_target, _signal, onConnectionPhase) => {
+      onConnectionPhase?.('discovering');
+      onConnectionPhase?.('connecting');
+      onConnectionPhase?.('authenticating');
+      onConnectionPhase?.('handshaking');
+      onConnectionPhase?.('waiting_for_ready');
+    },
+    finalizeAccess: async (_mountId, _signal, onAccessActivated) => {
+      onAccessActivated?.();
+    },
+  });
+
+  const result = await mounts.importInvitation(
+    invitation('guest-progress'),
+    false,
+    'import-progress',
+    (phase) => progress.push(phase),
+  );
+
+  assert.equal(result.kind, 'connected');
+  const visibleProgress = progress.filter((phase, index) => phase !== progress[index - 1]);
+  assert.deepEqual(visibleProgress, [
+    'validating_invitation',
+    'discovering_host',
+    'preparing_route',
+    'connecting',
+    'authenticating',
+    'finalizing_access',
+    'loading_session',
+  ]);
+  await mounts.close();
+});
+
 test('persists authenticated route rotation for reconnect and restart', async () => {
   const store = memoryStore();
   let observePeerEndpoint!: (endpoint: HostPeerEndpoint) => void;

--- a/apps/desktop/src/main/__tests__/session-collaboration-join-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/session-collaboration-join-dialog.test.ts
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { parseHTML } from 'linkedom';
+import { AstryxLocaleProvider, LocaleProvider, ToastProvider } from '@maka/ui';
+import { SessionCollaborationServicesProvider } from '../../renderer/features/session-collaboration/services-context.js';
+import type { SessionCollaborationServices } from '../../renderer/features/session-collaboration/ports.js';
+import {
+  SessionCollaborationJoinDialog,
+  type SessionCollaborationJoinCopy,
+} from '../../renderer/features/session-collaboration/ui/session-collaboration-join-dialog.js';
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+  HTMLElement: globalThis.HTMLElement,
+  HTMLIFrameElement: globalThis.HTMLIFrameElement,
+  Event: globalThis.Event,
+  Node: globalThis.Node,
+  CSS: globalThis.CSS,
+  matchMedia: globalThis.matchMedia,
+  requestAnimationFrame: globalThis.requestAnimationFrame,
+  cancelAnimationFrame: globalThis.cancelAnimationFrame,
+  IS_REACT_ACT_ENVIRONMENT: (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT,
+};
+
+let mountedRoot: Root | undefined;
+
+afterEach(async () => {
+  if (mountedRoot) await act(() => mountedRoot?.unmount());
+  mountedRoot = undefined;
+  Object.assign(globalThis, originalGlobals);
+});
+
+test('keeps loading progress visible while an irreversible import settles', async () => {
+  let reportProgress: Parameters<SessionCollaborationServices['importInvitation']>[1];
+  const services: SessionCollaborationServices = {
+    importInvitation: async (_input, onProgress) => {
+      reportProgress = onProgress;
+      return new Promise(() => undefined);
+    },
+    cancelImport: async () => 'settling',
+    readInvitationClipboard: async () => '',
+    listMounts: async () => [],
+    removeMount: async () => undefined,
+    getPendingTurnRequests: async () => [],
+    decideTurnRequest: async () => {
+      throw new Error('unused');
+    },
+    createOperationId: () => 'operation-1',
+  };
+  const { document } = installDom();
+  const container = document.querySelector('#root');
+  assert.ok(container);
+  mountedRoot = createRoot(container);
+  await act(async () => {
+    mountedRoot?.render(
+      createElement(LocaleProvider, {
+        locale: 'en',
+        children: createElement(AstryxLocaleProvider, {
+          children: createElement(ToastProvider, {
+            children: createElement(SessionCollaborationServicesProvider, {
+              services,
+              children: createElement(SessionCollaborationJoinDialog, {
+                copy: testCopy(),
+                onImported: assert.fail,
+                onClose: assert.fail,
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
+    await Promise.resolve();
+  });
+  await setTextArea(document, 'invitation');
+  await clickButton(document, 'join');
+  assert.ok(reportProgress);
+  await act(async () => reportProgress?.('loading_session'));
+  assert.match(document.body.textContent, /loadingSession/u);
+
+  await clickButton(document, 'close');
+
+  assert.match(document.body.textContent, /loadingSession/u);
+  assert.doesNotMatch(document.body.textContent, /finalizingAccess/u);
+});
+
+function installDom(): { document: Document } {
+  const parsed = parseHTML('<html><body><div id="root"></div></body></html>');
+  const { document, window } = parsed;
+  const matchMedia = (media: string) => ({
+    matches: false,
+    media,
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent: () => false,
+  });
+  Object.assign(window, { matchMedia, scrollTo() {} });
+  Object.assign(window.HTMLElement.prototype, {
+    showModal(this: HTMLElement) {
+      this.setAttribute('open', '');
+    },
+    close(this: HTMLElement) {
+      this.removeAttribute('open');
+    },
+  });
+  Object.assign(globalThis, {
+    document,
+    window,
+    matchMedia,
+    HTMLElement: window.HTMLElement,
+    HTMLIFrameElement: window.HTMLIFrameElement ?? class HTMLIFrameElement {},
+    Event: window.Event,
+    Node: window.Node,
+    CSS: { escape: (value: string) => value },
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(callback, 0),
+    cancelAnimationFrame: (handle: number) => clearTimeout(handle),
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  return { document };
+}
+
+async function setTextArea(document: Document, value: string): Promise<void> {
+  const textArea = document.querySelector('textarea') as HTMLTextAreaElement | null;
+  assert.ok(textArea);
+  await act(async () => {
+    textArea.value = value;
+    const propsKey = Object.keys(textArea).find((key) => key.startsWith('__reactProps$'));
+    assert.ok(propsKey);
+    const props = (textArea as unknown as Record<string, unknown>)[propsKey] as {
+      onChange?: (event: { target: HTMLTextAreaElement }) => void;
+    };
+    assert.ok(props.onChange);
+    props.onChange({ target: textArea });
+    await Promise.resolve();
+  });
+}
+
+async function clickButton(document: Document, label: string): Promise<void> {
+  const button = [...document.querySelectorAll<HTMLButtonElement>('button')].find(
+    (candidate) => candidate.textContent === label,
+  );
+  assert.ok(button, `missing button: ${label}`);
+  await act(async () => {
+    button.click();
+    await Promise.resolve();
+  });
+}
+
+function testCopy(): SessionCollaborationJoinCopy {
+  return new Proxy({}, {
+    get: (_target, property) => String(property),
+  }) as SessionCollaborationJoinCopy;
+}

--- a/apps/desktop/src/main/__tests__/session-collaboration-join-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/session-collaboration-join-dialog.test.ts
@@ -19,16 +19,19 @@
 
 import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
-import { act, createElement } from 'react';
+import { act, createElement, type ComponentProps } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { parseHTML } from 'linkedom';
 import { AstryxLocaleProvider, LocaleProvider, ToastProvider } from '@maka/ui';
-import { SessionCollaborationServicesProvider } from '../../renderer/features/session-collaboration/services-context.js';
-import type { SessionCollaborationServices } from '../../renderer/features/session-collaboration/ports.js';
 import {
   SessionCollaborationJoinDialog,
-  type SessionCollaborationJoinCopy,
-} from '../../renderer/features/session-collaboration/ui/session-collaboration-join-dialog.js';
+  SessionCollaborationServicesProvider,
+  type SessionCollaborationServices,
+} from '../../renderer/features/session-collaboration/testing.js';
+
+type SessionCollaborationJoinCopy = ComponentProps<
+  typeof SessionCollaborationJoinDialog
+>['copy'];
 
 const originalGlobals = {
   document: globalThis.document,

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -593,9 +593,9 @@ const guestSessionMountService = createDesktopGuestSessionMountService({
       },
     );
   },
-  finalizeAccess: async (mountId, signal) => {
+  finalizeAccess: async (mountId, signal, onAccessActivated) => {
     if (!runtimeHostManager) throw new Error('Runtime Host manager is unavailable');
-    await runtimeHostManager.finalizeGuestAccess(mountId, signal);
+    await runtimeHostManager.finalizeGuestAccess(mountId, signal, onAccessActivated);
   },
   unmount: async (mountId) => {
     if (!runtimeHostManager) return;

--- a/apps/desktop/src/main/runtime-host-collaboration-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-collaboration-ipc-main.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { RuntimeHostOperationError } from '@maka/runtime-host/client';
 import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
 import {
   encodeDesktopCollaborationInvitation,
@@ -91,10 +92,18 @@ export function registerRuntimeHostCollaborationIpc(
   handleReconnectableRead(
     ipcMain,
     'session-collaboration:turn-request:query',
-    (_event, sessionId: unknown) =>
-      client.queryCollaborationTurnRequests(
-        sessionId === undefined ? undefined : requiredId(sessionId, 'Session'),
-      ),
+    async (_event, sessionId: unknown) => {
+      const requestedSessionId =
+        sessionId === undefined ? undefined : requiredId(sessionId, 'Session');
+      try {
+        return await client.queryCollaborationTurnRequests(requestedSessionId);
+      } catch (error) {
+        if (requestedSessionId === undefined && isCollaborationInboxUnavailable(error)) {
+          return { canRequestTurns: false, requests: [] };
+        }
+        throw error;
+      }
+    },
   );
   ipcMain.handle(
     'session-collaboration:turn-request:acknowledge',
@@ -124,6 +133,14 @@ export function registerRuntimeHostCollaborationIpc(
     'session-collaboration:revokePrincipal',
     (_event, principalId: unknown) =>
       client.revokeCollaborationPrincipal(requiredId(principalId, 'Principal')),
+  );
+}
+
+function isCollaborationInboxUnavailable(error: unknown): boolean {
+  return (
+    error instanceof RuntimeHostOperationError &&
+    error.operation === 'collaboration.turn-request.query' &&
+    error.code === 'operation_unavailable'
   );
 }
 

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -205,6 +205,7 @@ export interface DesktopRuntimeHostCandidateStartInput
   readonly onExit?: (details: CandidateExitDetails) => void;
   readonly candidateLaunchBarrier?: RuntimeHostCandidateLaunchBarrier;
   readonly peerClient?: RuntimeHostPeerClient;
+  readonly refreshPeerRoutes?: boolean;
   readonly onConnectionPhase?: (phase: RuntimeHostConnectionPhase) => void;
   readonly onHostStatus?: (status: HostStatusResult) => void;
   readonly profileTarget?: {
@@ -440,6 +441,9 @@ async function startProfileDesktopRuntimeHostCandidate(
       : { handshakeTimeoutMs: input.handshakeTimeoutMs }),
     readyTimeoutMs: input.electionDeadlineMs ?? 45_000,
     ...(input.peerClient === undefined ? {} : { peerClient: input.peerClient }),
+    ...(input.refreshPeerRoutes === undefined
+      ? {}
+      : { refreshPeerRoutes: input.refreshPeerRoutes }),
     ...(input.onConnectionPhase === undefined
       ? {}
       : { onConnectionPhase: input.onConnectionPhase }),

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -79,7 +79,11 @@ export interface RuntimeHostDesktopManager {
     onConnectionPhase?: (phase: RuntimeHostConnectionPhase) => void,
     onHostStatus?: (status: HostStatusResult) => void,
   ): Promise<void>;
-  finalizeGuestAccess(mountId: string, signal?: AbortSignal): Promise<void>;
+  finalizeGuestAccess(
+    mountId: string,
+    signal?: AbortSignal,
+    onAccessActivated?: () => void,
+  ): Promise<void>;
   unmountGuest(mountId: string): Promise<void>;
   disable(profileId: string): Promise<void>;
   waitUntilReady(
@@ -208,6 +212,8 @@ interface DesktopRuntimeHostTargetGeneration {
   hostId?: string;
   lifecycle?: RuntimeHostReconnectLifecycle<DesktopRuntimeHostCandidate>;
   unsubscribeLifecycle?: () => void;
+  connectionPhaseObserver?: (phase: RuntimeHostConnectionPhase) => void;
+  skipPeerRouteRefreshOnce?: boolean;
   lastCandidate?: {
     readonly hostId: string;
     readonly hostEpoch: string;
@@ -355,11 +361,21 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     return this.#mutateTarget(profileId, () => this.#finalizeAccessCredential(profileId));
   }
 
-  finalizeGuestAccess(mountId: string, signal?: AbortSignal): Promise<void> {
-    return this.#mutateTarget(mountId, () => this.#finalizeAccessCredential(mountId, signal));
+  finalizeGuestAccess(
+    mountId: string,
+    signal?: AbortSignal,
+    onAccessActivated?: () => void,
+  ): Promise<void> {
+    return this.#mutateTarget(mountId, () =>
+      this.#finalizeAccessCredential(mountId, signal, onAccessActivated),
+    );
   }
 
-  async #finalizeAccessCredential(profileId: string, externalSignal?: AbortSignal): Promise<void> {
+  async #finalizeAccessCredential(
+    profileId: string,
+    externalSignal?: AbortSignal,
+    onAccessActivated?: () => void,
+  ): Promise<void> {
     const target = this.#requireTarget(profileId);
     if (target.target.profile.kind !== 'remote') {
       throw new Error('Only remote Runtime Host profiles can finalize pairing');
@@ -390,7 +406,14 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
             () => candidate.client.finalizeAccessCredential(remainingMs),
             signal,
           );
+          notifyAccessActivated(onAccessActivated);
           if (finalized.reconnectRequired) {
+            if (
+              target.target.profile.kind === 'remote' &&
+              target.target.profile.transport.kind === 'libp2p-direct'
+            ) {
+              target.skipPeerRouteRefreshOnce = true;
+            }
             await candidate.close();
             await this.#waitForReadyCandidate(lifecycle, candidate, signal);
           }
@@ -565,6 +588,10 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     });
     try {
       target.lifecycle = await this.#startLifecycle(target, false, signal);
+      // Import progress describes the initial connection only. Later
+      // reconnects have their own durable target state and must not restart the
+      // one-shot join UI from route discovery.
+      target.connectionPhaseObserver = undefined;
       if (this.#closed) {
         await target.lifecycle.close();
         throw new Error('Desktop Runtime Host manager is closed');
@@ -863,6 +890,8 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     let takeoverHostEpoch: string | undefined;
     let localRecoveryAttempted = false;
     const inheritedExit = target.input.onExit;
+    let refreshPeerRoutes = target.skipPeerRouteRefreshOnce !== true;
+    target.skipPeerRouteRefreshOnce = false;
     const tryRecoverLocalHost = async (): Promise<boolean> => {
       if (target.input.profileTarget || localRecoveryAttempted || !this.recoverLocalHost) {
         return false;
@@ -889,13 +918,15 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
             isTargetActive: () => this.#ipcMain.isActive(target.epoch),
             isTargetValid: () => target.valid,
             onConnectionPhase: (phase) => {
-              target.input.onConnectionPhase?.(phase);
+              target.connectionPhaseObserver?.(phase);
             },
+            ...(refreshPeerRoutes ? {} : { refreshPeerRoutes: false }),
             signal,
             ...(takeoverHostEpoch === undefined ? {} : { takeoverHostEpoch }),
           },
           target.observations,
         );
+        refreshPeerRoutes = true;
       } catch (error) {
         signal.throwIfAborted();
         if (await tryRecoverLocalHost()) continue;
@@ -1066,6 +1097,9 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       input,
       target,
       observations,
+      ...(input.onConnectionPhase
+        ? { connectionPhaseObserver: input.onConnectionPhase }
+        : {}),
       state: {
         epoch,
         target,
@@ -1230,6 +1264,14 @@ function pairingFinalizeTimedOut(error: unknown): boolean {
     error.operation === 'access.credential.finalize' &&
     error.reason === 'timeout'
   );
+}
+
+function notifyAccessActivated(observer: (() => void) | undefined): void {
+  try {
+    observer?.();
+  } catch {
+    // Presentation progress cannot control credential finalization.
+  }
 }
 
 function withRuntimeHostTarget(

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -212,7 +212,6 @@ interface DesktopRuntimeHostTargetGeneration {
   hostId?: string;
   lifecycle?: RuntimeHostReconnectLifecycle<DesktopRuntimeHostCandidate>;
   unsubscribeLifecycle?: () => void;
-  connectionPhaseObserver?: (phase: RuntimeHostConnectionPhase) => void;
   skipPeerRouteRefreshOnce?: boolean;
   lastCandidate?: {
     readonly hostId: string;
@@ -588,10 +587,6 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     });
     try {
       target.lifecycle = await this.#startLifecycle(target, false, signal);
-      // Import progress describes the initial connection only. Later
-      // reconnects have their own durable target state and must not restart the
-      // one-shot join UI from route discovery.
-      target.connectionPhaseObserver = undefined;
       if (this.#closed) {
         await target.lifecycle.close();
         throw new Error('Desktop Runtime Host manager is closed');
@@ -856,6 +851,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
               ? AbortSignal.any([signal, initialSignal])
               : signal,
             starting ? target.input.profileTarget?.sshInteraction : 'batch',
+            starting ? target.input.onConnectionPhase : undefined,
           ),
         onReconnectError: (error) => {
           console.warn('[runtime-host] reconnect attempt failed:', error);
@@ -886,6 +882,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     target: DesktopRuntimeHostTargetGeneration,
     signal: AbortSignal,
     sshInteraction: RuntimeHostSshInteraction | undefined,
+    onConnectionPhase: ((phase: RuntimeHostConnectionPhase) => void) | undefined,
   ): Promise<DesktopRuntimeHostCandidate> {
     let takeoverHostEpoch: string | undefined;
     let localRecoveryAttempted = false;
@@ -917,9 +914,10 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
             ipcMain: this.#ipcMain.createTarget(target.epoch),
             isTargetActive: () => this.#ipcMain.isActive(target.epoch),
             isTargetValid: () => target.valid,
-            onConnectionPhase: (phase) => {
-              target.connectionPhaseObserver?.(phase);
-            },
+            // Import progress belongs to the initial connection only. Override
+            // the callback inherited from target.input so reconnects cannot
+            // replay one-shot join progress.
+            onConnectionPhase: (phase) => onConnectionPhase?.(phase),
             ...(refreshPeerRoutes ? {} : { refreshPeerRoutes: false }),
             signal,
             ...(takeoverHostEpoch === undefined ? {} : { takeoverHostEpoch }),
@@ -1097,9 +1095,6 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       input,
       target,
       observations,
-      ...(input.onConnectionPhase
-        ? { connectionPhaseObserver: input.onConnectionPhase }
-        : {}),
       state: {
         epoch,
         target,

--- a/apps/desktop/src/main/runtime-host-guest-session-mounts.ts
+++ b/apps/desktop/src/main/runtime-host-guest-session-mounts.ts
@@ -135,7 +135,11 @@ export function createDesktopGuestSessionMountService(input: {
     onConnectionPhase?: (phase: RuntimeHostConnectionPhase) => void,
     onPeerEndpoint?: (endpoint: HostPeerEndpoint) => void,
   ) => Promise<void>;
-  readonly finalizeAccess: (mountId: string, signal: AbortSignal) => Promise<void>;
+  readonly finalizeAccess: (
+    mountId: string,
+    signal: AbortSignal,
+    onAccessActivated?: () => void,
+  ) => Promise<void>;
   readonly unmount: (mountId: string) => Promise<void>;
   readonly wait?: (delayMs: number, signal: AbortSignal) => Promise<void>;
   readonly onError?: (error: Error, mount: GuestSessionMount) => void;
@@ -225,7 +229,13 @@ export function createDesktopGuestSessionMountService(input: {
     if (activation.kind === 'import') {
       reportImportProgress(activation.onProgress, 'finalizing_access');
     }
-    const finalization = input.finalizeAccess(mount.mountId, activation.controller.signal);
+    const finalization = input.finalizeAccess(
+      mount.mountId,
+      activation.controller.signal,
+      activation.kind === 'import'
+        ? () => reportImportProgress(activation.onProgress, 'loading_session')
+        : undefined,
+    );
     activation.finalization = finalization;
     try {
       await finalization;
@@ -576,10 +586,9 @@ function collaborationProgressForConnectionPhase(
     case 'connecting':
       return 'connecting';
     case 'authenticating':
-      return 'authenticating';
     case 'handshaking':
     case 'waiting_for_ready':
-      return 'loading_session';
+      return 'authenticating';
   }
 }
 

--- a/apps/desktop/src/renderer/features/session-collaboration/testing.ts
+++ b/apps/desktop/src/renderer/features/session-collaboration/testing.ts
@@ -23,3 +23,6 @@ export {
   turnRequestPreview,
   unseenTurnRequests,
 } from './model/turn-request-inbox.js';
+export type { SessionCollaborationServices } from './ports.js';
+export { SessionCollaborationServicesProvider } from './services-context.js';
+export { SessionCollaborationJoinDialog } from './ui/session-collaboration-join-dialog.js';

--- a/apps/desktop/src/renderer/features/session-collaboration/ui/session-collaboration-join-dialog.tsx
+++ b/apps/desktop/src/renderer/features/session-collaboration/ui/session-collaboration-join-dialog.tsx
@@ -178,7 +178,11 @@ export function SessionCollaborationJoinDialog(props: {
       const result = await services.cancelImport(operationId);
       if (!open.current || activeOperationId.current !== operationId) return;
       if (result === 'settling') {
-        setJoinState({ kind: 'working', phase: 'finalizing_access' });
+        setJoinState((current) =>
+          current.kind === 'working' && current.phase === 'loading_session'
+            ? current
+            : { kind: 'working', phase: 'finalizing_access' },
+        );
         return;
       }
       finishClose();

--- a/packages/runtime-host/src/__tests__/peer-native.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-native.test.ts
@@ -156,7 +156,15 @@ module.exports = {
     native.default.resolveConnect(3);
     await control;
 
-    await client.connect(peerConnectInput('ready'));
+    const preparedBeforeReopen = preparedPeerIds.length;
+    const reopenPhases: string[] = [];
+    await client.connect(
+      { ...peerConnectInput('ready'), refreshRoutes: false },
+      undefined,
+      (phase) => reopenPhases.push(phase),
+    );
+    assert.equal(preparedPeerIds.length, preparedBeforeReopen);
+    assert.deepEqual(reopenPhases, ['connecting']);
     await client.connect(peerConnectInput('fallback'));
     await assert.rejects(client.connect(peerConnectInput('unreachable')), (failure: unknown) => {
       return failure instanceof RuntimeHostPeerError && failure.code === 'transit_unavailable';

--- a/packages/runtime-host/src/client/host-profile.ts
+++ b/packages/runtime-host/src/client/host-profile.ts
@@ -388,6 +388,7 @@ export async function connectRuntimeHostProfile(
     readonly readyTimeoutMs?: number;
     readonly sshInteraction?: RuntimeHostSshInteraction;
     readonly peerClient?: RuntimeHostPeerClient;
+    readonly refreshPeerRoutes?: boolean;
     readonly onConnectionPhase?: (phase: RuntimeHostConnectionPhase) => void;
     readonly onHostStatus?: (status: HostStatusResult) => void;
   },
@@ -445,6 +446,7 @@ export async function connectRemoteRuntimeHostProfile(
     readonly readyTimeoutMs?: number;
     readonly sshInteraction?: RuntimeHostSshInteraction;
     readonly peerClient?: RuntimeHostPeerClient;
+    readonly refreshPeerRoutes?: boolean;
     readonly onConnectionPhase?: (phase: RuntimeHostConnectionPhase) => void;
     readonly onHostStatus?: (status: HostStatusResult) => void;
   },
@@ -467,6 +469,9 @@ export async function connectRemoteRuntimeHostProfile(
       expectedRootId: input.profile.rootId,
       clientInstanceId: input.clientInstanceId,
       peerClient: requireRuntimeHostPeerClient(input.peerClient),
+      ...(input.refreshPeerRoutes === undefined
+        ? {}
+        : { refreshPeerRoutes: input.refreshPeerRoutes }),
       ...(input.signal === undefined ? {} : { signal: input.signal }),
       ...(input.connectTimeoutMs === undefined ? {} : { connectTimeoutMs: input.connectTimeoutMs }),
       ...(input.handshakeTimeoutMs === undefined
@@ -593,6 +598,7 @@ export async function connectPeerRuntimeHost(input: {
   readonly expectedRootId: string;
   readonly clientInstanceId: string;
   readonly peerClient: RuntimeHostPeerClient;
+  readonly refreshPeerRoutes?: boolean;
   readonly signal?: AbortSignal;
   readonly connectTimeoutMs?: number;
   readonly handshakeTimeoutMs?: number;
@@ -607,6 +613,7 @@ export async function connectPeerRuntimeHost(input: {
       routeHints: input.transport.routeHints,
       coordinationRelays: input.transport.coordinationRelays,
       directDeadlineMs: Math.min(input.connectTimeoutMs ?? 40_000, 120_000),
+      ...(input.refreshPeerRoutes === undefined ? {} : { refreshRoutes: input.refreshPeerRoutes }),
     },
     input.signal,
     input.onConnectionPhase,

--- a/packages/runtime-host/src/client/peer-client.ts
+++ b/packages/runtime-host/src/client/peer-client.ts
@@ -37,6 +37,7 @@ export interface RuntimeHostPeerConnectInput {
   readonly coordinationRelays?: readonly string[];
   readonly transitRelayPeerIds?: readonly string[];
   readonly directDeadlineMs: number;
+  readonly refreshRoutes?: boolean;
 }
 
 export type RuntimeHostPeerConnectionPhase = 'discovering' | 'connecting';
@@ -242,8 +243,10 @@ class RuntimeHostPeerClientImpl implements RuntimeHostPeerClient {
     signal?: AbortSignal,
     onPhase?: (phase: RuntimeHostPeerConnectionPhase) => void,
   ): Promise<RuntimeHostPeerNativeStream> {
-    notifyPhase(onPhase, 'discovering');
-    await this.#prepareRoutes(input, signal);
+    if (input.refreshRoutes !== false) {
+      notifyPhase(onPhase, 'discovering');
+      await this.#prepareRoutes(input, signal);
+    }
     notifyPhase(onPhase, 'connecting');
     return this.#connect(input, signal, 'application');
   }


### PR DESCRIPTION
## Summary

Present shared-session import as one continuous join instead of replaying route discovery after Guest access activation. The mandatory fresh authenticated stream remains intact, but its immediate peer reopen reuses the route prepared by the first stream and later reconnects return to normal route refresh.

Treat only an unsupported background collaboration inbox as empty, removing repeated `operation_unavailable` IPC errors without hiding explicit session failures or genuine reconnect diagnostics.

Refs #4554

## Verification

- `npm run check:renderer-architecture -- --base origin/main`
- `npm run lint`
- `npm run format:check`
- `npm run astryx:surface-inventory && npm run astryx:surface-inventory:test`
- `npm run build`
- `npm run typecheck`
- `npm run test:dist` (all workspace tests passed)
- `npm run astryx:theme -- --check`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- Focused behavior tests: 63 passed, 0 failed

The user-visible change is temporal rather than a static layout change: progress now advances once through validation, route preparation, authentication, access activation, and session loading, with no second discovery pass.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the lifecycle, peer-route reuse, background inbox fallback, and focused regression tests.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No