### PR TITLE
fix(desktop): 既有会话发送不再报告已解析会话 (onSessionResolved 契约)

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -352,7 +352,7 @@
           "@maka/ui": 1
         },
         "importSpecifiers": 39,
-        "nonTriviaTokens": 4275
+        "nonTriviaTokens": 4292
       },
       "src/renderer/app-shell-chrome-actions.tsx": {
         "importDeclarations": 5,

--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -352,7 +352,7 @@
           "@maka/ui": 1
         },
         "importSpecifiers": 39,
-        "nonTriviaTokens": 4278
+        "nonTriviaTokens": 4275
       },
       "src/renderer/app-shell-chrome-actions.tsx": {
         "importDeclarations": 5,

--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -352,7 +352,7 @@
           "@maka/ui": 1
         },
         "importSpecifiers": 39,
-        "nonTriviaTokens": 4292
+        "nonTriviaTokens": 4278
       },
       "src/renderer/app-shell-chrome-actions.tsx": {
         "importDeclarations": 5,

--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -352,7 +352,7 @@
           "@maka/ui": 1
         },
         "importSpecifiers": 39,
-        "nonTriviaTokens": 4278
+        "nonTriviaTokens": 4089
       },
       "src/renderer/app-shell-chrome-actions.tsx": {
         "importDeclarations": 5,

--- a/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
@@ -458,6 +458,46 @@ describe('composer first-send cleanup', () => {
     assert.equal(resolved, 0);
   });
 
+  it('does not report a resolved Session when the first send is outcome_unknown', async () => {
+    // `onSessionResolved` is the contract for a Session this send created AND
+    // whose first message projected. `outcome_unknown` maps to `unreconciled`:
+    // `send()` intentionally returns `true` (the Message may well have been
+    // admitted), but the callback must not fire — a consumer binding follow-up
+    // state to a newly resolved Session (e.g. a Work Board start claim) would
+    // otherwise bind to a Session whose first message was never confirmed.
+    let resolved = 0;
+    const removed: string[] = [];
+    const restoreWindow = installWindow({
+      newTasks: { create: async () => ({ id: 'session-1' }) },
+      sessions: {
+        submitMessage: async () => ({
+          ok: false,
+          reason: 'outcome_unknown' as const,
+        }),
+        remove: async (sessionId: string) => {
+          removed.push(sessionId);
+        },
+      },
+    });
+
+    try {
+      const actions = createAppShellChatActions(createActionsDeps());
+      const result = await actions.send('hello', undefined, {
+        onSessionResolved: () => {
+          resolved += 1;
+        },
+      });
+      // The row stays for canonical transcript to settle, so the session is
+      // kept and the send reports success — only the callback is silenced.
+      assert.equal(result, true);
+      assert.deepEqual(removed, []);
+    } finally {
+      restoreWindow();
+    }
+
+    assert.equal(resolved, 0);
+  });
+
   it('returns a sparse existing session to latest before sending', async () => {
     const latest = deferred<void>();
     const order: string[] = [];

--- a/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
@@ -423,6 +423,41 @@ describe('composer first-send cleanup', () => {
     assert.deepEqual(removed, []);
   });
 
+  it('does not report a resolved Session from an existing-Session send', async () => {
+    // `onSessionResolved` is the contract for a Session this send created and
+    // whose first message projected (the new-Session branch). An existing-
+    // Session send must never fire it, or a consumer binding follow-up state
+    // to a newly resolved Session (e.g. a Work Board start claim) would bind
+    // it to an unrelated pre-existing conversation.
+    let resolved = 0;
+    const restoreWindow = installWindow({
+      sessions: {
+        submitMessage: async () => ({
+          ok: true,
+          attachments: [],
+          skillInvocation: { loaded: [], failed: [] },
+        }),
+      },
+    });
+
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef: { current: 'existing-session' },
+      });
+      const result = await actions.send('hello', undefined, {
+        onSessionResolved: () => {
+          resolved += 1;
+        },
+      });
+      assert.equal(result, true);
+    } finally {
+      restoreWindow();
+    }
+
+    assert.equal(resolved, 0);
+  });
+
   it('returns a sparse existing session to latest before sending', async () => {
     const latest = deferred<void>();
     const order: string[] = [];

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -612,7 +612,11 @@ export function createAppShellChatActions(deps: {
       });
       if (submitted.kind === 'refused') return false;
       if (submitted.kind === 'unreconciled') return true;
-      options.onSessionResolved?.(sessionId);
+      // `onSessionResolved` is the contract for a Session this send CREATED
+      // and whose first message projected (the new-Session branch above). An
+      // existing-Session send must never report it, or a consumer that binds
+      // follow-up state to a newly resolved Session would bind it to an
+      // unrelated pre-existing conversation.
       return true;
     } catch (error) {
       // Capture ownership before cleanup clears the optimistic Session. A

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -454,6 +454,41 @@ export function createAppShellChatActions(deps: {
     };
     try {
       const messageId = crypto.randomUUID();
+      async function submitIntoSession(sessionId: string, messageId: string) {
+        if (exactTurn) armTurnActive(sessionId, messageId);
+        const attachmentItems =
+          pending && pending.length > 0
+            ? toComposerIngestItems(pending)
+            : undefined;
+        const retainedAttachments =
+          pending && pending.length > 0
+            ? retainedAttachmentRefs(pending)
+            : undefined;
+        const sendCommand = {
+          text,
+          ...(options.displayText ? { displayText: options.displayText } : {}),
+          ...copiedArray('attachmentItems', attachmentItems),
+          ...(retainedAttachments && retainedAttachments.length > 0
+            ? { retainedAttachments }
+            : {}),
+          ...copiedArray('directoryReferences', directoryReferences),
+          ...copiedArray('quotes', quotes),
+          ...copiedArray('workspaceFileReferences', options.workspaceFileReferences),
+        };
+        return submitAndProject({
+          sessionId,
+          messageId,
+          placement: 'current_turn',
+          command: {
+            ...sendCommand,
+            ...(options.turnOrchestration ? { turnOrchestration: options.turnOrchestration } : {}),
+          },
+          ...(options.displayText ? { displayText: options.displayText } : {}),
+          ...copiedArray('quotes', quotes),
+          exactTurn,
+          isSurfaceVisible: () => activeIdRef.current === sessionId,
+        });
+      }
       if (!initialSessionId) {
         if (!initialNewTaskTarget) return false;
         if (pending && pending.length > 0) preflightAttachmentItems(pending, uiLocale);
@@ -502,46 +537,14 @@ export function createAppShellChatActions(deps: {
           await discardUnsentSession();
           return false;
         }
-        if (exactTurn) armTurnActive(session.id, messageId);
-        const attachmentItems =
-          pending && pending.length > 0
-            ? toComposerIngestItems(pending)
-            : undefined;
-        const retainedAttachments =
-          pending && pending.length > 0
-            ? retainedAttachmentRefs(pending)
-            : undefined;
-        const sendCommand = {
-          text,
-          ...(options.displayText ? { displayText: options.displayText } : {}),
-          ...copiedArray('attachmentItems', attachmentItems),
-          ...(retainedAttachments && retainedAttachments.length > 0
-            ? { retainedAttachments }
-            : {}),
-          ...copiedArray('directoryReferences', directoryReferences),
-          ...copiedArray('quotes', quotes),
-          ...copiedArray('workspaceFileReferences', options.workspaceFileReferences),
-        };
-        const submitted = await submitAndProject({
-          sessionId: session.id,
-          messageId,
-          placement: 'current_turn',
-          command: {
-            ...sendCommand,
-            ...(options.turnOrchestration
-              ? { turnOrchestration: options.turnOrchestration }
-              : {}),
-          },
-          ...(options.displayText ? { displayText: options.displayText } : {}),
-          ...copiedArray('quotes', quotes),
-          exactTurn,
-          isSurfaceVisible: () => activeIdRef.current === session.id,
-        });
+        const submitted = await submitIntoSession(session.id, messageId);
         if (submitted.kind === 'refused') {
           await discardUnsentSession();
           return false;
         }
         unsentSessionId = undefined;
+        // The callback fires only when this send's first message projected;
+        // an unreconciled first message stays unreported.
         if (submitted.kind === 'projected') options.onSessionResolved?.(session.id);
         await refreshSessions();
         return true;
@@ -577,41 +580,9 @@ export function createAppShellChatActions(deps: {
           inlineReferences: [],
         },
       );
-      if (exactTurn) armTurnActive(sessionId, messageId);
-      const attachmentItems =
-        pending && pending.length > 0
-          ? toComposerIngestItems(pending)
-          : undefined;
-      const retainedAttachments =
-        pending && pending.length > 0
-          ? retainedAttachmentRefs(pending)
-          : undefined;
-      const sendCommand = {
-        text,
-        ...(options.displayText ? { displayText: options.displayText } : {}),
-        ...copiedArray('attachmentItems', attachmentItems),
-        ...(retainedAttachments && retainedAttachments.length > 0
-          ? { retainedAttachments }
-          : {}),
-        ...copiedArray('directoryReferences', directoryReferences),
-        ...copiedArray('quotes', quotes),
-        ...copiedArray('workspaceFileReferences', options.workspaceFileReferences),
-      };
-      const submitted = await submitAndProject({
-        sessionId,
-        messageId,
-        placement: 'current_turn',
-        command: {
-          ...sendCommand,
-          ...(options.turnOrchestration ? { turnOrchestration: options.turnOrchestration } : {}),
-        },
-        ...(options.displayText ? { displayText: options.displayText } : {}),
-        ...copiedArray('quotes', quotes),
-        exactTurn,
-        isSurfaceVisible: () => activeIdRef.current === sessionId,
-      });
+      const submitted = await submitIntoSession(sessionId, messageId);
       if (submitted.kind === 'refused') return false;
-      if (submitted.kind === 'unreconciled') return true;
+      // An existing-Session send never reports a resolved Session.
       return true;
     } catch (error) {
       // Capture ownership before cleanup clears the optimistic Session. A

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -542,7 +542,14 @@ export function createAppShellChatActions(deps: {
           return false;
         }
         unsentSessionId = undefined;
-        options.onSessionResolved?.(session.id);
+        // The callback only fires when this send's first message actually
+        // projected. `unreconciled` (outcome_unknown) may well have been
+        // admitted, but nothing proves it — reporting it would bind a consumer
+        // to a Session whose first message was never confirmed as projected,
+        // and the caller cannot correct that after `send()` returns `true`.
+        if (submitted.kind === 'projected') {
+          options.onSessionResolved?.(session.id);
+        }
         await refreshSessions();
         return true;
       }
@@ -616,7 +623,9 @@ export function createAppShellChatActions(deps: {
       // and whose first message projected (the new-Session branch above). An
       // existing-Session send must never report it, or a consumer that binds
       // follow-up state to a newly resolved Session would bind it to an
-      // unrelated pre-existing conversation.
+      // unrelated pre-existing conversation. An `unreconciled` first send is
+      // also excluded: `send()` reports it as `true`, but the callback never
+      // fires because the message was never confirmed as projected.
       return true;
     } catch (error) {
       // Capture ownership before cleanup clears the optimistic Session. A

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -542,14 +542,7 @@ export function createAppShellChatActions(deps: {
           return false;
         }
         unsentSessionId = undefined;
-        // The callback only fires when this send's first message actually
-        // projected. `unreconciled` (outcome_unknown) may well have been
-        // admitted, but nothing proves it — reporting it would bind a consumer
-        // to a Session whose first message was never confirmed as projected,
-        // and the caller cannot correct that after `send()` returns `true`.
-        if (submitted.kind === 'projected') {
-          options.onSessionResolved?.(session.id);
-        }
+        if (submitted.kind === 'projected') options.onSessionResolved?.(session.id);
         await refreshSessions();
         return true;
       }
@@ -619,13 +612,6 @@ export function createAppShellChatActions(deps: {
       });
       if (submitted.kind === 'refused') return false;
       if (submitted.kind === 'unreconciled') return true;
-      // `onSessionResolved` is the contract for a Session this send CREATED
-      // and whose first message projected (the new-Session branch above). An
-      // existing-Session send must never report it, or a consumer that binds
-      // follow-up state to a newly resolved Session would bind it to an
-      // unrelated pre-existing conversation. An `unreconciled` first send is
-      // also excluded: `send()` reports it as `true`, but the callback never
-      // fires because the message was never confirmed as projected.
       return true;
     } catch (error) {
       // Capture ownership before cleanup clears the optimistic Session. A


### PR DESCRIPTION
## 问题

`createAppShellChatActions.send()` 的既有会话分支**无条件**调用 `options.onSessionResolved?.(sessionId)`：

- 新会话分支（`initialSessionId` 为空时）仅在 `submitted.kind === 'projected'` 时触发——这是回调的**契约**：它只应报告"本次发送**新建**、且首条消息成功投射的会话"。
- 既有会话分支（`initialSessionId` 非空）无条件触发，语义错误。

当前 `main` 上该回调尚无任何调用方（死代码），所以无行为影响。但 #4598 一旦接入 start-task（把 `onSessionResolved` 注入为 `workBoard.linkSession` 的触发点），无条件调用会把 Work Board 条目误链接到**无关的既有会话**。

## 修复

移除既有会话分支对 `onSessionResolved` 的无条件调用，并用注释明确该回调的契约。新会话分支行为不变。

## 测试

新增回归测试：既有会话（`activeIdRef.current` 已设置）projected 发送**不**触发 `onSessionResolved`。

## 验证

- desktop main 全量 1984/1984 通过
- `tsc -p tsconfig.main.json` 0 error · biome lint clean · `git diff --check` clean

## 说明

这是 C1（跨会话误消费）的**根本修复**，独立于 #4598 提交，可直接合入 `main`。它把 `onSessionResolved` 的语义钉死在"新建会话首条消息投射"上，使 #4598 或任何后续消费方不会被错误绑定。剩余依赖 feature 的清理（start-task claim 的取消路径与编排测试）在 #4598 上另行处理。
