### PR TITLE
feat(cli): let TUI setup name a new connection

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -29,6 +29,7 @@ import { describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import { SHELL_RUN_UPDATE_BUFFER_MAX_ENTRIES } from '@maka/core/shell-run-result';
 import { resolveConnectionModelCatalog } from '@maka/core/model-catalog';
+import { deriveConnectionSlug } from '@maka/core/llm-connections';
 import { type PermissionMode } from '@maka/core/permission';
 import { type OrchestrationMode } from '@maka/core/orchestration';
 import { type SessionEvent, type ShellRunUpdate } from '@maka/core/events';
@@ -181,6 +182,7 @@ function defaultOnboardingProviders(): OnboardingProviderEntry[] {
     ...provider,
     target: { kind: 'create', providerType: provider.providerType },
     label: provider.label,
+    suggestedSlug: deriveConnectionSlug(provider.providerType),
     enabledModelIds: [],
   }));
 }
@@ -819,6 +821,8 @@ describe('Maka Pi TUI runner', () => {
       }
     });
     terminal.input('\r'); // pick provider -> key phase
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -840,7 +844,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('sk-good');
     terminal.input('\r');
     await waitFor(() => verifyCalls.length === 2);
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
     assert.deepEqual(verifyCalls, ['sk-bad', 'sk-good']);
 
     process.emit('SIGTERM');
@@ -877,11 +881,13 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('配置模型提供商'));
-    terminal.input('\r');
+    terminal.input('\r'); // pick provider -> identity step
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
     terminal.input('sk-test');
     terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
     terminal.input(' ');
     terminal.input('\r');
     await waitFor(() => saveCalls === 1);
@@ -1002,6 +1008,8 @@ describe('Maka Pi TUI runner', () => {
       }
     });
     terminal.input('\r'); // pick provider -> arms the key prompt
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -1059,6 +1067,8 @@ describe('Maka Pi TUI runner', () => {
       }
     });
     terminal.input('\r'); // pick provider -> key phase
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -1166,6 +1176,8 @@ describe('Maka Pi TUI runner', () => {
       }
     });
     terminal.input('\r'); // pick provider A -> key phase
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -1183,9 +1195,11 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-    // Abandon A: Esc back to search, move to the second provider, pick it, and
-    // start typing its key (do not submit).
-    terminal.input('\x1b');
+    // Abandon A: Esc back through the identity step to the search, move to the
+    // second provider, pick it, and start typing its key (do not submit).
+    terminal.input('\x1b'); // key -> identity (slug field)
+    terminal.input('\x1b'); // identity slug -> name field
+    terminal.input('\x1b'); // identity name -> search
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), '1/3') !== null;
@@ -1194,7 +1208,9 @@ describe('Maka Pi TUI runner', () => {
       }
     });
     terminal.input('\x1b[B'); // down to the second provider
-    terminal.input('\r');
+    terminal.input('\r'); // pick provider B -> identity step
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -1260,6 +1276,8 @@ describe('Maka Pi TUI runner', () => {
       }
     });
     terminal.input('\r'); // pick provider -> key phase
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -1269,7 +1287,7 @@ describe('Maka Pi TUI runner', () => {
     });
     terminal.input('sk-test');
     terminal.input('\r'); // verify ok -> models
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
     terminal.input(' '); // toggle the first model on
     terminal.input('\r'); // save A — deferred
     await waitFor(() => saveCalls.length === 1);
@@ -1280,11 +1298,11 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-    // Abandon A: Esc back to the key step.
+    // Abandon A: Esc back to the key step (3/4 with the identity step present).
     terminal.input('\x1b');
     await waitFor(() => {
       try {
-        return latestPlainLineContaining(terminal.writes.join(''), '2/3') !== null;
+        return latestPlainLineContaining(terminal.writes.join(''), '3/4') !== null;
       } catch {
         return false;
       }
@@ -1301,7 +1319,7 @@ describe('Maka Pi TUI runner', () => {
     assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /Models enabled/u);
 
     terminal.input('\r'); // verify the now-existing Connection
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
     terminal.input('\r'); // preserve the prior selection and save again
     await waitFor(() => saveCalls.length === 2);
     assert.deepEqual(saveCalls[1]?.target, {
@@ -1347,24 +1365,30 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
-    terminal.input('\r');
+    terminal.input('\r'); // pick provider -> identity step
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
     terminal.input('sk-a');
     terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
     terminal.input(' ');
     terminal.input('\r');
     await waitFor(() => saveCalls.length === 1);
 
     terminal.input('\x1b'); // models -> key
-    terminal.input('\x1b'); // key -> provider search
+    terminal.input('\x1b'); // key -> identity (slug field)
+    terminal.input('\x1b'); // identity slug -> name field
+    terminal.input('\x1b'); // identity name -> provider search
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('1/3'));
     terminal.input('\r'); // reselect the same add-account row as a new intent
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
     resolveFirstSave(savedOnboardingRefreshFailed('first-account-id'));
     terminal.input('sk-b');
     terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
     terminal.input(' ');
     terminal.input('\r');
     await waitFor(() => saveCalls.length === 2);
@@ -1417,10 +1441,13 @@ describe('Maka Pi TUI runner', () => {
     });
     // Filter down to the relay entries and pick the first (OpenAI Chat).
     terminal.input('relay');
-    terminal.input('\r');
-    // The relay flow inserts the base-URL step (2/4) before the key.
+    terminal.input('\r'); // pick relay -> identity step
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> base URL step
+    // The create flow inserts the identity step (2/5) and the relay flow the
+    // base-URL step (3/5) before the key.
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Base URL'));
-    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('2/4'));
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('3/5'));
     // A malformed endpoint is rejected in place, before any host call.
     terminal.input('not a url');
     terminal.input('\r');
@@ -1439,7 +1466,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
     await waitFor(() => verifyCalls.length === 1);
     assert.equal(verifyCalls[0]?.baseUrl, 'https://relay.example.test/v1');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('5/5'));
     terminal.input(' '); // toggle the discovered model on
     terminal.input('\r'); // save
     await waitFor(() => saveCalls.length === 1);
@@ -1493,6 +1520,8 @@ describe('Maka Pi TUI runner', () => {
       }
     });
     terminal.input('\r'); // pick provider -> key phase
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -1502,7 +1531,7 @@ describe('Maka Pi TUI runner', () => {
     });
     terminal.input('sk-test');
     terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
     terminal.input(' '); // toggle the first model on
     terminal.input('\r'); // save — deferred
     await waitFor(() => saveCalls.length === 1);
@@ -1510,7 +1539,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\x1b');
     await waitFor(() => {
       try {
-        return latestPlainLineContaining(terminal.writes.join(''), '2/3') !== null;
+        return latestPlainLineContaining(terminal.writes.join(''), '3/4') !== null;
       } catch {
         return false;
       }
@@ -1518,7 +1547,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\x03'); // Ctrl+C closes the wizard
     // The wizard frame leaving the screen proves the overlay released input
     // focus, so the next line routes to the editor.
-    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('2/3'));
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('3/4'));
     // The save completes after the user left. Its projection may be older than
     // a newer attempt, so it must not replace the running model choices.
     resolveFirstSave(
@@ -1579,6 +1608,8 @@ describe('Maka Pi TUI runner', () => {
       }
     });
     terminal.input('\r'); // pick provider -> key phase
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -1635,11 +1666,13 @@ describe('Maka Pi TUI runner', () => {
     });
 
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
-    terminal.input('\r');
+    terminal.input('\r'); // pick provider -> identity step
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
     terminal.input('sk-test');
     terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
     terminal.input(' ');
     terminal.input('\r');
 
@@ -1650,6 +1683,216 @@ describe('Maka Pi TUI runner', () => {
       }),
     ]);
     assert.equal(terminal.stopCalls, 1);
+  });
+
+  test('wizard identity step sends a caller-chosen slug and name on the create target', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const verifyCalls: OnboardingVerifyInput[] = [];
+    const saveCalls: OnboardingSaveInput[] = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        providers: [
+          {
+            providerType: 'openai',
+            label: 'OpenAI',
+            requiresBaseUrl: false,
+            target: { kind: 'create', providerType: 'openai' },
+            suggestedSlug: 'openai',
+            enabledModelIds: [],
+          },
+        ],
+        verify: async (input) => {
+          verifyCalls.push(input);
+          return { kind: 'ok', models: [{ id: 'gpt-5.5' }] };
+        },
+        save: async (input) => {
+          saveCalls.push(input);
+          return savedOnboardingResult();
+        },
+      }),
+    });
+
+    await waitForTuiPaint(terminal);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
+    terminal.input('\r'); // pick the only row -> identity step, name focused
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('2/4'));
+    // Replace the prefilled provider label with a display name.
+    for (let i = 0; i < 'OpenAI'.length; i++) terminal.input('\x7f');
+    terminal.input('Work OpenAI');
+    terminal.input('\r'); // name -> slug field
+    // Replace the derived suggestion with a chosen slug.
+    for (let i = 0; i < 'openai'.length; i++) terminal.input('\x7f');
+    terminal.input('openai-work');
+    terminal.input('\r'); // slug -> key phase
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
+    terminal.input('sk-live');
+    terminal.input('\r');
+    await waitFor(() => verifyCalls.length === 1);
+    assert.deepEqual(verifyCalls[0]?.target, {
+      kind: 'create',
+      providerType: 'openai',
+      slug: 'openai-work',
+      name: 'Work OpenAI',
+    });
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
+    terminal.input(' '); // toggle the model on
+    terminal.input('\r'); // save
+    await waitFor(() => saveCalls.length === 1);
+    assert.deepEqual(saveCalls[0]?.target, verifyCalls[0]?.target);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('accepting the identity defaults sends a bare create target any Host vintage takes', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const saveCalls: OnboardingSaveInput[] = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        providers: [
+          {
+            providerType: 'openai',
+            label: 'OpenAI',
+            requiresBaseUrl: false,
+            target: { kind: 'create', providerType: 'openai' },
+            suggestedSlug: 'openai',
+            enabledModelIds: [],
+          },
+        ],
+        save: async (input) => {
+          saveCalls.push(input);
+          return savedOnboardingResult();
+        },
+      }),
+    });
+
+    await waitForTuiPaint(terminal);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
+    terminal.input('\r'); // pick -> identity
+    terminal.input('\r'); // accept default name
+    terminal.input('\r'); // accept derived slug
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
+    terminal.input('sk-live');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
+    terminal.input(' ');
+    terminal.input('\r');
+    await waitFor(() => saveCalls.length === 1);
+    assert.deepEqual(saveCalls[0]?.target, { kind: 'create', providerType: 'openai' });
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('a slug_taken rejection bounces the wizard back to the identity step', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const verifyCalls: OnboardingVerifyInput[] = [];
+    const saveCalls: OnboardingSaveInput[] = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        providers: [
+          {
+            providerType: 'openai',
+            label: 'OpenAI',
+            requiresBaseUrl: false,
+            target: { kind: 'create', providerType: 'openai' },
+            suggestedSlug: 'openai',
+            enabledModelIds: [],
+          },
+        ],
+        verify: async (input) => {
+          verifyCalls.push(input);
+          return verifyCalls.length === 1
+            ? { kind: 'rejected' as const, reason: 'slug_taken' as const }
+            : { kind: 'ok', models: [{ id: 'gpt-5.5' }] };
+        },
+        save: async (input) => {
+          saveCalls.push(input);
+          return savedOnboardingResult();
+        },
+      }),
+    });
+
+    await waitForTuiPaint(terminal);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
+    terminal.input('\r'); // pick -> identity
+    terminal.input('\r'); // accept default name
+    terminal.input('\r'); // accept derived slug
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
+    terminal.input('sk-live');
+    terminal.input('\r');
+    // The Host-derived slug lost a race: the wizard returns to the identity
+    // step with the collision message, key draft cleared, slug text intact.
+    await waitFor(() => verifyCalls.length === 1);
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('That slug is already taken'),
+    );
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('2/4'));
+    for (let i = 0; i < 'openai'.length; i++) terminal.input('\x7f');
+    terminal.input('openai-9');
+    terminal.input('\r'); // slug -> key phase
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
+    terminal.input('sk-live');
+    terminal.input('\r');
+    await waitFor(() => verifyCalls.length === 2);
+    assert.deepEqual(verifyCalls[1]?.target, {
+      kind: 'create',
+      providerType: 'openai',
+      slug: 'openai-9',
+    });
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
+    terminal.input(' ');
+    terminal.input('\r');
+    await waitFor(() => saveCalls.length === 1);
+    assert.deepEqual(saveCalls[0]?.target, verifyCalls[1]?.target);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
   });
 
   test('freezes and preserves the editor draft while a boundary request owns input', async () => {
@@ -8038,11 +8281,13 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
-    terminal.input('\r');
+    terminal.input('\r'); // pick provider -> identity step
+    terminal.input('\r'); // accept default name -> slug field
+    terminal.input('\r'); // accept derived slug -> key phase
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('API key'));
     terminal.input('sk-test');
     terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('4/4'));
     terminal.input(' ');
     terminal.input('\r');
     await waitFor(() => saveCalls.length === 1);

--- a/packages/cli/src/__tests__/runtime-host-onboarding.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-onboarding.test.ts
@@ -259,6 +259,28 @@ describe('projectProviders', () => {
     );
   });
 
+  test('the create row carries the Host-derived slug suggestion for the identity step', () => {
+    const taken = {
+      ...relay,
+      connectionId: 'openai-id',
+      slug: 'openai',
+      providerType: 'openai' as const,
+    };
+    const entries = projectProviders(catalog([taken])).filter(
+      ({ providerType }) => providerType === 'openai',
+    );
+    const create = entries.find(({ target }) => target.kind === 'create');
+    assert.equal(
+      create && 'suggestedSlug' in create ? create.suggestedSlug : undefined,
+      'openai-2',
+    );
+    // …and with no existing connection the suggestion is the canonical base.
+    const bare = projectProviders(catalog([])).find(
+      ({ providerType }) => providerType === 'openai',
+    );
+    assert.equal(bare && 'suggestedSlug' in bare ? bare.suggestedSlug : undefined, 'openai');
+  });
+
   test('a canonical connection does not hide another account', () => {
     const canonical = { ...relay, connectionId: 'canonical-id', slug: 'openai-compatible' };
     const entries = projectProviders(catalog([relay, canonical])).filter(

--- a/packages/cli/src/pi-tui-contracts.ts
+++ b/packages/cli/src/pi-tui-contracts.ts
@@ -64,10 +64,24 @@ export interface OnboardableProvider {
   requiresBaseUrl: boolean;
 }
 
+export type OnboardingIdentityChoice = {
+  /** Caller-chosen slug; null keeps the Host-derived identity. */
+  readonly slug: string | null;
+  /** Caller-chosen display name; null keeps the provider label. */
+  readonly name: string | null;
+};
+
 export type OnboardingProviderEntry = OnboardableProvider &
   (
     | {
         target: Extract<ConnectionOnboardingTarget, { readonly kind: 'create' }>;
+        /**
+         * The identity the Host would derive, shown as the prefilled default
+         * on the identity step. Submitting it unchanged (or submitting
+         * nothing) keeps the wire target free of slug/name so any Host
+         * vintage accepts the save.
+         */
+        suggestedSlug: string;
         enabledModelIds: readonly string[];
       }
     | {

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -47,13 +47,16 @@ import type { InvocableSkillEntry } from '@maka/runtime/skill-invocation';
 import {
   providerDefaultsOf,
   providerMenuLabel,
+  validateSlug,
   type ModelInfo,
   type ProviderType,
 } from '@maka/core/llm-connections';
+import { CONNECTION_NAME_MAX_LENGTH } from '@maka/core/runtime-policy';
 import type {
   ModelChoice,
   OnboardingFailure,
   OnboardingFailureClass,
+  OnboardingIdentityChoice,
   OnboardingProviderEntry,
   OnboardingRejectionReason,
 } from './pi-tui-contracts.js';
@@ -77,6 +80,11 @@ interface TuiPickerCopy {
   readonly setupTitle: string;
   readonly baseUrlLabel: string;
   readonly apiKeyLabel: string;
+  readonly connectionNameLabel: string;
+  readonly connectionSlugLabel: string;
+  readonly identityHint: string;
+  readonly identitySlugInvalid: string;
+  readonly identityNameTooLong: string;
   readonly onboardingUnavailable: string;
   readonly onboardingRequestFailed: string;
   readonly onboardingRejections: Readonly<Record<OnboardingRejectionReason, string>>;
@@ -97,7 +105,7 @@ interface TuiPickerCopy {
   readonly providerSearchHint: string;
   readonly noMatchingProviders: string;
   readonly keyHints: Readonly<
-    Record<'reuse' | 'enter', Readonly<Record<'baseUrl' | 'provider', string>>>
+    Record<'reuse' | 'enter', Readonly<Record<'baseUrl' | 'identity' | 'provider', string>>>
   >;
   readonly submitAction: string;
   readonly verifyingKey: string;
@@ -988,14 +996,27 @@ function padLine(text: string, width: number): string {
 function keyEntryHint(
   copy: TuiPickerCopy,
   hasConnection: boolean,
-  returnsToBaseUrl: boolean,
+  returnsTo: 'baseUrl' | 'identity' | 'provider',
 ): string {
   const action = hasConnection ? 'reuse' : 'enter';
-  const destination = returnsToBaseUrl ? 'baseUrl' : 'provider';
-  return copy.keyHints[action][destination];
+  return copy.keyHints[action][returnsTo];
 }
 
-export type OnboardingWizardPhase = 'search' | 'baseUrl' | 'key' | 'models' | 'success';
+export type OnboardingWizardPhase =
+  | 'search'
+  | 'identity'
+  | 'baseUrl'
+  | 'key'
+  | 'models'
+  | 'success';
+
+/** The union's discriminant sits on `target.kind`, one level down — TS will
+ *  not narrow the entry from that check alone, so route through this guard. */
+function isCreateEntry(
+  entry: OnboardingProviderEntry,
+): entry is OnboardingProviderEntry & { suggestedSlug: string } {
+  return entry.target.kind === 'create';
+}
 
 export type OnboardingWizardStatus =
   | { kind: 'prompt' }
@@ -1010,6 +1031,10 @@ export interface OnboardingWizardInput {
    *   existing connection's identity, when the catalog resolved one — for
    *   verify/save, so saving edits that connection in place. */
   onPickProvider: (provider: OnboardingProviderEntry) => void;
+  /** identity submit (create targets only). `null` halves mean "keep the
+   *  Host-derived default", so a user who accepts the prefills sends a target
+   *  identical to one from a build without this step. */
+  onSubmitIdentity: (identity: OnboardingIdentityChoice) => void;
   /** baseUrl submit (only for `requiresBaseUrl` providers). Empty means "reuse
    *   the existing connection's persisted endpoint"; the wizard has already
    *   rejected an empty value for a provider with no connection. */
@@ -1045,7 +1070,11 @@ export class OnboardingWizard implements Component {
   private readonly searchEditor: Editor;
   private readonly baseUrlEditor: Editor;
   private readonly keyEditor: Editor;
+  private readonly nameEditor: Editor;
+  private readonly slugEditor: Editor;
   private readonly modelsSearchEditor: Editor;
+  private identityFocus: 'name' | 'slug' = 'name';
+  private identityNameDraft = '';
   private filtered: readonly OnboardingProviderEntry[];
   private list: SelectList;
   // Models phase state. Selection seeds from the picked provider's enabled set
@@ -1086,6 +1115,19 @@ export class OnboardingWizard implements Component {
     this.keyEditor.onSubmit = (value) => {
       if (this.picked) this.input.onSubmitKey(value);
     };
+    this.nameEditor = new Editor(tui, editorTheme(), { paddingX: 0 });
+    this.nameEditor.onSubmit = (value) => {
+      // Enter on the optional name advances to the slug field in-frame. The
+      // Editor clears itself on submit, so capture the value here and restore
+      // the visible text — Esc back from the slug field must not find a blank
+      // name, and the slug submit reads the draft, not the editor.
+      this.identityNameDraft = value;
+      this.nameEditor.setText(value);
+      this.identityFocus = 'slug';
+      this.status = { kind: 'prompt' };
+    };
+    this.slugEditor = new Editor(tui, editorTheme(), { paddingX: 0 });
+    this.slugEditor.onSubmit = (value) => this.submitIdentity(value);
     this.modelsSearchEditor = new Editor(tui, editorTheme(), { paddingX: 0 });
     this.modelsSearchEditor.onChange = (text) => this.applyModelQuery(text);
   }
@@ -1109,9 +1151,19 @@ export class OnboardingWizard implements Component {
 
   private enterKeyPhase(provider: OnboardingProviderEntry): void {
     this.picked = provider;
-    // A relay has no registry endpoint, so the wizard must collect one
+    // A create target stops at the identity step first: name and slug come
+    // prefilled with the Host-derived defaults, and accepting them verbatim
+    // sends the same bare target a build without this step would send.
+    // A relay has no registry endpoint, so the wizard must still collect one
     // before the key — the deferred phase-2 step from #1254 (#3405).
-    this.phase = provider.requiresBaseUrl ? 'baseUrl' : 'key';
+    const create = isCreateEntry(provider);
+    this.phase = create ? 'identity' : provider.requiresBaseUrl ? 'baseUrl' : 'key';
+    if (create) {
+      this.identityFocus = 'name';
+      this.nameEditor.setText(provider.label);
+      this.identityNameDraft = provider.label;
+      this.slugEditor.setText(provider.suggestedSlug);
+    }
     this.status = { kind: 'prompt' };
     this.baseUrlEditor.setText('');
     this.keyEditor.setText('');
@@ -1126,6 +1178,41 @@ export class OnboardingWizard implements Component {
     this.modelScroll = 0;
     this.modelsSearchEditor.setText('');
     this.input.onPickProvider(provider);
+  }
+
+  /**
+   * Slug submit on the identity step. The name field needs no validation of
+   * its own beyond the catalog's length cap: empty or untouched means the
+   * provider label stays. An empty or untouched slug likewise keeps the
+   * Host-derived identity — only a genuinely edited slug crosses the wire,
+   * and it must pass the same rule the catalog decoder enforces.
+   */
+  private submitIdentity(rawSlug: string): void {
+    const picked = this.picked;
+    if (!picked || !isCreateEntry(picked) || this.phase !== 'identity') return;
+    const slug = rawSlug.trim();
+    const name = this.identityNameDraft.trim();
+    if (name.length > CONNECTION_NAME_MAX_LENGTH) {
+      this.identityFocus = 'name';
+      this.status = { kind: 'error', text: this.copy.identityNameTooLong };
+      return;
+    }
+    const customSlug = slug.length > 0 && slug !== picked.suggestedSlug ? slug : null;
+    if (customSlug !== null) {
+      const error = validateSlug(customSlug);
+      if (error) {
+        this.identityFocus = 'slug';
+        this.status = { kind: 'error', text: this.copy.identitySlugInvalid };
+        return;
+      }
+    }
+    const defaultName = picked.label;
+    this.input.onSubmitIdentity({
+      slug: customSlug,
+      name: name.length > 0 && name !== defaultName ? name : null,
+    });
+    this.status = { kind: 'prompt' };
+    this.phase = picked.requiresBaseUrl ? 'baseUrl' : 'key';
   }
 
   private submitBaseUrl(value: string): void {
@@ -1193,6 +1280,17 @@ export class OnboardingWizard implements Component {
     this.modelScroll = 0;
   }
 
+  /** Runner hook: the Host rejected the requested slug — bounce back to the
+   *  identity step with the user's text intact so they can edit it. */
+  setIdentityError(text: string): void {
+    if (this.picked?.target.kind !== 'create') return;
+    this.phase = 'identity';
+    this.identityFocus = 'slug';
+    this.status = { kind: 'error', text };
+    this.keyEditor.setText('');
+    this.keyEditor.disableSubmit = false;
+  }
+
   /** Runner hook: verify is in flight. Lock the key field and show progress. */
   setVerifying(): void {
     if (this.phase !== 'key') return;
@@ -1254,19 +1352,38 @@ export class OnboardingWizard implements Component {
     this.searchEditor.invalidate();
     this.baseUrlEditor.invalidate();
     this.keyEditor.invalidate();
+    this.nameEditor.invalidate();
+    this.slugEditor.invalidate();
     this.modelsSearchEditor.invalidate();
     this.list.invalidate();
   }
 
-  /** Step label: relays have four steps (the base-URL one), the rest three. */
-  private step(position: number): string {
-    return `${position}/${this.picked?.requiresBaseUrl ? 4 : 3}`;
+  /** Step label: relays add a base-URL step, create targets an identity one. */
+  private stepFor(phase: 'search' | 'identity' | 'baseUrl' | 'key' | 'models'): string {
+    const create = this.picked?.target.kind === 'create';
+    const relay = this.picked?.requiresBaseUrl === true;
+    const total = 3 + (create ? 1 : 0) + (relay ? 1 : 0);
+    let position = 1;
+    if (phase === 'search') return `1/${total}`;
+    if (create) {
+      position += 1;
+      if (phase === 'identity') return `${position}/${total}`;
+    }
+    if (relay) {
+      position += 1;
+      if (phase === 'baseUrl') return `${position}/${total}`;
+    }
+    position += 1;
+    if (phase === 'key') return `${position}/${total}`;
+    return `${total}/${total}`;
   }
 
   handleInput(data: string): void {
     switch (this.phase) {
       case 'search':
         return this.handleSearchInput(data);
+      case 'identity':
+        return this.handleIdentityInput(data);
       case 'baseUrl':
         return this.handleBaseUrlInput(data);
       case 'key':
@@ -1278,14 +1395,40 @@ export class OnboardingWizard implements Component {
     }
   }
 
+  private handleIdentityInput(data: string): void {
+    if (matchesKey(data, Key.ctrl('c'))) {
+      this.input.onCancel();
+      return;
+    }
+    if (matchesKey(data, Key.escape)) {
+      // One level back: slug field → name field → provider search.
+      if (this.identityFocus === 'slug') {
+        this.identityFocus = 'name';
+        this.status = { kind: 'prompt' };
+        return;
+      }
+      this.phase = 'search';
+      this.picked = undefined;
+      this.status = { kind: 'prompt' };
+      this.input.onBack();
+      return;
+    }
+    (this.identityFocus === 'name' ? this.nameEditor : this.slugEditor).handleInput(data);
+  }
+
   private handleBaseUrlInput(data: string): void {
     if (matchesKey(data, Key.ctrl('c'))) {
       this.input.onCancel();
       return;
     }
     if (matchesKey(data, Key.escape)) {
-      this.phase = 'search';
-      this.picked = undefined;
+      // One level back: a create target returns to its identity step.
+      if (this.picked?.target.kind === 'create') {
+        this.phase = 'identity';
+      } else {
+        this.phase = 'search';
+        this.picked = undefined;
+      }
       this.status = { kind: 'prompt' };
       this.baseUrlEditor.setText('');
       this.input.onBack();
@@ -1323,10 +1466,12 @@ export class OnboardingWizard implements Component {
       return;
     }
     if (matchesKey(data, Key.escape)) {
-      // One level back: a relay returns to its base-URL step, everything
-      // else to the provider search.
+      // One level back: a relay returns to its base-URL step, a create target
+      // to its identity step, everything else to the provider search.
       if (this.picked?.requiresBaseUrl) {
         this.phase = 'baseUrl';
+      } else if (this.picked?.target.kind === 'create') {
+        this.phase = 'identity';
       } else {
         this.phase = 'search';
         this.picked = undefined;
@@ -1426,6 +1571,8 @@ export class OnboardingWizard implements Component {
     switch (this.phase) {
       case 'search':
         return this.renderSearch(safeWidth);
+      case 'identity':
+        return this.renderIdentity(safeWidth);
       case 'baseUrl':
         return this.renderBaseUrl(safeWidth);
       case 'key':
@@ -1437,11 +1584,45 @@ export class OnboardingWizard implements Component {
     }
   }
 
+  private focusOnly(active: Editor | null): void {
+    for (const editor of [
+      this.searchEditor,
+      this.nameEditor,
+      this.slugEditor,
+      this.baseUrlEditor,
+      this.keyEditor,
+      this.modelsSearchEditor,
+    ]) {
+      editor.focused = editor === active;
+    }
+  }
+
+  private renderIdentity(width: number): string[] {
+    this.focusOnly(this.identityFocus === 'name' ? this.nameEditor : this.slugEditor);
+    const label = this.picked?.label ?? '';
+    return [
+      padLine(
+        `${this.copy.setupTitle} ${ansi.dim(`· ${this.stepFor('identity')}`)} ${ansi.accent(label)}`,
+        width,
+      ),
+      padLine(ansi.dim(this.copy.identityHint), width),
+      padLine('', width),
+      ...this.renderFieldRow(this.nameEditor, this.copy.connectionNameLabel, width),
+      padLine('', width),
+      ...this.renderFieldRow(this.slugEditor, this.copy.connectionSlugLabel, width),
+      padLine('', width),
+      padLine(
+        this.status.kind === 'error'
+          ? ansi.red(`✗ ${this.status.text}`)
+          : ansi.dim(this.copy.continueAction),
+        width,
+      ),
+      padLine(ansi.accent('-'.repeat(width)), width),
+    ];
+  }
+
   private renderBaseUrl(width: number): string[] {
-    this.searchEditor.focused = false;
-    this.baseUrlEditor.focused = true;
-    this.keyEditor.focused = false;
-    this.modelsSearchEditor.focused = false;
+    this.focusOnly(this.baseUrlEditor);
     const label = this.picked?.label ?? '';
     const hint =
       this.picked?.target.kind === 'existing'
@@ -1449,7 +1630,7 @@ export class OnboardingWizard implements Component {
         : this.copy.enterBaseUrlHint;
     return [
       padLine(
-        `${this.copy.setupTitle} ${ansi.dim(`· ${this.step(2)}`)} ${ansi.accent(label)}`,
+        `${this.copy.setupTitle} ${ansi.dim(`· ${this.stepFor('baseUrl')}`)} ${ansi.accent(label)}`,
         width,
       ),
       padLine(ansi.dim(hint), width),
@@ -1467,13 +1648,10 @@ export class OnboardingWizard implements Component {
   }
 
   private renderSearch(width: number): string[] {
-    this.searchEditor.focused = true;
-    this.baseUrlEditor.focused = false;
-    this.keyEditor.focused = false;
-    this.modelsSearchEditor.focused = false;
+    this.focusOnly(this.searchEditor);
     return [
       padLine(
-        `${this.copy.setupTitle} ${ansi.dim(`· ${this.step(1)}`)} ${ansi.accent(String(this.filtered.length))}`,
+        `${this.copy.setupTitle} ${ansi.dim(`· ${this.stepFor('search')}`)} ${ansi.accent(String(this.filtered.length))}`,
         width,
       ),
       padLine(ansi.dim(this.copy.providerSearchHint), width),
@@ -1488,19 +1666,22 @@ export class OnboardingWizard implements Component {
   }
 
   private renderKey(width: number): string[] {
-    this.searchEditor.focused = false;
-    this.baseUrlEditor.focused = false;
-    this.keyEditor.focused = this.status.kind === 'prompt' || this.status.kind === 'error';
-    this.modelsSearchEditor.focused = false;
+    this.focusOnly(
+      this.status.kind === 'prompt' || this.status.kind === 'error' ? this.keyEditor : null,
+    );
     const label = this.picked?.label ?? '';
     const hint = keyEntryHint(
       this.copy,
       this.picked?.target.kind === 'existing',
-      this.picked?.requiresBaseUrl === true,
+      this.picked?.requiresBaseUrl === true
+        ? 'baseUrl'
+        : this.picked?.target.kind === 'create'
+          ? 'identity'
+          : 'provider',
     );
     return [
       padLine(
-        `${this.copy.setupTitle} ${ansi.dim(`· ${this.step(this.picked?.requiresBaseUrl ? 3 : 2)}`)} ${ansi.accent(label)}`,
+        `${this.copy.setupTitle} ${ansi.dim(`· ${this.stepFor('key')}`)} ${ansi.accent(label)}`,
         width,
       ),
       padLine(ansi.dim(hint), width),
@@ -1526,14 +1707,11 @@ export class OnboardingWizard implements Component {
   }
 
   private renderModels(width: number): string[] {
-    this.searchEditor.focused = false;
-    this.baseUrlEditor.focused = false;
-    this.keyEditor.focused = false;
-    this.modelsSearchEditor.focused = this.status.kind !== 'saving';
+    this.focusOnly(this.status.kind !== 'saving' ? this.modelsSearchEditor : null);
     const label = this.picked?.label ?? '';
     const lines = [
       padLine(
-        `${this.copy.setupTitle} ${ansi.dim(`· ${this.step(this.picked?.requiresBaseUrl ? 4 : 3)}`)} ${ansi.accent(label)}`,
+        `${this.copy.setupTitle} ${ansi.dim(`· ${this.stepFor('models')}`)} ${ansi.accent(label)}`,
         width,
       ),
       padLine(ansi.dim(this.copy.modelSelectionHint), width),
@@ -1588,10 +1766,7 @@ export class OnboardingWizard implements Component {
   }
 
   private renderSuccess(width: number): string[] {
-    this.searchEditor.focused = false;
-    this.baseUrlEditor.focused = false;
-    this.keyEditor.focused = false;
-    this.modelsSearchEditor.focused = false;
+    this.focusOnly(null);
     const label = this.picked?.label ?? '';
     return [
       padLine(

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -34,7 +34,11 @@ import {
 } from '@earendil-works/pi-tui';
 import type { PermissionMode } from '@maka/core/permission';
 import { isThinkingLevel, type ThinkingLevel } from '@maka/core/model-thinking';
-import { type ModelInfo, type ProviderType } from '@maka/core/llm-connections';
+import {
+  deriveConnectionSlug,
+  type ModelInfo,
+  type ProviderType,
+} from '@maka/core/llm-connections';
 import type { OrchestrationMode } from '@maka/core/orchestration';
 import type {
   SkillInvocationFailureReason,
@@ -74,6 +78,7 @@ import type {
   MakaOnboardingSurface,
   MakaPiTuiTurnActivitySurface,
   ModelChoice,
+  OnboardingIdentityChoice,
   OnboardingProviderEntry,
   SessionRecapGenerator,
 } from './pi-tui-contracts.js';
@@ -1238,6 +1243,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // The existing connection the picked provider resolved to, so saving edits
   // it in place (a Desktop-created relay may live under a custom slug).
   let wizardTarget: OnboardingProviderEntry['target'] | undefined;
+  // The identity step's answer for a create target. Null halves keep the wire
+  // target bare so any Host vintage accepts it; an edited slug/name rides on
+  // the target and gets `slug_taken` back when it loses.
+  let wizardIdentity: OnboardingIdentityChoice = { slug: null, name: null };
   let wizardModels: readonly ModelInfo[] = [];
   // Authoritative ready model choices for `/model`. A startup snapshot refreshed
   // in place after `/setup` saves so newly configured models are immediately
@@ -2149,6 +2158,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     wizardApiKey = '';
     wizardBaseUrl = '';
     wizardTarget = undefined;
+    wizardIdentity = { slug: null, name: null };
     wizardModels = [];
   };
 
@@ -2177,7 +2187,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       (result) => {
         if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
         if (result.kind !== 'ok') {
-          wizard.setKeyError(onboardingFailureMessage(result, locale));
+          // A rejected slug is the identity step's to fix, not the key's.
+          if (result.kind === 'rejected' && result.reason === 'slug_taken') {
+            wizard.setIdentityError(onboardingFailureMessage(result, locale));
+          } else {
+            wizard.setKeyError(onboardingFailureMessage(result, locale));
+          }
           requestRender();
           return;
         }
@@ -2220,7 +2235,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         (result) => {
           if (result.kind !== 'ok') {
             if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
-            wizard.setModelError(onboardingFailureMessage(result, locale));
+            if (result.kind === 'rejected' && result.reason === 'slug_taken') {
+              wizard.setIdentityError(onboardingFailureMessage(result, locale));
+            } else {
+              wizard.setModelError(onboardingFailureMessage(result, locale));
+            }
             requestRender();
             return;
           }
@@ -2280,6 +2299,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         ...provider,
         target: { kind: 'create' as const, providerType: provider.providerType },
         label: provider.label,
+        suggestedSlug: deriveConnectionSlug(provider.providerType),
         enabledModelIds: [],
       }));
     }
@@ -2301,10 +2321,23 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         // reselects the same catalog row. A late save may converge only the
         // exact target object captured by its own submit.
         wizardTarget = { ...provider.target };
+        wizardIdentity = { slug: null, name: null };
         wizardApiKey = '';
         wizardBaseUrl = '';
         wizardModels = [];
         wizardAttempt += 1; // a new pick supersedes any in-flight attempt
+        requestRender();
+      },
+      onSubmitIdentity: (identity) => {
+        wizardIdentity = identity;
+        if (wizardTarget?.kind === 'create') {
+          wizardTarget = {
+            kind: 'create',
+            providerType: wizardTarget.providerType,
+            ...(identity.slug === null ? {} : { slug: identity.slug }),
+            ...(identity.name === null ? {} : { name: identity.name }),
+          };
+        }
         requestRender();
       },
       onSubmitBaseUrl: (baseUrl) => {

--- a/packages/cli/src/runtime-host-onboarding.ts
+++ b/packages/cli/src/runtime-host-onboarding.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { offerableCatalogEntries } from '@maka/core/llm-connections';
+import { deriveConnectionSlug, offerableCatalogEntries } from '@maka/core/llm-connections';
 import type { RuntimeHostConnectionCatalogSnapshot as ConnectionCatalogSnapshot } from '@maka/runtime-host/client';
 import {
   readRuntimeHostConnectionCatalog,
@@ -130,6 +130,7 @@ export function projectRuntimeHostConnectionIdentities(
 
 export function projectProviders(catalog: ConnectionCatalogSnapshot): OnboardingProviderEntry[] {
   const entries: OnboardingProviderEntry[] = [];
+  const existingSlugs = catalog.connections.map((connection) => connection.slug);
   for (const provider of listApiKeyOnboardableProviders()) {
     for (const connection of catalog.connections) {
       if (connection.providerType !== provider.providerType) continue;
@@ -145,6 +146,7 @@ export function projectProviders(catalog: ConnectionCatalogSnapshot): Onboarding
       ...provider,
       target: { kind: 'create', providerType: provider.providerType },
       label: provider.label,
+      suggestedSlug: deriveConnectionSlug(provider.providerType, existingSlugs),
       enabledModelIds: [],
     });
   }

--- a/packages/cli/src/tui-copy-catalog.ts
+++ b/packages/cli/src/tui-copy-catalog.ts
@@ -281,6 +281,12 @@ export const TUI_COPY_RESOURCES = {
       setupTitle: 'Set Up Provider',
       baseUrlLabel: 'Base URL',
       apiKeyLabel: 'API key',
+      connectionNameLabel: 'Name',
+      connectionSlugLabel: 'Slug',
+      identityHint:
+        'Name this connection, or keep the defaults to auto-assign · Enter continues · Esc returns',
+      identitySlugInvalid: 'Slug must be 2–64 characters: lowercase letters, digits, and hyphens',
+      identityNameTooLong: 'Name must be 256 characters or fewer',
       onboardingUnavailable:
         'Onboarding is unavailable: this environment does not provide a setup surface.',
       onboardingRequestFailed: 'Could not reach the Runtime Host. Try again.',
@@ -291,6 +297,7 @@ export const TUI_COPY_RESOURCES = {
         base_url_not_configured: 'A Base URL is required for this provider.',
         catalog_full: 'The connection catalog is full.',
         model_unavailable: 'A selected model is no longer available. Verify and select again.',
+        slug_taken: 'That slug is already taken. Pick another, or clear it to auto-assign.',
         superseded: 'This connection changed. Reopen /setup and try again.',
       },
       onboardingFailures: {
@@ -324,11 +331,17 @@ export const TUI_COPY_RESOURCES = {
             'Leave blank to reuse the saved key, or enter a new key to rotate it · Esc returns to Base URL',
           provider:
             'Leave blank to reuse the saved key, or enter a new key to rotate it · Esc returns to provider selection',
+          // The identity step only exists for create targets, so a `reuse`
+          // hint never lands here; the provider text keeps the record total.
+          identity:
+            'Leave blank to reuse the saved key, or enter a new key to rotate it · Esc returns to provider selection',
         },
         enter: {
           baseUrl: 'Enter an API key · stored only on this machine · Esc returns to Base URL',
           provider:
             'Enter an API key · stored only on this machine · Esc returns to provider selection',
+          identity:
+            'Enter an API key · stored only on this machine · Esc returns to connection naming',
         },
       },
       submitAction: 'Enter to submit',
@@ -367,6 +380,11 @@ export const TUI_COPY_RESOURCES = {
       setupTitle: '配置模型提供商',
       baseUrlLabel: 'Base URL',
       apiKeyLabel: 'API key',
+      connectionNameLabel: '名称',
+      connectionSlugLabel: '标识（slug）',
+      identityHint: '为该连接起名，或保留默认值自动分配 · Enter 继续 · Esc 返回',
+      identitySlugInvalid: '标识需为 2–64 位小写字母、数字或连字符',
+      identityNameTooLong: '名称不能超过 256 个字符',
       onboardingUnavailable: 'Onboarding 不可用：当前运行环境未提供配置入口。',
       onboardingRequestFailed: '无法连接 Runtime Host，请重试。',
       onboardingRejections: {
@@ -376,6 +394,7 @@ export const TUI_COPY_RESOURCES = {
         base_url_not_configured: '该服务商需要填写 Base URL。',
         catalog_full: '连接目录已满。',
         model_unavailable: '所选模型已不可用，请重新验证并选择。',
+        slug_taken: '该标识已被占用。请更换，或清空后自动分配。',
         superseded: '该连接已发生变化，请重新打开 /setup 后重试。',
       },
       onboardingFailures: {
@@ -405,10 +424,13 @@ export const TUI_COPY_RESOURCES = {
         reuse: {
           baseUrl: '留空复用已保存的 key，或输入新 key 轮换 · Esc 返回 Base URL',
           provider: '留空复用已保存的 key，或输入新 key 轮换 · Esc 返回选择服务商',
+          // identity 步骤只存在于新建流程，reuse 不会落到这里；沿用 provider 文案保持记录完整。
+          identity: '留空复用已保存的 key，或输入新 key 轮换 · Esc 返回选择服务商',
         },
         enter: {
           baseUrl: '输入 API key · 仅本机存储 · Esc 返回 Base URL',
           provider: '输入 API key · 仅本机存储 · Esc 返回选择服务商',
+          identity: '输入 API key · 仅本机存储 · Esc 返回命名连接',
         },
       },
       submitAction: 'Enter 提交',

--- a/packages/core/src/runtime-policy.ts
+++ b/packages/core/src/runtime-policy.ts
@@ -305,6 +305,16 @@ export type ConnectionOnboardingTarget =
   | {
       readonly kind: 'create';
       readonly providerType: ProviderType;
+      /**
+       * Optional caller-requested identity. When absent, the Host derives the
+       * slug (`openai`, `openai-2`, …) and display name as before. When
+       * present, the Host validates the slug against the catalog and rejects
+       * the save with `slug_taken` on collision rather than silently deriving
+       * a different identity. A surface talking to an older Host must omit
+       * both keys — the wire decoder there rejects unknown fields.
+       */
+      readonly slug?: string;
+      readonly name?: string;
     }
   | {
       readonly kind: 'existing';

--- a/packages/runtime-host/protocol-compatible-changes/connection-onboarding-create-identity.json
+++ b/packages/runtime-host/protocol-compatible-changes/connection-onboarding-create-identity.json
@@ -1,5 +1,5 @@
 {
-  "epoch": 100,
+  "epoch": 101,
   "files": ["packages/runtime-host/src/protocol/connection-effects.ts"],
   "reason": "Adds optional slug/name to the connection onboarding create target (#4605). Surfaces omit both keys unless the user names the connection, so every unchanged flow is byte-identical on any Host vintage. An older Host rejects a named target as an unknown field, which fails closed: nothing commits and the surface reports its standard typed failure. Newer Hosts never emit new fields to older clients."
 }

--- a/packages/runtime-host/protocol-compatible-changes/connection-onboarding-create-identity.json
+++ b/packages/runtime-host/protocol-compatible-changes/connection-onboarding-create-identity.json
@@ -1,0 +1,5 @@
+{
+  "epoch": 100,
+  "files": ["packages/runtime-host/src/protocol/connection-effects.ts"],
+  "reason": "Adds optional slug/name to the connection onboarding create target (#4605). Surfaces omit both keys unless the user names the connection, so every unchanged flow is byte-identical on any Host vintage. An older Host rejects a named target as an unknown field, which fails closed: nothing commits and the surface reports its standard typed failure. Newer Hosts never emit new fields to older clients."
+}

--- a/packages/runtime-host/src/__tests__/connection-effect-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-effect-coordinator.test.ts
@@ -187,6 +187,118 @@ test('two create tickets cannot commit the same planned slug', async () => {
   });
 });
 
+test('onboards a caller-named connection with the requested slug and display name', async () => {
+  await withFixture(async ({ stores }) => {
+    const coordinator = onboardingCoordinator(stores, () => undefined, 'gpt-5');
+    const saved = await coordinator.handlers['connection.onboarding.save'](
+      {
+        target: {
+          kind: 'create',
+          providerType: 'openai',
+          slug: 'openai-work',
+          name: 'Work OpenAI',
+        },
+        apiKey: 'sk-live',
+        baseUrl: null,
+        enabledModelIds: ['gpt-5'],
+      },
+      context,
+    );
+    assertSaved(saved);
+    assert.equal(saved.result.connection.slug, 'openai-work');
+    const catalog = await stores.connectionCatalog.getSnapshot();
+    const created = catalog.connections.find(({ slug }) => slug === 'openai-work');
+    assert.equal(created?.name, 'Work OpenAI');
+
+    // An unnamed follow-up still derives its identity from the catalog — the
+    // requested slug never collides with it because the catalog did take it.
+    const derived = await coordinator.handlers['connection.onboarding.save'](
+      {
+        target: { kind: 'create', providerType: 'openai' },
+        apiKey: 'sk-live-2',
+        baseUrl: null,
+        enabledModelIds: ['gpt-5'],
+      },
+      context,
+    );
+    assertSaved(derived);
+    assert.equal(derived.result.connection.slug, 'openai');
+  });
+});
+
+test('rejects a requested slug that is already taken, before any discovery runs', async () => {
+  await withFixture(async ({ stores }) => {
+    const coordinator = onboardingCoordinator(stores, () => undefined, 'gpt-5');
+    const saved = await coordinator.handlers['connection.onboarding.save'](
+      {
+        target: { kind: 'create', providerType: 'openai', slug: 'openai-work' },
+        apiKey: 'sk-live',
+        baseUrl: null,
+        enabledModelIds: ['gpt-5'],
+      },
+      context,
+    );
+    assertSaved(saved);
+
+    const verify = await coordinator.handlers['connection.onboarding.verify'](
+      {
+        target: { kind: 'create', providerType: 'openai', slug: 'openai-work' },
+        apiKey: 'sk-live-2',
+        baseUrl: null,
+      },
+      context,
+    );
+    assert.equal(verify.ok, true);
+    if (!verify.ok) return;
+    assert.deepEqual(verify.result, { kind: 'rejected', reason: 'slug_taken' });
+
+    const save = await coordinator.handlers['connection.onboarding.save'](
+      {
+        target: { kind: 'create', providerType: 'openai', slug: 'openai-work' },
+        apiKey: 'sk-live-2',
+        baseUrl: null,
+        enabledModelIds: ['gpt-5'],
+      },
+      context,
+    );
+    assert.equal(save.ok, true);
+    if (!save.ok) return;
+    assert.deepEqual(save.result, { kind: 'rejected', reason: 'slug_taken' });
+    // Nothing was created: the taken slug still names exactly one connection.
+    const catalog = await stores.connectionCatalog.getSnapshot();
+    assert.equal(catalog.connections.filter(({ slug }) => slug === 'openai-work').length, 1);
+  });
+});
+
+test('a requested slug lost mid-flight reports slug_taken, never a silent rename', async () => {
+  await withFixture(async ({ stores }) => {
+    const requested = {
+      target: { kind: 'create', providerType: 'openai', slug: 'openai-work' } as const,
+      baseUrl: null,
+    };
+    const first = await stores.operations.beginConnectionOnboarding(requested);
+    const second = await stores.operations.beginConnectionOnboarding(requested);
+    assert.equal(first.kind, 'ready');
+    assert.equal(second.kind, 'ready');
+    if (first.kind !== 'ready' || second.kind !== 'ready') return;
+    assert.equal(first.candidate.slug, 'openai-work');
+    assert.equal(second.candidate.slug, 'openai-work');
+
+    const completion = {
+      suppliedSecret: 'sk-live',
+      enabledModelIds: ['gpt-5'],
+      discovery: { models: [{ id: 'gpt-5' }], source: 'fetched' as const, fetchedAt: 1 },
+    };
+    const committed = await stores.operations.completeConnectionOnboarding(
+      first.ticket,
+      completion,
+    );
+    assert.equal(committed.kind, 'committed');
+    const lost = await stores.operations.completeConnectionOnboarding(second.ticket, completion);
+    assert.deepEqual(lost, { kind: 'slug_taken' });
+  });
+});
+
 test('reports catalog_full both before discovery and when the last slot fills before commit', async () => {
   await withFixture(async ({ root, stores }) => {
     const connections = Array.from(

--- a/packages/runtime-host/src/__tests__/connection-effects-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-effects-protocol.test.ts
@@ -113,11 +113,39 @@ describe('Runtime Host connection effects protocol', () => {
       apiKey: 'transient-secret',
       baseUrl: null,
     });
-    assertInvalidRequest('connection.onboarding.verify', {
-      target: { kind: 'create', providerType: 'openai-compatible', slug: 'surface-owned' },
+    // A create target may carry a caller-chosen slug/name (#4605); both
+    // decode through the same catalog codecs as the rest of the wire.
+    const namedVerify = request('connection.onboarding.verify', {
+      target: { kind: 'create', providerType: 'openrouter', slug: 'openrouter-work', name: 'Work' },
       apiKey: 'transient-secret',
       baseUrl: null,
     });
+    assert.deepEqual(decodeClientFrame(namedVerify), namedVerify);
+    // …but a malformed requested slug fails decode like any other bad input.
+    assertInvalidRequest('connection.onboarding.verify', {
+      target: { kind: 'create', providerType: 'openrouter', slug: 'NOT A SLUG' },
+      apiKey: 'transient-secret',
+      baseUrl: null,
+    });
+    // …and the create target stays closed to fields it does not define.
+    assertInvalidRequest('connection.onboarding.verify', {
+      target: { kind: 'create', providerType: 'openai-compatible', slug2: 'surface-owned' },
+      apiKey: 'transient-secret',
+      baseUrl: null,
+    });
+    // slug_taken is the create target's collision answer, on both halves.
+    assert.deepEqual(
+      decodeHostFrame(
+        response('connection.onboarding.verify', { kind: 'rejected', reason: 'slug_taken' }),
+      ),
+      response('connection.onboarding.verify', { kind: 'rejected', reason: 'slug_taken' }),
+    );
+    assert.deepEqual(
+      decodeHostFrame(
+        response('connection.onboarding.save', { kind: 'rejected', reason: 'slug_taken' }),
+      ),
+      response('connection.onboarding.save', { kind: 'rejected', reason: 'slug_taken' }),
+    );
     assertInvalidResponse('connection.onboarding.verify', {
       kind: 'verified',
       models: [],

--- a/packages/runtime-host/src/protocol/connection-effects.ts
+++ b/packages/runtime-host/src/protocol/connection-effects.ts
@@ -21,6 +21,7 @@ import {
   CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION,
   decodeConnectionModelId,
   decodeConnectionModel,
+  decodeConnectionName,
   decodeConnectionSlug,
   decodeProviderType,
   decodeConnectionTestSummary,
@@ -36,6 +37,7 @@ import {
   requireEntityId,
   requireExactRecord,
   requireRecord,
+  requireShapedRecord,
   requireString,
 } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
@@ -109,6 +111,10 @@ export type ConnectionOnboardingVerifyResult =
         | 'connection_not_found'
         | 'credential_not_configured'
         | 'base_url_not_configured'
+        // The create target's caller-requested slug is taken. Surfaced at
+        // verify so the wizard can offer the identity step again before any
+        // model discovery runs.
+        | 'slug_taken'
         | 'catalog_full';
     }
   | { readonly kind: 'failed'; readonly errorClass: ConnectionEffectFailureClass };
@@ -132,6 +138,10 @@ export type ConnectionOnboardingSaveResult =
         | 'base_url_not_configured'
         | 'catalog_full'
         | 'model_unavailable'
+        // The caller asked for a slug that another connection already owns;
+        // nothing was created. Re-run the wizard with a different slug (or no
+        // slug for the derived identity).
+        | 'slug_taken'
         // The connection changed between model discovery and the commit; the
         // discovered inventory no longer describes it. Re-run the wizard.
         | 'superseded';
@@ -315,6 +325,7 @@ export function decodeConnectionOnboardingSaveResult(
       rejected.reason !== 'base_url_not_configured' &&
       rejected.reason !== 'catalog_full' &&
       rejected.reason !== 'model_unavailable' &&
+      rejected.reason !== 'slug_taken' &&
       rejected.reason !== 'superseded')
   ) {
     throw invalidProtocolFrame('Invalid connection onboarding save rejection');
@@ -346,13 +357,24 @@ export function decodeConnectionOnboardingVerifyInput(
 function decodeConnectionOnboardingTarget(value: unknown): ConnectionOnboardingTarget {
   const target = requireRecord(value, 'connection onboarding target');
   if (target.kind === 'create') {
-    const exact = requireExactRecord(target, 'create connection onboarding target', [
-      'kind',
-      'providerType',
-    ]);
+    // slug/name are optional so a surface that accepts the derived identity
+    // can keep talking to any Host vintage; a surface that lets the user name
+    // the connection must tolerate an older Host rejecting the extra fields.
+    const exact = requireShapedRecord(
+      target,
+      'create connection onboarding target',
+      ['kind', 'providerType'],
+      ['slug', 'name'],
+    );
     return {
       kind: 'create',
       providerType: decodeDomain(() => decodeProviderType(exact.providerType)),
+      ...(exact.slug === undefined
+        ? {}
+        : { slug: decodeDomain(() => decodeConnectionSlug(exact.slug)) }),
+      ...(exact.name === undefined
+        ? {}
+        : { name: decodeDomain(() => decodeConnectionName(exact.name)) }),
     };
   }
   if (target.kind === 'existing') {
@@ -402,6 +424,7 @@ export function decodeConnectionOnboardingVerifyResult(
       rejected.reason !== 'connection_not_found' &&
       rejected.reason !== 'credential_not_configured' &&
       rejected.reason !== 'base_url_not_configured' &&
+      rejected.reason !== 'slug_taken' &&
       rejected.reason !== 'catalog_full')
   ) {
     throw invalidProtocolFrame('Invalid connection onboarding rejection');

--- a/packages/runtime-host/src/server/connection-effect-coordinator.ts
+++ b/packages/runtime-host/src/server/connection-effect-coordinator.ts
@@ -229,6 +229,9 @@ export class HostConnectionEffectCoordinator {
     if (begun.kind === 'catalog_full') {
       return { kind: 'rejected', reason: 'catalog_full' };
     }
+    if (begun.kind === 'slug_taken') {
+      return { kind: 'rejected', reason: 'slug_taken' };
+    }
     const providerType = begun.candidate.providerType;
     const candidate = begun.existingConnection ?? undefined;
     const supplied = input.apiKey?.trim() ?? '';
@@ -304,6 +307,9 @@ export class HostConnectionEffectCoordinator {
       }
       if (committed.kind === 'target_missing') {
         return { kind: 'rejected', reason: 'connection_not_found' };
+      }
+      if (committed.kind === 'slug_taken') {
+        return { kind: 'rejected', reason: 'slug_taken' };
       }
       if (committed.kind === 'superseded') {
         return { kind: 'rejected', reason: 'superseded' };
@@ -479,6 +485,7 @@ type OnboardingDiscovery =
         | 'connection_not_found'
         | 'credential_not_configured'
         | 'base_url_not_configured'
+        | 'slug_taken'
         | 'catalog_full';
     }
   | { readonly kind: 'failed'; readonly errorClass: ConnectionEffectFailureClass };

--- a/packages/storage/src/__tests__/onboarding-transaction.test.ts
+++ b/packages/storage/src/__tests__/onboarding-transaction.test.ts
@@ -81,3 +81,45 @@ test('a journal written before the baseUrl field replays as no override', async 
   assert.equal(replayed?.baseUrl, null);
   assert.deepEqual(replayed?.enabledModelIds, ['relay/model']);
 });
+
+test('a caller-chosen display name round-trips through the journal', async () => {
+  const directory = await root();
+  const intent = prepareConnectionOnboardingIntent({
+    ...BASE,
+    name: 'Work Relay',
+    baseUrl: 'https://relay.example.test/v1',
+  });
+  assert.equal(intent.name, 'Work Relay');
+  await writeConnectionOnboardingIntent(directory, intent);
+  assert.deepEqual(await readConnectionOnboardingIntent(directory), intent);
+});
+
+test('a journal written before the name field replays with the provider default', async () => {
+  const directory = await root();
+  // Schema v2 predates `name`: the key is simply absent on crash replay.
+  const { slug: _slug, ...legacyBase } = BASE;
+  await writeFile(
+    join(directory, 'runtime-policy-onboarding.json'),
+    JSON.stringify({
+      schemaVersion: 2,
+      slug: 'openai-compatible-2',
+      baseUrl: null,
+      ...legacyBase,
+    }),
+  );
+  const replayed = await readConnectionOnboardingIntent(directory);
+  assert.equal(replayed?.schemaVersion, 2);
+  assert.equal(replayed?.name, null);
+});
+
+test('a malformed requested display name fails input decode, never the journal', async () => {
+  assert.throws(
+    () =>
+      prepareConnectionOnboardingIntent({
+        ...BASE,
+        name: 42,
+        baseUrl: null,
+      }),
+    /connection name/,
+  );
+});

--- a/packages/storage/src/runtime-policy/connection-catalog-document.ts
+++ b/packages/storage/src/runtime-policy/connection-catalog-document.ts
@@ -22,6 +22,7 @@ import { isDeepStrictEqual } from 'node:util';
 import {
   CONNECTION_CATALOG_MAX_CONNECTIONS,
   decodeCanonicalConnectionCatalogEntry,
+  decodeConnectionName,
   decodeConnectionSlug,
   decodeConnectionTarget,
   decodeConnectionTestSummary,
@@ -519,6 +520,7 @@ export class ConnectionCatalogDocumentOwner {
     rawConnectionId: string,
     rawSlug: string,
     rawProviderType: unknown,
+    rawName: string | null,
     rawBaseUrl: string | null,
     rawEnabledModelIds: readonly string[],
     rawResult: ConnectionModelDiscoveryResult,
@@ -530,6 +532,8 @@ export class ConnectionCatalogDocumentOwner {
     const connectionId = decodeConnectionInput(() => decodeRuntimePolicyEntityId(rawConnectionId));
     const slug = decodeConnectionInput(() => decodeConnectionSlug(rawSlug));
     const providerType = decodeConnectionInput(() => decodeProviderType(rawProviderType));
+    const requestedName =
+      rawName === null ? null : decodeConnectionInput(() => decodeConnectionName(rawName));
     const definition = PROVIDER_REGISTRY[providerType];
     // Identity first: the intent's connectionId names the connection being
     // edited, whatever slug it lives under — a relay created in Desktop under
@@ -568,7 +572,9 @@ export class ConnectionCatalogDocumentOwner {
     const changes = decodeConnectionInput(() =>
       normalizeConnectionCatalogEntryUpdateForProvider(
         {
-          name: previous?.name ?? definition.label,
+          // An edit keeps the stored name; a create takes the caller's choice
+          // when the wizard collected one, else the provider label.
+          name: previous?.name ?? requestedName ?? definition.label,
           ...(effectiveBaseUrl ? { baseUrl: effectiveBaseUrl } : {}),
           enabled: true,
           enabledModelIds: rawEnabledModelIds,
@@ -612,6 +618,9 @@ export class ConnectionCatalogDocumentOwner {
     const { relayModelProfiles: _staleProfiles, ...baseWithoutProfiles } = base;
     const finalized: ConnectionCatalogEntry = {
       ...baseWithoutProfiles,
+      // `changes.name` carries the edit-preserving / create-requested / provider
+      // -label resolution — `base` alone would keep the provider label forever.
+      name: changes.name,
       ...(relayModelProfiles ? { relayModelProfiles } : {}),
       ...(changes.baseUrl !== undefined ? { baseUrl: changes.baseUrl } : {}),
       revision: previous ? nextRevision(previous.revision) : 1,

--- a/packages/storage/src/runtime-policy/coordinator.ts
+++ b/packages/storage/src/runtime-policy/coordinator.ts
@@ -24,6 +24,7 @@ import {
   decodeConnectionModelId,
   connectionCredentialTarget,
   decodeConnectionCredentialTarget,
+  decodeConnectionName,
   decodeConnectionSlug,
   decodeProviderType,
   decodeRuntimePolicyEntityId,
@@ -236,6 +237,14 @@ interface ConnectionOnboardingBasis {
     | {
         readonly kind: 'create';
         readonly candidate: ConnectionOnboardingCandidateIdentity;
+        /**
+         * True when the caller chose the slug. A collision then reports
+         * `slug_taken` instead of `superseded`: the fix is the caller's
+         * (pick another slug), not a silent re-derivation.
+         */
+        readonly slugRequested: boolean;
+        /** Caller-chosen display name resolved at begin; falls back to the provider label. */
+        readonly name: string | null;
       }
     | {
         readonly kind: 'existing';
@@ -1219,16 +1228,27 @@ export class RuntimePolicyCoordinator {
         const providerType = decodeConnectionInput(() =>
           decodeProviderType(requestedTarget.providerType),
         );
+        const requestedSlug =
+          requestedTarget.slug === undefined
+            ? null
+            : decodeConnectionInput(() => decodeConnectionSlug(requestedTarget.slug));
         target = {
           kind: 'create',
           candidate: {
             connectionId: randomUUID(),
-            slug: deriveConnectionSlug(
-              providerType,
-              catalog.connections.map((connection) => connection.slug),
-            ),
+            slug:
+              requestedSlug ??
+              deriveConnectionSlug(
+                providerType,
+                catalog.connections.map((connection) => connection.slug),
+              ),
             providerType,
           },
+          slugRequested: requestedSlug !== null,
+          name:
+            requestedTarget.name === undefined
+              ? null
+              : decodeConnectionInput(() => decodeConnectionName(requestedTarget.name)),
         };
       } else if (requestedTarget.kind === 'existing') {
         const connectionId = decodeConnectionInput(() =>
@@ -1260,6 +1280,13 @@ export class RuntimePolicyCoordinator {
         catalog.connections.length >= CONNECTION_CATALOG_MAX_CONNECTIONS
       ) {
         return deepFreeze({ kind: 'catalog_full' as const });
+      }
+      if (
+        target.kind === 'create' &&
+        target.slugRequested &&
+        catalog.connections.some((connection) => connection.slug === target.candidate.slug)
+      ) {
+        return deepFreeze({ kind: 'slug_taken' as const });
       }
       const baseUrl =
         input.baseUrl === null
@@ -1353,6 +1380,9 @@ export class RuntimePolicyCoordinator {
           if (checked.kind === 'catalog_full') {
             return deepFreeze({ kind: 'catalog_full' as const });
           }
+          if (checked.kind === 'slug_taken') {
+            return deepFreeze({ kind: 'slug_taken' as const });
+          }
           return deepFreeze(
             checked.kind === 'target_missing'
               ? { kind: 'target_missing' as const }
@@ -1372,6 +1402,7 @@ export class RuntimePolicyCoordinator {
     | { readonly kind: 'unchanged' }
     | { readonly kind: 'target_missing' }
     | { readonly kind: 'catalog_full' }
+    | { readonly kind: 'slug_taken' }
     | { readonly kind: 'superseded'; readonly changed: ConnectionEffectChangedDomain[] }
   > {
     const changed: ConnectionEffectChangedDomain[] = [];
@@ -1405,6 +1436,20 @@ export class RuntimePolicyCoordinator {
           connection.slug === basis.target.candidate.slug,
       )
     ) {
+      // A caller-chosen slug losing the race is the caller's to fix, so it
+      // reports distinctly instead of as a generic basis change. A derived
+      // slug colliding still resolves by re-running the wizard, which simply
+      // derives again.
+      if (
+        basis.target.slugRequested &&
+        catalog.connections.some(
+          (connection) =>
+            connection.slug === basis.target.candidate.slug &&
+            connection.connectionId !== basis.target.candidate.connectionId,
+        )
+      ) {
+        return { kind: 'slug_taken' };
+      }
       changed.push('connection');
     } else if (catalog.connections.length >= CONNECTION_CATALOG_MAX_CONNECTIONS) {
       return { kind: 'catalog_full' };
@@ -1486,6 +1531,7 @@ export class RuntimePolicyCoordinator {
       connectionId,
       slug: candidate.slug,
       providerType: candidate.providerType,
+      name: basis.target.kind === 'create' ? basis.target.name : null,
       baseUrl: basis.baseUrl,
       invalidateLastTest,
     });
@@ -1494,12 +1540,16 @@ export class RuntimePolicyCoordinator {
       intent.connectionId,
       intent.slug,
       intent.providerType,
+      intent.name,
       intent.baseUrl,
       intent.enabledModelIds,
       intent.discovery,
       intent.invalidateLastTest,
     );
     if (catalogPreflight.kind === 'slug_conflict') {
+      if (basis.target.kind === 'create' && basis.target.slugRequested) {
+        return deepFreeze({ kind: 'slug_taken' as const });
+      }
       return deepFreeze({ kind: 'superseded' as const, changed: ['connection'] as const });
     }
     if (catalogPreflight.kind === 'catalog_full') {
@@ -2104,6 +2154,7 @@ export class RuntimePolicyCoordinator {
       intent.connectionId,
       slug,
       intent.providerType,
+      intent.name,
       intent.baseUrl,
       intent.enabledModelIds,
       intent.discovery,

--- a/packages/storage/src/runtime-policy/onboarding-transaction.ts
+++ b/packages/storage/src/runtime-policy/onboarding-transaction.ts
@@ -23,6 +23,7 @@ import {
   decodeProviderType,
   decodeCanonicalConnectionCatalogEntry,
   decodeCredentialVersionBasis,
+  decodeConnectionName,
   decodeConnectionSlug,
   decodeRuntimePolicyEntityId,
   normalizeCatalogConnectionBaseUrl,
@@ -60,6 +61,8 @@ export interface ConnectionOnboardingTransactionInput {
   readonly connectionId: unknown;
   readonly slug: unknown;
   readonly providerType: unknown;
+  /** Optional caller-chosen display name; absent/null keeps the provider default. */
+  readonly name?: unknown;
   readonly suppliedSecret: unknown;
   readonly baseUrl: unknown;
   readonly enabledModelIds: unknown;
@@ -73,6 +76,12 @@ export interface ConnectionOnboardingIntent {
   /** Absent only while replaying a schema-v1 identity-first intent. */
   readonly slug: string | null;
   readonly providerType: ProviderType;
+  /**
+   * Caller-chosen display name pinned into the durable intent; null falls
+   * back to the provider label at upsert. Absent in intents journaled before
+   * this field existed — they decode to null and behave exactly as before.
+   */
+  readonly name: string | null;
   readonly suppliedSecret: string | null;
   readonly baseUrl: string | null;
   readonly enabledModelIds: readonly string[];
@@ -170,6 +179,10 @@ export function prepareConnectionOnboardingIntent(
     connectionId: decode(() => decodeRuntimePolicyEntityId(input.connectionId)),
     slug: decode(() => decodeConnectionSlug(input.slug)),
     providerType,
+    name:
+      input.name === undefined || input.name === null
+        ? null
+        : decode(() => decodeConnectionName(input.name)),
     suppliedSecret,
     baseUrl,
     enabledModelIds: normalized.enabledModelIds,
@@ -199,6 +212,7 @@ export async function readConnectionOnboardingIntent(
       'connectionId',
       'slug',
       'providerType',
+      'name',
       'suppliedSecret',
       'baseUrl',
       'enabledModelIds',
@@ -220,6 +234,7 @@ export async function readConnectionOnboardingIntent(
       'connectionId',
       'slug',
       'providerType',
+      'name',
       'suppliedSecret',
       'baseUrl',
       'enabledModelIds',
@@ -245,6 +260,7 @@ export async function readConnectionOnboardingIntent(
       connectionId: raw.connectionId,
       slug:
         raw.schemaVersion === 1 ? deriveLegacyIntentPlaceholderSlug(raw.providerType) : raw.slug,
+      name: raw.name,
       suppliedSecret: raw.suppliedSecret,
       baseUrl: raw.baseUrl,
       enabledModelIds: raw.enabledModelIds,

--- a/packages/storage/src/runtime-policy/operations.ts
+++ b/packages/storage/src/runtime-policy/operations.ts
@@ -280,6 +280,10 @@ export type BeginConnectionOnboardingResult =
   | { readonly kind: 'target_missing' }
   | { readonly kind: 'provider_unsupported' }
   | { readonly kind: 'catalog_full' }
+  // The create target's caller-requested slug already belongs to another
+  // connection. Nothing is derived or renamed silently — the caller picks a
+  // different slug (or omits it for the derived identity) and retries.
+  | { readonly kind: 'slug_taken' }
   | {
       readonly kind: 'ready';
       readonly ticket: ConnectionOnboardingTicket;
@@ -326,6 +330,10 @@ export type CommitConnectionOnboardingResult =
   // The explicitly targeted connection no longer exists (or changed provider
   // type) between the caller's snapshot and this commit.
   | { readonly kind: 'target_missing' }
+  // The create target's caller-requested slug was taken between begin and
+  // this commit. A derived slug colliding stays `superseded` — a retry
+  // re-derives — but a requested slug is the caller's choice to fix.
+  | { readonly kind: 'slug_taken' }
   // The discovery basis (connection revision, credential, or proxy) changed
   // between begin and complete: committing would bind another endpoint or
   // credential to a model inventory it never produced.


### PR DESCRIPTION
## Summary

Closes #4605. The TUI `/setup` wizard can now name a new connection — custom slug and display name — instead of accepting only the Host-derived `openai-2` identity. Desktop had this via its multi-step catalog flow; the TUI gets it through managed onboarding, which keeps the whole create in one Host transaction.

## How it works

- **Protocol**: the onboarding `create` target accepts optional `slug` / `name` (`connection-effects.ts`). The decoder moves from an exact to a shaped record for those two keys only — unknown fields are still rejected. Callers that accept the defaults send the bare target, so any Host vintage keeps working; no epoch bump.
- **Storage**: `beginConnectionOnboarding` validates a requested slug against the catalog and rejects early with `slug_taken`; `checkOnboardingBasis` and the commit preflight map a mid-flight collision of a *requested* slug to `slug_taken` (a *derived* slug keeps reporting `superseded`, since retry simply re-derives). The chosen name is pinned into the durable onboarding intent, so crash recovery replays it exactly; intents journaled before this field decode with `name: null`.
- **TUI**: the wizard gains an identity step for create targets (search → identity → baseUrl? → key → models), prefilled with the derived slug and provider label. Editing nothing sends a bare target; editing sends the choice. A `slug_taken` rejection bounces back to the identity step with the user's text intact. Copy lands in both locales (en / zh-CN).

## Also fixes

`prepareOnboardingUpsert` computed `changes.name` but never applied it — the finalized entry always kept the provider label. The upsert now applies it; existing targets resolve to `previous.name`, so only create behavior changes.

## Tests

- Protocol contract: slug/name decode, malformed slug rejection, closed-shape guard, `slug_taken` on both verify and save halves.
- Host coordinator: named create persists name + slug; taken slug rejected before discovery; mid-flight loss reports `slug_taken`.
- Storage: intent journal round-trips the name; pre-field journals replay as `null`.
- TUI: custom identity reaches verify/save unchanged; defaults send a bare target; `slug_taken` bounces to the identity step. Existing wizard flow tests updated for the new step.

`cli` 751, `storage` 1084, `runtime-host` 1605, `core` 762 tests pass; desktop typecheck, biome, and `check-tui-copy` are clean.

## Out of scope

- Renaming existing connections (slug is immutable by design; name edit could follow via `connection.catalog.update`).
- Migrating Desktop's add-provider form onto managed onboarding.
