### PR TITLE
fix(runtime-host): recover approved Guest regeneration

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-local-operator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-local-operator.test.ts
@@ -185,6 +185,7 @@ test('local update runs the selected package against the exact managed deploymen
         deploymentId,
       },
       expectedHost: { hostEpoch: 'older-host', pid: 42 },
+      allowManualUpdate: true,
     },
     (phase) => phases.push(phase),
   );
@@ -200,12 +201,48 @@ test('local update runs the selected package against the exact managed deploymen
     '--expected-root-path', '/tmp/maka/root',
     '--expected-root-id', 'a'.repeat(64),
     '--expected-deployment-id', deploymentId,
+    '--allow-manual-update',
   ]);
   assert.equal(
     environment?.[RUNTIME_HOST_OPERATOR_PROJECT_DIRECTORY_CONFIGURATION_REQUEST_ENV],
     '1',
   );
   assert.deepEqual(phases, ['staging']);
+
+  const developmentIntegrity = `sha512-${Buffer.alloc(64, 9).toString('base64')}`;
+  await operator.runUpdate(
+    {
+      setupPackage: {
+        kind: 'development_archive',
+        path: '/tmp/maka-agent-development.tgz',
+        integrity: developmentIntegrity,
+      },
+      target: {
+        serviceId: 'a'.repeat(64),
+        rootPath: '/tmp/maka/root',
+        rootId: 'a'.repeat(64),
+        deploymentId,
+      },
+      allowManualUpdate: true,
+      allowInterruptActiveTasks: true,
+    },
+    () => undefined,
+  );
+
+  assert.deepEqual(args, [
+    'exec', '--yes', '--package', '/tmp/maka-agent-development.tgz', '--',
+    'maka', 'runtime-host', 'service', 'update', '--framed',
+    '--managed-root-id', 'a'.repeat(64),
+    '--expected-service-id', 'a'.repeat(64),
+    '--expected-root-path', '/tmp/maka/root',
+    '--expected-root-id', 'a'.repeat(64),
+    '--expected-deployment-id', deploymentId,
+    '--allow-interrupt-active-tasks',
+  ]);
+  assert.equal(
+    environment?.[RUNTIME_HOST_SETUP_SOURCE_PACKAGE_INTEGRITY_ENV],
+    developmentIntegrity,
+  );
 });
 
 test('local Peer Mesh join keeps invitations off argv and accepts bounded large results', async (t) => {

--- a/apps/desktop/src/main/runtime-host-local-operator.ts
+++ b/apps/desktop/src/main/runtime-host-local-operator.ts
@@ -425,7 +425,7 @@ export function createDesktopRuntimeHostLocalOperator(input: {
               ? ['--expected-host-json', JSON.stringify(command.expectedHost)]
               : []),
             ...managedTargetArgs(command.target),
-            ...(command.allowManualUpdate ? ['--allow-manual-update'] : []),
+            ...(command.allowManualUpdate && targetVersion ? ['--allow-manual-update'] : []),
             ...(command.allowInterruptActiveTasks ? ['--allow-interrupt-active-tasks'] : []),
           ],
         },

--- a/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
@@ -31,7 +31,10 @@ import {
   type RuntimeHostManagedDeploymentConfig,
   type RuntimeHostSupervisorProvider,
 } from '@maka/runtime-host/operator';
-import type { connectExistingRuntimeHost } from '@maka/runtime-host/client';
+import {
+  RuntimeHostOperationError,
+  type connectExistingRuntimeHost,
+} from '@maka/runtime-host/client';
 import { resolveStorageRoot, tryAcquireStateRootOwner } from '@maka/storage/root-authority';
 import type {
   RuntimeHostLifecycleProvider,
@@ -531,6 +534,80 @@ test('does not consume replacement consent after the supervised Host exits', asy
     { code: 'owner_changed' },
   );
   assert.equal(retired, false);
+});
+
+test('requires explicit interruption authority when a supervised Host drains before diagnostics', async (t) => {
+  const stateRoot = await mkdtemp(join(tmpdir(), 'maka-lifecycle-diagnostics-drain-'));
+  t.after(() => rm(stateRoot, { recursive: true, force: true }));
+  const capability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+  let owner: Awaited<ReturnType<typeof tryAcquireStateRootOwner>> =
+    await tryAcquireStateRootOwner(capability);
+  assert.ok(owner);
+  t.after(async () => owner?.close());
+  const events: string[] = [];
+  const connectExisting = (async () => {
+    events.push('connect');
+    return {
+      kind: 'connected',
+      registration: { hostEpoch: 'host-a', pid: 42 },
+      connection: {
+        request: async (operation: string) => {
+          events.push(operation);
+          throw new RuntimeHostOperationError(
+            'host.diagnostics.query',
+            'host_draining',
+            'Runtime Host is draining',
+          );
+        },
+        close: async () => {
+          events.push('close');
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof connectExistingRuntimeHost>>;
+  }) as typeof connectExistingRuntimeHost;
+  const supervisor = {
+    status: async () => {
+      events.push('status');
+      return { active: true, pid: 42 };
+    },
+    retire: async () => {
+      events.push('retire');
+      await owner?.close();
+      owner = undefined;
+    },
+  };
+
+  assert.deepEqual(
+    await retireRuntimeHostLifecycleOwner({
+      rootPath: capability.canonicalPath,
+      rootId: capability.rootId,
+      connectExisting,
+      expectedOwner: { hostEpoch: 'host-a', pid: 42 },
+      supervisor,
+    }),
+    { kind: 'active_tasks' },
+  );
+  const retired = await retireRuntimeHostLifecycleOwner({
+    rootPath: capability.canonicalPath,
+    rootId: capability.rootId,
+    connectExisting,
+    expectedOwner: { hostEpoch: 'host-a', pid: 42 },
+    supervisor,
+    allowInterruptActiveTasks: true,
+  });
+  assert.equal(retired.kind, 'retired');
+  if (retired.kind === 'retired') await retired.owner.close();
+  assert.deepEqual(events, [
+    'connect',
+    'status',
+    'host.diagnostics.query',
+    'close',
+    'connect',
+    'status',
+    'host.diagnostics.query',
+    'retire',
+    'close',
+  ]);
 });
 
 test('requires explicit interruption authority to recover an unreachable supervised transition', async (t) => {

--- a/packages/cli/src/runtime-host-lifecycle-transaction.ts
+++ b/packages/cli/src/runtime-host-lifecycle-transaction.ts
@@ -28,6 +28,8 @@ import {
 import {
   connectExistingRuntimeHost,
   prepareConnectedRuntimeHostRetirement,
+  RuntimeHostOperationError,
+  RuntimeHostRequestInterruptedError,
   waitForRuntimeHostReady,
 } from '@maka/runtime-host/client';
 import { RUNTIME_HOST_PROTOCOL_VERSION } from '@maka/runtime-host/protocol';
@@ -316,6 +318,7 @@ function assertRecoveryTarget(
 export async function retireRuntimeHostLifecycleOwner(input: {
   readonly rootPath: string;
   readonly rootId: string;
+  readonly connectExisting?: typeof connectExistingRuntimeHost;
   readonly allowInterruptActiveTasks?: boolean;
   /**
    * Freshness fence evaluated before a canonical supervised-deployment retirement is admitted.
@@ -357,7 +360,7 @@ export async function retireRuntimeHostLifecycleOwner(input: {
       throw error;
     }
   }
-  const connected = await connectExistingRuntimeHost({
+  const connected = await (input.connectExisting ?? connectExistingRuntimeHost)({
     rootPath: capability.canonicalPath,
     protocol: {
       min: RUNTIME_HOST_PROTOCOL_VERSION,
@@ -384,31 +387,44 @@ export async function retireRuntimeHostLifecycleOwner(input: {
     );
   }
   try {
-    const diagnostics = await connected.connection.request('host.diagnostics.query', {});
     const supervisorStatus = await input.supervisor?.status();
     if (supervisorStatus) assertExpectedSupervisorOwner(input.expectedOwner, supervisorStatus);
     if (
       supervisorStatus &&
-      (!supervisorStatus.active || supervisorStatus.pid !== diagnostics.pid)
+      (!supervisorStatus.active || supervisorStatus.pid !== connected.registration.pid)
     ) {
       throw new RuntimeHostLifecycleTransactionError(
         'transition_failed',
-        'The supervisor and State Root report different Runtime Host processes',
+        'The supervisor and Runtime Host registration report different processes',
       );
     }
-    // The exact Root owner and canonical supervisor now agree while the deployment lock is held.
-    // This admits retirement of that deployment; a later same-deployment restart is not a new
-    // authority, but it must not acquire the Root before the supervisor is retired.
-    const prepared = await prepareConnectedRuntimeHostRetirement(
-      connected.connection,
-      input.allowInterruptActiveTasks ? 'interrupt_active_work' : 'refuse_active_work',
-    );
-    if (prepared.kind === 'active_tasks') return prepared;
-    if (prepared.pid !== diagnostics.pid) {
-      throw new RuntimeHostLifecycleTransactionError(
-        'transition_failed',
-        'The Runtime Host process changed while retirement was prepared',
+    try {
+      const diagnostics = await connected.connection.request('host.diagnostics.query', {});
+      if (diagnostics.pid !== connected.registration.pid) {
+        throw new RuntimeHostLifecycleTransactionError(
+          'transition_failed',
+          'The Runtime Host registration and diagnostics report different processes',
+        );
+      }
+      // The exact Root owner and canonical supervisor now agree while the deployment lock is held.
+      // This admits retirement of that deployment; a later same-deployment restart is not a new
+      // authority, but it must not acquire the Root before the supervisor is retired.
+      const prepared = await prepareConnectedRuntimeHostRetirement(
+        connected.connection,
+        input.allowInterruptActiveTasks ? 'interrupt_active_work' : 'refuse_active_work',
       );
+      if (prepared.kind === 'active_tasks') return prepared;
+      if (prepared.pid !== diagnostics.pid) {
+        throw new RuntimeHostLifecycleTransactionError(
+          'transition_failed',
+          'The Runtime Host process changed while retirement was prepared',
+        );
+      }
+    } catch (error) {
+      if (!isRuntimeHostRetirementUnavailable(error) || !input.supervisor) throw error;
+      if (!input.allowInterruptActiveTasks) return { kind: 'active_tasks' };
+      await input.supervisor.retire();
+      return waitForRuntimeHostLifecycleOwner(capability, input.timeoutMs ?? 45_000);
     }
     const retirement = await waitForRuntimeHostLifecycleOwner(
       capability,
@@ -424,6 +440,14 @@ export async function retireRuntimeHostLifecycleOwner(input: {
   } finally {
     await connected.connection.close().catch(() => undefined);
   }
+}
+
+function isRuntimeHostRetirementUnavailable(error: unknown): boolean {
+  return (
+    error instanceof RuntimeHostRequestInterruptedError ||
+    (error instanceof RuntimeHostOperationError &&
+      (error.code === 'host_not_ready' || error.code === 'host_draining'))
+  );
 }
 
 function assertExpectedRuntimeHostOwner(

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -875,6 +875,64 @@ test('turn.start durably binds a Guest request approval to the admitted Turn', a
   }
 });
 
+test('turn.regenerate durably binds a Guest request approval to the admitted Turn', async () => {
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) =>
+      backends.register('ai-sdk', (context) => new FakeBackend(context)),
+  });
+  const authorization = {
+    kind: 'session_turn_access_request' as const,
+    requestId: 'request-regenerate-1',
+    principalId: 'session_guest:guest-1',
+    grantId: 'grant-1',
+    approvedAt: 1_788_000_000_000,
+    approvedBy: 'local_owner',
+  };
+  const input = {
+    sessionId: fixture.sessionId,
+    sourceTurnId: 'turn-regenerate-source',
+    turnId: 'turn-regenerate-approved',
+  };
+  try {
+    assertStartedTurn(
+      await fixture.interactiveTurns.handlers['turn.start'](
+        {
+          sessionId: fixture.sessionId,
+          turnId: input.sourceTurnId,
+          content: { text: 'Regenerate this approved request.' },
+        },
+        operationContext(fixture.hostEpoch, fixture.acquireResidency),
+      ),
+    );
+    await fixture.coordinator.whenIdle(fixture.sessionId);
+
+    const regenerated = await fixture.interactiveTurns.handlers['turn.regenerate'](input, {
+      ...operationContext(fixture.hostEpoch, fixture.acquireResidency),
+      principal: authorization.principalId,
+      turnAdmissionAuthorization: authorization,
+    });
+    assert.equal(regenerated.ok, true, JSON.stringify(regenerated));
+    const admission = await fixture.stores.agentRunStore.readRootTurnAdmission(
+      fixture.sessionId,
+      input.turnId,
+    );
+    assert.deepEqual(admission?.execution, {
+      kind: 'regenerate',
+      sourceTurnId: input.sourceTurnId,
+    });
+    assert.deepEqual(admission?.authorization, authorization);
+
+    const conflictingRetry = await fixture.interactiveTurns.handlers['turn.regenerate'](
+      input,
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(conflictingRetry.ok, false);
+    if (!conflictingRetry.ok) assert.equal(conflictingRetry.error.code, 'operation_conflict');
+  } finally {
+    await fixture.dispose();
+  }
+});
+
 test('turn.start resolves explicit Skills once before durable admission and replays the result', async () => {
   let preparationCount = 0;
   let blocked = false;

--- a/packages/storage/src/__tests__/regenerate-root-admission.test.ts
+++ b/packages/storage/src/__tests__/regenerate-root-admission.test.ts
@@ -36,6 +36,7 @@ test('regenerate admission durably binds the immutable source Turn', async () =>
       kind: 'regenerate',
       sourceTurnId: 'source-turn',
     });
+    assert.deepEqual(admitted.admission.authorization, input.authorization);
     store.close?.();
 
     const reopened = createSqliteAgentRunStore(root);
@@ -116,6 +117,14 @@ function admissionInput(overrides: Partial<AdmitRootTurnInput> = {}): AdmitRootT
     previousRootTurnId: null,
     normalizedInput: { text: 'Original request' },
     sourceMessages: [],
+    authorization: {
+      kind: 'session_turn_access_request',
+      requestId: 'request-regenerate',
+      principalId: 'session_guest:guest-1',
+      grantId: 'grant-1',
+      approvedAt: 45,
+      approvedBy: 'local_owner',
+    },
     admittedAt: 50,
     ...overrides,
   };

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1897,9 +1897,13 @@ function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
       'Invalid root turn admission contract: Skill invocation requires external message execution',
     );
   }
-  if (admission.authorization && execution.kind !== 'external_message') {
+  if (
+    admission.authorization &&
+    execution.kind !== 'external_message' &&
+    execution.kind !== 'regenerate'
+  ) {
     throw new Error(
-      'Invalid root turn admission contract: authorization proof requires external message execution',
+      'Invalid root turn admission contract: authorization proof requires external message or regenerate execution',
     );
   }
   if (execution.kind === 'claimed_agent_graph_intent') {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Fix approved Session Guest regeneration from crashing the managed Runtime Host and replaying the same pending request on every restart.

The Guest approval is durable authorization for the regenerated root, so the storage contract now accepts that proof for both external messages and regenerations. The coordinator test exercises the real store boundary and verifies that a retry without the same proof conflicts.

This also makes Desktop repair usable after that crash:

- an interrupted `host.upgrade.prepare` is treated as an unknown retirement outcome;
- without explicit interruption authority, repair reports possible active work instead of guessing;
- after the user explicitly authorizes interruption, the exact supervised deployment is retired and the State Root fence is acquired before replacement;
- development archives no longer receive the published-version-only `--allow-manual-update` flag.

No workspace or Session data is migrated or deleted.

## Root cause

PR #4608 began carrying `session_turn_access_request` authorization into `turn.regenerate`, but the durable admission store still rejected authorization on every execution kind except `external_message`. The approval coordinator consequently requested Host drain while leaving the request pending. Startup replay hit the same invariant again, producing the apparent `MANAGED_ROOT_REQUIRES_OPERATOR` loop.

The existing Repair action then had two independent failure paths: it aborted on an interrupted retirement mutation, and a subsequent development-archive repair passed an invalid CLI flag combination.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm --workspace @maka/storage run build` and the regenerate admission test
- `npm --workspace @maka/runtime-host run build` and the approved-regenerate coordinator test
- `npm --workspace @maka/cli run build`
- `npm --workspace @maka/desktop run build:main` and the local-operator test
- `npm --workspace @maka/runtime-host run test:dist`: 1,607 passed, 12 skipped, 0 failed
- `npm run build:test`, then `node scripts/run-workspace-tests-parallel.mjs --concurrency=1`: all workspace tests passed
- Recovered the original damaged macOS development workspace through the real Electron Repair flow: the managed deployment was replaced, the pending approval advanced to `started`, and the Session loaded with its regenerated answer without deleting state

The default concurrent local runner exceeded existing fixed Runtime Host startup deadlines under process contention; the same compiled Runtime Host suite passed in isolation and every workspace passed serially.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the persisted crash loop, implemented the contract and recovery fixes, added focused tests, and exercised the real Electron repair path.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

修复 Session Guest 的“重新生成”请求在批准后导致 managed Runtime Host 崩溃，并在每次启动时反复重放同一条待处理请求的问题。

Guest 审批记录是重新生成这条 root Turn 的持久授权凭据，因此存储契约现在同时允许外部消息和重新生成携带这份凭据。协调器测试会穿过真实存储边界，并确认缺少同一份授权的重试会发生冲突。

同时补齐崩溃后的 Desktop 修复路径：

- `host.upgrade.prepare` 中断时，不猜测这次修改是否已经生效；
- 未经用户明确允许中断时，先提示 Host 可能仍有工作；
- 用户明确确认后，只停止身份匹配的受管部署，并在替换前取得 State Root 所有权；
- 开发归档不再携带只适用于已发布版本选择器的 `--allow-manual-update` 参数。

不会迁移或删除工作区、Session 数据。

## 根因

#4608 开始把 `session_turn_access_request` 授权传给 `turn.regenerate`，但持久化 admission 仍只允许 `external_message` 携带授权。审批协调器因此要求 Host 退出，却把请求留在 pending 状态；下次启动重放后再次撞上同一条不变量，最终表现为 `MANAGED_ROOT_REQUIRES_OPERATOR` 循环。

原来的“修复”操作还有两个独立问题：退休请求在连接中断后直接失败；再次修复开发归档时，又传入了 CLI 不接受的参数组合。

## 验证

- lint、format、typecheck 均通过
- storage、Runtime Host、CLI 与 Desktop 的针对性构建和测试通过
- Runtime Host 全套：1,607 通过，12 跳过，0 失败
- 完整测试构建后串行运行所有 workspace：全部通过
- 直接使用原来已经损坏的 macOS 开发工作区走了一遍真实 Electron 修复流程：managed Host 成功替换，pending 审批进入 `started`，原 Session 和重新生成的回答均可正常加载，未清理任何用户状态

本机并发执行时，已有的 Runtime Host 固定启动时限在进程竞争下被超过；同一份产物隔离运行 Runtime Host 全套和串行运行全部 workspace 均通过。

</details>