### PR TITLE
fix(core): sync Volcengine Agent Plan catalog with the official plan

### DIFF
--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -184,6 +184,12 @@ describe('Volcengine Agent Plan official catalog mirror', () => {
     assert.equal(metadata.capabilities?.vision, true);
   });
 
+  it('pins glm-5.3 to the plan page table literals', () => {
+    const metadata = lookupModelMetadata('volcengine-agent-plan', 'glm-5.3');
+    assert.equal(metadata.contextWindow, 1_024_000);
+    assert.equal(metadata.maxOutputTokens, 128_000);
+  });
+
   it('carries the official 1M context window for minimax-m3', () => {
     assert.equal(
       lookupModelMetadata('volcengine-agent-plan', 'minimax-m3').contextWindow,

--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -164,3 +164,40 @@ describe('deepseek v4 flash vision exp metadata regression', () => {
     );
   });
 });
+
+// The Agent Plan gateway has no model-list endpoint its key can reach and has
+// no models.dev snapshot, so its catalog is a hand-maintained mirror of the
+// official plan page (volcengine docs 2366394) and its model release and
+// retirement announcements. These tests pin that mirror to the facts those
+// pages published as of 2026-09.
+describe('Volcengine Agent Plan official catalog mirror', () => {
+  it('offers glm-5.3-flash with the facts the plan page publishes', () => {
+    assert.ok(
+      providerFallbackModelIds(PROVIDER_REGISTRY['volcengine-agent-plan']).includes(
+        'glm-5.3-flash',
+      ),
+    );
+    const metadata = lookupModelMetadata('volcengine-agent-plan', 'glm-5.3-flash');
+    assert.equal(metadata.displayName, 'GLM-5.3-Flash');
+    assert.equal(metadata.contextWindow, 1_024_000);
+    assert.equal(metadata.maxOutputTokens, 128_000);
+    assert.equal(metadata.capabilities?.vision, true);
+  });
+
+  it('carries the official 1M context window for minimax-m3', () => {
+    assert.equal(
+      lookupModelMetadata('volcengine-agent-plan', 'minimax-m3').contextWindow,
+      1_024_000,
+    );
+  });
+
+  it('records the upstream retirement of glm-5.2, kimi-k2.6 and minimax-m2.7', () => {
+    for (const modelId of ['glm-5.2', 'kimi-k2.6', 'minimax-m2.7']) {
+      assert.equal(
+        lookupModelMetadata('volcengine-agent-plan', modelId).lifecycle,
+        'deprecated',
+        modelId,
+      );
+    }
+  });
+});

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -287,9 +287,9 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
 };
 const VOLCENGINE_AGENT_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'ark-code-latest': agentPlanModel('Ark Code Latest', 256_000, 32_000, { vision: true }),
-  // Agent Plan currently exposes GLM-5.3 in its ark-code-latest routing catalog.
-  // The underlying model's published limits are 1M context and 128K output.
-  'glm-5.3': agentPlanModel('GLM-5.3', 1_000_000, 131_072),
+  // The plan page lists "glm-5.3 (glm-latest)": thinking is on by default and
+  // cannot be turned off.
+  'glm-5.3': agentPlanModel('GLM-5.3', 1_024_000, 128_000),
   'doubao-seed-2.0-mini': agentPlanModel('Doubao Seed 2.0 Mini', 256_000, 128_000, {
     vision: true,
   }),
@@ -309,11 +309,23 @@ const VOLCENGINE_AGENT_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'doubao-seed-2.0-pro': agentPlanModel('Doubao Seed 2.0 Pro', 256_000, 128_000, {
     lifecycle: 'deprecated',
   }),
-  'minimax-m2.7': agentPlanModel('MiniMax-M2.7', 200_000, 128_000),
-  'minimax-m3': agentPlanModel('MiniMax-M3', 512_000, 128_000, { vision: true }),
-  'glm-5.2': agentPlanModel('GLM-5.2', 1_024_000, 128_000),
+  'minimax-m2.7': agentPlanModel('MiniMax-M2.7', 200_000, 128_000, {
+    // Upstream retirement notice of 2026-08-04; the gateway routes to minimax-m3.
+    lifecycle: 'deprecated',
+  }),
+  'minimax-m3': agentPlanModel('MiniMax-M3', 1_024_000, 128_000, { vision: true }),
+  'glm-5.2': agentPlanModel('GLM-5.2', 1_024_000, 128_000, {
+    // Upstream service ended 2026-08-31; the gateway routes to glm-5.3.
+    lifecycle: 'deprecated',
+  }),
+  // Official alias of glm-5.3 (the plan page lists "glm-5.3 (glm-latest)").
   'glm-latest': agentPlanModel('GLM Latest', 1_024_000, 128_000),
-  'kimi-k2.6': agentPlanModel('Kimi-K2.6', 256_000, 32_000, { vision: true }),
+  'glm-5.3-flash': agentPlanModel('GLM-5.3-Flash', 1_024_000, 128_000, { vision: true }),
+  'kimi-k2.6': agentPlanModel('Kimi-K2.6', 256_000, 32_000, {
+    // Upstream service ended 2026-08-18; migrate to kimi-k2.7-code or kimi-k3.
+    lifecycle: 'deprecated',
+    vision: true,
+  }),
   'kimi-k2.7-code': agentPlanModel('Kimi-K2.7-Code', 256_000, 32_000, { vision: true }),
   'deepseek-v4-pro': agentPlanModel('DeepSeek-V4-Pro', 1_024_000, 384_000),
   'kimi-k3': agentPlanModel('Kimi-K3', 1_024_000, 128_000, { vision: true }),

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -285,6 +285,13 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'kimi-k2.6': planModel('Kimi-K2.6', true, 256_000, 32_000),
   'kimi-k2.7-code': planModel('Kimi-K2.7-Code', true, 256_000, 32_000),
 };
+// Hand-maintained mirror of the official Agent Plan personal plan page
+// (docs.volcengine.com/docs/82379/2366394) and its model release/retirement
+// announcements (82379/2578669, 82379/2578673): the gateway has no
+// model-list endpoint its plan key can reach and models.dev has no snapshot.
+// The page's table lists windows as "1024k"/"128k"; transcribe those
+// literals as 1_024_000/128_000 (its prose "1M" is the same figure rounded).
+// Re-check the page before editing an entry here.
 const VOLCENGINE_AGENT_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'ark-code-latest': agentPlanModel('Ark Code Latest', 256_000, 32_000, { vision: true }),
   // The plan page lists "glm-5.3 (glm-latest)": thinking is on by default and

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -353,6 +353,7 @@ const volcengineCodingPlanModelIds = [
 const volcengineAgentPlanModelIds = [
   'ark-code-latest',
   'glm-5.3',
+  'glm-5.3-flash',
   'doubao-seed-2.0-mini',
   'doubao-seed-2.0-lite',
   'deepseek-v4-flash',


### PR DESCRIPTION
## Summary

The Volcengine Agent Plan gateway exposes no model-list endpoint its plan key can reach and has no models.dev snapshot, so its catalog in Maka is a hand-maintained mirror of the official plan page and its model release/retirement announcements. That mirror had drifted from what the plan actually serves:

- `glm-5.3-flash` (launched 2026-08-28, natively multimodal, 1024k context / 128k output) was missing entirely.
- `minimax-m3` now serves the plan page's 1024k context window (transcribed as `1_024_000`); we shipped 512k.
- `glm-5.2` (service ended 2026-08-31, gateway auto-routes to `glm-5.3`), `kimi-k2.6` (ended 2026-08-18) and `minimax-m2.7` (2026-08-04 retirement batch) were retired upstream while their metadata still described them as active.

This PR mirrors the official facts as of 2026-09 (sourced note added above the table in `model-metadata.ts`; the page's table literal "1024k" is transcribed as `1_024_000`): it offers `glm-5.3-flash` with its published limits and vision support, corrects `minimax-m3`'s window, and marks the three retired ids `deprecated` so existing connections keep sending while the catalog records the retirement. `glm-5.3`'s limits are normalized to the plan page's 1024k/128k like its siblings.

Behavior change: yes, catalog-level — a new selectable model on Agent Plan, a corrected context window (which feeds the context-budget policy), and retirement recorded for three ids. No migration impact: fallback lists are not an allowlist (#3330), so stored connections are unaffected.

## Verification

- New tests in `packages/core/src/__tests__/model-metadata.test.ts` pin the three obligations above; each failed against `main` and passes with the change.
- `npm run test:dist --workspace @maka/core` → 771 pass, 0 fail.
- `npm run test:dist --workspace @maka/runtime` → 3162 pass, 0 fail (includes the Agent Plan connection-probe and context-budget suites).
- `npm run test:dist --workspace @maka/runtime-host` → 0 fail (includes the Agent Plan fallback-catalog replay).
- `npm run format`, `npm run lint`, `@maka/core` typecheck → clean.

Not run: full-repo `npm test` (not requested); desktop E2E (no UI flow change — the model picker renders Host-resolved catalog rows, and the settings storybook story for this provider uses fixed fixtures, so it does not exercise this data).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (coding agent) — verified the official plan facts, implemented the catalog/metadata sync and its tests, drafted the commit and this PR.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above

