### PR TITLE
test(desktop): deselect-proof the code-scroll selection drag

### DIFF
--- a/apps/desktop/e2e/code-scroll.spec.ts
+++ b/apps/desktop/e2e/code-scroll.spec.ts
@@ -100,12 +100,20 @@ test('a one-line Markdown code block exposes native and selection horizontal scr
     (element as HTMLElement).scrollLeft = 0;
     window.getSelection()?.removeAllRanges();
   });
-  const code = viewport.locator('code');
-  const codeBox = await code.boundingBox();
-  if (!codeBox) throw new Error('code line has no visible bounds');
-  const textY = codeBox.y + Math.min(codeBox.height / 2, 18);
-  await page.mouse.move(codeBox.x + 24, textY);
+  const line = viewport.locator('code > [data-line]').first();
+  // Font loading reflows the glyphs; measure only after it settles or the
+  // anchor can land outside the text and no selection ever forms.
+  await page.evaluate(() => document.fonts.ready.then(() => undefined));
+  const lineBox = await line.boundingBox();
+  if (!lineBox) throw new Error('code line has no visible bounds');
+  const textY = lineBox.y + Math.min(lineBox.height / 2, 18);
+  await page.mouse.move(lineBox.x + 24, textY);
   await page.mouse.down();
+  // Prove the selection anchored before the long auto-scroll drag.
+  await page.mouse.move(lineBox.x + 90, textY, { steps: 6 });
+  await expect.poll(
+    () => viewport.evaluate(() => window.getSelection()?.toString().length ?? 0),
+  ).toBeGreaterThan(0);
   await page.mouse.move(metrics.rect.x + metrics.rect.width + 50, textY, { steps: 20 });
   await expect.poll(
     () => viewport.evaluate((element) => (element as HTMLElement).scrollLeft),


### PR DESCRIPTION
## Summary

The code-scroll selection-drag test raced selection anchoring: mousedown on a guessed container offset (`codeBox.x + 24`) sometimes landed outside the glyphs — cold-start font loading reflows the line after the box is measured — so no selection anchor formed and the long drag auto-scrolled without selecting, failing at the end with an opaque zero. The fix makes anchoring observable instead of assumed: measure after `document.fonts.ready`, anchor on the first `[data-line]`, prove the selection exists with a short in-viewport drag, then start the long auto-scroll drag. A future anchoring failure now surfaces at the establishment step with a retry window.

Fixes #4633

## Verification

Before (unpatched, first run after a fresh `build:with-deps`; same failure as CI run 33726683004):

```
Error: expect(received).toBeGreaterThan(expected)
Expected: > 10
Received:   0
Call Log:
- Timeout 10000ms exceeded while waiting on the predicate
```

After (patched, five consecutive runs including the cold one):

```
1 passed (7.9s)
1 passed (7.4s)
1 passed (7.7s)
1 passed (7.3s)
1 passed (7.3s)
```

Anchor-position mechanism confirmed by counter-experiment: anchoring at `x + 2` (leading whitespace) fails 4/5 runs.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — diagnosis, patch, and this description, under the contributor's direction; the commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it