### PR TITLE
fix(runtime): recover once from output-free streams closed before completion

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -24,7 +24,12 @@ import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { join, resolve } from 'node:path';
 import { describe, test } from 'node:test';
-import type { ModelMessage, ModelStreamResult } from '../model-protocol.js';
+import type {
+  ModelFailure,
+  ModelMessage,
+  ModelStreamEvent,
+  ModelStreamResult,
+} from '../model-protocol.js';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
 import { APICallError, type LanguageModelV4StreamPart } from '@ai-sdk/provider';
 import type { RuntimeInvocationRootAuthority } from '@maka/core/runtime-event';
@@ -8039,6 +8044,324 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
   });
 
+  test('retries an output-free protocol-incomplete stream once', async () => {
+    const durable = durableTurnHarness('turn-incomplete-retry', 'finish the report');
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        calls += 1;
+        const chunks: LanguageModelV4StreamPart[] =
+          calls === 1
+            ? [{ type: 'stream-start', warnings: [] }, incompleteStreamErrorPart()]
+            : [
+                { type: 'stream-start', warnings: [] },
+                { type: 'text-start', id: 'text-1' },
+                { type: 'text-delta', id: 'text-1', delta: 'Recovered' },
+                { type: 'text-end', id: 'text-1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: emptyUsage(),
+                },
+              ];
+        return {
+          stream: simulateReadableStream({
+            chunks,
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+      providerRetrySleep: async () => {},
+    });
+
+    const events = await drainDurably(backend.send(durable.input()), durable);
+
+    assert.equal(calls, 2);
+    assert.deepEqual(
+      events
+        .filter((event) => event.type === 'provider_retry')
+        .map(({ phase, attempt, maxAttempts, reason }) => ({
+          phase,
+          attempt,
+          maxAttempts,
+          reason,
+        })),
+      [
+        { phase: 'scheduled', attempt: 2, maxAttempts: 2, reason: 'stream_truncated' },
+        { phase: 'started', attempt: 2, maxAttempts: 2, reason: 'stream_truncated' },
+      ],
+    );
+    assert.equal(
+      events.some((event) => event.type === 'error'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
+  });
+
+  test('stops after one protocol-incomplete stream recovery and preserves the provider error', async () => {
+    const durable = durableTurnHarness('turn-incomplete-exhausted', 'finish the report');
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        calls += 1;
+        return {
+          stream: simulateReadableStream({
+            chunks: [{ type: 'stream-start', warnings: [] }, incompleteStreamErrorPart()],
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+      providerRetrySleep: async () => {},
+    });
+
+    const events = await drainDurably(backend.send(durable.input()), durable);
+    const error = events.find(
+      (event): event is Extract<SessionEvent, { type: 'error' }> => event.type === 'error',
+    );
+
+    assert.equal(calls, 2);
+    assert.equal(
+      events.filter((event) => event.type === 'provider_retry' && event.phase === 'scheduled')
+        .length,
+      1,
+    );
+    assert.equal(error?.code, 'invalid_request_error');
+    assert.deepEqual(error?.retry, { decision: 'exhausted', attempts: 2 });
+    assert.match(error?.message ?? '', /stream closed before response\.completed/);
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
+  test('fails closed on protocol-incomplete streams after observable output or a step boundary', async () => {
+    const cases: Array<{ name: string; events: ModelStreamEvent[] }> = [
+      { name: 'text', events: [{ kind: 'text', text: 'partial answer' }] },
+      { name: 'thinking', events: [{ kind: 'thinking', text: 'partial thought' }] },
+      { name: 'tool activity', events: [{ kind: 'provider-tool-input' }] },
+      {
+        name: 'continuation metadata',
+        events: [{ kind: 'text-end', providerOptions: { openai: { itemId: 'item-1' } } }],
+      },
+      { name: 'completed step', events: [{ kind: 'step-finish', finishReason: 'stop' }] },
+    ];
+
+    for (const candidate of cases) {
+      let calls = 0;
+      const backend = createTestAiSdkBackend({
+        sessionId: 'session-1',
+        header: header(),
+        appendMessage: async () => {},
+        connection: connection(),
+        apiKey: 'sk-test',
+        modelId: 'mock-model-id',
+        modelFactory: () => completionModel(),
+        tools: [],
+        newId: idGenerator(),
+        now: monotonicClock(),
+        providerRetrySleep: async () => {},
+      });
+      const failure = incompleteStreamFailure();
+      (
+        backend as unknown as {
+          modelAdapter: { startStream: () => Promise<ModelStreamResult> };
+        }
+      ).modelAdapter.startStream = async () => {
+        calls += 1;
+        return {
+          events: (async function* () {
+            for (const event of candidate.events) yield event;
+            yield { kind: 'error' as const, failure };
+          })(),
+          outcome: Promise.resolve({
+            kind: 'failed',
+            failure,
+            request: { messages: [] },
+            continuation: 'none',
+          }),
+        };
+      };
+
+      const events: SessionEvent[] = [];
+      for await (const event of backend.send({
+        turnId: `turn-${candidate.name}`,
+        text: 'hi',
+        context: [],
+      })) {
+        events.push(event);
+      }
+
+      assert.equal(calls, 1, candidate.name);
+      assert.equal(
+        events.some((event) => event.type === 'provider_retry'),
+        false,
+        candidate.name,
+      );
+      assert.equal(
+        events.find((event) => event.type === 'complete')?.stopReason,
+        'error',
+        candidate.name,
+      );
+    }
+  });
+
+  test('retries a post-tool protocol-incomplete stream without re-running the durable tool', async () => {
+    const durable = durableTurnHarness('turn-incomplete-after-tool', 'read notes');
+    let providerCalls = 0;
+    let toolCalls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        providerCalls += 1;
+        const chunks: LanguageModelV4StreamPart[] =
+          providerCalls === 1
+            ? [
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'read-1',
+                  toolName: 'Read',
+                  input: JSON.stringify({ path: 'notes.md' }),
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: emptyUsage(),
+                },
+              ]
+            : providerCalls === 2
+              ? [{ type: 'stream-start', warnings: [] }, incompleteStreamErrorPart()]
+              : [
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'text-start', id: 'text-final' },
+                  { type: 'text-delta', id: 'text-final', delta: 'done' },
+                  { type: 'text-end', id: 'text-final' },
+                  {
+                    type: 'finish',
+                    finishReason: { unified: 'stop', raw: 'stop' },
+                    usage: emptyUsage(),
+                  },
+                ];
+        return {
+          stream: simulateReadableStream({
+            chunks,
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [
+        {
+          name: 'Read',
+          description: 'Read notes',
+          parameters: z.object({ path: z.string() }),
+          impl: async () => {
+            toolCalls += 1;
+            return 'notes contents';
+          },
+        },
+      ],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+      providerRetrySleep: async () => {},
+    });
+
+    const events = await drainDurably(backend.send(durable.input()), durable);
+
+    assert.equal(providerCalls, 3);
+    assert.equal(toolCalls, 1);
+    assert.equal(events.filter((event) => event.type === 'tool_result').length, 1);
+    assert.equal(
+      durable.ledger.filter((event) => event.content?.kind === 'function_response').length,
+      1,
+    );
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
+  });
+
+  test('Stop aborts the turn while protocol-incomplete recovery is waiting', async () => {
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        calls += 1;
+        return {
+          stream: simulateReadableStream({
+            chunks: [{ type: 'stream-start', warnings: [] }, incompleteStreamErrorPart()],
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      providerRetrySleep: async (_delayMs, signal) =>
+        await new Promise<void>((_resolve, reject) => {
+          const abort = () =>
+            reject(signal.reason ?? Object.assign(new Error('aborted'), { name: 'AbortError' }));
+          if (signal.aborted) abort();
+          else signal.addEventListener('abort', abort, { once: true });
+        }),
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+      if (event.type === 'provider_retry' && event.phase === 'scheduled') {
+        await backend.stop('user_stop');
+      }
+    }
+
+    assert.equal(calls, 1);
+    assert.equal(
+      events.some((event) => event.type === 'provider_retry' && event.phase === 'started'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'user_stop');
+  });
+
   test('records exhaustion of output-free truncated stream recovery', async () => {
     const durable = durableTurnHarness('turn-truncated-exhausted', 'analyse the image');
     let calls = 0;
@@ -14697,7 +15020,9 @@ describe('AiSdkBackend steering durability and identity', () => {
     // while the answer streams has no boundary left to land on. Whether
     // "Steer" works at all must not depend on the model happening to call a
     // tool afterwards (#3529).
-    const model = textCompletionModel('the first answer');
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => textCompletionModel('the first answer').doStream(options),
+    });
     const durable = durableTurnHarness('turn-1', 'start');
     const backend = steeringBackend(model, {
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
@@ -14732,6 +15057,7 @@ describe('AiSdkBackend steering durability and identity', () => {
     // with it. Draining without taking another step would satisfy every
     // assertion above while the user still never gets an answer.
     assert.equal(model.doStreamCalls.length, 2);
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
     const secondPrompt = JSON.stringify(model.doStreamCalls[1]?.prompt);
     assert.match(secondPrompt, /late steer/);
     // …and it has to carry what the model just said, or the correction lands on
@@ -15886,6 +16212,28 @@ function emptyUsage() {
   return {
     inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
     outputTokens: { total: 0, text: 0, reasoning: 0 },
+  };
+}
+
+function incompleteStreamErrorPart(): LanguageModelV4StreamPart {
+  return {
+    type: 'error',
+    error: {
+      code: 'invalid_request_error',
+      message:
+        'stream error: stream disconnected before completion: stream closed before response.completed',
+    },
+  };
+}
+
+function incompleteStreamFailure(): ModelFailure {
+  return {
+    type: 'model_failure',
+    kind: 'stream_truncated',
+    message:
+      'stream error: stream disconnected before completion: stream closed before response.completed (code=invalid_request_error)',
+    retryable: false,
+    code: 'invalid_request_error',
   };
 }
 

--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -30,6 +30,23 @@ import {
 } from '../provider-error-classification.js';
 
 describe('Provider error classification', () => {
+  test('classifies nested protocol-incomplete invalid_request_error as stream_truncated', () => {
+    const failure = providerModelFailure(
+      new Error('SDK stream error', {
+        cause: {
+          type: 'invalid_request_error',
+          code: 'invalid_request_error',
+          message:
+            'stream error: stream disconnected before completion: stream closed before response.completed',
+        },
+      }),
+    );
+
+    assert.equal(failure.kind, 'stream_truncated');
+    assert.equal(failure.code, 'invalid_request_error');
+    assert.equal(failure.retryable, false);
+  });
+
   test('projects only bounded allowlisted facts into durable diagnostics', () => {
     const diagnostic = providerFailureDiagnostic(
       Object.assign(new Error('must not persist sk-secret-or-prompt'), {

--- a/packages/runtime/src/ai-sdk-turn.ts
+++ b/packages/runtime/src/ai-sdk-turn.ts
@@ -2028,12 +2028,6 @@ export class AiSdkTurn {
             const settledWatchdogTimeout = consumeWatchdogTimeout();
             providerOutcome = await result.outcome;
             const incompleteStreamTerminal = providerOutcome.kind === 'truncated';
-            const incompleteStreamHasNoObservableOutput =
-              incompleteStreamTerminal &&
-              !attemptSawText &&
-              !attemptSawThinking &&
-              !attemptSawToolActivity &&
-              !attemptSawContinuationMetadata;
             const attemptFailure =
               settledWatchdogTimeout?.error ??
               (providerOutcome.kind === 'completed' ? undefined : providerOutcome.failure);
@@ -2043,6 +2037,15 @@ export class AiSdkTurn {
                 settledWatchdogTimeout || providerOutcome.kind === 'completed'
                   ? this.deps.modelAdapter.normalizeFailure(attemptFailure)
                   : providerOutcome.failure;
+              const protocolIncompleteStreamFailure =
+                providerOutcome.kind === 'failed' && failure.kind === 'stream_truncated';
+              const incompleteStreamHasNoObservableOutput =
+                (incompleteStreamTerminal &&
+                  !attemptSawText &&
+                  !attemptSawThinking &&
+                  !attemptSawToolActivity &&
+                  !attemptSawContinuationMetadata) ||
+                (protocolIncompleteStreamFailure && attemptHasNoObservableOutput());
               if (this.loopStopRequested) {
                 terminalProviderError = settledWatchdogTimeout?.error ?? failure;
                 terminalProviderErrorReason =
@@ -2143,7 +2146,7 @@ export class AiSdkTurn {
                 idleWatchdogRetryCount < MAX_IDLE_WATCHDOG_RETRIES_PER_STEP &&
                 attemptCanRecoverWithSealedThinking();
               const incompleteStreamRecovery =
-                incompleteStreamTerminal &&
+                (incompleteStreamTerminal || protocolIncompleteStreamFailure) &&
                 incompleteStreamRetryCount < MAX_INCOMPLETE_STREAM_RETRIES_PER_STEP &&
                 incompleteStreamHasNoObservableOutput;
               // Same seal-and-retry contract as the watchdog path, entered when
@@ -2181,7 +2184,7 @@ export class AiSdkTurn {
                 retry = { decision: 'declined', because: 'policy' };
               } else if (!(failure.retryable || idleWatchdogRecovery || incompleteStreamRecovery)) {
                 retry =
-                  incompleteStreamTerminal &&
+                  (incompleteStreamTerminal || protocolIncompleteStreamFailure) &&
                   incompleteStreamRetryCount >= MAX_INCOMPLETE_STREAM_RETRIES_PER_STEP
                     ? { decision: 'exhausted', attempts: providerAttempt }
                     : { decision: 'declined', because: 'policy' };


### PR DESCRIPTION
## Summary

Recover once from output-free protocol-incomplete streams using the canonical `stream_truncated` failure kind introduced by #4951. This rewrite changes only `ai-sdk-turn.ts` and two test files: a `failed` outcome with that failure kind enters the existing once-per-step incomplete-stream recovery gate, with the existing `stream_truncated` retry reason.

Fixes #4599

Refs #4947 #4951

## Changes

- `packages/runtime/src/ai-sdk-turn.ts`: admit canonical protocol failures into bounded recovery and report `{ decision: 'exhausted', attempts: 2 }` after the single recovery is spent.
- `packages/runtime/src/__tests__/ai-sdk-backend.test.ts`: replay five regression cases for recovery, exhaustion with the original provider error, observable-output and step-boundary guards, durable tool execution, and Stop during backoff. The existing late-steer test now creates a fresh stream per request and asserts successful completion.
- `packages/runtime/src/__tests__/provider-error-classification.test.ts`: pin the existing classification of a nested `invalid_request_error` carrying both premature-close phrases as `stream_truncated`, with `retryable: false`.

## Recovery guards

The protocol path requires `attemptHasNoObservableOutput()`, remaining step budget, and an unused per-step incomplete-stream recovery allowance. Text, thinking, tool activity, continuation metadata, and a completed-step boundary each prevent recovery. The existing context-overflow gate, provider-attempt limit, abortable backoff, and durable tool-result replay remain in force.

The provider's `invalid_request_error` code and terminal message remain available after exhaustion. The post-tool test asserts one tool execution, one `tool_result`, and one durable `function_response` across recovery.

## Verification

Rewritten on 2026-09-09 against `8d5c4612`; head `b87917e7`.

- Red on unpatched main: of the five backend regression tests, 4 fail and 1 pass (the fail-closed case, which main already satisfies by declining). The nested-cause classifier test passes on main and only pins existing behaviour.
- Targeted set (`ai-sdk-backend`, `provider-error-classification`): 258/258.
- `@maka/runtime` suite: 3364 tests, 3351 pass, 13 skip, 0 fail.
- Format check, lint, workspace typecheck and `git diff --check origin/main...HEAD`: clean.
- Diffstat: 3 files, +378/-10; production change +12/-8 in `ai-sdk-turn.ts`.

One existing test needed a fixture change: the late-steer test reused an already-consumed stream for its second request. On main that empty request fails as `stream_truncated` and is declined, so the test's two-call assertion held by accident. With the recovery admitted, the empty request is retried once and the count becomes three. The test now builds a fresh stream per request and additionally asserts that the turn completes with `end_turn`.

### Coverage limits

Tests use deterministic fake streams and adapter events. Live upstream close timing, a local relay, and the full matrix of SDK error constructors remain outside this verification.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi drafted the implementation, tests, and this PR body; commit trailer `Generated-by: pi (gpt-6-astra)`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
