### PR TITLE
chore(deps): bump qs and fast-uri to clear the production dependency audit

### DIFF
--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -9253,7 +9253,7 @@ SOFTWARE.
 
 ================================================================================
 
-Package: fast-uri@3.1.5
+Package: fast-uri@3.1.7
 Declared license: BSD-3-Clause
 Selected license: BSD-3-Clause
 Repository: git+https://github.com/fastify/fast-uri.git
@@ -12590,7 +12590,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-Package: qs@6.15.3
+Package: qs@6.16.0
 Declared license: BSD-3-Clause
 Selected license: BSD-3-Clause
 Repository: https://github.com/ljharb/qs.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -8114,9 +8114,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -11896,9 +11896,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/packages/cli/THIRD_PARTY_NOTICES.txt
+++ b/packages/cli/THIRD_PARTY_NOTICES.txt
@@ -4108,7 +4108,7 @@ SOFTWARE.
 
 ================================================================================
 
-Package: fast-uri@3.1.5
+Package: fast-uri@3.1.7
 Declared license: BSD-3-Clause
 Selected license: BSD-3-Clause
 Repository: git+https://github.com/fastify/fast-uri.git
@@ -6483,7 +6483,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-Package: qs@6.15.3
+Package: qs@6.16.0
 Declared license: BSD-3-Clause
 Selected license: BSD-3-Clause
 Repository: https://github.com/ljharb/qs.git


### PR DESCRIPTION
## Summary

`npm audit --omit=dev` reports two advisories against production dependencies: `qs@6.15.3` (moderate — array-limit bypass via bracket-key comma parsing; DoS via attacker-controlled `isBuffer`), reached through `@larksuiteoapi/node-sdk` in `@maka/runtime`, and `fast-uri@3.1.x` (high — host confusion and SSRF via IDN, IPv6 and percent-decoding normalization; GHSA-5jgf-p345-68v8 and siblings). The **Build CLI release candidate** step and the **Dependency audit** workflow fail on any such advisory, so every PR on `main` currently fails regardless of its content (e.g. https://github.com/apache/maka/actions/runs/33648229722, https://github.com/apache/maka/actions/runs/33655577529). `qs` resolves to 6.16.0 and `fast-uri` to 3.1.7; the production dependency notices (Desktop and CLI) are regenerated for the new versions.

## Verification

`npm audit --omit=dev --audit-level=moderate` → clean; `npm audit --omit=dev --workspace maka-agent --json` → `total: 0`; `npm run check:third-party-notices` and `npm run check:cli-third-party-notices` → clean. No source changes.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — diagnosis and the lockfile bump; verified by the author.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

https://claude.ai/code/session_014ajaRxC4jydavY9nYUFj5J