### PR TITLE
chore(desktop): price only regressive dependency edges in the renderer ratchet

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -292,22 +292,19 @@
   "legacyAppShell": {
     "files": {
       "src/renderer/app-shell-app-update.ts": {
-        "importDeclarations": 2,
+        "importDeclarations": 0,
         "bridgePaths": {},
         "environmentCapabilities": {},
         "hookCalls": {},
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
-          "@maka/ui": 1
-        },
-        "importSpecifiers": 2,
+        "dependencyPaths": {},
+        "importSpecifiers": 0,
         "nonTriviaTokens": 92
       },
       "src/renderer/app-shell-chat-actions.ts": {
-        "importDeclarations": 25,
+        "importDeclarations": 9,
         "bridgePaths": {
           "window.maka.newTasks.create": 1,
           "window.maka.sessions.remove": 1,
@@ -323,33 +320,17 @@
           "createAppShellChatActions"
         ],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./app-shell-copy.js": 1,
-          "./app-shell-session-ui-state.js": 1,
           "./attachment-preflight.js": 1,
           "./composer-attachments.js": 1,
-          "./desktop-transcript-range-store.js": 1,
           "./locales/shell-copy.js": 1,
           "./model-connection-errors.js": 1,
-          "./session-message-settlement.js": 1,
-          "./session-workspace-actions.js": 1,
           "./session-workspace-errors.js": 1,
           "./skill-invocation-feedback.js": 1,
-          "@maka/core/collaboration": 1,
-          "@maka/core/events": 2,
-          "@maka/core/model-thinking": 1,
-          "@maka/core/orchestration": 1,
-          "@maka/core/runtime-inputs": 1,
-          "@maka/core/sandbox-boundary": 1,
-          "@maka/core/session": 1,
           "@maka/core/session-name": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/core/user-question": 1,
-          "@maka/runtime/skill-invocation": 1,
           "@maka/ui": 1
         },
-        "importSpecifiers": 38,
+        "importSpecifiers": 16,
         "nonTriviaTokens": 4086
       },
       "src/renderer/app-shell-chrome-actions.tsx": {
@@ -373,7 +354,7 @@
         "nonTriviaTokens": 408
       },
       "src/renderer/app-shell-command-actions.ts": {
-        "importDeclarations": 16,
+        "importDeclarations": 7,
         "bridgePaths": {
           "window.maka.connections.setDefault": 1,
           "window.maka.connections.test": 1,
@@ -392,62 +373,18 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/diagnostics-contract.js": 1,
           "./app-shell-copy.js": 1,
-          "./application/contracts/session-start-mode.js": 1,
           "./command-palette-commands.js": 1,
-          "./command-palette-types.js": 1,
           "./conversation-markdown.js": 1,
           "./default-runtime-host-operation.js": 1,
           "./locales/settings-test-result-copy.js": 1,
           "./locales/shell-copy.js": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/permission": 1,
-          "@maka/core/session": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1,
           "react": 1
         },
-        "importSpecifiers": 22,
+        "importSpecifiers": 11,
         "nonTriviaTokens": 2307
       },
       "src/renderer/app-shell-context-compaction.ts": {
-        "importDeclarations": 4,
-        "bridgePaths": {},
-        "environmentCapabilities": {},
-        "hookCalls": {},
-        "lifecycleMethods": {},
-        "unresolvedDependencies": 0,
-        "actionFactories": [],
-        "dependencyPaths": {
-          "./locales/shell-copy.js": 1,
-          "@maka/core/events": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/runtime-host/protocol": 1
-        },
-        "importSpecifiers": 4,
-        "nonTriviaTokens": 612
-      },
-      "src/renderer/app-shell-copy.ts": {
-        "importDeclarations": 5,
-        "bridgePaths": {},
-        "environmentCapabilities": {},
-        "hookCalls": {},
-        "lifecycleMethods": {},
-        "unresolvedDependencies": 0,
-        "actionFactories": [],
-        "dependencyPaths": {
-          "./locales/shell-copy.js": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/redaction": 1,
-          "@maka/core/text-file-import": 1,
-          "@maka/core/ui-locale": 1
-        },
-        "importSpecifiers": 6,
-        "nonTriviaTokens": 515
-      },
-      "src/renderer/app-shell-detail-panel.tsx": {
         "importDeclarations": 1,
         "bridgePaths": {},
         "environmentCapabilities": {},
@@ -456,13 +393,40 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "react": 1
+          "./locales/shell-copy.js": 1
         },
         "importSpecifiers": 1,
+        "nonTriviaTokens": 612
+      },
+      "src/renderer/app-shell-copy.ts": {
+        "importDeclarations": 2,
+        "bridgePaths": {},
+        "environmentCapabilities": {},
+        "hookCalls": {},
+        "lifecycleMethods": {},
+        "unresolvedDependencies": 0,
+        "actionFactories": [],
+        "dependencyPaths": {
+          "./locales/shell-copy.js": 1,
+          "@maka/core/redaction": 1
+        },
+        "importSpecifiers": 3,
+        "nonTriviaTokens": 515
+      },
+      "src/renderer/app-shell-detail-panel.tsx": {
+        "importDeclarations": 0,
+        "bridgePaths": {},
+        "environmentCapabilities": {},
+        "hookCalls": {},
+        "lifecycleMethods": {},
+        "unresolvedDependencies": 0,
+        "actionFactories": [],
+        "dependencyPaths": {},
+        "importSpecifiers": 0,
         "nonTriviaTokens": 87
       },
       "src/renderer/app-shell-e2e-fixture.ts": {
-        "importDeclarations": 6,
+        "importDeclarations": 1,
         "bridgePaths": {
           "window.maka.e2eFixture.getState": 1
         },
@@ -476,18 +440,13 @@
           "createAppShellE2eFixtureActions"
         ],
         "dependencyPaths": {
-          "./features/workbar": 1,
-          "./theme": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1,
-          "react": 1
+          "./theme": 1
         },
-        "importSpecifiers": 8,
+        "importSpecifiers": 1,
         "nonTriviaTokens": 672
       },
       "src/renderer/app-shell-effects.ts": {
-        "importDeclarations": 23,
+        "importDeclarations": 13,
         "bridgePaths": {
           "window.maka.app.info": 1,
           "window.maka.appWindow.subscribeCommand": 1,
@@ -523,33 +482,25 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "../shared/runtime-host-identity.js": 1,
           "./app-shell-copy": 1,
           "./browser-storage": 1,
           "./desktop-transcript-range-store.js": 1,
           "./locales/conversation-copy.js": 1,
-          "./nav-selection.js": 1,
           "./session-event-health": 1,
           "./shell-run-update-state.js": 1,
           "./theme": 1,
           "./titlebar-modal-sync": 1,
           "@astryxdesign/core/hooks": 1,
-          "@maka/core/connections": 1,
-          "@maka/core/events": 2,
           "@maka/core/redaction": 1,
-          "@maka/core/session": 1,
-          "@maka/core/session-event-health": 2,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1,
+          "@maka/core/session-event-health": 1,
           "react": 1
         },
-        "importSpecifiers": 37,
+        "importSpecifiers": 21,
         "nonTriviaTokens": 3823
       },
       "src/renderer/app-shell-overlays.tsx": {
-        "importDeclarations": 14,
+        "importDeclarations": 8,
         "bridgePaths": {},
         "environmentCapabilities": {
           "window": 2,
@@ -567,27 +518,21 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./app-shell-command-actions": 1,
           "./command-palette": 1,
           "./keyboard-help": 1,
           "./locales/shell-remaining-copy.js": 1,
           "./settings/settings-modal": 1,
-          "./settings/tasks-settings-page": 1,
-          "./settings/ui-locale-update-gate": 1,
           "@astryxdesign/core/hooks": 1,
           "@astryxdesign/core/Spinner": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "react": 1
         },
-        "importSpecifiers": 22,
+        "importSpecifiers": 12,
         "nonTriviaTokens": 977
       },
       "src/renderer/app-shell-project-actions.ts": {
-        "importDeclarations": 9,
+        "importDeclarations": 5,
         "bridgePaths": {
           "window.maka.app.openPath": 4,
           "window.maka.app.resolveProjectGitInfo": 1,
@@ -607,21 +552,17 @@
           "createAppShellProjectActions"
         ],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./app-shell-copy": 1,
           "./default-runtime-host-operation.js": 1,
           "./locales/shell-copy.js": 1,
           "./open-path": 1,
-          "./session-workspace-errors": 1,
-          "@maka/core/project": 1,
-          "@maka/core/ui-locale": 1,
-          "react": 1
+          "./session-workspace-errors": 1
         },
-        "importSpecifiers": 15,
+        "importSpecifiers": 9,
         "nonTriviaTokens": 2284
       },
       "src/renderer/app-shell-revision-actions.ts": {
-        "importDeclarations": 11,
+        "importDeclarations": 6,
         "bridgePaths": {
           "window.maka.sessions.abandonSessionCopy": 2,
           "window.maka.sessions.reviseBeforeTurn": 1
@@ -634,22 +575,18 @@
           "createAppShellRevisionActions"
         ],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./locales/conversation-copy.js": 1,
           "./locales/shell-copy.js": 1,
           "./session-copy-attempt.js": 1,
           "./session-message-settlement.js": 1,
-          "./session-workspace-actions.js": 1,
           "./session-workspace-errors.js": 1,
-          "@maka/core/session": 2,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1
+          "@maka/core/session": 1
         },
-        "importSpecifiers": 17,
+        "importSpecifiers": 10,
         "nonTriviaTokens": 2316
       },
       "src/renderer/app-shell-session-events.ts": {
-        "importDeclarations": 8,
+        "importDeclarations": 3,
         "bridgePaths": {},
         "environmentCapabilities": {
           "requestAnimationFrame": 1,
@@ -663,20 +600,15 @@
           "createAppShellSessionEventHandlers"
         ],
         "dependencyPaths": {
-          "./app-shell-chat-actions.js": 1,
-          "./app-shell-session-ui-state.js": 1,
           "./locales/conversation-copy.js": 1,
           "./model-connection-errors.js": 1,
-          "@maka/core/events": 1,
-          "@maka/core/session": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1
         },
-        "importSpecifiers": 21,
+        "importSpecifiers": 12,
         "nonTriviaTokens": 2974
       },
       "src/renderer/app-shell-session-start-actions.ts": {
-        "importDeclarations": 7,
+        "importDeclarations": 3,
         "bridgePaths": {
           "window.maka.newTasks.create": 1,
           "window.maka.onboarding.setMilestone": 1
@@ -689,15 +621,11 @@
           "createAppShellSessionStartActions"
         ],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
-          "./application/contracts/session-start-mode.js": 1,
           "./locales/shell-copy.js": 1,
           "./model-connection-errors.js": 1,
-          "./session-workspace-errors.js": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1
+          "./session-workspace-errors.js": 1
         },
-        "importSpecifiers": 11,
+        "importSpecifiers": 7,
         "nonTriviaTokens": 650
       },
       "src/renderer/app-shell-session-ui-state.ts": {
@@ -715,7 +643,7 @@
         "nonTriviaTokens": 7
       },
       "src/renderer/app-shell-stop-action.ts": {
-        "importDeclarations": 4,
+        "importDeclarations": 2,
         "bridgePaths": {
           "window.maka.sessions.stop": 1
         },
@@ -727,16 +655,14 @@
           "createAppShellStopAction"
         ],
         "dependencyPaths": {
-          "./app-shell-session-ui-state.js": 1,
           "./locales/conversation-copy.js": 1,
-          "./locales/shell-copy.js": 1,
-          "@maka/core/ui-locale": 1
+          "./locales/shell-copy.js": 1
         },
-        "importSpecifiers": 4,
+        "importSpecifiers": 2,
         "nonTriviaTokens": 302
       },
       "src/renderer/app-shell-turn-actions.ts": {
-        "importDeclarations": 9,
+        "importDeclarations": 4,
         "bridgePaths": {
           "window.maka.sessions.branchFromTurn": 1,
           "window.maka.sessions.regenerateTurn": 1
@@ -749,21 +675,16 @@
           "createAppShellTurnActions"
         ],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./locales/conversation-copy.js": 1,
           "./locales/shell-copy.js": 1,
           "./session-copy-attempt.js": 1,
-          "./session-workspace-actions.js": 1,
-          "./session-workspace-errors.js": 1,
-          "@maka/core/session": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1
+          "./session-workspace-errors.js": 1
         },
-        "importSpecifiers": 10,
+        "importSpecifiers": 5,
         "nonTriviaTokens": 650
       },
       "src/renderer/app-shell-turn-view-model.ts": {
-        "importDeclarations": 7,
+        "importDeclarations": 6,
         "bridgePaths": {},
         "environmentCapabilities": {},
         "hookCalls": {
@@ -779,15 +700,14 @@
           "./interrupted-resume.js": 1,
           "./session-status-presentation.js": 1,
           "./turn-footer-actions.js": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "react": 1
         },
-        "importSpecifiers": 18,
+        "importSpecifiers": 11,
         "nonTriviaTokens": 1408
       },
       "src/renderer/app-shell.tsx": {
-        "importDeclarations": 102,
+        "importDeclarations": 92,
         "bridgePaths": {
           "window.maka.app.installUpdate": 1,
           "window.maka.app.retryUpdateDownload": 1,
@@ -877,13 +797,11 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "../preload/transcript-contract.js": 1,
           "./agent-graph-panel": 1,
           "./app-shell-app-update": 1,
           "./app-shell-chat-actions": 1,
           "./app-shell-chrome-actions": 1,
-          "./app-shell-command-actions": 1,
           "./app-shell-context-compaction": 1,
           "./app-shell-detail-panel": 1,
           "./app-shell-e2e-fixture": 1,
@@ -933,7 +851,6 @@
           "./settings/provider-brand-marks": 1,
           "./settings/provider-display": 1,
           "./settings/runtime-host-ssh-terminal-dialog.js": 1,
-          "./settings/tasks-settings-page": 1,
           "./stale-sessions": 1,
           "./use-active-execution-boundary": 1,
           "./use-app-shell-composer-quotes": 1,
@@ -964,25 +881,20 @@
           "./workspace-readiness-recovery": 1,
           "@astryxdesign/core/AppShell": 1,
           "@astryxdesign/core/Button": 1,
-          "@maka/core/connections": 1,
-          "@maka/core/events": 1,
           "@maka/core/onboarding-milestone": 1,
-          "@maka/core/orchestration": 1,
-          "@maka/core/project": 1,
           "@maka/core/session": 1,
           "@maka/core/session-revisions": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/slash-command-catalog": 2,
-          "@maka/core/ui-locale": 2,
+          "@maka/core/slash-command-catalog": 1,
+          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
         },
-        "importSpecifiers": 180,
+        "importSpecifiers": 148,
         "nonTriviaTokens": 15620
       },
       "src/renderer/use-app-shell-composer-quotes.ts": {
-        "importDeclarations": 3,
+        "importDeclarations": 2,
         "bridgePaths": {},
         "environmentCapabilities": {},
         "hookCalls": {
@@ -993,14 +905,13 @@
         "actionFactories": [],
         "dependencyPaths": {
           "./pending-items.js": 1,
-          "@maka/core/events": 1,
           "react": 1
         },
-        "importSpecifiers": 7,
+        "importSpecifiers": 5,
         "nonTriviaTokens": 360
       },
       "src/renderer/use-app-shell-session-list.ts": {
-        "importDeclarations": 11,
+        "importDeclarations": 10,
         "bridgePaths": {
           "window.maka.sessions.list": 1
         },
@@ -1014,7 +925,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./live-turn-snapshot.js": 1,
           "./locales/conversation-copy.js": 1,
           "./locales/shell-copy.js": 1,
@@ -1026,11 +936,11 @@
           "@maka/ui": 1,
           "react": 1
         },
-        "importSpecifiers": 17,
+        "importSpecifiers": 13,
         "nonTriviaTokens": 581
       },
       "src/renderer/use-app-shell-session-ui-reads.ts": {
-        "importDeclarations": 3,
+        "importDeclarations": 2,
         "bridgePaths": {},
         "environmentCapabilities": {},
         "hookCalls": {
@@ -1040,15 +950,14 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./app-shell-session-ui-state.js": 1,
           "./live-turn-snapshot.js": 1,
           "./use-external-store-selector.js": 1
         },
-        "importSpecifiers": 7,
+        "importSpecifiers": 5,
         "nonTriviaTokens": 322
       },
       "src/renderer/use-app-shell-session-workspace.ts": {
-        "importDeclarations": 11,
+        "importDeclarations": 8,
         "bridgePaths": {},
         "environmentCapabilities": {},
         "hookCalls": {
@@ -1065,17 +974,14 @@
         "dependencyPaths": {
           "./app-shell-session-ui-state.js": 1,
           "./bootstrap-selection-lease.js": 1,
-          "./desktop-transcript-range-store.js": 1,
           "./new-task-reload-intent.js": 1,
           "./session-catalog-state.js": 1,
           "./session-workspace-actions.js": 1,
           "./use-app-shell-session-list.js": 1,
           "./use-external-store-selector.js": 1,
-          "@maka/core/session": 1,
-          "@maka/ui": 1,
           "react": 1
         },
-        "importSpecifiers": 14,
+        "importSpecifiers": 10,
         "nonTriviaTokens": 480
       }
     },
@@ -1097,8 +1003,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../shared/runtime-host-identity.js": 1,
-          "@maka/runtime-host/protocol": 1
+          "../shared/runtime-host-identity.js": 1
         }
       },
       "src/preload/external-session-import-result.ts": {
@@ -1108,9 +1013,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/session": 1
-        }
+        "dependencyPaths": {}
       },
       "src/preload/runtime-host-renderer-operations.ts": {
         "bridgePaths": {},
@@ -1119,9 +1022,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/runtime-host/protocol": 1
-        }
+        "dependencyPaths": {}
       },
       "src/preload/transcript-contract.ts": {
         "bridgePaths": {},
@@ -1165,10 +1066,6 @@
           "@astryxdesign/core/Button": 1,
           "@astryxdesign/core/EmptyState": 1,
           "@astryxdesign/core/Spinner": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/runtime-host/client": 1,
-          "@maka/runtime-host/protocol": 1,
-          "@maka/runtime/stream-graph-read-model": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
@@ -1190,9 +1087,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "../preload/bridge-contract.js": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/astryx-theme/type-scale.ts": {
         "bridgePaths": {},
@@ -1212,8 +1107,7 @@
         "actionFactories": [],
         "dependencyPaths": {
           "./locales/conversation-copy.js": 1,
-          "@maka/core/attachments": 1,
-          "@maka/core/ui-locale": 1
+          "@maka/core/attachments": 1
         }
       },
       "src/renderer/bootstrap-selection-lease.ts": {
@@ -1251,7 +1145,7 @@
         "dependencyPaths": {
           "./composer-mentions.js": 1,
           "./new-task-reload-intent.js": 1,
-          "@maka/ui": 2,
+          "@maka/ui": 1,
           "react": 1
         }
       },
@@ -1268,22 +1162,15 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./app-shell-session-ui-state": 1,
           "./chat-recovery-notice": 1,
           "./locales/conversation-copy": 1,
           "./locales/shell-copy": 1,
           "./onboarding-hero": 1,
-          "./task-readiness-notice": 1,
           "./use-app-shell-session-ui-reads": 1,
           "./use-deep-research-run": 1,
           "./use-external-store-selector": 1,
-          "./use-shell-chat-model": 1,
-          "./workspace-readiness-recovery": 1,
           "@astryxdesign/core": 1,
           "@maka/core/deep-research": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/onboarding": 1,
-          "@maka/core/settings": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -1296,9 +1183,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./use-shell-chat-model": 1,
-          "@maka/ui": 1,
-          "react": 1
+          "@maka/ui": 1
         }
       },
       "src/renderer/command-palette-commands.ts": {
@@ -1309,16 +1194,9 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./command-palette-types.js": 1,
           "./locales/shell-copy.js": 1,
           "./settings/settings-nav.js": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/permission": 1,
           "@maka/core/provider-registry": 1,
-          "@maka/core/session": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1,
           "@maka/ui/icons": 1
         }
       },
@@ -1329,9 +1207,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/ui/icons": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/command-palette.tsx": {
         "bridgePaths": {},
@@ -1350,7 +1226,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./command-palette-types": 2,
           "./locales/shell-copy": 1,
           "@astryxdesign/core/EmptyState": 1,
           "@astryxdesign/core/hooks": 1,
@@ -1367,9 +1242,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/events": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/composer-defaults.ts": {
         "bridgePaths": {},
@@ -1401,9 +1274,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
-          "@maka/core/settings": 1,
-          "@maka/runtime/skill-invocation": 1,
           "react": 1
         }
       },
@@ -1416,8 +1286,7 @@
         "actionFactories": [],
         "dependencyPaths": {
           "./locales/shell-remaining-copy.js": 1,
-          "@maka/core/session": 2,
-          "@maka/core/ui-locale": 1,
+          "@maka/core/session": 1,
           "@maka/ui": 1
         }
       },
@@ -1428,10 +1297,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/pet": 1,
-          "@maka/core/session": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/custom-pet-companion.tsx": {
         "bridgePaths": {
@@ -1473,9 +1339,8 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "@maka/core/daily-review": 2,
-          "@maka/core/redaction": 1,
-          "@maka/core/ui-locale": 1
+          "@maka/core/daily-review": 1,
+          "@maka/core/redaction": 1
         }
       },
       "src/renderer/default-runtime-host-operation.ts": {
@@ -1487,9 +1352,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "../preload/bridge-contract.js": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/derive-turn-lineage-badges.ts": {
         "bridgePaths": {},
@@ -1499,9 +1362,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./locales/conversation-copy.js": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1
+          "./locales/conversation-copy.js": 1
         }
       },
       "src/renderer/desktop-execution-boundary-surface.ts": {
@@ -1512,8 +1373,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "@maka/core/permission": 1,
-          "@maka/core/sandbox-boundary": 2
+          "@maka/core/sandbox-boundary": 1
         }
       },
       "src/renderer/desktop-slash-command.ts": {
@@ -1540,7 +1400,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/transcript-contract.js": 1,
           "../shared/desktop-session-projection.js": 1,
           "../shared/runtime-host-identity.js": 1,
           "@maka/core/persisted-value": 1,
@@ -1574,7 +1433,6 @@
         "dependencyPaths": {
           "./locales/shell-copy.js": 1,
           "@maka/core/diagnostic-log": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
@@ -1587,9 +1445,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/events": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/interrupted-resume.ts": {
         "bridgePaths": {},
@@ -1643,10 +1499,8 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./app-shell-session-ui-state": 1,
           "./use-app-shell-session-ui-reads": 1,
           "./use-external-store-selector": 1,
-          "@maka/core/session": 1,
           "react": 1
         }
       },
@@ -1658,9 +1512,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./model-wait-state.js": 1,
-          "./session-event-health.js": 1,
-          "@maka/ui": 1
+          "./session-event-health.js": 1
         }
       },
       "src/renderer/local-memory-digest.ts": {
@@ -1673,9 +1525,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/local-memory": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/artifact-copy.ts": {
         "bridgePaths": {},
@@ -1684,9 +1534,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/browser-copy.ts": {
         "bridgePaths": {},
@@ -1695,9 +1543,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/conversation-copy.ts": {
         "bridgePaths": {},
@@ -1706,12 +1552,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/connection-readiness": 1,
-          "@maka/core/model-call-attempt": 1,
-          "@maka/core/session-send-projection": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/external-session-import-copy.ts": {
         "bridgePaths": {},
@@ -1720,9 +1561,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/mcp-copy.ts": {
         "bridgePaths": {},
@@ -1731,9 +1570,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/onboarding-copy.ts": {
         "bridgePaths": {},
@@ -1742,11 +1579,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "../onboarding-hero-copy.js": 1,
-          "@maka/core/onboarding": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/permission-center-copy.ts": {
         "bridgePaths": {},
@@ -1755,11 +1588,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/capabilities": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/plan-mode-copy.ts": {
         "bridgePaths": {},
@@ -1768,10 +1597,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/plan": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/session-collaboration-copy.ts": {
         "bridgePaths": {},
@@ -1780,9 +1606,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-bot-copy.ts": {
         "bridgePaths": {},
@@ -1791,11 +1615,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/bot-chat-settings": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-daily-review-copy.ts": {
         "bridgePaths": {},
@@ -1804,9 +1624,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-data-copy.ts": {
         "bridgePaths": {},
@@ -1815,10 +1633,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1,
-          "@maka/storage/config-transfer": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-health-copy.ts": {
         "bridgePaths": {},
@@ -1827,11 +1642,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/health": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-memory-copy.ts": {
         "bridgePaths": {},
@@ -1840,10 +1651,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/local-memory": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-navigation-copy.ts": {
         "bridgePaths": {},
@@ -1852,11 +1660,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "../settings/nav-group-summary.js": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-preferences-copy.ts": {
         "bridgePaths": {},
@@ -1865,10 +1669,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-projects-copy.ts": {
         "bridgePaths": {},
@@ -1877,11 +1678,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "../../preload/bridge-contract.js": 2,
-          "@maka/core/ui-locale": 1,
-          "@maka/runtime-host/operator": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-shared-copy.ts": {
         "bridgePaths": {},
@@ -1890,9 +1687,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-subagents-copy.ts": {
         "bridgePaths": {},
@@ -1901,11 +1696,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/model-thinking": 1,
-          "@maka/core/subagent-settings": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-tasks-copy.ts": {
         "bridgePaths": {},
@@ -1914,9 +1705,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-test-result-copy.ts": {
         "bridgePaths": {},
@@ -1925,10 +1714,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-usage-copy.ts": {
         "bridgePaths": {},
@@ -1937,9 +1723,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/settings-web-search-copy.ts": {
         "bridgePaths": {},
@@ -1948,10 +1732,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1,
-          "@maka/core/web-search": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/locales/shell-copy.ts": {
         "bridgePaths": {},
@@ -1961,12 +1742,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "@maka/core/goal": 1,
-          "@maka/core/permission": 1,
-          "@maka/core/redaction": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/slash-command-catalog": 1,
-          "@maka/core/ui-locale": 1
+          "@maka/core/redaction": 1
         }
       },
       "src/renderer/locales/shell-remaining-copy.ts": {
@@ -1976,9 +1752,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/mcp-brand-contrast.ts": {
         "bridgePaths": {},
@@ -1998,11 +1772,8 @@
         "actionFactories": [],
         "dependencyPaths": {
           "./mcp-brand-contrast.js": 1,
-          "./mcp-catalog": 1,
           "@ant-design/icons-svg/es/asn/DingtalkOutlined.js": 1,
-          "@ant-design/icons-svg/es/types.js": 1,
-          "react": 1,
-          "simple-icons": 2
+          "simple-icons": 1
         }
       },
       "src/renderer/mcp-catalog.ts": {
@@ -2012,10 +1783,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/mcp": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/mcp-command-line.ts": {
         "bridgePaths": {},
@@ -2045,9 +1813,8 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./locales/mcp-copy.js": 1,
           "./mcp-command-line.js": 1,
-          "@maka/core/mcp": 2
+          "@maka/core/mcp": 1
         }
       },
       "src/renderer/mcp-page.tsx": {
@@ -2093,7 +1860,7 @@
           "@astryxdesign/core/Dialog": 1,
           "@astryxdesign/core/Layout": 1,
           "@astryxdesign/core/MetadataList": 1,
-          "@maka/core/mcp": 2,
+          "@maka/core/mcp": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
@@ -2108,9 +1875,8 @@
         "actionFactories": [],
         "dependencyPaths": {
           "./locales/shell-remaining-copy.js": 1,
-          "@maka/core/llm-connections": 2,
-          "@maka/core/model-catalog": 1,
-          "@maka/core/ui-locale": 1
+          "@maka/core/llm-connections": 1,
+          "@maka/core/model-catalog": 1
         }
       },
       "src/renderer/model-connection-errors.ts": {
@@ -2124,10 +1890,7 @@
           "./application/contracts/connection-error-cleaner.js": 1,
           "./locales/conversation-copy.js": 1,
           "./locales/shell-copy.js": 1,
-          "./session-error-presentation.js": 1,
-          "@maka/core/connection-readiness": 1,
-          "@maka/core/events": 1,
-          "@maka/core/ui-locale": 1
+          "./session-error-presentation.js": 1
         }
       },
       "src/renderer/model-wait-state.ts": {
@@ -2147,8 +1910,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./browser-storage.js": 1,
-          "@maka/ui": 1
+          "./browser-storage.js": 1
         }
       },
       "src/renderer/new-task-reload-intent.ts": {
@@ -2179,9 +1941,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./locales/onboarding-copy.js": 1,
-          "@maka/core/onboarding": 1,
-          "@maka/core/ui-locale": 1
+          "./locales/onboarding-copy.js": 1
         }
       },
       "src/renderer/onboarding-hero.tsx": {
@@ -2199,12 +1959,8 @@
           "./onboarding-provider-types": 1,
           "./settings/provider-display": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/onboarding": 1,
-          "@maka/core/settings": 1,
           "@maka/ui": 1,
-          "@maka/ui/icons": 1,
-          "react": 1
+          "@maka/ui/icons": 1
         }
       },
       "src/renderer/onboarding-provider-types.ts": {
@@ -2214,9 +1970,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/llm-connections": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/open-path.ts": {
         "bridgePaths": {},
@@ -2226,8 +1980,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./locales/shell-copy.js": 1,
-          "@maka/core/ui-locale": 1
+          "./locales/shell-copy.js": 1
         }
       },
       "src/renderer/pending-items.ts": {
@@ -2246,10 +1999,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/permission": 1,
-          "@maka/core/session": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/plan-mode-panel.tsx": {
         "bridgePaths": {
@@ -2276,9 +2026,6 @@
           "./locales/plan-mode-copy.js": 1,
           "@astryxdesign/core/Banner": 1,
           "@astryxdesign/core/Collapsible": 1,
-          "@maka/core/events": 1,
-          "@maka/core/plan": 1,
-          "@maka/core/session": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -2312,7 +2059,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./locales/shell-copy.js": 1,
           "@astryxdesign/core/Button": 1,
           "@astryxdesign/core/Dialog": 1,
@@ -2320,7 +2066,6 @@
           "@astryxdesign/core/Layout": 1,
           "@astryxdesign/core/Stack": 1,
           "@astryxdesign/core/Text": 1,
-          "@maka/core/project": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
@@ -2351,7 +2096,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./observable-state.js": 1,
           "react": 1
         }
@@ -2386,7 +2130,6 @@
           "@astryxdesign/core": 1,
           "@astryxdesign/core/Dialog": 1,
           "@astryxdesign/core/Layout": 1,
-          "@maka/runtime-host/protocol": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -2410,8 +2153,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./locales/conversation-copy.js": 1,
-          "@maka/core/ui-locale": 1
+          "./locales/conversation-copy.js": 1
         }
       },
       "src/renderer/session-event-health.ts": {
@@ -2422,10 +2164,8 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "@maka/core/session": 1,
-          "@maka/core/session-event-health": 2,
-          "@maka/core/tool-result-status": 1,
-          "@maka/ui": 1
+          "@maka/core/session-event-health": 1,
+          "@maka/core/tool-result-status": 1
         }
       },
       "src/renderer/session-health-notice.ts": {
@@ -2436,10 +2176,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./locales/conversation-copy.js": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/session-send-projection": 1,
-          "@maka/core/ui-locale": 1
+          "./locales/conversation-copy.js": 1
         }
       },
       "src/renderer/session-message-settlement.ts": {
@@ -2455,9 +2192,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
-          "./desktop-transcript-range-store.js": 1,
-          "@maka/core/session": 1
+          "./desktop-transcript-range-store.js": 1
         }
       },
       "src/renderer/session-read-state.ts": {
@@ -2467,9 +2202,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/session": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/session-status-presentation.ts": {
         "bridgePaths": {},
@@ -2481,9 +2214,7 @@
         "dependencyPaths": {
           "./locales/conversation-copy.js": 1,
           "./session-error-presentation.js": 1,
-          "@maka/core/sandbox-boundary": 1,
-          "@maka/core/session": 1,
-          "@maka/core/ui-locale": 1
+          "@maka/core/sandbox-boundary": 1
         }
       },
       "src/renderer/session-trace-refresh.ts": {
@@ -2493,9 +2224,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/events": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/session-workspace-actions.ts": {
         "bridgePaths": {
@@ -2507,12 +2236,9 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./desktop-transcript-range-store.js": 1,
           "./new-task-reload-intent.js": 1,
           "./transient-message-projection.js": 1,
-          "@maka/core/session": 1,
-          "@maka/runtime-host/protocol": 1,
-          "@maka/ui": 1
+          "@maka/runtime-host/protocol": 1
         }
       },
       "src/renderer/session-workspace-errors.ts": {
@@ -2523,9 +2249,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./locales/shell-copy.js": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1
+          "./locales/shell-copy.js": 1
         }
       },
       "src/renderer/settings/about-settings-page.tsx": {
@@ -2549,7 +2273,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "../default-runtime-host-operation.js": 1,
           "../locales/settings-preferences-copy.js": 1,
           "./about-update-status.js": 1,
@@ -2570,10 +2293,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
-          "../locales/settings-preferences-copy.js": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/settings/action-guard.ts": {
         "bridgePaths": {},
@@ -2640,10 +2360,8 @@
           "./password-input": 1,
           "./settings-section": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/bot-chat-settings": 1,
           "@maka/core/bot-onboarding": 1,
           "@maka/core/settings": 1,
-          "@maka/runtime/bots": 1,
           "@maka/ui": 2,
           "@maka/ui/icons": 1,
           "react": 1
@@ -2664,12 +2382,9 @@
           "./bot-settings-view-model": 1,
           "./settings-section": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/bot-chat-settings": 1,
           "@maka/core/settings": 1,
-          "@maka/runtime/bots": 1,
           "@maka/ui": 2,
-          "@maka/ui/icons": 1,
-          "react": 1
+          "@maka/ui/icons": 1
         }
       },
       "src/renderer/settings/bot-chat-settings-page.tsx": {
@@ -2699,10 +2414,6 @@
           "./bot-chat-overview": 1,
           "./bot-chat-shared": 1,
           "./settings-error-copy": 1,
-          "@maka/core/bot-chat-settings": 1,
-          "@maka/core/bot-onboarding": 1,
-          "@maka/core/settings": 1,
-          "@maka/runtime/bots": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -2716,9 +2427,6 @@
         "actionFactories": [],
         "dependencyPaths": {
           "../locales/settings-bot-copy": 1,
-          "@maka/core/bot-chat-settings": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/runtime/bots": 1,
           "@maka/ui": 1
         }
       },
@@ -2750,7 +2458,6 @@
           "@astryxdesign/core": 1,
           "@astryxdesign/core/Dialog": 1,
           "@astryxdesign/core/Layout": 1,
-          "@maka/core/bot-onboarding": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
@@ -2764,9 +2471,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "@maka/core/bot-chat-settings": 1,
-          "@maka/core/bot-events": 1,
-          "@maka/runtime/bots": 1
+          "@maka/core/bot-events": 1
         }
       },
       "src/renderer/settings/bot-wechat-login.tsx": {
@@ -2793,8 +2498,6 @@
           "@astryxdesign/core/Collapsible": 1,
           "@astryxdesign/core/Dialog": 1,
           "@astryxdesign/core/Layout": 1,
-          "@maka/core/bot-chat-settings": 1,
-          "@maka/runtime/bots": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
@@ -2816,9 +2519,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/pet": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/settings/custom-pet-settings-section.tsx": {
         "bridgePaths": {
@@ -2879,8 +2580,6 @@
           "./settings-skeleton": 1,
           "./use-action-guard": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/daily-review": 1,
-          "@maka/core/llm-connections": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -2916,7 +2615,6 @@
           "./settings-rows": 1,
           "./settings-section": 1,
           "./use-action-guard": 1,
-          "@maka/storage/config-transfer": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -2940,7 +2638,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../features/connection-settings": 1,
           "../features/network-proxy/index.js": 1,
           "../locales/settings-preferences-copy.js": 1,
           "../locales/settings-shared-copy.js": 1,
@@ -2951,15 +2648,12 @@
           "./provider-brand-marks": 1,
           "./runtime-host-settings-target.js": 1,
           "./settings-error-copy": 1,
-          "./settings-resource-state.js": 1,
           "./settings-section": 1,
           "./settings-skeleton.js": 1,
           "./use-action-guard": 1,
           "./use-optimistic-settings-draft": 1,
           "@maka/core/chat-model-choice": 1,
-          "@maka/core/llm-connections": 1,
           "@maka/core/model-thinking": 1,
-          "@maka/core/settings": 3,
           "@maka/ui": 2,
           "react": 1
         }
@@ -2986,7 +2680,7 @@
           "./settings-skeleton": 1,
           "./settings-status-summary-filter": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/health": 2,
+          "@maka/core/health": 1,
           "@maka/ui": 2,
           "react": 1
         }
@@ -3013,8 +2707,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
-          "../../preload/external-session-catalog.js": 1,
           "../locales/external-session-import-copy.js": 1,
           "../locales/shell-copy.js": 1,
           "./runtime-host-settings-target.js": 1,
@@ -3042,10 +2734,8 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../locales/settings-memory-copy": 1,
           "./memory-settings-labels": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/local-memory": 1,
           "@maka/ui": 1
         }
       },
@@ -3056,11 +2746,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "../locales/settings-memory-copy": 1,
-          "@maka/core/local-memory": 1,
-          "@maka/ui": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/settings/memory-settings-page.tsx": {
         "bridgePaths": {},
@@ -3081,7 +2767,6 @@
           "./memory-settings-sections": 1,
           "./settings-section": 1,
           "./use-memory-settings-controller": 1,
-          "@maka/core/settings": 1,
           "@maka/ui": 2,
           "@maka/ui/icons": 1,
           "react": 1
@@ -3095,7 +2780,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../locales/settings-memory-copy": 1,
           "./settings-section": 1,
           "@maka/ui": 1
         }
@@ -3110,8 +2794,7 @@
         "dependencyPaths": {
           "../locales/settings-memory-copy.js": 1,
           "./memory-settings-labels.js": 1,
-          "@maka/core/local-memory": 2,
-          "@maka/core/settings": 1,
+          "@maka/core/local-memory": 1,
           "@maka/ui": 1
         }
       },
@@ -3205,9 +2888,8 @@
           "./settings-status-summary-filter": 1,
           "./use-action-guard": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/capabilities": 2,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 3,
+          "@maka/core/capabilities": 1,
+          "@maka/ui": 2,
           "@maka/ui/icons": 1,
           "react": 1
         }
@@ -3239,8 +2921,6 @@
           "./settings-section": 1,
           "./settings-skeleton.js": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -3271,7 +2951,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "../locales/settings-projects-copy.js": 1,
           "../locales/settings-shared-copy.js": 1,
           "../project-path-display.js": 1,
@@ -3283,8 +2962,6 @@
           "./settings-section": 1,
           "./use-action-guard": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/project": 1,
-          "@maka/core/settings": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
@@ -3312,7 +2989,7 @@
           "./use-action-guard": 1,
           "@astryxdesign/core": 1,
           "@astryxdesign/core/Collapsible": 1,
-          "@maka/core/llm-connections": 3,
+          "@maka/core/llm-connections": 2,
           "@maka/ui": 1,
           "react": 1
         }
@@ -3344,7 +3021,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "@maka/core/llm-connections": 2
+          "@maka/core/llm-connections": 1
         }
       },
       "src/renderer/settings/provider-brand-marks.tsx": {
@@ -3379,8 +3056,6 @@
           "../assets/provider-brands/xiaomimimo.svg": 1,
           "../assets/provider-brands/zai.svg": 1,
           "../assets/provider-brands/zenmux.svg": 1,
-          "@maka/core/llm-connections": 1,
-          "react": 1,
           "simple-icons": 1
         }
       },
@@ -3451,10 +3126,7 @@
         "actionFactories": [],
         "dependencyPaths": {
           "../features/connection-settings/index.js": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/provider-registry": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui": 1
+          "@maka/core/provider-registry": 1
         }
       },
       "src/renderer/settings/provider-display-copy.ts": {
@@ -3464,10 +3136,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/llm-connections": 1,
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/settings/provider-display.tsx": {
         "bridgePaths": {},
@@ -3478,8 +3147,7 @@
         "actionFactories": [],
         "dependencyPaths": {
           "./provider-brand-marks": 1,
-          "./provider-display-copy": 1,
-          "@maka/core/llm-connections": 1
+          "./provider-display-copy": 1
         }
       },
       "src/renderer/settings/provider-endpoint-presentation.ts": {
@@ -3509,12 +3177,10 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "../features/connection-settings": 1,
           "./runtime-host-settings-target.js": 1,
           "./use-oauth-login-flow": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/llm-connections": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -3537,7 +3203,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../features/connection-settings": 2,
+          "../features/connection-settings": 1,
           "./provider-catalog-page": 1,
           "./provider-connection-detail": 1,
           "./provider-connection-status": 1,
@@ -3573,9 +3239,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/model-thinking": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/settings/request-customization-editor.tsx": {
         "bridgePaths": {},
@@ -3587,7 +3251,6 @@
         "dependencyPaths": {
           "./password-input": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/llm-connections": 1,
           "@maka/core/runtime-policy": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1
@@ -3600,9 +3263,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "react": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/settings/runtime-host-management-dialog.tsx": {
         "bridgePaths": {
@@ -3632,7 +3293,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "../../shared/runtime-host-project-directory-policy.js": 1,
           "../features/runtime-host-management": 1,
           "../locales/settings-projects-copy.js": 1,
@@ -3667,7 +3327,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "../../shared/runtime-host-project-directory-policy.js": 1,
           "../locales/settings-projects-copy.js": 1,
           "./runtime-host-project-directory-editor.js": 1,
@@ -3704,7 +3363,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "../features/runtime-host-management": 1,
           "../features/session-collaboration": 1,
           "../locales/session-collaboration-copy.js": 1,
@@ -3715,7 +3373,6 @@
           "./settings-error-copy.js": 1,
           "./settings-section.js": 1,
           "@astryxdesign/core": 1,
-          "@maka/runtime-host/client": 1,
           "@maka/runtime-host/protocol": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
@@ -3730,7 +3387,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../locales/settings-projects-copy.js": 1,
           "@maka/runtime-host/protocol": 1,
           "@maka/ui": 1
         }
@@ -3745,7 +3401,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -3772,7 +3427,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "../locales/settings-projects-copy.js": 1,
           "../theme": 1,
           "@astryxdesign/core/Dialog": 1,
@@ -3793,7 +3447,6 @@
         "dependencyPaths": {
           "../locales/settings-shared-copy.js": 1,
           "@maka/core/redaction": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1
         }
       },
@@ -3824,15 +3477,9 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "../locales/settings-shared-copy": 1,
-          "./settings-nav": 2,
+          "./settings-nav": 1,
           "./settings-surface": 1,
-          "./tasks-settings-page": 1,
-          "./ui-locale-update-gate": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -3848,10 +3495,7 @@
           "../browser-storage.js": 1,
           "../locales/settings-navigation-copy.js": 1,
           "./nav-group-summary.js": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/ui/icons": 1,
-          "react": 1
+          "@maka/ui/icons": 1
         }
       },
       "src/renderer/settings/settings-request-authority.ts": {
@@ -3898,8 +3542,7 @@
         "actionFactories": [],
         "dependencyPaths": {
           "@astryxdesign/core": 1,
-          "@maka/ui/icons": 1,
-          "react": 1
+          "@maka/ui/icons": 1
         }
       },
       "src/renderer/settings/settings-rows.tsx": {
@@ -3910,8 +3553,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./settings-section.js": 1,
-          "react": 1
+          "./settings-section.js": 1
         }
       },
       "src/renderer/settings/settings-section.tsx": {
@@ -3923,8 +3565,7 @@
         "actionFactories": [],
         "dependencyPaths": {
           "@astryxdesign/core": 1,
-          "@maka/ui": 1,
-          "react": 1
+          "@maka/ui": 1
         }
       },
       "src/renderer/settings/settings-skeleton.tsx": {
@@ -3940,8 +3581,7 @@
           "../locales/settings-shared-copy.js": 1,
           "./settings-section.js": 1,
           "@astryxdesign/core": 1,
-          "@maka/ui": 1,
-          "react": 1
+          "@maka/ui": 1
         }
       },
       "src/renderer/settings/settings-snapshot-cache.ts": {
@@ -3951,11 +3591,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/settings": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/settings/settings-status-badge.ts": {
         "bridgePaths": {},
@@ -4008,7 +3644,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
           "../../shared/settings-ownership.js": 1,
           "../browser-storage": 1,
           "../features/connection-settings": 1,
@@ -4038,13 +3673,10 @@
           "./settings-snapshot-cache.js": 1,
           "./subagent-settings-page": 1,
           "./tasks-settings-page": 1,
-          "./ui-locale-update-gate": 1,
           "./usage-settings-page": 1,
           "./web-search-settings-page": 1,
           "@astryxdesign/core": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/settings": 2,
-          "@maka/core/ui-locale": 1,
+          "@maka/core/settings": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
@@ -4058,10 +3690,8 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./settings-status-badge.js": 1,
-          "@maka/core/llm-connections": 2,
-          "@maka/core/provider-registry": 1,
-          "@maka/core/subagent-settings": 1
+          "@maka/core/llm-connections": 1,
+          "@maka/core/provider-registry": 1
         }
       },
       "src/renderer/settings/subagent-settings-page.tsx": {
@@ -4092,8 +3722,6 @@
           "./subagent-preset-presentation.js": 1,
           "@astryxdesign/core": 1,
           "@maka/core/llm-connections": 1,
-          "@maka/core/model-thinking": 1,
-          "@maka/core/settings": 1,
           "@maka/core/subagent-settings": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
@@ -4108,8 +3736,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../features/session-navigation/index.js": 1,
-          "@maka/core/session": 1
+          "../features/session-navigation/index.js": 1
         }
       },
       "src/renderer/settings/tasks-settings-page.tsx": {
@@ -4125,8 +3752,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../../preload/bridge-contract.js": 1,
-          "../features/session-navigation": 1,
           "../locales/settings-shared-copy.js": 1,
           "../locales/settings-tasks-copy.js": 1,
           "./settings-error-copy": 1,
@@ -4135,7 +3760,6 @@
           "@astryxdesign/core": 1,
           "@astryxdesign/core/List": 1,
           "@astryxdesign/core/TextInput": 1,
-          "@maka/core/project": 1,
           "@maka/core/relative-time": 1,
           "@maka/runtime-host/profile-kind": 1,
           "@maka/ui": 1,
@@ -4150,9 +3774,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/ui-locale": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/settings/usage-settings-page.tsx": {
         "bridgePaths": {},
@@ -4164,10 +3786,9 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../features/usage": 3,
+          "../features/usage": 2,
           "./settings-error-copy": 1,
           "./settings-section": 1,
-          "@maka/core/settings": 1,
           "@maka/ui": 1
         }
       },
@@ -4211,8 +3832,7 @@
           "./relay-thinking-bulk": 1,
           "./runtime-host-settings-target.js": 1,
           "./use-action-guard": 1,
-          "./use-oauth-login-flow": 1,
-          "@maka/core/llm-connections": 3,
+          "@maka/core/llm-connections": 2,
           "@maka/core/model-catalog": 1,
           "@maka/core/model-thinking": 1,
           "@maka/core/provider-registry": 1,
@@ -4261,9 +3881,7 @@
           "./runtime-host-settings-target.js": 1,
           "./settings-error-copy": 1,
           "./use-action-guard": 1,
-          "@maka/core/local-memory": 2,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
+          "@maka/core/local-memory": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -4288,7 +3906,6 @@
           "./oauth-login-flow-guard": 1,
           "./runtime-host-settings-target.js": 1,
           "@maka/core/redaction": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -4308,7 +3925,7 @@
         "dependencyPaths": {
           "./optimistic-settings-draft-controller": 1,
           "@maka/ui": 1,
-          "react": 2
+          "react": 1
         }
       },
       "src/renderer/settings/web-search-settings-page.tsx": {
@@ -4340,8 +3957,7 @@
           "./use-action-guard": 1,
           "@astryxdesign/core": 1,
           "@maka/core/search": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/web-search": 2,
+          "@maka/core/web-search": 1,
           "@maka/ui": 2,
           "react": 1
         }
@@ -4353,9 +3969,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/session": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/settled-session-transients.ts": {
         "bridgePaths": {},
@@ -4364,10 +3978,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/session": 1,
-          "@maka/ui": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/shell-chat-model-selection.ts": {
         "bridgePaths": {},
@@ -4376,9 +3987,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/chat-model-choice": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/shell-run-update-state.ts": {
         "bridgePaths": {},
@@ -4388,7 +3997,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "@maka/core/events": 1,
           "@maka/core/shell-run-result": 1
         }
       },
@@ -4409,9 +4017,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./locales/shell-copy.js": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/runtime/skill-invocation": 1
+          "./locales/shell-copy.js": 1
         }
       },
       "src/renderer/stale-sessions.ts": {
@@ -4421,9 +4027,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/session-send-projection": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/task-readiness-notice.ts": {
         "bridgePaths": {},
@@ -4496,10 +4100,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/session": 1,
-          "@maka/ui": 1
-        }
+        "dependencyPaths": {}
       },
       "src/renderer/turn-footer-actions.ts": {
         "bridgePaths": {},
@@ -4509,9 +4110,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./locales/conversation-copy.js": 1,
-          "@maka/core/session": 1,
-          "@maka/core/ui-locale": 1
+          "./locales/conversation-copy.js": 1
         }
       },
       "src/renderer/use-active-execution-boundary.ts": {
@@ -4531,7 +4130,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "@maka/core/sandbox-boundary": 1,
           "react": 1
         }
       },
@@ -4572,7 +4170,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "@maka/core/deep-research-run": 1,
           "react": 1
         }
       },
@@ -4640,13 +4237,9 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./locales/onboarding-copy.js": 1,
-          "@maka/core/llm-connections": 1,
           "@maka/core/onboarding-milestone": 1,
           "@maka/core/redaction": 1,
-          "@maka/core/session": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -4671,13 +4264,9 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "./app-shell-project-actions": 1,
           "./default-runtime-host-operation.js": 1,
           "./use-stable-actions.js": 1,
-          "@maka/core/project": 1,
-          "@maka/core/ui-locale": 1,
-          "@maka/runtime-host/profile-kind": 1,
           "react": 1
         }
       },
@@ -4695,8 +4284,6 @@
         "actionFactories": [],
         "dependencyPaths": {
           "./browser-storage": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/settings": 1,
           "react": 1
         }
       },
@@ -4717,9 +4304,7 @@
           "./locales/shell-copy": 1,
           "./settings/ui-locale-update-gate": 1,
           "./theme": 1,
-          "@maka/core/model-thinking": 1,
           "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
           "react": 1
         }
       },
@@ -4733,18 +4318,10 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./composer-defaults.js": 1,
           "./locales/conversation-copy.js": 1,
           "./session-health-notice.js": 1,
-          "./shell-chat-model-selection.js": 2,
+          "./shell-chat-model-selection.js": 1,
           "./use-new-task-choice.js": 1,
-          "@maka/core/chat-model-choice": 1,
-          "@maka/core/llm-connections": 1,
-          "@maka/core/model-thinking": 1,
-          "@maka/core/session": 1,
-          "@maka/core/session-send-projection": 1,
-          "@maka/core/settings": 1,
-          "@maka/core/ui-locale": 1,
           "react": 1
         }
       },
@@ -4763,14 +4340,10 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
-          "../shared/desktop-connection-snapshot.js": 1,
           "../shared/runtime-host-identity.js": 1,
           "./default-runtime-host-operation.js": 1,
           "./locales/shell-copy.js": 1,
           "./locales/shell-remaining-copy.js": 1,
-          "@maka/core/connections": 1,
-          "@maka/core/ui-locale": 1,
           "react": 1
         }
       },
@@ -4784,10 +4357,8 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./live-turn-snapshot.js": 1,
           "./model-wait-state.js": 1,
-          "./use-delayed-flag.js": 1,
-          "@maka/core/session": 1
+          "./use-delayed-flag.js": 1
         }
       },
       "src/renderer/use-shell-memory-pill.ts": {
@@ -4806,7 +4377,6 @@
         "dependencyPaths": {
           "./default-runtime-host-operation.js": 1,
           "./locales/shell-copy.js": 1,
-          "@maka/core/ui-locale": 1,
           "react": 1
         }
       },
@@ -4823,7 +4393,6 @@
         "actionFactories": [],
         "dependencyPaths": {
           "./locales/shell-copy.js": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -4894,8 +4463,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
-          "@maka/core/task-submission-readiness": 1,
           "react": 1
         }
       },
@@ -4936,9 +4503,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../shared/work-board-ipc.js": 1,
           "@maka/core/work-board": 1,
-          "@maka/storage/work-board-store": 1,
           "react": 1
         }
       },
@@ -4961,7 +4526,6 @@
           "@astryxdesign/core": 1,
           "@astryxdesign/core/Button": 1,
           "@astryxdesign/core/TextInput": 1,
-          "@maka/core/work-board": 1,
           "@maka/ui": 1,
           "@maka/ui/icons": 1,
           "react": 1
@@ -4975,8 +4539,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./workhub-route-policy.js": 1,
-          "@maka/runtime-host/protocol": 1
+          "./workhub-route-policy.js": 1
         }
       },
       "src/renderer/workhub-coordination-host-scope.ts": {
@@ -4987,8 +4550,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../shared/runtime-host-identity.js": 1,
-          "./workhub-session-port.js": 1
+          "../shared/runtime-host-identity.js": 1
         }
       },
       "src/renderer/workhub-coordination-lifecycle.ts": {
@@ -4999,7 +4561,6 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/bridge-contract.js": 1,
           "../shared/runtime-host-identity.js": 1
         }
       },
@@ -5012,10 +4573,8 @@
         "actionFactories": [],
         "dependencyPaths": {
           "./desktop-transcript-range-store.js": 1,
-          "./workhub-controller.js": 2,
-          "./workhub-session-port.js": 1,
-          "@maka/core/session": 1,
-          "@maka/runtime-host/protocol": 1
+          "./workhub-controller.js": 1,
+          "@maka/core/session": 1
         }
       },
       "src/renderer/workhub-route-policy.ts": {
@@ -5053,10 +4612,9 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "../preload/transcript-contract.js": 1,
           "../shared/runtime-host-identity.js": 1,
           "./desktop-transcript-range-store.js": 1,
-          "./workhub-controller.js": 2,
+          "./workhub-controller.js": 1,
           "@maka/core/session": 1
         }
       },
@@ -5072,12 +4630,10 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./workhub-controller.js": 1,
           "./workhub-coordination-port.js": 1,
           "./workhub-send-lease.js": 1,
           "@astryxdesign/core": 1,
           "@astryxdesign/core/Button": 1,
-          "@maka/core/ui-locale": 1,
           "@maka/ui": 1,
           "react": 1
         }
@@ -5090,9 +4646,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./onboarding-hero-copy.js": 1,
-          "@maka/core/onboarding": 1,
-          "@maka/core/ui-locale": 1
+          "./onboarding-hero-copy.js": 1
         }
       },
       "src/shared/desktop-connection-snapshot.ts": {
@@ -5102,10 +4656,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/chat-model-choice": 1,
-          "@maka/core/llm-connections": 1
-        }
+        "dependencyPaths": {}
       },
       "src/shared/desktop-session-projection.ts": {
         "bridgePaths": {},
@@ -5115,12 +4666,7 @@
         "unresolvedDependencies": 0,
         "actionFactories": [],
         "dependencyPaths": {
-          "./runtime-host-identity.js": 1,
-          "@maka/core/daily-review": 1,
-          "@maka/core/events": 1,
-          "@maka/core/session": 1,
-          "@maka/core/settings": 1,
-          "@maka/runtime-host/profile-kind": 1
+          "./runtime-host-identity.js": 1
         }
       },
       "src/shared/goal-arm.ts": {
@@ -5130,9 +4676,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/runtime/goal-state": 1
-        }
+        "dependencyPaths": {}
       },
       "src/shared/runtime-host-identity.ts": {
         "bridgePaths": {},
@@ -5161,9 +4705,7 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/core/settings": 1
-        }
+        "dependencyPaths": {}
       },
       "src/shared/work-board-ipc.ts": {
         "bridgePaths": {},
@@ -5172,15 +4714,13 @@
         "lifecycleMethods": {},
         "unresolvedDependencies": 0,
         "actionFactories": [],
-        "dependencyPaths": {
-          "@maka/storage/work-board-store": 1
-        }
+        "dependencyPaths": {}
       }
     }
   },
   "rootDebt": {
     "src/renderer/app.tsx": {
-      "importDeclarations": 6,
+      "importDeclarations": 5,
       "bridgePaths": {
         "window.maka.appWindow.notifyRendererReady": 1
       },
@@ -5196,18 +4736,17 @@
       "unresolvedDependencies": 0,
       "actionFactories": [],
       "dependencyPaths": {
-        "../preload/bridge-contract.js": 1,
         "./app-shell": 1,
         "./astryx-theme-mode": 1,
         "./astryx-theme/maka": 1,
         "@astryxdesign/core/theme": 1,
         "react": 1
       },
-      "importSpecifiers": 7,
+      "importSpecifiers": 6,
       "nonTriviaTokens": 206
     },
     "src/renderer/main.tsx": {
-      "importDeclarations": 8,
+      "importDeclarations": 7,
       "bridgePaths": {
         "window.maka.onboarding.getSnapshot": 2
       },
@@ -5220,7 +4759,6 @@
       "unresolvedDependencies": 0,
       "actionFactories": [],
       "dependencyPaths": {
-        "../preload/bridge-contract.js": 1,
         "./app": 1,
         "./cached-theme-bootstrap": 1,
         "./composition/desktop-feature-services": 1,
@@ -5229,7 +4767,7 @@
         "@maka/ui": 1,
         "react-dom/client": 1
       },
-      "importSpecifiers": 8,
+      "importSpecifiers": 7,
       "nonTriviaTokens": 268
     }
   },
@@ -5249,7 +4787,6 @@
       "unresolvedDependencies": 0,
       "actionFactories": [],
       "dependencyPaths": {
-        "@astryxdesign/core/theme": 1,
         "react": 1
       }
     },

--- a/apps/desktop/scripts/check-renderer-architecture.mjs
+++ b/apps/desktop/scripts/check-renderer-architecture.mjs
@@ -434,6 +434,26 @@ function bridgePath(node, windowAliases, bridgeAliases = new Map()) {
   return `${base}.${property}`;
 }
 
+function typeOnlySourceDependency(node) {
+  if (node.type === 'ImportDeclaration') {
+    return (
+      node.importKind === 'type' ||
+      (node.specifiers.length > 0 &&
+        node.specifiers.every((specifier) => specifier.importKind === 'type'))
+    );
+  }
+  if (node.type === 'ExportNamedDeclaration') {
+    return (
+      node.exportKind === 'type' ||
+      (node.specifiers.length > 0 &&
+        node.specifiers.every((specifier) => specifier.exportKind === 'type'))
+    );
+  }
+  if (node.type === 'ExportAllDeclaration') return node.exportKind === 'type';
+  if (node.type === 'TSImportType') return true;
+  return false;
+}
+
 function sourceDependency(node) {
   if (
     (node.type === 'ImportDeclaration' ||
@@ -1083,9 +1103,9 @@ export function analyzeRendererSource(source, file = 'fixture.ts') {
   }
 
   function visit(node, parent) {
-    if (node.type === 'ImportDeclaration') {
+    if (node.type === 'ImportDeclaration' && !typeOnlySourceDependency(node)) {
       importDeclarations += 1;
-      importSpecifiers += node.specifiers.length;
+      importSpecifiers += node.specifiers.filter((specifier) => specifier.importKind !== 'type').length;
     }
     if (node.type === 'TSImportEqualsDeclaration') {
       importDeclarations += 1;
@@ -1094,7 +1114,11 @@ export function analyzeRendererSource(source, file = 'fixture.ts') {
     const dependency = sourceDependency(node);
     if (dependency !== undefined) {
       dependencies.push(dependency);
-      dependencyPaths[dependency] = (dependencyPaths[dependency] ?? 0) + 1;
+      // Type-only imports are erased at compile time: they stay in `dependencies`
+      // for closure reachability but record no debt.
+      if (!typeOnlySourceDependency(node)) {
+        dependencyPaths[dependency] = (dependencyPaths[dependency] ?? 0) + 1;
+      }
     }
     if (
       (node.type === 'ImportExpression' && staticString(node.source) === undefined) ||
@@ -2391,29 +2415,39 @@ function validateCopyCatalogFiles(desktopRoot, violations) {
   }
 }
 
-function withoutValidatedCatalogDependencies(desktopRoot, importerPath, dependencyPaths) {
+function withoutSanctionedDependencies(desktopRoot, section, importerPath, dependencyPaths) {
   const filtered = {};
   for (const [dependency, count] of Object.entries(dependencyPaths)) {
-    const target = resolveDependency(desktopRoot, resolve(desktopRoot, importerPath), dependency);
-    if (target && isValidatedCopyCatalog(desktopRoot, normalizePath(relative(desktopRoot, target)))) continue;
+    if (isSanctionedDependencyTarget(desktopRoot, section, importerPath, dependency)) continue;
     filtered[dependency] = count;
   }
   return filtered;
 }
 
+function isSanctionedDependencyTarget(desktopRoot, section, importerPath, dependency) {
+  const target = resolveDependency(desktopRoot, resolve(desktopRoot, importerPath), dependency);
+  if (!target) return false;
+  const targetRelative = normalizePath(relative(desktopRoot, target));
+  if (isValidatedCopyCatalog(desktopRoot, targetRelative)) return true;
+  // Root entries are meant to become thin mounts; only catalogs are free for them.
+  if (section === 'rootDebt') return false;
+  if (zoneFor(targetRelative).kind === 'shell' || isPublicApplicationPath(targetRelative)) return true;
+  const targetFeature = featureForAbsolutePath(desktopRoot, target);
+  return Boolean(targetFeature && isPublicFeaturePath(targetFeature.subpath));
+}
+
+const MIGRATION_SWAP_ZONES = {
+  rootDebt: ['bootstrap', 'composition'],
+  rootDebtClosure: ['application', 'bootstrap', 'composition', 'platform'],
+};
+
 function allowsMigrationDependency({ base, current, dependency, desktopRoot, path, section }) {
+  const swapZones = MIGRATION_SWAP_ZONES[section];
+  if (!swapZones) return false;
   if (metricTotal(current.dependencyPaths) > metricTotal(base.dependencyPaths)) return false;
   const target = resolveDependency(desktopRoot, resolve(desktopRoot, path), dependency);
   if (!target) return false;
-  const targetRelative = normalizePath(relative(desktopRoot, target));
-  const targetZone = zoneFor(targetRelative);
-  if (section === 'legacyAppShell' || section === 'legacyAppShellClosure') {
-    if (targetZone.kind === 'shell' || isPublicApplicationPath(targetRelative)) return true;
-    const targetFeature = featureForAbsolutePath(desktopRoot, target);
-    return Boolean(targetFeature && isPublicFeaturePath(targetFeature.subpath));
-  }
-  if (section === 'rootDebt') return ['bootstrap', 'composition'].includes(targetZone.kind);
-  return ['application', 'bootstrap', 'composition', 'platform'].includes(targetZone.kind);
+  return swapZones.includes(zoneFor(normalizePath(relative(desktopRoot, target))).kind);
 }
 
 function debtForPath(desktopRoot, path) {
@@ -2538,11 +2572,11 @@ function validateMonotonicDebt(config, baseConfig, desktopRoot, violations) {
       if (!base) continue;
       const currentView = {
         ...current,
-        dependencyPaths: withoutValidatedCatalogDependencies(desktopRoot, path, current.dependencyPaths),
+        dependencyPaths: withoutSanctionedDependencies(desktopRoot, section, path, current.dependencyPaths),
       };
       const baseView = {
         ...base,
-        dependencyPaths: withoutValidatedCatalogDependencies(desktopRoot, path, base.dependencyPaths),
+        dependencyPaths: withoutSanctionedDependencies(desktopRoot, section, path, base.dependencyPaths),
       };
       const metrics = section.endsWith('Closure') ? CAPABILITY_DEBT_METRICS : ROOT_DEBT_METRICS;
       for (const metric of metrics) {

--- a/apps/desktop/scripts/check-renderer-architecture.mjs
+++ b/apps/desktop/scripts/check-renderer-architecture.mjs
@@ -1595,6 +1595,14 @@ function validateDependencies({
         violations.push(`${fileRelative}: Desktop adapter imports an outer or legacy implementation: ${dependency}`);
       }
     }
+
+    if (
+      sourceZone.kind === 'legacy' &&
+      targetZone.kind === 'application' &&
+      !isPublicApplicationPath(targetRelative)
+    ) {
+      violations.push(`${fileRelative}: legacy renderer code imports application implementation instead of a public entry: ${dependency}`);
+    }
   }
 }
 
@@ -2273,21 +2281,14 @@ function inspectCopyCatalog(source, file) {
           }
         }
       }
-      const typeOnly =
-        statement.importKind === 'type' ||
-        (statement.specifiers.length > 0 &&
-          statement.specifiers.every((specifier) => specifier.importKind === 'type'));
-      if (!typeOnly) runtimeDependencies.push(statement.source.value);
+      if (!typeOnlySourceDependency(statement)) runtimeDependencies.push(statement.source.value);
     }
     if (
       (statement.type === 'ExportNamedDeclaration' || statement.type === 'ExportAllDeclaration') &&
-      statement.source
+      statement.source &&
+      !typeOnlySourceDependency(statement)
     ) {
-      const typeOnly =
-        statement.exportKind === 'type' ||
-        (statement.specifiers?.length > 0 &&
-          statement.specifiers.every((specifier) => specifier.exportKind === 'type'));
-      if (!typeOnly) runtimeDependencies.push(statement.source.value);
+      runtimeDependencies.push(statement.source.value);
     }
     if (
       statement.type === 'TSImportEqualsDeclaration' &&

--- a/apps/desktop/scripts/check-renderer-architecture.test.mjs
+++ b/apps/desktop/scripts/check-renderer-architecture.test.mjs
@@ -2218,9 +2218,9 @@ describe('renderer architecture checker fixtures', () => {
     const appShellPath = 'src/renderer/app-shell.tsx';
     const appShellSource = `
       import { AlphaHost } from './features/alpha/index.js';
-      import type { SessionScope } from './application/contracts/session-scope.js';
-      export function AppShell(props: { readonly scope: SessionScope }) {
-        return <AlphaHost scope={props.scope} />;
+      import { defaultSessionScope } from './application/contracts/session-scope.js';
+      export function AppShell() {
+        return <AlphaHost scope={defaultSessionScope} />;
       }
     `;
     const currentDebt = debtForSource(appShellSource, appShellPath);
@@ -2256,7 +2256,7 @@ describe('renderer architecture checker fixtures', () => {
           export function AlphaHost(_props: unknown) { return null; }
         `,
         'src/renderer/application/contracts/session-scope.ts': `
-          export interface SessionScope { readonly sessionId?: string }
+          export const defaultSessionScope = { sessionId: undefined };
         `,
       },
       (desktopRoot) => {
@@ -2469,6 +2469,174 @@ describe('validated copy catalog dependencies', () => {
           violationsFor(desktopRoot, currentConfig, baseWithoutCatalog(currentConfig)),
           [],
         );
+      },
+    );
+  });
+
+  it('exempts a validated catalog\'s own type-only contract imports from dependency debt', async () => {
+    await withDesktopFixture(
+      transitiveAppShellFiles(
+        `
+          import { FIXTURE_COPY } from './locales/fixture-copy.js';
+          export const legacySessionHelper = FIXTURE_COPY.en.byCode.missing;
+        `,
+        {
+          [CATALOG_PATH]: `
+            import type { UiCatalog } from '@maka/core/ui-locale';
+            import type { FixtureErrorCode } from '../fixture-contract.js';
+            export interface FixtureCopy { readonly byCode: Record<FixtureErrorCode, string>; }
+            export const FIXTURE_COPY = {
+              en: { byCode: { missing: 'Missing' } },
+              zh: { byCode: { missing: '缺失' } },
+            } satisfies UiCatalog<FixtureCopy>;
+          `,
+          'src/renderer/fixture-contract.ts': `export type FixtureErrorCode = 'missing';`,
+        },
+      ),
+      (desktopRoot) => {
+        const currentConfig = generateArchitectureConfig(desktopRoot, catalogSeedConfig());
+        const baseConfig = baseWithoutCatalog(currentConfig);
+        delete baseConfig.legacyAppShell.closure['src/renderer/fixture-contract.ts'];
+        baseConfig.legacyRendererFiles = baseConfig.legacyRendererFiles.filter(
+          (path) => path !== 'src/renderer/fixture-contract.ts',
+        );
+        const violations = violationsFor(desktopRoot, currentConfig, baseConfig);
+        assert.ok(
+          !violations.some((violation) => violation.includes('fixture-copy')),
+          `type-only contract import must carry no debt, received:\n${violations.join('\n')}`,
+        );
+      },
+    );
+  });
+
+  const IMPORT_FORMS = [
+    [`import type { A } from './x.js'; export type B = A;`, 0, 0, {}],
+    [`import { type A } from './x.js'; export type B = A;`, 0, 0, {}],
+    [`export type { A } from './x.js';`, 0, 0, {}],
+    [`export type * from './x.js';`, 0, 0, {}],
+    [`export type B = import('./x.js').A;`, 0, 0, {}],
+    [`import { a, type A } from './x.js'; export const b: A = a;`, 1, 1, { './x.js': 1 }],
+    [`import './x.js';`, 1, 0, { './x.js': 1 }],
+    [`export * from './x.js';`, 0, 0, { './x.js': 1 }],
+  ];
+
+  for (const [source, importDeclarations, importSpecifiers, dependencyPaths] of IMPORT_FORMS) {
+    it(`prices only the runtime part of \`${source.split(';')[0]}\``, () => {
+      const debt = debtForSource(source, 'src/renderer/fixture.ts');
+      assert.deepEqual(
+        { importDeclarations: debt.importDeclarations, importSpecifiers: debt.importSpecifiers, dependencyPaths: debt.dependencyPaths },
+        { importDeclarations, importSpecifiers, dependencyPaths },
+      );
+    });
+  }
+
+  it('records no dependency debt for a new type-only import anywhere in the closure', async () => {
+    await withDesktopFixture(
+      transitiveAppShellFiles(
+        `
+          import type { LegacyShape } from './legacy-session-store.js';
+          export const legacySessionHelper: LegacyShape = { kind: 'legacy' };
+        `,
+        {
+          'src/renderer/legacy-session-store.ts': `export interface LegacyShape { kind: string }`,
+        },
+      ),
+      (desktopRoot) => {
+        const currentConfig = generateArchitectureConfig(desktopRoot, catalogSeedConfig());
+        const baseConfig = structuredClone(currentConfig);
+        baseConfig.legacyAppShell.closure[TRANSITIVE_LEGACY_HELPER_PATH].dependencyPaths = {};
+        delete baseConfig.legacyAppShell.closure['src/renderer/legacy-session-store.ts'];
+        baseConfig.legacyRendererFiles = baseConfig.legacyRendererFiles.filter(
+          (path) => path !== 'src/renderer/legacy-session-store.ts',
+        );
+        const violations = violationsFor(desktopRoot, currentConfig, baseConfig);
+        assert.ok(
+          !violations.some((violation) => violation.includes('dependency debt')),
+          `type-only edge must carry no debt, received:\n${violations.join('\n')}`,
+        );
+      },
+    );
+  });
+
+  it('starts counting the moment a type-only edge turns into a runtime import', async () => {
+    await withDesktopFixture(
+      transitiveAppShellFiles(
+        `
+          import { legacySessionStore } from './legacy-session-store.js';
+          export const legacySessionHelper = legacySessionStore;
+        `,
+        {
+          'src/renderer/legacy-session-store.ts': `export const legacySessionStore = 'legacy';`,
+        },
+      ),
+      (desktopRoot) => {
+        const currentConfig = generateArchitectureConfig(desktopRoot, catalogSeedConfig());
+        const baseConfig = structuredClone(currentConfig);
+        // The base recorded the same edge as type-only: no debt entry.
+        baseConfig.legacyAppShell.closure[TRANSITIVE_LEGACY_HELPER_PATH].dependencyPaths = {};
+        const violations = violationsFor(desktopRoot, currentConfig, baseConfig);
+        assertHasViolation(
+          violations,
+          /^src\/renderer\/legacy-session-helper\.ts: new dependency debt \.\/legacy-session-store\.js$/u,
+        );
+      },
+    );
+  });
+
+  const NEW_EDGE_TARGETS = [
+    ['src/renderer/application/contracts/fixture-diagnostics.ts', 'free'],
+    ['src/renderer/shell/fixture-shell.ts', 'free'],
+    ['src/renderer/features/alpha/index.ts', 'free'],
+    ['src/renderer/application/sessions/fixture-service.ts', 'priced'],
+    ['src/renderer/features/alpha/fixture-internal.ts', 'priced'],
+  ];
+
+  for (const [targetPath, pricing] of NEW_EDGE_TARGETS) {
+    it(`${pricing === 'free' ? 'exempts' : 'prices'} a new legacy edge to ${targetPath}`, async () => {
+      const specifier = `./${targetPath.slice('src/renderer/'.length).replace(/\.ts$/u, '.js')}`;
+      await withDesktopFixture(
+        transitiveAppShellFiles(
+          `
+            import { reportFixture } from '${specifier}';
+            export const legacySessionHelper = reportFixture('legacy');
+          `,
+          { [targetPath]: `export function reportFixture(scope: string): string { return scope; }` },
+        ),
+        (desktopRoot) => {
+          const currentConfig = generateArchitectureConfig(desktopRoot, catalogSeedConfig());
+          const baseConfig = structuredClone(currentConfig);
+          baseConfig.legacyAppShell.closure[TRANSITIVE_LEGACY_HELPER_PATH].dependencyPaths = {};
+          const violations = violationsFor(desktopRoot, currentConfig, baseConfig);
+          const priced = violations.some((violation) =>
+            violation.startsWith(`${TRANSITIVE_LEGACY_HELPER_PATH}: new dependency debt`),
+          );
+          assert.equal(priced, pricing === 'priced', violations.join('\n'));
+        },
+      );
+    });
+  }
+
+  it('keeps pricing every non-catalog edge for a root entry', async () => {
+    const source = `
+      import { AlphaFeature } from './features/alpha/index.js';
+      import { FIXTURE_COPY } from './locales/fixture-copy.js';
+      export const main = [AlphaFeature, FIXTURE_COPY];
+    `;
+    await withDesktopFixture(
+      {
+        [RENDERER_ENTRY_PATH]: source,
+        'src/renderer/features/alpha/index.ts': `export const AlphaFeature = 'alpha';`,
+        [CATALOG_PATH]: catalogSource(),
+      },
+      (desktopRoot) => {
+        const seedConfig = rendererEntrySeedConfig();
+        seedConfig.legacyGrowthDirectories = ['src/renderer/locales'];
+        const currentConfig = generateArchitectureConfig(desktopRoot, seedConfig);
+        const baseConfig = structuredClone(currentConfig);
+        baseConfig.rootDebt[RENDERER_ENTRY_PATH].dependencyPaths = {};
+        const violations = violationsFor(desktopRoot, currentConfig, baseConfig);
+        assertHasViolation(violations, /^src\/renderer\/main\.tsx: new dependency debt \.\/features\/alpha\/index\.js$/u);
+        assert.ok(!violations.some((violation) => violation.includes('fixture-copy')), violations.join('\n'));
       },
     );
   });

--- a/apps/desktop/scripts/check-renderer-architecture.test.mjs
+++ b/apps/desktop/scripts/check-renderer-architecture.test.mjs
@@ -2616,6 +2616,27 @@ describe('validated copy catalog dependencies', () => {
     });
   }
 
+  it('rejects a legacy type-only edge into an application implementation as a hard violation', async () => {
+    await withDesktopFixture(
+      transitiveAppShellFiles(
+        `
+          import type { FixtureService } from './application/sessions/fixture-service.js';
+          export const legacySessionHelper: FixtureService = { kind: 'legacy' };
+        `,
+        { 'src/renderer/application/sessions/fixture-service.ts': `export interface FixtureService { kind: string }` },
+      ),
+      (desktopRoot) => {
+        const currentConfig = generateArchitectureConfig(desktopRoot, catalogSeedConfig());
+        const violations = violationsFor(desktopRoot, currentConfig, structuredClone(currentConfig));
+        assertHasViolation(
+          violations,
+          /^src\/renderer\/legacy-session-helper\.ts: legacy renderer code imports application implementation instead of a public entry: \.\/application\/sessions\/fixture-service\.js$/u,
+        );
+        assert.ok(!violations.some((violation) => violation.includes('dependency debt')), violations.join('\n'));
+      },
+    );
+  });
+
   it('keeps pricing every non-catalog edge for a root entry', async () => {
     const source = `
       import { AlphaFeature } from './features/alpha/index.js';

--- a/apps/desktop/src/renderer/README.md
+++ b/apps/desktop/src/renderer/README.md
@@ -103,20 +103,26 @@ not grow. Their transitive support closures ratchet only architectural
 capabilities and dependencies, so ordinary implementation can evolve without
 token-count ledger noise. A support entry may move one way from the AppShell
 closure to the root closure without resetting its budget; the reverse move is
-rejected. Legacy import allowlists may only shrink relative to the base branch. Same-count
-dependency replacement is allowed only when it moves ownership behind a shell,
-feature public, or application public/contract boundary.
+rejected. Legacy import allowlists may only shrink relative to the base branch.
 
-Validated copy catalogs are the one admitted dependency class: the locale
-policy (#2672) forces user-visible copy out of business files and into
-`locales/*-copy.ts` catalogs, which necessarily adds import edges the debt
+Dependency-path debt prices only regressive runtime edges. Type-only imports
+are erased at compile time and never count. Edges into a shell, feature public,
+or application public/contract boundary are the direction the migration wants,
+so the AppShell family and both closures may add them freely; root entries may
+not, because `main.tsx` and `app.tsx` are meant to become thin mounts, and
+they may only replace an existing edge, same-count, with a bootstrap or
+composition target (their closure may also replace into application or
+platform).
+
+Validated copy catalogs are admitted for every section, root entries included:
+the locale policy (#2672) forces user-visible copy out of business files and
+into `locales/*-copy.ts` catalogs, which necessarily adds import edges the debt
 ratchet would otherwise forbid. A catalog is admitted structurally, re-verified
 on every run: it must carry a `UiCatalog` marker from `@maka/core/ui-locale`,
 record zero tracked hook/bridge/lifecycle/environment/action-factory
 capabilities, and keep its runtime imports to bare package specifiers — never
 relative or `@maka/desktop/` paths — so a catalog cannot become a dependency
-tunnel. Type-only imports are erased at compile time and stay admitted
-regardless of target. A `locales/*-copy.ts` file that fails validation is a
+tunnel. A `locales/*-copy.ts` file that fails validation is a
 dedicated violation (`copy catalog validation failed: …`), never a silent fall
 back to the ratchet. Admitted edges are excluded from dependency-count
 ratchets, closure admission, and feature/Desktop-adapter legacy budgets;


### PR DESCRIPTION
## Summary

Follow-up calibration to #4493. The ratchet's purpose is to stop the legacy renderer from getting worse; two of its pricing decisions also punished getting better. (1) Type-only imports are erased at compile time and cannot carry behavior, yet were priced like runtime edges — compliance produced token accounting (`Parameters<typeof …>` extraction, statement merging, re-export forms chosen for the counter) instead of structure. Type edges now keep closure reachability (one rewritten into a runtime import starts counting the moment it changes) but record no `dependencyPaths`, `importDeclarations`, or `importSpecifiers` debt; a mixed `import { a, type A }` counts only its runtime specifier. (2) Edges into sanctioned targets — validated catalogs, shell, public application paths, feature public APIs — are exactly where the migration wants legacy files to point, yet net-zero blocked adding them outright; they are now excluded from dependency accounting for the AppShell family and both closures.

This deliberately removes `dependencyPaths` as the structural growth cap for sanctioned edges in the two closure sections; their capability metrics and closure-admission rules remain unchanged. Root entries are deliberately not widened: `main.tsx` and `app.tsx` are meant to become thin mounts, so for them only validated catalogs are free and the same-count swap into bootstrap/composition stays their only migration path. With every target the AppShell family may move toward now sanctioned, `allowsMigrationDependency` collapses to a per-section swap-zone table (`rootDebt`, `rootDebtClosure`); the AppShell sections have none. Runtime edges into legacy code and bare packages are priced exactly as before; every capability, token, and closure-admission ratchet is untouched.

`isPublicApplicationPath` (any top-level `application/<module>`, not only `contracts/`) is reused on purpose: it is the same boundary `validateDependencies` already holds composition and platform to, and legacy code sits at that tier, not at the feature tier. Legacy imports of application internals are now hard violations independent of whether the edge exists at runtime, so type-only edges cannot bypass that boundary.

Refs #2672

## Verification

```
checker fixtures:  89 pass / 0 fail, incl.:
  8 import forms priced table-driven: import type / { type A } / export type { } from /
    export type * from / import('./x').A record 0 declarations, 0 specifiers, no edge;
    import { a, type A } records 1/1; bare side-effect import 1/0; export * from is an edge
  type-only edge records no debt anywhere in the closure; rewritten as runtime it is flagged
  new legacy edge to application contract / shell / feature index: exempt
  legacy edge to application implementation / feature internal: hard violation
  root entry adding a feature-index edge beside a catalog: feature edge priced, catalog not
  AppShell replacement test now uses a runtime application-contract edge
ledger regenerated vs origin/main:
  dependencyPaths  408 entries removed, 32 decreased, 0 added, 0 increased (196 files)
  import counts    46 entries decreased across 23 AppShell/root files, 0 increased
  legacyRendererFiles / growth dirs / feature+platform imports / ownership: byte-identical
real-tree check:   passed against origin/main
biome:             clean
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — rule design (with cross-model review), implementation, fixtures, and the original description; OpenCode — reviewer-feedback implementation, regression fixture, and description update, under the contributor's direction. The affected commits carry the corresponding `Generated-by` trailers.

## Checklist

- [x] Tests cover the change and fail without it

