### PR TITLE
fix(deps): clear the CLI production audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5069,9 +5069,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8114,9 +8114,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -11896,9 +11896,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/packages/cli/THIRD_PARTY_NOTICES.txt
+++ b/packages/cli/THIRD_PARTY_NOTICES.txt
@@ -4108,7 +4108,7 @@ SOFTWARE.
 
 ================================================================================
 
-Package: fast-uri@3.1.5
+Package: fast-uri@3.1.7
 Declared license: BSD-3-Clause
 Selected license: BSD-3-Clause
 Repository: git+https://github.com/fastify/fast-uri.git
@@ -6483,7 +6483,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-Package: qs@6.15.3
+Package: qs@6.16.0
 Declared license: BSD-3-Clause
 Selected license: BSD-3-Clause
 Repository: https://github.com/ljharb/qs.git


### PR DESCRIPTION
## Summary

`Build CLI release candidate` fails on main and on every open PR:

```
Error: CLI production dependency audit failed: {"info":0,"low":0,"moderate":1,"high":1,"critical":0,"total":2}
```

Two advisories landed on transitive production dependencies of the CLI — `fast-uri` (high) and `qs` (moderate). `scripts/release-cli-package.mjs` audits production dependencies before it packs, so the gate is doing its job; the lockfile has to move.

`packages/cli/THIRD_PARTY_NOTICES.txt` moves with it. The notice file records the exact resolved versions, and `check:cli-third-party-notices` — the next step in the same script — fails with `fast-uri@3.1.5: missing from package-lock.json` if only the lockfile changes. Regenerated with `node scripts/generate-third-party-notices.mjs --target cli`.

`@xmldom/xmldom` (dev) is in the diff because `npm audit fix` resolves the root lockfile as a whole.

## Why the open Dependabot PRs do not cover this

- #4586, #4587 — same packages, but in `packages/eval/harbor/deepseek-harness-toolchain/package-lock.json`. That is a different lockfile; the CLI audit reads the root one.
- #4585 — root lockfile, but `@xmldom/xmldom` is a dev dependency and the audit runs `--omit=dev`.

Merging all three leaves the gate red.

## Verification

- `npm audit --omit=dev` — 2 vulnerabilities (1 high, 1 moderate) before, **0** after.
- `node scripts/generate-third-party-notices.mjs --target cli --check` — OK.
- `npm ci` clean.
- `npm run release:cli:pack -- --allow-dirty` gets past both gates above and then stops on `cargo deny`, which is not installed on this machine. CI has it.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code diagnosed the failing gate, applied `npm audit fix`, regenerated the notice file and drafted this description; the scope and the decision to keep it separate from the e2e work in #4577 were the author's.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes
- [x] No — dependency versions only
