### PR TITLE
refactor(desktop): share the feature services context and pass bridge namespaces through

### DIFF
--- a/apps/desktop/src/renderer/README.md
+++ b/apps/desktop/src/renderer/README.md
@@ -64,7 +64,11 @@ application -> shared contracts + injected ports
   preload, main, or `platform/desktop`. Consumers use its public `index` entry;
   `testing` is test/Storybook-only.
 - `platform/desktop/` is the outer adapter zone for the preload bridge. It
-  implements narrow inward-facing ports rather than exporting the whole bridge;
+  implements narrow inward-facing ports rather than exporting the whole bridge:
+  where a port is a structural subset of one bridge namespace the adapter hands
+  that namespace through as-is (`sessions: bridge.sessions`) instead of
+  restating each method, and hand-writes the blocks that rename, guard, or
+  translate;
   composition and adapters consume application public entries, not deep
   implementation modules. Adapters may own bridge and browser-environment
   access, but never React UI/hooks/class lifecycle, Electron/Node imports, or

--- a/apps/desktop/src/renderer/application/contracts/feature-services.tsx
+++ b/apps/desktop/src/renderer/application/contracts/feature-services.tsx
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createContext, useContext, type ReactElement, type ReactNode } from 'react';
+
+export interface ServicesContext<S> {
+  /** Mounts one services object for the feature's subtree. */
+  readonly Provider: (props: {
+    readonly services: S;
+    readonly children?: ReactNode;
+  }) => ReactElement;
+  /** Reads the mounted services; throws when the Provider is missing. */
+  readonly useServices: () => S;
+}
+
+/**
+ * One services context per feature slice.
+ *
+ * A slice declares its inward-facing services type in `ports.ts` and gets the
+ * Provider/hook pair from here instead of restating twenty lines of
+ * `createContext` boilerplate. `providerName` is the Provider's displayName
+ * and the name in the error a consumer sees when nothing is mounted, so the
+ * message stays `<Feature>ServicesProvider is missing` for every slice.
+ */
+export function createServicesContext<S>(providerName: string): ServicesContext<S> {
+  const Context = createContext<S | null>(null);
+  function Provider(props: {
+    readonly services: S;
+    readonly children?: ReactNode;
+  }): ReactElement {
+    return <Context.Provider value={props.services}>{props.children}</Context.Provider>;
+  }
+  Provider.displayName = providerName;
+  function useServices(): S {
+    const services = useContext(Context);
+    if (!services) throw new Error(`${providerName} is missing`);
+    return services;
+  }
+  return { Provider, useServices };
+}

--- a/apps/desktop/src/renderer/features/connection-settings/services-context.tsx
+++ b/apps/desktop/src/renderer/features/connection-settings/services-context.tsx
@@ -17,26 +17,18 @@
  * under the License.
  */
 
-import { createContext, useContext, useSyncExternalStore, type ReactNode } from 'react';
+import { useSyncExternalStore, type ReactNode } from 'react';
+import { createServicesContext } from '../../application/contracts/feature-services.js';
 import type { ApiKeyOnboardingBridge, ConnectionSettingsServices } from './ports.js';
 
-const ConnectionSettingsServicesContext = createContext<ConnectionSettingsServices | null>(null);
+const { Provider, useServices } = createServicesContext<ConnectionSettingsServices>(
+  'ConnectionSettingsServicesProvider',
+);
 
-export function ConnectionSettingsServicesProvider(props: {
-  readonly services: ConnectionSettingsServices;
-  readonly children?: ReactNode;
-}) {
-  return (
-    <ConnectionSettingsServicesContext.Provider value={props.services}>
-      {props.children}
-    </ConnectionSettingsServicesContext.Provider>
-  );
-}
+export const ConnectionSettingsServicesProvider = Provider;
 
 export function useConnectionSettingsServices(): ConnectionSettingsServices {
-  const services = useContext(ConnectionSettingsServicesContext);
-  if (!services) throw new Error('ConnectionSettingsServicesProvider is missing');
-  return services;
+  return useServices();
 }
 
 export function ConnectionSettingsServicesConsumer(props: {

--- a/apps/desktop/src/renderer/features/goals/services-context.tsx
+++ b/apps/desktop/src/renderer/features/goals/services-context.tsx
@@ -17,24 +17,13 @@
  * under the License.
  */
 
-import { createContext, useContext, type ReactNode } from 'react';
+import { createServicesContext } from '../../application/contracts/feature-services.js';
 import type { GoalServices } from './ports.js';
 
-const GoalServicesContext = createContext<GoalServices | null>(null);
+const { Provider, useServices } = createServicesContext<GoalServices>('GoalServicesProvider');
 
-export function GoalServicesProvider(props: {
-  services: GoalServices;
-  children?: ReactNode;
-}) {
-  return (
-    <GoalServicesContext.Provider value={props.services}>
-      {props.children}
-    </GoalServicesContext.Provider>
-  );
-}
+export const GoalServicesProvider = Provider;
 
 export function useGoalServices(): GoalServices {
-  const services = useContext(GoalServicesContext);
-  if (!services) throw new Error('GoalServicesProvider is missing');
-  return services;
+  return useServices();
 }

--- a/apps/desktop/src/renderer/features/module-hub/services-context.tsx
+++ b/apps/desktop/src/renderer/features/module-hub/services-context.tsx
@@ -17,24 +17,13 @@
  * under the License.
  */
 
-import { createContext, useContext, type ReactNode } from 'react';
+import { createServicesContext } from '../../application/contracts/feature-services.js';
 import type { ModuleHubServices } from './ports.js';
 
-const ModuleHubServicesContext = createContext<ModuleHubServices | null>(null);
+const { Provider, useServices } = createServicesContext<ModuleHubServices>('ModuleHubServicesProvider');
 
-export function ModuleHubServicesProvider(props: {
-  services: ModuleHubServices;
-  children?: ReactNode;
-}) {
-  return (
-    <ModuleHubServicesContext.Provider value={props.services}>
-      {props.children}
-    </ModuleHubServicesContext.Provider>
-  );
-}
+export const ModuleHubServicesProvider = Provider;
 
 export function useModuleHubServices(): ModuleHubServices {
-  const services = useContext(ModuleHubServicesContext);
-  if (!services) throw new Error('ModuleHubServicesProvider is missing');
-  return services;
+  return useServices();
 }

--- a/apps/desktop/src/renderer/features/runtime-host-management/services-context.tsx
+++ b/apps/desktop/src/renderer/features/runtime-host-management/services-context.tsx
@@ -17,24 +17,13 @@
  * under the License.
  */
 
-import { createContext, useContext, type ReactNode } from 'react';
+import { createServicesContext } from '../../application/contracts/feature-services.js';
 import type { RuntimeHostManagementServices } from './ports.js';
 
-const RuntimeHostManagementServicesContext = createContext<RuntimeHostManagementServices | null>(null);
+const { Provider, useServices } = createServicesContext<RuntimeHostManagementServices>('RuntimeHostManagementServicesProvider');
 
-export function RuntimeHostManagementServicesProvider(props: {
-  readonly services: RuntimeHostManagementServices;
-  readonly children?: ReactNode;
-}) {
-  return (
-    <RuntimeHostManagementServicesContext.Provider value={props.services}>
-      {props.children}
-    </RuntimeHostManagementServicesContext.Provider>
-  );
-}
+export const RuntimeHostManagementServicesProvider = Provider;
 
 export function useRuntimeHostManagementServices(): RuntimeHostManagementServices {
-  const services = useContext(RuntimeHostManagementServicesContext);
-  if (!services) throw new Error('RuntimeHostManagementServicesProvider is missing');
-  return services;
+  return useServices();
 }

--- a/apps/desktop/src/renderer/features/session-collaboration/services-context.tsx
+++ b/apps/desktop/src/renderer/features/session-collaboration/services-context.tsx
@@ -17,25 +17,13 @@
  * under the License.
  */
 
-import { createContext, useContext, type ReactNode } from 'react';
+import { createServicesContext } from '../../application/contracts/feature-services.js';
 import type { SessionCollaborationServices } from './ports.js';
 
-const SessionCollaborationServicesContext =
-  createContext<SessionCollaborationServices | null>(null);
+const { Provider, useServices } = createServicesContext<SessionCollaborationServices>('SessionCollaborationServicesProvider');
 
-export function SessionCollaborationServicesProvider(props: {
-  readonly services: SessionCollaborationServices;
-  readonly children?: ReactNode;
-}) {
-  return (
-    <SessionCollaborationServicesContext.Provider value={props.services}>
-      {props.children}
-    </SessionCollaborationServicesContext.Provider>
-  );
-}
+export const SessionCollaborationServicesProvider = Provider;
 
 export function useSessionCollaborationServices(): SessionCollaborationServices {
-  const services = useContext(SessionCollaborationServicesContext);
-  if (!services) throw new Error('SessionCollaborationServicesProvider is missing');
-  return services;
+  return useServices();
 }

--- a/apps/desktop/src/renderer/features/session-navigation/services-context.tsx
+++ b/apps/desktop/src/renderer/features/session-navigation/services-context.tsx
@@ -17,27 +17,13 @@
  * under the License.
  */
 
-import { createContext, useContext, type ReactNode } from 'react';
+import { createServicesContext } from '../../application/contracts/feature-services.js';
 import type { SessionNavigationServices } from './ports.js';
 
-const SessionNavigationServicesContext =
-  createContext<SessionNavigationServices | null>(null);
+const { Provider, useServices } = createServicesContext<SessionNavigationServices>('SessionNavigationServicesProvider');
 
-export function SessionNavigationServicesProvider(props: {
-  services: SessionNavigationServices;
-  children?: ReactNode;
-}) {
-  return (
-    <SessionNavigationServicesContext.Provider value={props.services}>
-      {props.children}
-    </SessionNavigationServicesContext.Provider>
-  );
-}
+export const SessionNavigationServicesProvider = Provider;
 
 export function useSessionNavigationServices(): SessionNavigationServices {
-  const services = useContext(SessionNavigationServicesContext);
-  if (!services) {
-    throw new Error('SessionNavigationServicesProvider is missing');
-  }
-  return services;
+  return useServices();
 }

--- a/apps/desktop/src/renderer/features/session-settings/services-context.tsx
+++ b/apps/desktop/src/renderer/features/session-settings/services-context.tsx
@@ -17,24 +17,13 @@
  * under the License.
  */
 
-import { createContext, useContext, type ReactNode } from 'react';
+import { createServicesContext } from '../../application/contracts/feature-services.js';
 import type { SessionSettingsServices } from './ports.js';
 
-const SessionSettingsServicesContext = createContext<SessionSettingsServices | null>(null);
+const { Provider, useServices } = createServicesContext<SessionSettingsServices>('SessionSettingsServicesProvider');
 
-export function SessionSettingsServicesProvider(props: {
-  readonly services: SessionSettingsServices;
-  readonly children?: ReactNode;
-}) {
-  return (
-    <SessionSettingsServicesContext.Provider value={props.services}>
-      {props.children}
-    </SessionSettingsServicesContext.Provider>
-  );
-}
+export const SessionSettingsServicesProvider = Provider;
 
 export function useSessionSettingsServices(): SessionSettingsServices {
-  const services = useContext(SessionSettingsServicesContext);
-  if (!services) throw new Error('SessionSettingsServicesProvider is missing');
-  return services;
+  return useServices();
 }

--- a/apps/desktop/src/renderer/features/task-entry/services-context.tsx
+++ b/apps/desktop/src/renderer/features/task-entry/services-context.tsx
@@ -17,24 +17,13 @@
  * under the License.
  */
 
-import { createContext, useContext, type ReactNode } from 'react';
+import { createServicesContext } from '../../application/contracts/feature-services.js';
 import type { TaskEntryServices } from './ports.js';
 
-const TaskEntryServicesContext = createContext<TaskEntryServices | null>(null);
+const { Provider, useServices } = createServicesContext<TaskEntryServices>('TaskEntryServicesProvider');
 
-export function TaskEntryServicesProvider(props: {
-  services: TaskEntryServices;
-  children?: ReactNode;
-}) {
-  return (
-    <TaskEntryServicesContext.Provider value={props.services}>
-      {props.children}
-    </TaskEntryServicesContext.Provider>
-  );
-}
+export const TaskEntryServicesProvider = Provider;
 
 export function useTaskEntryServices(): TaskEntryServices {
-  const services = useContext(TaskEntryServicesContext);
-  if (!services) throw new Error('TaskEntryServicesProvider is missing');
-  return services;
+  return useServices();
 }

--- a/apps/desktop/src/renderer/features/workbar/services-context.tsx
+++ b/apps/desktop/src/renderer/features/workbar/services-context.tsx
@@ -17,26 +17,13 @@
  * under the License.
  */
 
-import { createContext, useContext, type ReactNode } from 'react';
+import { createServicesContext } from '../../application/contracts/feature-services.js';
 import type { WorkbarServices } from './ports.js';
 
-const WorkbarServicesContext = createContext<WorkbarServices | null>(null);
+const { Provider, useServices } = createServicesContext<WorkbarServices>('WorkbarServicesProvider');
 
-export function WorkbarServicesProvider(props: {
-  services: WorkbarServices;
-  children?: ReactNode;
-}) {
-  return (
-    <WorkbarServicesContext.Provider value={props.services}>
-      {props.children}
-    </WorkbarServicesContext.Provider>
-  );
-}
+export const WorkbarServicesProvider = Provider;
 
 export function useWorkbarServices(): WorkbarServices {
-  const services = useContext(WorkbarServicesContext);
-  if (!services) {
-    throw new Error('WorkbarServicesProvider is missing');
-  }
-  return services;
+  return useServices();
 }

--- a/apps/desktop/src/renderer/platform/desktop/create-module-hub-services.ts
+++ b/apps/desktop/src/renderer/platform/desktop/create-module-hub-services.ts
@@ -84,22 +84,7 @@ export function createDesktopModuleHubServices(
       delete: (skillRef, host) => bridge.skills.delete(skillRef, host),
       open: (skillId, target, host) => bridge.skills.open(skillId, target, host),
     },
-    scheduledTasks: {
-      list: (host) => bridge.scheduledTasks.list(host),
-      create: (input, host) => bridge.scheduledTasks.create(input, host),
-      update: (id, patch, host) =>
-        bridge.scheduledTasks.update(id, patch, host),
-      setEnabled: (id, enabled, host) =>
-        bridge.scheduledTasks.setEnabled(id, enabled, host),
-      triggerNow: (id, host) => bridge.scheduledTasks.triggerNow(id, host),
-      snooze: (id, host) => bridge.scheduledTasks.snooze(id, host),
-      clearRunHistory: (id, host) =>
-        bridge.scheduledTasks.clearRunHistory(id, host),
-      delete: (id, host) => bridge.scheduledTasks.delete(id, host),
-      subscribeChanges: (handler) =>
-        bridge.scheduledTasks.subscribeChanges(handler),
-      subscribeDue: (handler) => bridge.scheduledTasks.subscribeDue(handler),
-    },
+    scheduledTasks: bridge.scheduledTasks,
     clientSettings: {
       supported: clientSettingsSupported,
       async getKeepSystemAwake() {

--- a/apps/desktop/src/renderer/platform/desktop/create-session-navigation-services.ts
+++ b/apps/desktop/src/renderer/platform/desktop/create-session-navigation-services.ts
@@ -27,19 +27,6 @@ export function createDesktopSessionNavigationServices(
   bridge: DesktopSessionNavigationBridge = window.maka,
 ): SessionNavigationServices {
   return {
-    sessions: {
-      list: () => bridge.sessions.list(),
-      setFlagged: (sessionId, flagged, options) =>
-        bridge.sessions.setFlagged(sessionId, flagged, options),
-      archive: (sessionId, options) =>
-        bridge.sessions.archive(sessionId, options),
-      unarchive: (sessionId, options) =>
-        bridge.sessions.unarchive(sessionId, options),
-      rename: (sessionId, name, options) =>
-        bridge.sessions.rename(sessionId, name, options),
-      remove: (sessionId, options) =>
-        bridge.sessions.remove(sessionId, options),
-      previewRemoval: (sessionId) => bridge.sessions.previewRemoval(sessionId),
-    },
+    sessions: bridge.sessions,
   };
 }

--- a/apps/desktop/src/renderer/platform/desktop/create-task-entry-services.ts
+++ b/apps/desktop/src/renderer/platform/desktop/create-task-entry-services.ts
@@ -27,12 +27,6 @@ export function createDesktopTaskEntryServices(
   bridge: DesktopTaskEntryBridge = window.maka,
 ): TaskEntryServices {
   return {
-    catalog: {
-      getCatalog: () => bridge.newTasks.getCatalog(),
-      subscribeChanges: (handler) => bridge.newTasks.subscribeChanges(handler),
-      addProject: (host) => bridge.newTasks.addProject(host),
-      relinkProject: (host, projectId) =>
-        bridge.newTasks.relinkProject(host, projectId),
-    },
+    catalog: bridge.newTasks,
   };
 }

--- a/apps/desktop/src/renderer/platform/desktop/create-workbar-services.ts
+++ b/apps/desktop/src/renderer/platform/desktop/create-workbar-services.ts
@@ -54,19 +54,8 @@ export function createDesktopWorkbarServices(
       subscribeSessionEvents: (sessionId, handler) =>
         bridge.sessions.subscribeEvents(sessionId, handler),
     },
-    terminal: {
-      start: (sessionId) => bridge.shellRuns.start(sessionId),
-      stop: (input) => bridge.shellRuns.stop(input),
-      attach: (input) => bridge.shellRuns.attach(input),
-      detach: (input) => bridge.shellRuns.detach(input),
-      write: (input) => bridge.shellRuns.write(input),
-      subscribePtyData: (handler) => bridge.shellRuns.subscribePtyData(handler),
-      subscribeResync: (handler) => bridge.shellRuns.subscribeResync(handler),
-    },
-    todo: {
-      read: (sessionId) => bridge.todo.read(sessionId),
-      subscribeChanges: (handler) => bridge.todo.subscribeChanges(handler),
-    },
+    terminal: bridge.shellRuns,
+    todo: bridge.todo,
     browser: {
       setActiveSession: (sessionId) => bridge.browser.setActiveSession(sessionId),
       setViewport: (input) => bridge.browser.setViewport(input),
@@ -103,13 +92,7 @@ export function createDesktopWorkbarServices(
       subscribeUsageChanges: (sessionId, handler) =>
         bridge.inspector.subscribeUsageChanges(sessionId, handler),
     },
-    attachments: {
-      readBytes: (sessionId, artifactId) =>
-        bridge.attachments.readBytes(sessionId, artifactId),
-      pickFiles: () => bridge.attachments.pickFiles(),
-      previewApproval: (approvalId) =>
-        bridge.attachments.previewApproval(approvalId),
-    },
+    attachments: bridge.attachments,
     sideChat: {
       listSessions: () => bridge.sessions.list(),
       listTurns: (sessionId) => bridge.sessions.listTurns(sessionId),

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -6,7 +6,7 @@ Generated against `@astryxdesign/core@0.5.2` (194 component exports).
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 244 files — blocker 0, reimplementation 0, polish 1, aligned 243.
+**Totals:** 245 files — blocker 0, reimplementation 0, polish 1, aligned 244.
 
 ## Exclusions (explicit)
 
@@ -33,6 +33,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/app-shell-overlays.tsx` | shell-chrome-or-panel | Spinner | aligned — uses Astryx (Spinner) | aligned |
 | `apps/desktop/src/renderer/app-shell.tsx` | shell-chrome-or-panel | AppShell, Button | aligned — uses Astryx (AppShell, Button) | aligned |
 | `apps/desktop/src/renderer/app.tsx` | other | Theme | aligned — uses Astryx (Theme) | aligned |
+| `apps/desktop/src/renderer/application/contracts/feature-services.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/cascade-layers.css` | styles | n/a (css) | aligned — no off-rhythm control heights flagged | aligned |
 | `apps/desktop/src/renderer/chat-composer-region.tsx` | shell-chrome-or-panel | Banner, Button | aligned — uses Astryx (Banner, Button) | aligned |
 | `apps/desktop/src/renderer/chat-message-surface.tsx` | shell-chrome-or-panel | Skeleton | aligned — uses Astryx (Skeleton) | aligned |

--- a/docs/astryx-surface-file-inventory.paths
+++ b/docs/astryx-surface-file-inventory.paths
@@ -4,6 +4,7 @@ apps/desktop/src/renderer/app-shell-detail-panel.tsx
 apps/desktop/src/renderer/app-shell-overlays.tsx
 apps/desktop/src/renderer/app-shell.tsx
 apps/desktop/src/renderer/app.tsx
+apps/desktop/src/renderer/application/contracts/feature-services.tsx
 apps/desktop/src/renderer/cascade-layers.css
 apps/desktop/src/renderer/chat-composer-region.tsx
 apps/desktop/src/renderer/chat-message-surface.tsx


### PR DESCRIPTION
## Summary

Nine feature slices each restate the same twenty-line services context and hand-write Desktop adapter forwarders whose signatures equal the bridge methods they forward to (the per-slice join cost Astro-Han measured on #3439: identical `services-context.tsx` files, and adapters equivalent to `{ sessions: bridge.sessions }`). This PR removes the restatement without changing any port, consumer, or behavior.

- `application/contracts/feature-services.tsx` exports `createServicesContext<S>(providerName)`, returning the Provider/hook pair. `application/contracts` is the one renderer zone every feature may import. Each slice's `services-context.tsx` is now four lines; every exported name, type, and error message (`<Feature>ServicesProvider is missing`) is unchanged, and `connection-settings` keeps its two extra components.
- Desktop adapters hand a bridge namespace through where the port is a structural subset of it: `sessions: bridge.sessions` (Session Navigation), `catalog: bridge.newTasks` (Task Entry), `scheduledTasks: bridge.scheduledTasks` (Module Hub), and `terminal: bridge.shellRuns`, `todo: bridge.todo`, `attachments: bridge.attachments` (Workbar) — 33 identity forwarders gone. Blocks that rename, guard, filter, or translate (`goal`, `skills`, `dailyReview`, `browser`, `artifacts`, `inspector`, `review`, `sideChat`, `sessionCollaboration`, `peerMesh`) stay hand-written. I tried `{ ...bridge.ns, <adaptation> }` for those and backed it out: the adapter tests drive Proxy-based bridge recorders that have no own keys, so a spread copies nothing, and the same would hold for any bridge double built that way. Passing the namespace object itself keeps late binding and works with every double.
- Preload bridge namespaces are plain objects with no `this` usage, so passing one through is runtime-safe, and the port types stay narrow, so nothing new is reachable from feature code.
Net: 91 lines removed across 17 files. `composition/desktop-feature-services.tsx` is deliberately untouched; the tenth slice from #4498 can adopt the factory after it lands.

Refs #4582

## Verification

On the exact head, under Node 24, all green:

- `npm --workspace @maka/desktop run test:dist` — 1969/1969
- `npm --workspace @maka/desktop run typecheck` — preload, main, renderer, storybook
- `npm run lint`, `npm run format:check`
- `npm run check:renderer-architecture -- --base upstream/main`, `npm run check:app-shell-hooks` (42 hooks / 78 call sites, unchanged)
- `npm run astryx:surface-inventory` (regenerated for the new file), `npx knip --workspace apps/desktop`, `npm run check:asf-headers`, `git diff --check`
- `npm --workspace @maka/desktop run build:renderer`

`renderer-architecture.json` needed no regeneration beyond the rebase: `application/contracts` is an explicit owner zone, so the new file is governed by zone rules rather than recorded as debt.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — implementation and local validation. The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it — the existing adapter and boundary suites are the contract; no new tests, because the change removes restatement rather than adding behavior
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
