### PR TITLE
test(desktop): wait for initial transcript tail

### DIFF
--- a/apps/desktop/e2e/transcript-scroll.spec.ts
+++ b/apps/desktop/e2e/transcript-scroll.spec.ts
@@ -634,6 +634,25 @@ test('history asked for at the very top of the scroller still lands above the re
     .getAttribute('data-transcript-turn-id');
   const firstBefore = await firstLoadedTurn();
 
+  // The fixture is ready when the transcript exists, before its initial tail
+  // positioning necessarily completes. Writing zero while it is still at zero
+  // is a no-op, so no reader scroll event asks for earlier history. Require one
+  // geometry sample to prove both that the initial pin moved and where it
+  // landed before exercising the real move to the top.
+  await expect.poll(async () => {
+    const metrics = await scrollMetrics(page);
+    return {
+      positionedAwayFromStart: metrics.scrollTop > 0,
+      settledAtTail: metrics.distance <= 4,
+      metrics,
+    };
+  }, {
+    message: 'the initial transcript tail positioning settles',
+  }).toMatchObject({
+    positionedAwayFromStart: true,
+    settledAtTail: true,
+  });
+
   // The one position where the browser declines to anchor, and the one the
   // wheel-to-load path puts the reader in.
   await page.evaluate((selector) => {


### PR DESCRIPTION
## Summary

The prompt-rail E2E fixture becomes ready when the transcript DOM appears, before initial tail positioning necessarily settles. Under concurrent Xvfb load, the top-history test can therefore assign `scrollTop = 0` while it is already zero; that no-op emits no reader scroll event and never requests earlier history.

Wait for one real geometry sample with `scrollTop > 0` and distance-to-tail `<= 4` before exercising the move to the top. The failed readiness assertion retains the complete scroll metrics for diagnosis. This changes only the test synchronization: product behavior, shared fixtures, and the existing history-load timeout are unchanged.

Fixes #4618

## Verification

- `npx playwright test --config e2e/playwright.config.ts e2e/transcript-scroll.spec.ts --grep "history asked for at the very top" --workers=4 --repeat-each=16` — 16 passed.
- `npx playwright test --config e2e/playwright.config.ts e2e/transcript-scroll.spec.ts --workers=4` — 11 passed.
- `npm --workspace @maka/desktop run typecheck` — passed.
- `npm run lint` — 3,156 files checked, no fixes.
- `npm run format:check` — 1,873 files checked, no fixes.
- `git diff --check` — passed.

The unmodified target did not reproduce on this macOS worktree in 80 four-worker repeats; the red-state evidence is the linked CI/Xvfb failure and the instrumented reproductions recorded in #4618. One earlier local full-file four-worker run hit a geometry failure in the unmodified sibling test `earlier history lands above the turn the reader is on`; that sibling passed 8/8 in isolation and the subsequent full-file run passed 11/11.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex authored the test synchronization, ran the diagnostics and verification, and prepared the issue and pull request text.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
