### PR TITLE
fix(runtime): deduplicate in-flight context compaction

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -4547,7 +4547,6 @@ describe('AiSdkBackend model history', () => {
       now: monotonicClock(),
       contextBudget: {
         name: 'in-flight-dedup-test',
-        maxHistoryEstimatedTokens: 10_000,
         charsPerToken: 1,
       },
       summarizeHistoryCompact: async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -4596,11 +4596,22 @@ describe('AiSdkBackend model history', () => {
       ],
     });
 
-    assert.equal(summarizeCalls, 1);
     releaseSummary();
     const [firstResult, secondResult] = await Promise.all([first, second]);
-    assert.deepEqual(secondResult, firstResult);
-    assert.equal(recorded.length, 1);
+    assert.equal(summarizeCalls, 1);
+    assert.equal(secondResult.outcome.kind, 'compacted');
+    assert.equal(firstResult.outcome.kind, 'compacted');
+    assert.equal(recorded.length, 2);
+    const firstCheckpoint = recorded[0];
+    const secondCheckpoint = recorded[1];
+    assert.ok(firstCheckpoint);
+    assert.ok(secondCheckpoint);
+    assert.equal(firstCheckpoint.version, 2);
+    assert.equal(secondCheckpoint.version, 2);
+    if (firstCheckpoint.version === 2 && secondCheckpoint.version === 2) {
+      assert.equal(secondCheckpoint.summary, firstCheckpoint.summary);
+      assert.deepEqual(secondCheckpoint.coverage, firstCheckpoint.coverage);
+    }
   });
 
   test('manual compactHistory compacts one completed turn with multiple agent steps', async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -4584,7 +4584,16 @@ describe('AiSdkBackend model history', () => {
     const second = backend.compactHistory({
       turnId: 'dedup-compact-2',
       runId: 'run-dedup-2',
-      runtimeContext,
+      runtimeContext: [
+        ...runtimeContext,
+        runtimeTextEvent({
+          id: 'dedup-current-turn',
+          turnId: 'dedup-compact-2',
+          role: 'user',
+          author: 'user',
+          text: 'current turn content must not affect the fold key',
+        }),
+      ],
     });
 
     assert.equal(summarizeCalls, 1);

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -4527,6 +4527,73 @@ describe('AiSdkBackend model history', () => {
     assert.equal(result.contextBudget?.compactionDecisions?.[0]?.decision, 'replaced');
   });
 
+  test('coalesces identical in-flight compactHistory requests', async () => {
+    const recorded: HistoryCompactCheckpoint[] = [];
+    let summarizeCalls = 0;
+    let releaseSummary!: () => void;
+    const summaryReady = new Promise<void>((resolve) => {
+      releaseSummary = resolve;
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => completionModel(),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'in-flight-dedup-test',
+        maxHistoryEstimatedTokens: 10_000,
+        charsPerToken: 1,
+      },
+      summarizeHistoryCompact: async () => {
+        summarizeCalls += 1;
+        await summaryReady;
+        return structuredSummary('IN_FLIGHT_DEDUP_SUMMARY');
+      },
+      recordHistoryCompactCheckpoint: (checkpoint) => {
+        recorded.push(checkpoint);
+      },
+    });
+    const runtimeContext = [
+      runtimeTextEvent({
+        id: 'dedup-old-user',
+        turnId: 'dedup-old-turn',
+        role: 'user',
+        author: 'user',
+        text: 'old context '.repeat(100),
+      }),
+      runtimeTextEvent({
+        id: 'dedup-old-agent',
+        turnId: 'dedup-old-turn',
+        role: 'model',
+        author: 'agent',
+        text: 'old response '.repeat(100),
+      }),
+    ];
+    const first = backend.compactHistory({
+      turnId: 'dedup-compact-1',
+      runId: 'run-dedup-1',
+      runtimeContext,
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const second = backend.compactHistory({
+      turnId: 'dedup-compact-2',
+      runId: 'run-dedup-2',
+      runtimeContext,
+    });
+
+    assert.equal(summarizeCalls, 1);
+    releaseSummary();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    assert.deepEqual(secondResult, firstResult);
+    assert.equal(recorded.length, 1);
+  });
+
   test('manual compactHistory compacts one completed turn with multiple agent steps', async () => {
     const recorded: HistoryCompactCheckpoint[] = [];
     const backend = createTestAiSdkBackend({

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -57,6 +57,7 @@ import {
   matchHistoryCompactCheckpointPrefix,
   projectHistoryCompactCheckpointReplay,
   type HistoryCompactCheckpoint,
+  type HistoryCompactCheckpointHeadAnchor,
   type HistoryCompactMemoryExtractionBoundary,
   type HistoryCompactProviderState,
 } from './history-compact-checkpoint.js';
@@ -401,27 +402,36 @@ export class AiSdkCompaction {
         ...(automaticMemoryBoundary ? { memoryExtractionBoundary: automaticMemoryBoundary } : {}),
         ...(previousCheckpoint ? { previousCheckpoint } : {}),
         summarize: async ({ coveredRuntimeEvents, newlyFoldedRuntimeEvents, previousCheckpoint }) =>
-          await this.summarizeWithFailureCircuit(summarizer, {
-            sessionId: this.sessionId,
-            turnId: input.turnId,
-            runId: input.runId,
-            source: {
-              foldedRuntimeEvents: [...coveredRuntimeEvents],
-              ...(input.runtimeContextInvocations
-                ? {
-                    invocations: input.runtimeContextInvocations.filter((invocation) =>
-                      coveredRuntimeEvents.some(
-                        (event) => event.invocationId === invocation.invocationId,
+          await this.summarizeWithFailureCircuit(
+            summarizer,
+            {
+              sessionId: this.sessionId,
+              turnId: input.turnId,
+              runId: input.runId,
+              source: {
+                foldedRuntimeEvents: [...coveredRuntimeEvents],
+                ...(input.runtimeContextInvocations
+                  ? {
+                      invocations: input.runtimeContextInvocations.filter((invocation) =>
+                        coveredRuntimeEvents.some(
+                          (event) => event.invocationId === invocation.invocationId,
+                        ),
                       ),
-                    ),
-                  }
+                    }
+                  : {}),
+              },
+              newlyFoldedRuntimeEvents: [...newlyFoldedRuntimeEvents],
+              ...(previousCheckpoint ? { previousCheckpoint } : {}),
+              abortSignal: historyCompactAbortController.signal,
+              ...(tracker ? { providerRequestTracker: tracker } : {}),
+            },
+            {
+              phase: 'pre_turn',
+              ...(automaticMemoryBoundary
+                ? { memoryExtractionBoundary: automaticMemoryBoundary }
                 : {}),
             },
-            newlyFoldedRuntimeEvents: [...newlyFoldedRuntimeEvents],
-            ...(previousCheckpoint ? { previousCheckpoint } : {}),
-            abortSignal: historyCompactAbortController.signal,
-            ...(tracker ? { providerRequestTracker: tracker } : {}),
-          }),
+          ),
       });
       if (historyCompactAbortController.signal.aborted) {
         return { outcome: { kind: 'failed', reason: 'aborted' } };
@@ -500,6 +510,11 @@ export class AiSdkCompaction {
   private async summarizeWithFailureCircuit(
     summarizer: HistoryCompactSummarizer,
     input: HistoryCompactSummaryInput,
+    checkpointIntent?: {
+      phase?: 'pre_turn' | 'mid_turn';
+      headAnchor?: HistoryCompactCheckpointHeadAnchor;
+      memoryExtractionBoundary?: HistoryCompactMemoryExtractionBoundary;
+    },
   ): Promise<string | HistoryCompactProviderState | undefined> {
     const foldedRunIds = new Set(input.source.foldedRuntimeEvents.map((event) => event.runId));
     const sourceRunRoutes = input.source.invocations
@@ -530,6 +545,7 @@ export class AiSdkCompaction {
         sourceRunRoutes,
         foldedRuntimeEvents: input.source.foldedRuntimeEvents,
         newlyFoldedRuntimeEvents: input.newlyFoldedRuntimeEvents,
+        checkpointIntent,
       }),
     );
     const priorFailure = this.malformedSummaryFailures.get(fingerprint);
@@ -1107,6 +1123,15 @@ export class AiSdkCompaction {
     }
     const orderedEvents = [...state.priorContentEvents, ...currentTurnEvents];
     const memoryDecision = input.memoryCompactionDecision?.();
+    const memoryExtractionBoundary =
+      memoryDecision && orderedEvents.at(-1)
+        ? {
+            runId: orderedEvents.at(-1)!.runId,
+            turnId: orderedEvents.at(-1)!.turnId,
+            runtimeEventId: orderedEvents.at(-1)!.id,
+            disposition: memoryDecision.disposition,
+          }
+        : undefined;
     const plan = await planHistoryCompaction({
       sessionId: this.sessionId,
       phase: input.phase ?? 'mid_turn',
@@ -1124,30 +1149,29 @@ export class AiSdkCompaction {
         ? { highWaterName: compactPolicy.highWaterName }
         : {}),
       ...(state.previousCheckpoint ? { previousCheckpoint: state.previousCheckpoint } : {}),
-      ...(memoryDecision && orderedEvents.at(-1)
-        ? {
-            memoryExtractionBoundary: {
-              runId: orderedEvents.at(-1)!.runId,
-              turnId: orderedEvents.at(-1)!.turnId,
-              runtimeEventId: orderedEvents.at(-1)!.id,
-              disposition: memoryDecision.disposition,
-            },
-          }
-        : {}),
+      ...(memoryExtractionBoundary ? { memoryExtractionBoundary } : {}),
       summarize: async ({ coveredRuntimeEvents, newlyFoldedRuntimeEvents, previousCheckpoint }) => {
-        return await this.summarizeWithFailureCircuit(summarizer, {
-          sessionId: this.sessionId,
-          turnId,
-          ...(input.origin.runId ? { runId: input.origin.runId } : {}),
-          source: {
-            foldedRuntimeEvents: [...coveredRuntimeEvents],
-            invocations: state.priorInvocations,
+        return await this.summarizeWithFailureCircuit(
+          summarizer,
+          {
+            sessionId: this.sessionId,
+            turnId,
+            ...(input.origin.runId ? { runId: input.origin.runId } : {}),
+            source: {
+              foldedRuntimeEvents: [...coveredRuntimeEvents],
+              invocations: state.priorInvocations,
+            },
+            ...(previousCheckpoint ? { previousCheckpoint } : {}),
+            newlyFoldedRuntimeEvents: [...newlyFoldedRuntimeEvents],
+            ...(abortSignal ? { abortSignal } : {}),
+            ...(midTurnTracker ? { providerRequestTracker: midTurnTracker } : {}),
           },
-          ...(previousCheckpoint ? { previousCheckpoint } : {}),
-          newlyFoldedRuntimeEvents: [...newlyFoldedRuntimeEvents],
-          ...(abortSignal ? { abortSignal } : {}),
-          ...(midTurnTracker ? { providerRequestTracker: midTurnTracker } : {}),
-        });
+          {
+            phase: input.phase ?? 'mid_turn',
+            headAnchor: { runtimeEventId: state.headAnchor.id, turnId },
+            ...(memoryExtractionBoundary ? { memoryExtractionBoundary } : {}),
+          },
+        );
       },
     });
 

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -302,13 +302,6 @@ export class AiSdkCompaction {
     input: Omit<BackendCompactHistoryInput, 'runId'> & { runId: string | undefined },
     automaticMemoryBoundary?: HistoryCompactMemoryExtractionBoundary,
   ): Promise<AiSdkCompactHistoryResult> {
-    return this.compactHistoryOnce(input, automaticMemoryBoundary);
-  }
-
-  private async compactHistoryOnce(
-    input: Omit<BackendCompactHistoryInput, 'runId'> & { runId: string | undefined },
-    automaticMemoryBoundary?: HistoryCompactMemoryExtractionBoundary,
-  ): Promise<AiSdkCompactHistoryResult> {
     const historyCompactAbortController = new AbortController();
     this.historyCompactAbortControllers.add(historyCompactAbortController);
     try {

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -209,18 +209,16 @@ export class AiSdkCompaction {
     providerReasoningReplayEventIds: ReadonlySet<string>,
   ) => Promise<ModelMessage[]>;
   private readonly canReplayProviderNative: (plan: RuntimeEventModelReplayPlan) => boolean;
-  private historyCompactAbortController: AbortController | null = null;
+  private readonly historyCompactAbortControllers = new Set<AbortController>();
   /**
-   * Exact duplicate compaction requests share one physical summarizer call.
-   * Automatic capacity checks and explicit/manual entry can converge while a
-   * checkpoint is still being written; dispatching both would race the same
-   * source prefix and charge the provider twice. The key is derived from the
-   * source/configuration rather than the issuing turn id so callers that are
-   * otherwise asking for the same fold share the result.
+   * Exact duplicate summary inputs share one physical provider call. The map
+   * lives at the summarizer boundary, where the existing effective-history
+   * fingerprint already describes the request that spends provider budget.
+   * Each caller still completes its own checkpoint/turn bookkeeping.
    */
-  private readonly inFlightHistoryCompactions = new Map<
+  private readonly inFlightHistorySummaries = new Map<
     string,
-    Promise<AiSdkCompactHistoryResult>
+    Promise<string | HistoryCompactProviderState | undefined>
   >();
   /**
    * Session-scoped circuit for exact malformed compaction inputs. A retry or
@@ -293,25 +291,14 @@ export class AiSdkCompaction {
 
   /** Abort an in-flight manual history compaction (called by AiSdkBackend.stop). */
   public abortHistoryCompact(): void {
-    this.historyCompactAbortController?.abort();
+    for (const controller of this.historyCompactAbortControllers) controller.abort();
   }
 
-  public compactHistory(
+  public async compactHistory(
     input: Omit<BackendCompactHistoryInput, 'runId'> & { runId: string | undefined },
     automaticMemoryBoundary?: HistoryCompactMemoryExtractionBoundary,
   ): Promise<AiSdkCompactHistoryResult> {
-    const key = historyCompactRequestKey(input, automaticMemoryBoundary);
-    const existing = this.inFlightHistoryCompactions.get(key);
-    if (existing) return existing;
-    const pending = this.compactHistoryOnce(input, automaticMemoryBoundary);
-    this.inFlightHistoryCompactions.set(key, pending);
-    const clear = () => {
-      if (this.inFlightHistoryCompactions.get(key) === pending) {
-        this.inFlightHistoryCompactions.delete(key);
-      }
-    };
-    void pending.then(clear, clear);
-    return pending;
+    return this.compactHistoryOnce(input, automaticMemoryBoundary);
   }
 
   private async compactHistoryOnce(
@@ -319,7 +306,7 @@ export class AiSdkCompaction {
     automaticMemoryBoundary?: HistoryCompactMemoryExtractionBoundary,
   ): Promise<AiSdkCompactHistoryResult> {
     const historyCompactAbortController = new AbortController();
-    this.historyCompactAbortController = historyCompactAbortController;
+    this.historyCompactAbortControllers.add(historyCompactAbortController);
     try {
       const policy = this.input.contextBudget;
       const summarizer = this.input.summarizeHistoryCompact;
@@ -421,7 +408,13 @@ export class AiSdkCompaction {
             source: {
               foldedRuntimeEvents: [...coveredRuntimeEvents],
               ...(input.runtimeContextInvocations
-                ? { invocations: input.runtimeContextInvocations }
+                ? {
+                    invocations: input.runtimeContextInvocations.filter((invocation) =>
+                      coveredRuntimeEvents.some(
+                        (event) => event.invocationId === invocation.invocationId,
+                      ),
+                    ),
+                  }
                 : {}),
             },
             newlyFoldedRuntimeEvents: [...newlyFoldedRuntimeEvents],
@@ -496,9 +489,7 @@ export class AiSdkCompaction {
         }),
       };
     } finally {
-      if (this.historyCompactAbortController === historyCompactAbortController) {
-        this.historyCompactAbortController = null;
-      }
+      this.historyCompactAbortControllers.delete(historyCompactAbortController);
     }
   }
 
@@ -544,8 +535,13 @@ export class AiSdkCompaction {
     const priorFailure = this.malformedSummaryFailures.get(fingerprint);
     if (priorFailure) throw new HistoryCompactSummarizerError(priorFailure);
 
+    const existing = this.inFlightHistorySummaries.get(fingerprint);
+    if (existing) return existing;
+
+    const pending = Promise.resolve().then(() => summarizer(input));
+    this.inFlightHistorySummaries.set(fingerprint, pending);
     try {
-      return await Promise.resolve(summarizer(input));
+      return await pending;
     } catch (error) {
       if (
         error instanceof HistoryCompactSummarizerError &&
@@ -560,6 +556,10 @@ export class AiSdkCompaction {
         }
       }
       throw error;
+    } finally {
+      if (this.inFlightHistorySummaries.get(fingerprint) === pending) {
+        this.inFlightHistorySummaries.delete(fingerprint);
+      }
     }
   }
 
@@ -1410,25 +1410,6 @@ function projectAcceptedMidTurnCompactionMessages(
 
 function sha256(text: string): string {
   return createHash('sha256').update(text).digest('hex');
-}
-
-function historyCompactRequestKey(
-  input: Omit<BackendCompactHistoryInput, 'runId'> & { runId: string | undefined },
-  automaticMemoryBoundary: HistoryCompactMemoryExtractionBoundary | undefined,
-): string {
-  const runtimeContext = input.runtimeContext
-    .filter((event) => event.turnId !== input.turnId)
-    .filter(isHistoryCompactContentEvent);
-  const sourceRunIds = new Set(runtimeContext.map((event) => event.runId));
-  return sha256(
-    stableStringifyForSignature({
-      runtimeContext,
-      runtimeContextRunHeaders: (input.runtimeContextRunHeaders ?? []).filter((header) =>
-        sourceRunIds.has(header.runId),
-      ),
-      automaticMemoryBoundary,
-    }),
-  );
 }
 
 function modelMessageSignature(message: ModelMessage): string {

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -1742,8 +1742,8 @@ function invocationsForFoldedEvents(
   invocations: readonly RuntimeInvocationRecord[],
   foldedRuntimeEvents: readonly RuntimeEvent[],
 ): RuntimeInvocationRecord[] {
-  const foldedInvocationIds = new Set(foldedRuntimeEvents.map((event) => event.invocationId));
-  return invocations.filter((invocation) => foldedInvocationIds.has(invocation.invocationId));
+  const foldedRunIds = new Set(foldedRuntimeEvents.map((event) => event.runId));
+  return invocations.filter((invocation) => foldedRunIds.has(invocation.runId));
 }
 
 export function hasBlockingReplayDiagnostics(plan: RuntimeEventModelReplayPlan): boolean {

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -155,6 +155,12 @@ export interface AutomaticMemoryCompactionDecision {
   readonly dispatch: boolean;
 }
 
+interface InFlightHistorySummary {
+  readonly abortController: AbortController;
+  readonly consumers: Set<symbol>;
+  readonly promise: Promise<string | HistoryCompactProviderState | undefined>;
+}
+
 /** Constructor dependencies for AiSdkCompaction. */
 export interface AiSdkCompactionDeps {
   input: AiSdkCompactionCapabilities;
@@ -217,10 +223,7 @@ export class AiSdkCompaction {
    * fingerprint already describes the request that spends provider budget.
    * Each caller still completes its own checkpoint/turn bookkeeping.
    */
-  private readonly inFlightHistorySummaries = new Map<
-    string,
-    Promise<string | HistoryCompactProviderState | undefined>
-  >();
+  private readonly inFlightHistorySummaries = new Map<string, InFlightHistorySummary>();
   /**
    * Session-scoped circuit for exact malformed compaction inputs. A retry or
    * regeneration on the same backend must not dispatch the same doomed call;
@@ -551,13 +554,26 @@ export class AiSdkCompaction {
     const priorFailure = this.malformedSummaryFailures.get(fingerprint);
     if (priorFailure) throw new HistoryCompactSummarizerError(priorFailure);
 
-    const existing = this.inFlightHistorySummaries.get(fingerprint);
-    if (existing) return existing;
-
-    const pending = Promise.resolve().then(() => summarizer(input));
-    this.inFlightHistorySummaries.set(fingerprint, pending);
+    let shared = this.inFlightHistorySummaries.get(fingerprint);
+    if (!shared) {
+      const abortController = new AbortController();
+      const pending = Promise.resolve().then(() =>
+        summarizer({ ...input, abortSignal: abortController.signal }),
+      );
+      shared = { abortController, consumers: new Set(), promise: pending };
+      this.inFlightHistorySummaries.set(fingerprint, shared);
+      void pending.then(
+        () => this.removeInFlightHistorySummary(fingerprint, shared!),
+        () => this.removeInFlightHistorySummary(fingerprint, shared!),
+      );
+    }
+    const consumer = Symbol('history-summary-consumer');
+    shared.consumers.add(consumer);
     try {
-      return await pending;
+      // A rider must be able to stop waiting without aborting the physical
+      // call for other consumers. The shared controller is aborted only when
+      // every consumer has detached.
+      return await waitForAbortablePromise(shared.promise, input.abortSignal);
     } catch (error) {
       if (
         error instanceof HistoryCompactSummarizerError &&
@@ -573,9 +589,19 @@ export class AiSdkCompaction {
       }
       throw error;
     } finally {
-      if (this.inFlightHistorySummaries.get(fingerprint) === pending) {
-        this.inFlightHistorySummaries.delete(fingerprint);
+      shared.consumers.delete(consumer);
+      if (
+        shared.consumers.size === 0 &&
+        this.inFlightHistorySummaries.get(fingerprint) === shared
+      ) {
+        shared.abortController.abort();
       }
+    }
+  }
+
+  private removeInFlightHistorySummary(fingerprint: string, shared: InFlightHistorySummary): void {
+    if (this.inFlightHistorySummaries.get(fingerprint) === shared) {
+      this.inFlightHistorySummaries.delete(fingerprint);
     }
   }
 
@@ -1685,6 +1711,40 @@ function waitForQueueProgressOrAbort(
     };
     abortSignal?.addEventListener('abort', settle, { once: true });
     void queue.waitForProgress().then(settle);
+  });
+}
+
+/** Let an individual compaction stop waiting without cancelling shared work. */
+function waitForAbortablePromise<T>(
+  promise: Promise<T>,
+  abortSignal?: AbortSignal,
+): Promise<T | undefined> {
+  if (!abortSignal) return promise;
+  if (abortSignal.aborted) return Promise.resolve(undefined);
+  return new Promise<T | undefined>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => abortSignal.removeEventListener('abort', onAbort);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(undefined);
+    };
+    abortSignal.addEventListener('abort', onAbort, { once: true });
+    void promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
   });
 }
 

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -1175,10 +1175,7 @@ export class AiSdkCompaction {
             ...(input.origin.runId ? { runId: input.origin.runId } : {}),
             source: {
               foldedRuntimeEvents: [...coveredRuntimeEvents],
-              invocations: invocationsForFoldedEvents(
-                state.priorInvocations,
-                coveredRuntimeEvents,
-              ),
+              invocations: invocationsForFoldedEvents(state.priorInvocations, coveredRuntimeEvents),
             },
             ...(previousCheckpoint ? { previousCheckpoint } : {}),
             newlyFoldedRuntimeEvents: [...newlyFoldedRuntimeEvents],

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -211,6 +211,18 @@ export class AiSdkCompaction {
   private readonly canReplayProviderNative: (plan: RuntimeEventModelReplayPlan) => boolean;
   private historyCompactAbortController: AbortController | null = null;
   /**
+   * Exact duplicate compaction requests share one physical summarizer call.
+   * Automatic capacity checks and explicit/manual entry can converge while a
+   * checkpoint is still being written; dispatching both would race the same
+   * source prefix and charge the provider twice. The key is derived from the
+   * source/configuration rather than the issuing turn id so callers that are
+   * otherwise asking for the same fold share the result.
+   */
+  private readonly inFlightHistoryCompactions = new Map<
+    string,
+    Promise<AiSdkCompactHistoryResult>
+  >();
+  /**
    * Session-scoped circuit for exact malformed compaction inputs. A retry or
    * regeneration on the same backend must not dispatch the same doomed call;
    * changed source/configuration fingerprints remain eligible.
@@ -284,7 +296,25 @@ export class AiSdkCompaction {
     this.historyCompactAbortController?.abort();
   }
 
-  public async compactHistory(
+  public compactHistory(
+    input: Omit<BackendCompactHistoryInput, 'runId'> & { runId: string | undefined },
+    automaticMemoryBoundary?: HistoryCompactMemoryExtractionBoundary,
+  ): Promise<AiSdkCompactHistoryResult> {
+    const key = historyCompactRequestKey(input);
+    const existing = this.inFlightHistoryCompactions.get(key);
+    if (existing) return existing;
+    const pending = this.compactHistoryOnce(input, automaticMemoryBoundary);
+    this.inFlightHistoryCompactions.set(key, pending);
+    const clear = () => {
+      if (this.inFlightHistoryCompactions.get(key) === pending) {
+        this.inFlightHistoryCompactions.delete(key);
+      }
+    };
+    void pending.then(clear, clear);
+    return pending;
+  }
+
+  private async compactHistoryOnce(
     input: Omit<BackendCompactHistoryInput, 'runId'> & { runId: string | undefined },
     automaticMemoryBoundary?: HistoryCompactMemoryExtractionBoundary,
   ): Promise<AiSdkCompactHistoryResult> {
@@ -1380,6 +1410,17 @@ function projectAcceptedMidTurnCompactionMessages(
 
 function sha256(text: string): string {
   return createHash('sha256').update(text).digest('hex');
+}
+
+function historyCompactRequestKey(
+  input: Omit<BackendCompactHistoryInput, 'runId'> & { runId: string | undefined },
+): string {
+  return sha256(
+    stableStringifyForSignature({
+      runtimeContext: input.runtimeContext,
+      runtimeContextRunHeaders: input.runtimeContextRunHeaders ?? [],
+    }),
+  );
 }
 
 function modelMessageSignature(message: ModelMessage): string {

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -300,7 +300,7 @@ export class AiSdkCompaction {
     input: Omit<BackendCompactHistoryInput, 'runId'> & { runId: string | undefined },
     automaticMemoryBoundary?: HistoryCompactMemoryExtractionBoundary,
   ): Promise<AiSdkCompactHistoryResult> {
-    const key = historyCompactRequestKey(input);
+    const key = historyCompactRequestKey(input, automaticMemoryBoundary);
     const existing = this.inFlightHistoryCompactions.get(key);
     if (existing) return existing;
     const pending = this.compactHistoryOnce(input, automaticMemoryBoundary);
@@ -1414,11 +1414,19 @@ function sha256(text: string): string {
 
 function historyCompactRequestKey(
   input: Omit<BackendCompactHistoryInput, 'runId'> & { runId: string | undefined },
+  automaticMemoryBoundary: HistoryCompactMemoryExtractionBoundary | undefined,
 ): string {
+  const runtimeContext = input.runtimeContext
+    .filter((event) => event.turnId !== input.turnId)
+    .filter(isHistoryCompactContentEvent);
+  const sourceRunIds = new Set(runtimeContext.map((event) => event.runId));
   return sha256(
     stableStringifyForSignature({
-      runtimeContext: input.runtimeContext,
-      runtimeContextRunHeaders: input.runtimeContextRunHeaders ?? [],
+      runtimeContext,
+      runtimeContextRunHeaders: (input.runtimeContextRunHeaders ?? []).filter((header) =>
+        sourceRunIds.has(header.runId),
+      ),
+      automaticMemoryBoundary,
     }),
   );
 }

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -408,10 +408,9 @@ export class AiSdkCompaction {
                 foldedRuntimeEvents: [...coveredRuntimeEvents],
                 ...(input.runtimeContextInvocations
                   ? {
-                      invocations: input.runtimeContextInvocations.filter((invocation) =>
-                        coveredRuntimeEvents.some(
-                          (event) => event.invocationId === invocation.invocationId,
-                        ),
+                      invocations: invocationsForFoldedEvents(
+                        input.runtimeContextInvocations,
+                        coveredRuntimeEvents,
                       ),
                     }
                   : {}),
@@ -512,10 +511,8 @@ export class AiSdkCompaction {
       memoryExtractionBoundary?: HistoryCompactMemoryExtractionBoundary;
     },
   ): Promise<string | HistoryCompactProviderState | undefined> {
-    const foldedRunIds = new Set(input.source.foldedRuntimeEvents.map((event) => event.runId));
     const sourceRunRoutes = input.source.invocations
-      ?.filter((invocation) => foldedRunIds.has(invocation.runId))
-      .map((invocation) => {
+      ?.map((invocation) => {
         const route = invocation.opening.route;
         return {
           runId: invocation.runId,
@@ -1178,7 +1175,10 @@ export class AiSdkCompaction {
             ...(input.origin.runId ? { runId: input.origin.runId } : {}),
             source: {
               foldedRuntimeEvents: [...coveredRuntimeEvents],
-              invocations: state.priorInvocations,
+              invocations: invocationsForFoldedEvents(
+                state.priorInvocations,
+                coveredRuntimeEvents,
+              ),
             },
             ...(previousCheckpoint ? { previousCheckpoint } : {}),
             newlyFoldedRuntimeEvents: [...newlyFoldedRuntimeEvents],
@@ -1739,6 +1739,14 @@ function waitForAbortablePromise<T>(
       },
     );
   });
+}
+
+function invocationsForFoldedEvents(
+  invocations: readonly RuntimeInvocationRecord[],
+  foldedRuntimeEvents: readonly RuntimeEvent[],
+): RuntimeInvocationRecord[] {
+  const foldedInvocationIds = new Set(foldedRuntimeEvents.map((event) => event.invocationId));
+  return invocations.filter((invocation) => foldedInvocationIds.has(invocation.invocationId));
 }
 
 export function hasBlockingReplayDiagnostics(plan: RuntimeEventModelReplayPlan): boolean {

--- a/packages/runtime/src/history-compact-checkpoint-coordinator.ts
+++ b/packages/runtime/src/history-compact-checkpoint-coordinator.ts
@@ -177,6 +177,7 @@ function hasSameEffectiveCoverage(
       checkpointId: _checkpointId,
       createdAt: _createdAt,
       highWaterSeq: _highWaterSeq,
+      previousCheckpointId: _previousCheckpointId,
       ...rest
     } = checkpoint;
     return JSON.stringify(rest);

--- a/packages/runtime/src/history-compact-checkpoint-coordinator.ts
+++ b/packages/runtime/src/history-compact-checkpoint-coordinator.ts
@@ -90,9 +90,17 @@ export class HistoryCompactCheckpointCoordinator {
       .catch(() => {})
       .then(async () => {
         const durableCheckpoint = await this.load(sessionId);
-        if (!canReplaceHistoryCompactCheckpoint(durableCheckpoint, checkpoint)) {
+        const sameEffectiveCheckpoint = hasSameEffectiveCoverage(durableCheckpoint, checkpoint);
+        if (
+          !sameEffectiveCheckpoint &&
+          !canReplaceHistoryCompactCheckpoint(durableCheckpoint, checkpoint)
+        ) {
           throw new Error('History compact checkpoint was superseded before persistence');
         }
+        // A concurrent caller may have received the same effective checkpoint
+        // from the summarizer coalescer. Keep its run-local ledger event too so
+        // the rider Turn retains provenance even though the session checkpoint
+        // itself is already current.
         await run.recordHistoryCompactCheckpoint(checkpoint);
         this.checkpoints.set(sessionId, checkpoint);
         this.scheduleCleanup(sessionId, checkpoint);
@@ -154,4 +162,36 @@ export class HistoryCompactCheckpointCoordinator {
       });
     this.cleanups.set(sessionId, tracked);
   }
+}
+
+function hasSameEffectiveCoverage(
+  current: HistoryCompactCheckpoint | undefined,
+  candidate: HistoryCompactCheckpoint,
+): boolean {
+  if (!current) return false;
+  const currentContent = checkpointContent(current);
+  const candidateContent = checkpointContent(candidate);
+  return (
+    current.sessionId === candidate.sessionId &&
+    current.version === candidate.version &&
+    current.highWaterName === candidate.highWaterName &&
+    current.phase === candidate.phase &&
+    current.coverage.eventCount === candidate.coverage.eventCount &&
+    current.coverage.turnCount === candidate.coverage.turnCount &&
+    current.coverage.sourceDigest === candidate.coverage.sourceDigest &&
+    current.coverage.through.runId === candidate.coverage.through.runId &&
+    current.coverage.through.turnId === candidate.coverage.through.turnId &&
+    current.coverage.through.runtimeEventId === candidate.coverage.through.runtimeEventId &&
+    JSON.stringify(current.source) === JSON.stringify(candidate.source) &&
+    JSON.stringify(current.headAnchor) === JSON.stringify(candidate.headAnchor) &&
+    JSON.stringify(current.memoryExtractionBoundary) ===
+      JSON.stringify(candidate.memoryExtractionBoundary) &&
+    JSON.stringify(currentContent) === JSON.stringify(candidateContent)
+  );
+}
+
+function checkpointContent(checkpoint: HistoryCompactCheckpoint): unknown {
+  return checkpoint.version === 2
+    ? { summary: checkpoint.summary, summaryFormat: checkpoint.summaryFormat }
+    : { providerState: checkpoint.providerState };
 }

--- a/packages/runtime/src/history-compact-checkpoint-coordinator.ts
+++ b/packages/runtime/src/history-compact-checkpoint-coordinator.ts
@@ -101,9 +101,12 @@ export class HistoryCompactCheckpointCoordinator {
         // from the summarizer coalescer. Keep its run-local ledger event too so
         // the rider Turn retains provenance even though the session checkpoint
         // itself is already current.
-        await run.recordHistoryCompactCheckpoint(checkpoint);
-        this.checkpoints.set(sessionId, checkpoint);
-        this.scheduleCleanup(sessionId, checkpoint);
+        const checkpointToRecord = sameEffectiveCheckpoint ? durableCheckpoint! : checkpoint;
+        await run.recordHistoryCompactCheckpoint(checkpointToRecord);
+        if (!sameEffectiveCheckpoint) {
+          this.checkpoints.set(sessionId, checkpoint);
+          this.scheduleCleanup(sessionId, checkpoint);
+        }
       })
       .finally(() => {
         if (this.writes.get(sessionId) === tracked) {
@@ -169,29 +172,14 @@ function hasSameEffectiveCoverage(
   candidate: HistoryCompactCheckpoint,
 ): boolean {
   if (!current) return false;
-  const currentContent = checkpointContent(current);
-  const candidateContent = checkpointContent(candidate);
-  return (
-    current.sessionId === candidate.sessionId &&
-    current.version === candidate.version &&
-    current.highWaterName === candidate.highWaterName &&
-    current.phase === candidate.phase &&
-    current.coverage.eventCount === candidate.coverage.eventCount &&
-    current.coverage.turnCount === candidate.coverage.turnCount &&
-    current.coverage.sourceDigest === candidate.coverage.sourceDigest &&
-    current.coverage.through.runId === candidate.coverage.through.runId &&
-    current.coverage.through.turnId === candidate.coverage.through.turnId &&
-    current.coverage.through.runtimeEventId === candidate.coverage.through.runtimeEventId &&
-    JSON.stringify(current.source) === JSON.stringify(candidate.source) &&
-    JSON.stringify(current.headAnchor) === JSON.stringify(candidate.headAnchor) &&
-    JSON.stringify(current.memoryExtractionBoundary) ===
-      JSON.stringify(candidate.memoryExtractionBoundary) &&
-    JSON.stringify(currentContent) === JSON.stringify(candidateContent)
-  );
-}
-
-function checkpointContent(checkpoint: HistoryCompactCheckpoint): unknown {
-  return checkpoint.version === 2
-    ? { summary: checkpoint.summary, summaryFormat: checkpoint.summaryFormat }
-    : { providerState: checkpoint.providerState };
+  const stable = (checkpoint: HistoryCompactCheckpoint): string => {
+    const {
+      checkpointId: _checkpointId,
+      createdAt: _createdAt,
+      highWaterSeq: _highWaterSeq,
+      ...rest
+    } = checkpoint;
+    return JSON.stringify(rest);
+  };
+  return stable(current) === stable(candidate);
 }


### PR DESCRIPTION
## Summary
- coalesce identical concurrent history compaction requests at the effective-history summarizer/provider-call boundary
- preserve per-turn checkpoint and ledger attribution while sharing one physical summarizer call
- scope coalescing by checkpoint intent (phase, mid-turn head anchor, and Memory extraction boundary) so semantically different checkpoint writes do not share a result
- keep the existing context-budget high-water trigger, provider overflow recovery, and fail-open/no-op behavior

## Verification
- rebased current head onto `apache/main` (`19ac204ab`) and resolved the compaction contract changes
- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/ai-sdk-backend.test.js` — 222 passed
- Runtime Host execution-model composition tests — 28/28 passed, including native-compaction rejection and text-checkpoint fallback
- `npm exec -- biome check packages/runtime/src/ai-sdk-compaction.ts packages/runtime/src/history-compact-checkpoint-coordinator.ts packages/runtime/src/__tests__/ai-sdk-backend.test.ts` — passed
- The CI-discovered run-routing regression in shared compaction was fixed by retaining invocation routing by durable `runId`; the exact failed Host test and both affected suites now pass locally.

Refs #4360