### PR TITLE
fix(desktop): land prompt-rail jumps at the top and fence the e2e sends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,18 @@ jobs:
             npm exec -w @maka/desktop -- playwright test \
               --config e2e/playwright.config.ts --workers="$worker_count"
 
+      # Playwright keeps a trace, a video and a screenshot for every failed
+      # test. Without this they die with the runner, and an e2e flake can only
+      # be diagnosed by reproducing it.
+      - name: Upload Desktop e2e results
+        if: failure() && steps.plan.outputs.e2e == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-e2e-results
+          path: apps/desktop/e2e/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Browser WebContentsView semantic smoke
         if: steps.plan.outputs.e2e == 'true'
         # Hosted Linux runners cannot configure Electron's SUID helper. This

--- a/apps/desktop/e2e/accessibility-coverage.spec.ts
+++ b/apps/desktop/e2e/accessibility-coverage.spec.ts
@@ -52,13 +52,27 @@ async function tabTo(page: Page, target: Locator, label: string, limit = 30): Pr
   ).toBe(true);
 }
 
+/**
+ * Walk to the skip link from the document start, taking the start back if a
+ * cold start moves it.
+ *
+ * Parking focus on `body` is not a one-shot the renderer respects: the composer
+ * restores its draft caret with `getSelection().addRange(...)`, and a range set
+ * inside a `contenteditable` focuses it — so once per cold start, tens of
+ * milliseconds after the park and with no `focus()` call to fence on, focus
+ * lands in the composer. A walk that starts there has to run out the tab ring
+ * and wrap around, which is over budget. The restore fires once, so re-park and
+ * walk again rather than widening the budget — the budget is the assertion.
+ */
 async function enterMainFromSkipLink(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    document.body.tabIndex = -1;
-    document.body.focus();
-  });
   const skipLink = page.getByRole('link', { name: '跳到主要内容' });
-  await tabTo(page, skipLink, 'skip link', 10);
+  await expect(async () => {
+    await page.evaluate(() => {
+      document.body.tabIndex = -1;
+      document.body.focus();
+    });
+    await tabTo(page, skipLink, 'skip link', 10);
+  }).toPass({ timeout: 30_000 });
   await page.keyboard.press('Enter');
   await expect(page.getByRole('main')).toBeFocused();
   await page.evaluate(() => document.body.removeAttribute('tabindex'));

--- a/apps/desktop/e2e/accessibility-coverage.spec.ts
+++ b/apps/desktop/e2e/accessibility-coverage.spec.ts
@@ -19,7 +19,7 @@
 
 import { FAKE_HOLD_OPEN_PROMPT } from '@maka/runtime/test-only/fake-backend';
 import type { CDPSession, Locator, Page } from '@playwright/test';
-import { expect, test, COMPOSER_INPUT } from './fixtures';
+import { awaitSendReady, expect, test, COMPOSER_INPUT } from './fixtures';
 import { auditAxTree } from '../../../scripts/ax-tree-audit.mjs';
 import { groupedNav } from '../src/renderer/settings/settings-nav';
 
@@ -183,6 +183,7 @@ test('data-backed conversation exposes ordered todos and keyboard access to tool
   await page.keyboard.insertText('/graph on');
   const send = page.getByRole('button', { name: '发送' });
   await tabTo(page, send, 'Send button', 20);
+  await awaitSendReady(page);
   await page.keyboard.press('Enter');
   await expect(page.getByText('Graph Mode 已开启', { exact: true })).toBeVisible();
   await assertAxHealth(cdp, 'overlay/graph-mode-toast');
@@ -203,6 +204,7 @@ test('toast and error states expose healthy live regions', async ({ window: page
   const cdp = await page.context().newCDPSession(page);
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill('/graph history');
+  await awaitSendReady(page);
   await composer.press('Enter');
   await expect(page.getByText('Graph 历史', { exact: true })).toBeVisible();
   await assertAxHealth(cdp, 'overlay/graph-history-toast');
@@ -224,10 +226,17 @@ test('a streaming answer exposes a healthy live conversation state', async ({ wi
   await tabTo(page, composer, 'streaming composer', 60);
   await page.keyboard.insertText(FAKE_HOLD_OPEN_PROMPT);
   const send = page.getByRole('button', { name: '发送' });
+  // After the Tab walk, not before it: a tooltip-carrying Astryx Button is
+  // disabled via `aria-disabled`, so it stays focusable and `tabTo` would
+  // reach it either way.
   await tabTo(page, send, 'streaming Send button', 20);
+  await awaitSendReady(page);
   await page.keyboard.press('Enter');
 
-  await expect(page.locator('.maka-bubble-streaming')).toContainText('Fake backend waiting');
+  await expect(page.locator('.maka-bubble-streaming')).toContainText(
+    'Fake backend waiting',
+    { timeout: 20_000 },
+  );
   await expect(page.getByRole('button', { name: '停止' })).toBeEnabled();
   await assertAxHealth(cdp, 'conversation/streaming');
 
@@ -254,8 +263,8 @@ test('composer and workbar entry points expose named actionable controls', async
   await tabTo(page, composer, 'new-task composer', 60);
   await page.keyboard.insertText(prompt);
   const send = page.getByRole('button', { name: '发送' });
-  await expect(send).toBeEnabled();
   await tabTo(page, send, 'new-task Send button', 20);
+  await awaitSendReady(page);
   await page.keyboard.press('Enter');
   await expect(page.getByText(`Fake backend received: ${prompt}`)).toBeVisible({
     timeout: 30_000,

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -72,6 +72,27 @@ export async function ensureSidebarExpanded(page: Page): Promise<void> {
 }
 
 /**
+ * Wait until the composer is in a state where Enter is a real submission: the
+ * connections projection has produced at least one connection, the draft is
+ * non-empty, no known blocker is showing and no earlier send is still in
+ * flight. 发送 is disabled for all of that, so it is the one signal covering
+ * it; intermediate signals (a cleared draft, an updated model label) resolve
+ * earlier and mean nothing here.
+ *
+ * It does NOT cover the submission-readiness probe: an unresolved snapshot is
+ * not a hard block, so the button is enabled while the probe is in flight, and
+ * `send()` awaits the probe again on its own. A slow probe is absorbed by the
+ * assertions' 20s; a probe that comes back blocked still drops the send with
+ * no feedback, which is a product gap, not something a test-side fence can
+ * close.
+ */
+export async function awaitSendReady(page: Page): Promise<void> {
+  await expect(page.getByRole('button', { name: '发送' })).toBeEnabled({
+    timeout: 20_000,
+  });
+}
+
+/**
  * Wait for the default Host's Coordination Session and the WorkHub projection
  * to agree that the surface is ready. A mounted WorkHub main is not sufficient:
  * it is also rendered while the Host reconnects and the projection reloads.
@@ -670,9 +691,9 @@ export const test = base.extend<E2eTestFixtures, E2eWorkerFixtures>({
       use,
     );
   },
-  // This scenario is read-only at the Host boundary. Keep its real Electron +
-  // Host composition warm for the worker, while the test-scoped wrapper below
-  // restores Host and renderer state between tests.
+  // Keep this scenario's real Electron + Host composition warm for the worker,
+  // while the test-scoped wrapper below restores Host and renderer state
+  // between tests. Tests on it may run a Turn, so the reset is not read-only.
   promptRailWorker: [async ({}, use) => {
     await withE2eWindow({
       seed: false,
@@ -717,7 +738,15 @@ export const test = base.extend<E2eTestFixtures, E2eWorkerFixtures>({
   promptRailMotionWindow: async ({}, use) => {
     await withE2eWindow({
       seed: false,
-      readinessSelector: '[data-turn-id]',
+      // The transcript and the fixture attributes arrive on two unordered
+      // async paths: `runDeferredStartupRefreshes` fires `refreshSessions()`
+      // and `applyE2eFixture()` side by side, and only the second one — after
+      // its `e2eFixture.getState()` IPC resolves — writes
+      // `data-maka-scroll-motion`. A turn can therefore paint while the
+      // document still says nothing about scroll motion. Requiring both in one
+      // selector is what makes "this window scrolls smoothly" true by the time
+      // a test body reads it.
+      readinessSelector: 'html[data-maka-scroll-motion="smooth"] [data-turn-id]',
       e2eFixtureScenario: 'chat-prompt-rail',
       showWindow: true,
       scrollMotion: 'smooth',

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -81,10 +81,14 @@ export async function ensureSidebarExpanded(page: Page): Promise<void> {
  *
  * It does NOT cover the submission-readiness probe: an unresolved snapshot is
  * not a hard block, so the button is enabled while the probe is in flight, and
- * `send()` awaits the probe again on its own. A slow probe is absorbed by the
- * assertions' 20s; a probe that comes back blocked still drops the send with
- * no feedback, which is a product gap, not something a test-side fence can
- * close.
+ * `send()` awaits the probe again on its own — a first send inside a barrier
+ * that gives up at 30s. The post-send assertions wait 20s, which covers every
+ * admission measured here but not that whole barrier. Widening them past it
+ * buys nothing: the 60s test budget is the real cap, a send admitted at 25s
+ * leaves the multi-send specs unable to finish anyway, and the only change
+ * would be trading a named assertion failure for a bare test timeout. A probe
+ * that comes back blocked still drops the send with no feedback, which is a
+ * product gap, not something a test-side fence can close.
  */
 export async function awaitSendReady(page: Page): Promise<void> {
   await expect(page.getByRole('button', { name: '发送' })).toBeEnabled({
@@ -752,6 +756,7 @@ export const test = base.extend<E2eTestFixtures, E2eWorkerFixtures>({
       // a test body reads it.
       readinessSelector: 'html[data-maka-scroll-motion="smooth"] [data-turn-id]',
       e2eFixtureScenario: 'chat-prompt-rail',
+      locale: 'zh',
       showWindow: true,
       scrollMotion: 'smooth',
     }, use);

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -703,6 +703,10 @@ export const test = base.extend<E2eTestFixtures, E2eWorkerFixtures>({
       // assertion that names it.
       readinessSelector: '[data-turn-id]',
       e2eFixtureScenario: 'chat-prompt-rail',
+      // Every other fixture window names its locale; without one the renderer
+      // takes the host's, so any test that reaches a control by its label
+      // passes on a Chinese desktop and cannot find it on an English CI runner.
+      locale: 'zh',
       showWindow: true,
     }, async (page, { app }) => {
       const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }));

--- a/apps/desktop/e2e/streaming-remount.spec.ts
+++ b/apps/desktop/e2e/streaming-remount.spec.ts
@@ -23,7 +23,13 @@ import {
   FAKE_WAIT_FOR_STEERING_LARGE_RESPONSE_PROMPT,
 } from '@maka/runtime/test-only/fake-backend';
 import type { Locator } from '@playwright/test';
-import { COMPOSER_INPUT, ensureSidebarExpanded, expect, test } from './fixtures';
+import {
+  awaitSendReady,
+  COMPOSER_INPUT,
+  ensureSidebarExpanded,
+  expect,
+  test,
+} from './fixtures';
 
 interface SessionObservationLatchWindow extends Window {
   /** E2E-only preload affordance; see the MAKA_E2E block in preload.ts. */
@@ -54,10 +60,12 @@ test('a failed first observation seed reconnects to the live Turn', async ({ win
 
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill(FAKE_HOLD_OPEN_PROMPT);
+  await awaitSendReady(page);
   await composer.press('Enter');
 
   await expect(page.locator('.maka-bubble-streaming')).toContainText(
     'Fake backend waiting',
+    { timeout: 20_000 },
   );
   await page.getByRole('button', { name: '停止' }).click();
   await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, {
@@ -73,11 +81,12 @@ test('remounting a live surface leaves accumulated output settled', async ({
 
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill(FAKE_HOLD_OPEN_REWRITE_PROMPT);
+  await awaitSendReady(page);
   await composer.press('Enter');
 
   const accumulatedOutput = 'prefix sk-123456789012345';
   const liveBubble = page.locator('.maka-bubble-streaming');
-  await expect(liveBubble).toContainText(accumulatedOutput);
+  await expect(liveBubble).toContainText(accumulatedOutput, { timeout: 20_000 });
 
   const sidebar = page.getByRole('navigation', { name: '任务列表' });
   await ensureSidebarExpanded(page);
@@ -137,8 +146,12 @@ test('keeps a completed reply after an interrupted turn and conversation remount
   expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(false);
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill('temporary conversation');
+  await awaitSendReady(page);
   await composer.press('Enter');
-  await expect(page.getByRole('log')).toContainText('Fake backend received: temporary conversation');
+  await expect(page.getByRole('log')).toContainText(
+    'Fake backend received: temporary conversation',
+    { timeout: 20_000 },
+  );
   await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, {
     timeout: 20_000,
   });
@@ -157,9 +170,11 @@ test('keeps a completed reply after an interrupted turn and conversation remount
   await expect(composer).toHaveText('');
 
   await composer.fill(FAKE_HOLD_OPEN_PROMPT);
+  await awaitSendReady(page);
   await composer.press('Enter');
   await expect(page.locator('.maka-bubble-streaming')).toContainText(
     'Fake backend waiting',
+    { timeout: 20_000 },
   );
   const originalSessionId = await sidebar
     .locator('[data-session-id]:has([aria-current="page"])')
@@ -178,9 +193,7 @@ test('keeps a completed reply after an interrupted turn and conversation remount
     { timeout: 20_000 },
   ).toBe(0);
   await composer.fill(FAKE_WAIT_FOR_STEERING_LARGE_RESPONSE_PROMPT);
-  await expect(page.getByRole('button', { name: '发送' })).toBeEnabled({
-    timeout: 20_000,
-  });
+  await awaitSendReady(page);
   await composer.press('Enter');
   await expect(page.locator('.maka-user-message', {
     hasText: FAKE_WAIT_FOR_STEERING_LARGE_RESPONSE_PROMPT,
@@ -220,11 +233,12 @@ test('returning to a live conversation settles output accumulated while away', a
   expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(false);
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill(FAKE_HOLD_OPEN_PROMPT);
+  await awaitSendReady(page);
   await composer.press('Enter');
 
   const accumulatedOutput = 'Fake backend waiting for the test to stop the Turn.';
   const liveBubble = page.locator('.maka-bubble-streaming');
-  await expect(liveBubble).toContainText(accumulatedOutput);
+  await expect(liveBubble).toContainText(accumulatedOutput, { timeout: 20_000 });
 
   const sidebar = page.getByRole('navigation', { name: '任务列表' });
   await page.getByRole('button', { name: '展开侧边栏' }).click();
@@ -239,9 +253,11 @@ test('returning to a live conversation settles output accumulated while away', a
   await sidebar.getByRole('button', { name: '新任务', exact: true }).click();
   await expect(composer).toHaveText('');
   await composer.fill('temporary second conversation');
+  await awaitSendReady(page);
   await composer.press('Enter');
   await expect(page.getByRole('log')).toContainText(
     'Fake backend received: temporary second conversation',
+    { timeout: 20_000 },
   );
   await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, {
     timeout: 20_000,

--- a/apps/desktop/e2e/transcript-scroll.spec.ts
+++ b/apps/desktop/e2e/transcript-scroll.spec.ts
@@ -17,7 +17,13 @@
  * under the License.
  */
 
-import { expect, test, COMPOSER_INPUT, ensureSidebarExpanded } from './fixtures';
+import {
+  awaitSendReady,
+  expect,
+  test,
+  COMPOSER_INPUT,
+  ensureSidebarExpanded,
+} from './fixtures';
 import type { Page } from '@playwright/test';
 
 /**
@@ -196,6 +202,8 @@ function measureTailLag(page: Page, frames: number): Promise<{
 async function sendPrompt(page: Page, text: string): Promise<void> {
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill(text);
+  // Switching Session or model restarts asynchronous send admission.
+  await awaitSendReady(page);
   await composer.press('Enter');
 }
 
@@ -313,7 +321,9 @@ test('switching Sessions restores a Turn anchor while a tail Session follows bac
       .__makaBackgroundTailProbe = state;
   }, tailSessionId);
   await sendPrompt(page, LONG_PROMPT);
-  await expect(page.locator('.maka-user-message', { hasText: '第 1 行' })).toBeVisible();
+  await expect(page.locator('.maka-user-message', { hasText: '第 1 行' })).toBeVisible({
+    timeout: 20_000,
+  });
 
   // The transcript collapses before each async replacement. This round trip
   // therefore exercises the production ordering that made a saved scrollTop

--- a/packages/ui/src/__tests__/rail-alignment-claim.test.ts
+++ b/packages/ui/src/__tests__/rail-alignment-claim.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { resolveRailAlignedTarget } from '../chat-view.js';
+
+test('a rail claim aims its own navigation and nothing after it', () => {
+  // The click, before the shell has published anything.
+  let claim = resolveRailAlignedTarget({ turnId: 'a' }, undefined).claim;
+  assert.deepEqual(claim, { turnId: 'a' });
+
+  // The load the click asked for. The reveal has to agree with the rail.
+  let resolved = resolveRailAlignedTarget(claim, { turnId: 'a', nonce: 1 });
+  assert.equal(resolved.target?.align, 'start');
+  claim = resolved.claim;
+
+  // Still the same command, re-rendered while the loaded range settles.
+  resolved = resolveRailAlignedTarget(claim, { turnId: 'a', nonce: 1 });
+  assert.equal(resolved.target?.align, 'start');
+  claim = resolved.claim;
+
+  // A later search for the same Turn is a different command, and wants the
+  // search contract back.
+  resolved = resolveRailAlignedTarget(claim, { turnId: 'a', nonce: 2 });
+  assert.equal(resolved.target?.align, 'center');
+  assert.equal(resolved.claim, undefined);
+});
+
+test('a search for another Turn spends an unconsumed rail claim', () => {
+  const resolved = resolveRailAlignedTarget({ turnId: 'a' }, { turnId: 'b', nonce: 1 });
+  assert.equal(resolved.target?.align, 'center');
+  assert.equal(resolved.claim, undefined);
+});
+
+test('a search with no rail claim behind it is centred', () => {
+  const resolved = resolveRailAlignedTarget(undefined, { turnId: 'a', nonce: 1 });
+  assert.equal(resolved.target?.align, 'center');
+  assert.deepEqual(resolved.target, { turnId: 'a', nonce: 1, align: 'center' });
+});

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -91,6 +91,35 @@ export interface ChatViewGoalIndicatorProps {
   goalIndicator?: SessionContextGoal;
 }
 
+/** A rail click's outstanding request that the reveal for its Turn agree with it. */
+export type RailAlignmentClaim = { turnId: string; nonce?: number };
+
+/**
+ * Which edge the transcript's reveal should use for the target the shell is
+ * publishing, and what is left of the rail's claim afterwards.
+ *
+ * A claim belongs to the one navigation its click asked for, not to the Turn:
+ * it binds to the first target that arrives for that Turn and is spent on
+ * anything else. A later search for the same Turn is a different command with
+ * its own nonce, and gets the search contract back.
+ */
+export function resolveRailAlignedTarget<T extends { turnId: string; nonce: number }>(
+  claim: RailAlignmentClaim | undefined,
+  target: T | undefined,
+): {
+  claim: RailAlignmentClaim | undefined;
+  target: (T & { align: 'start' | 'center' }) | undefined;
+} {
+  if (!target) return { claim, target: undefined };
+  const aimedByRail = claim !== undefined
+    && claim.turnId === target.turnId
+    && (claim.nonce === undefined || claim.nonce === target.nonce);
+  return {
+    claim: aimedByRail ? { turnId: target.turnId, nonce: target.nonce } : undefined,
+    target: { ...target, align: aimedByRail ? 'start' : 'center' },
+  };
+}
+
 /** Persistent navigation position with a direct path back to the transcript tail. */
 export function TranscriptHistoryNotice({
   title,
@@ -518,27 +547,16 @@ export function ChatView(props: {
   // top for a second after the rail has landed it. The reveal keeps its other
   // job of recording the reading position; it just has to agree with the rail
   // about the edge.
-  const railAimedTurnIdRef = useRef<string | undefined>(undefined);
+  const railClaimRef = useRef<RailAlignmentClaim | undefined>(undefined);
   const navigatePromptRailFallback = useCallback((turn: PromptAnchorRailTurn) => {
     if (!turnIdsRef.current.has(turn.turnId) && turn.sequence !== undefined) {
-      railAimedTurnIdRef.current = turn.turnId;
+      railClaimRef.current = { turnId: turn.turnId };
       loadTranscriptTurnRef.current?.({ turnId: turn.turnId, sequence: turn.sequence });
     }
   }, []);
-  // Navigating anywhere else resolves the claim, so a click the shell ignored
-  // cannot re-aim a later search.
-  if (props.scrollTargetTurn && props.scrollTargetTurn.turnId !== railAimedTurnIdRef.current) {
-    railAimedTurnIdRef.current = undefined;
-  }
-  const scrollTargetTurn = props.scrollTargetTurn
-    ? {
-        ...props.scrollTargetTurn,
-        align:
-          props.scrollTargetTurn.turnId === railAimedTurnIdRef.current
-            ? ('start' as const)
-            : ('center' as const),
-      }
-    : undefined;
+  const railAlignment = resolveRailAlignedTarget(railClaimRef.current, props.scrollTargetTurn);
+  railClaimRef.current = railAlignment.claim;
+  const scrollTargetTurn = railAlignment.target;
   const inlineTransientMessages = tailTurnId
     ? transientMessages.filter((message) => {
         const turn = turns.find((candidate) => candidate.turnId === tailTurnId);

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -510,11 +510,35 @@ export function ChatView(props: {
   }
   const scrollRef = chatLayout.scrollContainerRef;
   const scrollAuthority = useTranscriptScrollAuthority();
+  // A rail click aims itself: it puts the prompt at the top of the scrollport
+  // and holds it there while the loaded range settles. Asking the shell to load
+  // an unloaded prompt also publishes a scroll target, and that reveal centres
+  // the turn with the app's scroll motion — a second answer to "where should
+  // this turn sit", and an animated one, which walks the prompt back off the
+  // top for a second after the rail has landed it. The reveal keeps its other
+  // job of recording the reading position; it just has to agree with the rail
+  // about the edge.
+  const railAimedTurnIdRef = useRef<string | undefined>(undefined);
   const navigatePromptRailFallback = useCallback((turn: PromptAnchorRailTurn) => {
     if (!turnIdsRef.current.has(turn.turnId) && turn.sequence !== undefined) {
+      railAimedTurnIdRef.current = turn.turnId;
       loadTranscriptTurnRef.current?.({ turnId: turn.turnId, sequence: turn.sequence });
     }
   }, []);
+  // Navigating anywhere else resolves the claim, so a click the shell ignored
+  // cannot re-aim a later search.
+  if (props.scrollTargetTurn && props.scrollTargetTurn.turnId !== railAimedTurnIdRef.current) {
+    railAimedTurnIdRef.current = undefined;
+  }
+  const scrollTargetTurn = props.scrollTargetTurn
+    ? {
+        ...props.scrollTargetTurn,
+        align:
+          props.scrollTargetTurn.turnId === railAimedTurnIdRef.current
+            ? ('start' as const)
+            : ('center' as const),
+      }
+    : undefined;
   const inlineTransientMessages = tailTurnId
     ? transientMessages.filter((message) => {
         const turn = turns.find((candidate) => candidate.turnId === tailTurnId);
@@ -540,7 +564,7 @@ export function ChatView(props: {
     scrollRef,
     sessionId: props.activeSession?.id,
     messages: props.messages,
-    target: props.scrollTargetTurn,
+    target: scrollTargetTurn,
     restoreTarget: props.restoreTargetTurn,
     onReadingAnchorChange: props.onReadingAnchorChange,
     behavior: props.scrollBehavior,

--- a/packages/ui/src/use-chat-scroll.ts
+++ b/packages/ui/src/use-chat-scroll.ts
@@ -40,7 +40,13 @@ export function useChatScroll(input: {
   scrollRef: RefObject<HTMLElement | null>;
   sessionId?: string;
   messages: readonly StoredMessage[];
-  target?: { turnId: string; nonce: number };
+  /**
+   * A turn to reveal, and where its requester wants it. `center` with the
+   * app's scroll motion is the reveal a search result wants; `start` is for a
+   * requester that is already aiming this turn itself and only needs the
+   * reveal to agree with it, instantly and at the same edge.
+   */
+  target?: { turnId: string; nonce: number; align?: 'start' | 'center' };
   restoreTarget?: { turnId: string; unavailable?: boolean };
   onReadingAnchorChange?(turnId?: string): void;
   behavior: ScrollBehavior;
@@ -182,7 +188,12 @@ export function useChatScroll(input: {
 
   useEffect(() => {
     const explicitTarget = input.target?.turnId
-      ? { kind: 'search' as const, turnId: input.target.turnId, nonce: input.target.nonce }
+      ? {
+          kind: 'search' as const,
+          turnId: input.target.turnId,
+          nonce: input.target.nonce,
+          align: input.target.align ?? ('center' as const),
+        }
       : undefined;
     const restoreTurnId = activation.current?.restoreTurnId;
     const target = explicitTarget ?? (restoreTurnId
@@ -217,9 +228,13 @@ export function useChatScroll(input: {
       }
       handledTarget.current = chosen;
       const targetElement = element as HTMLElement;
+      const alignToStart = target.kind !== 'search' || target.align === 'start';
       targetElement.scrollIntoView({
-        behavior: target.kind === 'search' ? input.behavior : 'auto',
-        block: target.kind === 'search' ? 'center' : 'start',
+        // A reveal that agrees with a requester already aiming this turn has to
+        // be instant too: an animated one is a second writer moving the
+        // scroller for a second after the requester has landed it.
+        behavior: alignToStart ? 'auto' : input.behavior,
+        block: alignToStart ? 'start' : 'center',
       });
       // A command can land at the browser's existing offset and therefore
       // produce no scroll event. Reuse the authority-backed reporter so that


### PR DESCRIPTION
## Summary

Desktop e2e tests failed on main and on PR reruns with `element(s) not found` right after a send, and were green on rerun. Every send goes through an asynchronous admission chain, and the specs pressed Enter after an *intermediate* signal — a mounted composer, a cleared draft, an updated model label — none of which says the shell will accept a submission. Moving Desktop e2e to 4 workers on one runner (#4523) cut each worker's CPU share and removed the margin that had been hiding it.

Fencing those sends left three more failures in the same specs, none of them a send. All three are chased to their cause here rather than deferred, so the specs this PR touches run clean end to end: a second writer moving the transcript scroller in the product, a cold-start focus race in the test, and a fixture window that never named its locale.

## Test changes

- `fixtures.ts` — one exported `awaitSendReady(page)` waits for 发送 to be enabled: connections projected, no confirmed blocker, a draft to send, no send already in flight. One send in `streaming-remount.spec.ts` already did this by hand; the helper is that wait named once instead of copied. What the button cannot say is whether the readiness probe has answered — an unresolved snapshot is not a hard block, so Send stays enabled while the probe is in flight and `send()` awaits it again on its own. The 20s assertions cover every admission measured here, but not the whole 30s first-send observation barrier; widening them past it buys nothing, because a 60s test budget is the real cap and a send admitted at 25s leaves the multi-send specs unable to finish either way. A probe that comes back *blocked* still drops the submission silently, which is the third item in #4573 and is a product gap no test-side fence can close.
- `streaming-remount.spec.ts` — `await expect(composer).toHaveText('')` after 新任务 proves only that the draft key swapped. Every send in the file goes through `awaitSendReady`, and the assertions that observe the resulting Turn carry an explicit `{ timeout: 20_000 }` — above the config-wide 10s default, below the 60s test timeout.
- `transcript-scroll.spec.ts` — `await expect(modelSwitcher).toContainText('glm-4.5')` waits on the switcher's local label, not on the Session committing model and connection identity. `sendPrompt` now fences, and the `.maka-user-message` assertion carries 20s.
- `accessibility-coverage.spec.ts` — three sends fenced. In the two that reach Send by keyboard the fence goes *after* the Tab walk: a tooltip-carrying Astryx Button is disabled through `aria-disabled` and stays focusable, so `tabTo` reaches it either way and an earlier fence would only reopen the window it was meant to close.
- `fixtures.ts` — `promptRailMotionWindow` gated readiness on `[data-turn-id]` alone. The transcript and the fixture attributes arrive on two unordered async paths: `runDeferredStartupRefreshes` fires `refreshSessions()` and `applyE2eFixture()` side by side, and only the second writes `data-maka-scroll-motion`, after its `e2eFixture.getState()` IPC resolves. One selector — `html[data-maka-scroll-motion="smooth"] [data-turn-id]` — now requires both.

No e2e test is added: the diff under `apps/desktop/e2e` adds zero `test(` blocks and only changes what existing tests wait on. Roughly 40 bare-Enter sends remain in other specs; they can adopt the helper when they fail.

## Product change: two writers aiming the same turn

`prompt-rail.spec.ts:213` failed on *the clicked prompt reaches the top* — 68px against a 24px bound, held for the full 10s poll. A settled wrong position, not motion still in flight, and it reproduces outside the test.

Clicking a rail tick for a prompt outside the resident range asks the shell to load it, and the shell answers a load request by publishing a scroll target. That target is the search reveal: `block: 'center'` with the app's scroll motion. So two writers aim at the same turn with different answers — the rail's instant `block: 'start'` jump, and a smooth centring animation a frame or two behind it. On `chat-prompt-rail`, whose head is 110 turns outside the resident range, the rail lands turn 1 at the top, the centring scroll then walks the transcript back down over ~950ms and clamps at `scrollTop` 0, leaving the prompt 68px below the top. The rail's hold re-aims and wins that race most of the time, which is what made this look like flake; when the range arrives while the animation is already running, the hold sees a moving scroller every frame, never re-aims, and the prompt never reaches the top at all.

The reveal is not redundant — it also records the reading position, so dropping it for rail navigations loses the anchor a session switch restores from. Only its alignment conflicts, and the transcript is where both facts meet: it aimed the turn and it consumes the reveal, so `ChatView` reconciles them and the shell keeps publishing one kind of target. A reveal for the turn the rail is holding is instant and top-aligned; every other one, a search result included, is centred and animated as before. The claim belongs to the one navigation the click asked for, not to the turn: it binds to the first target that arrives for that turn and is spent on anything else, so a later search for the same turn — a different command with its own nonce — gets the search contract back. `resolveRailAlignedTarget` is that rule as a pure function, covered by `packages/ui/src/__tests__/rail-alignment-claim.test.ts`.

## Fixture locale

`transcript-scroll.spec.ts:259` failed on CI at the fence itself with `element(s) not found`, on an English page. `promptRailWorker` passed no `locale`, so its renderer took the host's: Chinese on a developer's desktop, English on the CI runner, and every label-addressed control a coin flip. It now names `zh`, and so does `promptRailMotionWindow`, the other window that had been inheriting the host locale — it only reaches data attributes today, but the next label-addressed step there would bring the same failure back.

## Skip link

`accessibility-coverage.spec.ts:222` failed on `enterMainFromSkipLink`, which parks focus on `body` and asserts the skip link is within ten Tab presses of the document start. Parking is not a one-shot the renderer respects: the composer restores its draft caret with `getSelection().addRange(...)`, and a range set inside a `contenteditable` focuses it — so once per cold start, tens of milliseconds after the park and with no `focus()` call to fence on, focus lands in the composer. A walk that starts there runs out the tab ring and wraps around, over budget. The restore fires once, so the park and the walk retry together rather than the budget growing to absorb the wrap-around; the budget is the assertion and it stays where it was.

The product side of that — a caret restore that takes focus, and moves the sequential focus navigation starting point even if focus is handed back — is a real a11y defect and is being fixed separately; that change removes this retry as part of its own diff.

## What this PR deliberately does not do

An earlier revision also made the shell block sends while the readiness probe was unresolved, so that an enabled Send meant admission was settled. CI disproved it: `pending` reaches the composer through `sendBlocked`, and `sendCurrent` *discards* a submission on `sendBlocked` rather than waiting, so an Enter pressed during the probe window — `send-message.spec.ts:35` does exactly that at cold start, and so does a user who types immediately after launch — was silently dropped where it previously waited for the probe and went through. Splitting the two facts (disable the button, still hand the keystroke to `send()`) needs one more prop across the shell boundary, which `app-shell.tsx` cannot afford under the renderer architecture ratchet. So the gate is out, and the honest order is: give a dropped submission feedback first (#4573, item 3), then tighten the button.

Closes #4573

## Verification

- macOS, `playwright test e2e/send-message.spec.ts e2e/streaming-remount.spec.ts e2e/transcript-scroll.spec.ts e2e/accessibility-coverage.spec.ts e2e/prompt-rail.spec.ts` → **31 passed**.
- Before the scroll-anchor fix, `prompt-rail.spec.ts` repeated 20 times gave 16 passed / 4 failed, every failure the same *reaches the top* assertion at 68px; with the fixture motion gate reverted and everything else identical, 18 / 2. The `"smooth"` / `undefined` failure the issue names appeared in neither run of 20 — the motion gate is a real race, but the anchoring bug is what dominated that test.
- Linux CI ran Desktop e2e green on the revision that carried these test changes plus the reverted gate; the two failures that followed on the next revision were the fixture locale (fixed here) and the gate itself (removed here).
- `npm exec -w @maka/ui -- npm run test:dist` → **328 passed**, including the rail-then-search alignment sequence.
- `npm run format`, `npm run lint`, `npm exec -w @maka/desktop -- npm run typecheck`, and `node apps/desktop/scripts/check-renderer-architecture.mjs --base origin/main` — all clean.

The CI artifact step is not exercised locally; it only runs on a failing job. It is what produced the evidence for the locale diagnosis above.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code drafted the spec and fixture changes, the scroll-anchor fix, the CI step and this description; the root-cause analysis, the scope decisions and the verification runs were reviewed by the author.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — the prompt rail's scroll target, described above
- [ ] No

