### PR TITLE
fix(desktop): accept Intel Mach-O architecture in package verification

### DIFF
--- a/scripts/verify-macos-dmg.mjs
+++ b/scripts/verify-macos-dmg.mjs
@@ -112,7 +112,9 @@ export async function smokePackagedFilesystemWorker(
 
 function assertSingleArchitecture(output, subject, expectedArch) {
   const architectures = output.trim().split(/\s+/).filter(Boolean);
-  if (architectures.length !== 1 || architectures[0] !== expectedArch) {
+  // lipo names Intel Mach-O slices x86_64; Node and the release target use x64.
+  const machoArch = expectedArch === 'x64' ? 'x86_64' : expectedArch;
+  if (architectures.length !== 1 || architectures[0] !== machoArch) {
     throw new Error(
       `${subject} must contain only ${expectedArch}, found: ${architectures.join(', ')}`,
     );

--- a/scripts/verify-packaged-app.test.mjs
+++ b/scripts/verify-packaged-app.test.mjs
@@ -192,92 +192,63 @@ const options = {
   collectPackagedAllowlist: () => allowlistOf(PTY_PACKAGES),
 };
 
-describe('macOS packaged architecture', () => {
-  async function verifyArchitecture(expectedArch, lipoOutput) {
-    const { verifyPackagedMacApp } = await import('./verify-macos-dmg.mjs');
-    const asarPackages = await Promise.all(
-      PTY_PACKAGES.map(async (name) => {
-        const manifest = JSON.parse(
-          await readFile(new URL(`../node_modules/${name}/package.json`, import.meta.url), 'utf8'),
-        );
-        return `${name}@${manifest.version}`;
-      }),
-    );
-    const resources = await makeResources({
-      asarPackages,
-      notices: await readFile(
-        new URL('../apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt', import.meta.url),
-        'utf8',
-      ),
-      rendererLicenses: [
-        'licenses/renderer/GEIST_LICENSE.txt',
-        'licenses/renderer/GEIST_MONO_LICENSE.txt',
-      ],
-    });
-    await writeFile(
-      join(resources, 'app-update.yml'),
-      'provider: github\nowner: apache\nrepo: maka\nchannel: dev\nupdaterCacheDirName: "@makadesktop-updater"\n',
-    );
-    const version = '0.2.0-dev.14.20260902';
-    const app = join(dirname(resources), 'Maka.app');
-    await mkdir(join(app, 'Contents'), { recursive: true });
-    await rename(resources, join(app, 'Contents', 'Resources'));
-    // The archive and update configuration are real; macOS command output and
-    // app launches are the system boundaries this portable test substitutes.
-    await verifyPackagedMacApp(app, {
-      expectedArch,
-      channel: 'nightly',
-      environment: { MAKA_DESKTOP_NIGHTLY_VERSION: version },
-      requirePath: async () => {},
-      smokeFilesystemWorker: async () => {},
-      smokeRenderer: async () => {},
-      run: async (command, args) => {
-        if (command === 'plutil') {
-          const values = {
-            CFBundleIdentifier: 'com.maka.desktop',
-            CFBundleShortVersionString: version,
-            CFBundleExecutable: 'Maka',
-          };
-          assert.ok(Object.hasOwn(values, args[1]));
-          return { stdout: `${values[args[1]]}\n` };
-        }
-        if (command === 'lipo') return { stdout: lipoOutput };
-        if (
-          ['codesign', 'spctl', 'xcrun', join(app, 'Contents', 'MacOS', 'Maka')].includes(command)
-        ) {
-          return { stdout: '' };
-        }
-        throw new Error(`Unexpected command: ${command}`);
-      },
-    });
-  }
-
-  test('accepts the Intel Mach-O architecture for an x64 package', async () => {
-    await assert.doesNotReject(verifyArchitecture('x64', 'x86_64\n'));
-  });
-
-  test('accepts the ARM Mach-O architecture for an arm64 package', async () => {
-    await assert.doesNotReject(verifyArchitecture('arm64', 'arm64\n'));
-  });
-
-  for (const [expectedArch, wrongArch] of [
-    ['x64', 'arm64'],
-    ['arm64', 'x86_64'],
-  ]) {
-    test(`rejects the other architecture in an ${expectedArch} package`, async () => {
-      await assert.rejects(
-        verifyArchitecture(expectedArch, `${wrongArch}\n`),
-        /Maka executable must contain only/,
+test('accepts the Intel Mach-O architecture for an x64 package', async () => {
+  const { verifyPackagedMacApp } = await import('./verify-macos-dmg.mjs');
+  const asarPackages = await Promise.all(
+    PTY_PACKAGES.map(async (name) => {
+      const manifest = JSON.parse(
+        await readFile(new URL(`../node_modules/${name}/package.json`, import.meta.url), 'utf8'),
       );
-    });
-
-    test(`rejects a universal binary in an ${expectedArch} package`, async () => {
-      await assert.rejects(
-        verifyArchitecture(expectedArch, 'x86_64 arm64\n'),
-        /Maka executable must contain only/,
-      );
-    });
-  }
+      return `${name}@${manifest.version}`;
+    }),
+  );
+  const resources = await makeResources({
+    asarPackages,
+    notices: await readFile(
+      new URL('../apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt', import.meta.url),
+      'utf8',
+    ),
+    rendererLicenses: [
+      'licenses/renderer/GEIST_LICENSE.txt',
+      'licenses/renderer/GEIST_MONO_LICENSE.txt',
+    ],
+  });
+  await writeFile(
+    join(resources, 'app-update.yml'),
+    'provider: github\nowner: apache\nrepo: maka\nchannel: dev\nupdaterCacheDirName: "@makadesktop-updater"\n',
+  );
+  const version = '0.2.0-dev.14.20260902';
+  const app = join(dirname(resources), 'Maka.app');
+  await mkdir(join(app, 'Contents'), { recursive: true });
+  await rename(resources, join(app, 'Contents', 'Resources'));
+  // The archive and update configuration are real; macOS command output and
+  // app launches are the system boundaries this portable test substitutes.
+  await verifyPackagedMacApp(app, {
+    expectedArch: 'x64',
+    channel: 'nightly',
+    environment: { MAKA_DESKTOP_NIGHTLY_VERSION: version },
+    requirePath: async () => {},
+    smokeFilesystemWorker: async () => {},
+    smokeRenderer: async () => {},
+    run: async (command, args) => {
+      if (command === 'plutil') {
+        const values = {
+          CFBundleIdentifier: 'com.maka.desktop',
+          CFBundleShortVersionString: version,
+          CFBundleExecutable: 'Maka',
+        };
+        assert.ok(Object.hasOwn(values, args[1]));
+        return { stdout: `${values[args[1]]}\n` };
+      }
+      if (command === 'lipo') return { stdout: 'x86_64\n' };
+      if (
+        ['codesign', 'spctl', 'xcrun', join(app, 'Contents', 'MacOS', 'Maka')].includes(command)
+      ) {
+        return { stdout: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    },
+  });
 });
 
 describe('assertPackagedDependencyClosure', () => {

--- a/scripts/verify-packaged-app.test.mjs
+++ b/scripts/verify-packaged-app.test.mjs
@@ -18,7 +18,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { after, describe, test } from 'node:test';
@@ -191,6 +191,94 @@ const options = {
   collectClosure: () => [{ name: 'react', version: '19.2.0' }],
   collectPackagedAllowlist: () => allowlistOf(PTY_PACKAGES),
 };
+
+describe('macOS packaged architecture', () => {
+  async function verifyArchitecture(expectedArch, lipoOutput) {
+    const { verifyPackagedMacApp } = await import('./verify-macos-dmg.mjs');
+    const asarPackages = await Promise.all(
+      PTY_PACKAGES.map(async (name) => {
+        const manifest = JSON.parse(
+          await readFile(new URL(`../node_modules/${name}/package.json`, import.meta.url), 'utf8'),
+        );
+        return `${name}@${manifest.version}`;
+      }),
+    );
+    const resources = await makeResources({
+      asarPackages,
+      notices: await readFile(
+        new URL('../apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt', import.meta.url),
+        'utf8',
+      ),
+      rendererLicenses: [
+        'licenses/renderer/GEIST_LICENSE.txt',
+        'licenses/renderer/GEIST_MONO_LICENSE.txt',
+      ],
+    });
+    await writeFile(
+      join(resources, 'app-update.yml'),
+      'provider: github\nowner: apache\nrepo: maka\nchannel: dev\nupdaterCacheDirName: "@makadesktop-updater"\n',
+    );
+    const version = '0.2.0-dev.14.20260902';
+    const app = join(dirname(resources), 'Maka.app');
+    await mkdir(join(app, 'Contents'), { recursive: true });
+    await rename(resources, join(app, 'Contents', 'Resources'));
+    // The archive and update configuration are real; macOS command output and
+    // app launches are the system boundaries this portable test substitutes.
+    await verifyPackagedMacApp(app, {
+      expectedArch,
+      channel: 'nightly',
+      environment: { MAKA_DESKTOP_NIGHTLY_VERSION: version },
+      requirePath: async () => {},
+      smokeFilesystemWorker: async () => {},
+      smokeRenderer: async () => {},
+      run: async (command, args) => {
+        if (command === 'plutil') {
+          const values = {
+            CFBundleIdentifier: 'com.maka.desktop',
+            CFBundleShortVersionString: version,
+            CFBundleExecutable: 'Maka',
+          };
+          assert.ok(Object.hasOwn(values, args[1]));
+          return { stdout: `${values[args[1]]}\n` };
+        }
+        if (command === 'lipo') return { stdout: lipoOutput };
+        if (
+          ['codesign', 'spctl', 'xcrun', join(app, 'Contents', 'MacOS', 'Maka')].includes(command)
+        ) {
+          return { stdout: '' };
+        }
+        throw new Error(`Unexpected command: ${command}`);
+      },
+    });
+  }
+
+  test('accepts the Intel Mach-O architecture for an x64 package', async () => {
+    await assert.doesNotReject(verifyArchitecture('x64', 'x86_64\n'));
+  });
+
+  test('accepts the ARM Mach-O architecture for an arm64 package', async () => {
+    await assert.doesNotReject(verifyArchitecture('arm64', 'arm64\n'));
+  });
+
+  for (const [expectedArch, wrongArch] of [
+    ['x64', 'arm64'],
+    ['arm64', 'x86_64'],
+  ]) {
+    test(`rejects the other architecture in an ${expectedArch} package`, async () => {
+      await assert.rejects(
+        verifyArchitecture(expectedArch, `${wrongArch}\n`),
+        /Maka executable must contain only/,
+      );
+    });
+
+    test(`rejects a universal binary in an ${expectedArch} package`, async () => {
+      await assert.rejects(
+        verifyArchitecture(expectedArch, 'x86_64 arm64\n'),
+        /Maka executable must contain only/,
+      );
+    });
+  }
+});
 
 describe('assertPackagedDependencyClosure', () => {
   test('accepts an artifact whose asar, bundle record, and shipped notices match', async () => {


### PR DESCRIPTION
## Summary

Intel macOS Nightly packaging and Apple notarization succeed, but verification fails with `Maka executable must contain only x64, found: x86_64` ([failed run](https://github.com/apache/maka/actions/runs/33671124683/job/100384778598)). The verifier compares Node's target name directly with `lipo`'s Mach-O architecture name, preventing the entire Desktop release from publishing.

Map `x64` to `x86_64` at the existing architecture assertion. Both Nightly and formal releases use this verifier; wrong architectures and universal binaries remain rejected. No artifact naming, update configuration, or migration changes are needed. The existing assertion is extended without adding a second architecture authority; one regression test covers the observed Intel failure through the packaged-app verifier.

## Verification

- The Intel regression failed with the exact Nightly error before the fix and passed afterward.
- `node --test scripts/verify-packaged-app.test.mjs` — 19 passed, including the single Intel regression.
- `node --test scripts/desktop-nightly-stage.test.mjs` — 2 passed during the initial validation; the staging code is unchanged.
- `npm run format` and `npm run lint` — passed.
- Built the core, storage, MCP, and runtime workspaces required to load the verifier. No TypeScript changed.
- The regression test uses real ASAR and update configuration fixtures, substituting macOS commands and app launches. It does not establish that a new signed Intel build or release publication succeeds.

## Rollout

After review and merge, dispatch a **fresh npm Nightly**; Desktop Nightly rejects in-place workflow reruns. Confirm all five Desktop targets pass, including Intel signing verification and PTY/filesystem-worker/renderer smoke checks, then confirm the GitHub prerelease and downloadable artifacts are published. This PR has not triggered another Nightly.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the failed run, implemented the mapping, and added and ran the Intel regression test.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally (typecheck is not applicable to the MJS-only changes)

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

