### PR TITLE
fix(i18n): require an explicit locale on presentation helpers

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -403,7 +403,7 @@
           "./locales/shell-copy.js": 1
         },
         "importSpecifiers": 1,
-        "nonTriviaTokens": 612
+        "nonTriviaTokens": 610
       },
       "src/renderer/app-shell-copy.ts": {
         "importDeclarations": 2,

--- a/apps/desktop/src/main/__tests__/app-shell-command-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-command-actions.test.ts
@@ -70,17 +70,17 @@ test('targets manual diagnostics to the current task or new-task Host profile', 
 });
 
 test('presents every successful-frame context compaction outcome', () => {
-  assert.deepEqual(contextCompactionNotice({ kind: 'compacted', checkpointId: 'checkpoint-1' }), {
+  assert.deepEqual(contextCompactionNotice({ kind: 'compacted', checkpointId: 'checkpoint-1' }, 'en'), {
     level: 'success',
     title: 'Context compacted',
     description: 'Older context was replaced with a checkpoint summary.',
   });
-  assert.deepEqual(contextCompactionNotice({ kind: 'unchanged', reason: 'already_compacted' }), {
+  assert.deepEqual(contextCompactionNotice({ kind: 'unchanged', reason: 'already_compacted' }, 'en'), {
     level: 'info',
     title: 'Nothing to compact',
     description: 'The task already uses the latest checkpoint.',
   });
-  assert.deepEqual(contextCompactionNotice({ kind: 'failed', reason: 'write_failed' }), {
+  assert.deepEqual(contextCompactionNotice({ kind: 'failed', reason: 'write_failed' }, 'en'), {
     level: 'error',
     title: 'Compaction failed',
     description: 'The task could not be compacted. Try again later.',

--- a/apps/desktop/src/main/__tests__/attachment-preflight.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-preflight.test.ts
@@ -29,19 +29,19 @@ describe('attachment preflight (before session create)', () => {
       size: 100,
       source: { type: 'file' as const, file: { size: 100 } },
     }));
-    assert.throws(() => preflightAttachmentItems(items), /8/);
+    assert.throws(() => preflightAttachmentItems(items, 'zh-CN'), /8/);
   });
 
   test('rejects an oversized File so no empty session is created', () => {
     assert.throws(
-      () => preflightAttachmentItems([{ size: CAP + 1, source: { type: 'file', file: { size: CAP + 1 } } }]),
+      () => preflightAttachmentItems([{ size: CAP + 1, source: { type: 'file', file: { size: CAP + 1 } } }], 'zh-CN'),
       /50MB/,
     );
   });
 
   test('rejects an oversized approval-token attachment by pending size', () => {
     assert.throws(
-      () => preflightAttachmentItems([{ size: CAP + 1, source: { type: 'approval', approvalId: 'a1' } }]),
+      () => preflightAttachmentItems([{ size: CAP + 1, source: { type: 'approval', approvalId: 'a1' } }], 'zh-CN'),
       /50MB/,
     );
   });
@@ -52,8 +52,16 @@ describe('attachment preflight (before session create)', () => {
         preflightAttachmentItems([
           { size: 10, source: { type: 'approval', approvalId: 'dup' } },
           { size: 10, source: { type: 'approval', approvalId: 'dup' } },
-        ]),
+        ], 'zh-CN'),
       /重复/,
+    );
+    assert.throws(
+      () =>
+        preflightAttachmentItems([
+          { size: 10, source: { type: 'approval', approvalId: 'dup' } },
+          { size: 10, source: { type: 'approval', approvalId: 'dup' } },
+        ], 'en'),
+      /already added/,
     );
   });
 
@@ -62,7 +70,7 @@ describe('attachment preflight (before session create)', () => {
       preflightAttachmentItems([
         { size: 100, source: { type: 'approval', approvalId: 'a1' } },
         { size: 100, source: { type: 'file', file: { size: 100 } } },
-      ]),
+      ], 'zh-CN'),
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/conversation-markdown.test.ts
+++ b/apps/desktop/src/main/__tests__/conversation-markdown.test.ts
@@ -58,10 +58,11 @@ describe('renderConversationMarkdown', () => {
         modelId: 'fake',
       },
     ];
-    const md = renderConversationMarkdown('skill session', messages);
+    const md = renderConversationMarkdown('skill session', messages, 'zh-CN');
     assert.match(md, /## 你/);
     assert.ok(md.includes(typed), 'export shows the typed prompt');
     assert.ok(!md.includes('<invoked-skill'), 'export must not include the skill envelope');
     assert.ok(!md.includes('Secret skill body'), 'export must not include skill body');
+    assert.match(renderConversationMarkdown('skill session', messages, 'en'), /## You/);
   });
 });

--- a/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
+++ b/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
@@ -96,7 +96,7 @@ describe('latest interrupted resume candidate', () => {
         content: { kind: 'text', text: 'ok' },
       },
       { type: 'tool_call', id: 'call-2', turnId: 'turn-1', ts: 5, toolName: 'Read', args: {} },
-    ]);
+    ], 'en');
 
     assert.deepEqual(turn?.tools.map((tool) => tool.status), ['completed', 'interrupted']);
     assert.equal(latestInterruptedResumeTurnId(turn ? [turn] : []), undefined);

--- a/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
+++ b/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
@@ -186,6 +186,7 @@ describe('model catalog picker helpers', () => {
         }),
       ],
       '',
+      'zh-CN',
     );
     const keys = options.map(([key]) => key);
     assert.ok(
@@ -197,5 +198,10 @@ describe('model catalog picker helpers', () => {
       false,
       `unsupported Codex model was offered: ${JSON.stringify(keys)}`,
     );
+  });
+
+  it('labels a saved-but-unavailable selection in the UI locale', () => {
+    const [, label] = buildCatalogDailyReviewModelOptions([], 'codex::gone', 'en').at(-1)!;
+    assert.equal(label, 'gone · codex · Currently unavailable');
   });
 });

--- a/apps/desktop/src/main/__tests__/session-error-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-error-presentation.test.ts
@@ -26,12 +26,14 @@ import { describeTurnErrorClass } from '../../renderer/session-status-presentati
 
 describe('provider capacity presentation', () => {
   it('uses capacity-specific copy instead of the unknown error fallback', () => {
-    assert.match(describeSessionErrorReason('provider_capacity') ?? '', /满载/);
-    assert.match(describeTurnErrorClass('provider_capacity'), /满载/);
+    assert.match(describeSessionErrorReason('provider_capacity', 'zh-CN') ?? '', /满载/);
+    assert.match(describeSessionErrorReason('provider_capacity', 'en') ?? '', /at capacity/);
+    assert.match(describeTurnErrorClass('provider_capacity', 'zh-CN'), /满载/);
+    assert.match(describeTurnErrorClass('provider_capacity', 'en'), /at capacity/);
   });
 
   it('does not recommend an immediate direct retry', () => {
-    const label = describeTurnErrorClass('provider_capacity');
+    const label = describeTurnErrorClass('provider_capacity', 'zh-CN');
     assert.match(label, /等几分钟|换一个模型/);
     assert.doesNotMatch(label, /直接重试/);
   });

--- a/apps/desktop/src/renderer/app-shell-context-compaction.ts
+++ b/apps/desktop/src/renderer/app-shell-context-compaction.ts
@@ -32,7 +32,7 @@ export interface ContextCompactionNotice {
 
 export function contextCompactionNotice(
   outcome: ContextCompactionOutcome,
-  uiLocale: UiLocale = 'en',
+  uiLocale: UiLocale,
 ): ContextCompactionNotice {
   const copy = getShellCopy(uiLocale).app;
   if (outcome.kind === 'compacted') {

--- a/apps/desktop/src/renderer/attachment-preflight.ts
+++ b/apps/desktop/src/renderer/attachment-preflight.ts
@@ -38,7 +38,7 @@ type PreflightItem = {
  * File blobs are sized by the browser File object; approval-token attachments
  * are sized by the pending size stamped at pick time (main re-stats).
  */
-export function preflightAttachmentItems(items: readonly PreflightItem[], locale: UiLocale = 'zh-CN'): void {
+export function preflightAttachmentItems(items: readonly PreflightItem[], locale: UiLocale): void {
   const copy = getDesktopConversationCopy(locale).attachments;
   if (items.length > MAX_ATTACHMENT_COUNT) throw new Error(copy.tooMany);
   const seen = new Set<string>();

--- a/apps/desktop/src/renderer/conversation-markdown.ts
+++ b/apps/desktop/src/renderer/conversation-markdown.ts
@@ -43,7 +43,7 @@ import { getShellRemainingCopy } from './locales/shell-remaining-copy.js';
  *   export that the user is going to paste somewhere public.
  * - **user text** left untouched (the user typed it, they own it).
  */
-export function renderConversationMarkdown(sessionName: string, messages: StoredMessage[], locale: UiLocale = 'zh-CN'): string {
+export function renderConversationMarkdown(sessionName: string, messages: StoredMessage[], locale: UiLocale): string {
   const copy = getShellRemainingCopy(locale).conversationExport;
   const lines: string[] = [];
   lines.push(`# ${sessionName}`);

--- a/apps/desktop/src/renderer/derive-turn-lineage-badges.ts
+++ b/apps/desktop/src/renderer/derive-turn-lineage-badges.ts
@@ -46,11 +46,11 @@ export interface TurnLineageBadgeInput {
   regeneratedToTurnId?: string;
   /** True when the target turn id still exists in the materialized view. */
   existsTurn(turnId: string): boolean;
-  locale?: UiLocale;
+  locale: UiLocale;
 }
 
 export function deriveTurnLineageBadges(input: TurnLineageBadgeInput): TurnLineageBadge[] {
-  const copy = getDesktopConversationCopy(input.locale ?? 'zh-CN').lineage;
+  const copy = getDesktopConversationCopy(input.locale).lineage;
   const badges: TurnLineageBadge[] = [];
 
   const forwardFrom = input.regeneratedFromTurnId ?? input.retriedFromTurnId;

--- a/apps/desktop/src/renderer/features/connection-settings/provider-panel-shared.ts
+++ b/apps/desktop/src/renderer/features/connection-settings/provider-panel-shared.ts
@@ -25,7 +25,7 @@ import { cleanErrorMessage } from '../../application/contracts/connection-error-
 
 export type CredentialPresenceStatus = boolean | 'loading' | 'error';
 
-export function providerPanelActionErrorMessage(error: unknown, locale: UiLocale = 'zh-CN'): string {
+export function providerPanelActionErrorMessage(error: unknown, locale: UiLocale): string {
   const shared = getProviderSettingsCopy(locale).shared;
   // Electron wraps ipcMain.handle rejections as "Error invoking remote method
   // '<channel>': Error: <message>". Classify the original message, not the
@@ -59,7 +59,7 @@ export interface ConnectionTestTroubleshootingCopy {
 export function connectionTestFailureFallback(
   result: ConnectionTestResult,
   copy: ConnectionTestTroubleshootingCopy,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): string {
   const shared = getProviderSettingsCopy(locale).shared;
   if (result.statusCode === 429) return shared.rateLimit;
@@ -77,14 +77,14 @@ export function connectionTestFailureFallback(
 export function connectionTestFailureMessage(
   result: ConnectionTestResult,
   copy: ConnectionTestTroubleshootingCopy,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): string {
   const fallback = connectionTestFailureFallback(result, copy, locale);
   if (!result.errorMessage) return fallback;
   return generalizedErrorMessageForLocale(new Error(result.errorMessage), fallback, locale);
 }
 
-export function connectionLastTestMessageDisplay(message: string | undefined, locale: UiLocale = 'zh-CN'): string | undefined {
+export function connectionLastTestMessageDisplay(message: string | undefined, locale: UiLocale): string | undefined {
   if (!message) return undefined;
   const trimmed = message.trim();
   if (!trimmed) return undefined;

--- a/apps/desktop/src/renderer/features/session-navigation/model/session-project-grouping.ts
+++ b/apps/desktop/src/renderer/features/session-navigation/model/session-project-grouping.ts
@@ -28,7 +28,7 @@ const UNGROUPED_KEY = '__ungrouped__';
 export function deriveProjectGroups(
   sessions: ReadonlyArray<SessionSummary>,
   projects: ReadonlyArray<ProjectRecord>,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): SessionHistoryGroup[] {
   const sessionsByProject = new Map<string, SessionSummary[]>();
   const canonicalProjectIds = new Map<string, string>();

--- a/apps/desktop/src/renderer/model-catalog-choices.ts
+++ b/apps/desktop/src/renderer/model-catalog-choices.ts
@@ -48,7 +48,7 @@ export function buildCatalogRecommendedDefaultModel(providerType: ProviderType):
 export function buildCatalogDailyReviewModelOptions(
   connections: readonly (LlmConnection & HostResolvedConnectionCatalog)[],
   currentModelKey: string,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): Array<readonly [string, string]> {
   const current = parseDailyReviewModelKey(currentModelKey);
   const candidates: Array<{ key: string; label: string; safeSourceLabel: string }> = [];

--- a/apps/desktop/src/renderer/model-connection-errors.ts
+++ b/apps/desktop/src/renderer/model-connection-errors.ts
@@ -46,7 +46,7 @@ export function noRealConnectionReasonFromEvent(event: Extract<SessionEvent, { t
   ).reason;
 }
 
-export function noRealConnectionSetupDescription(reason: string | undefined, locale: UiLocale = 'zh-CN'): string {
+export function noRealConnectionSetupDescription(reason: string | undefined, locale: UiLocale): string {
   const copy = getDesktopConversationCopy(locale).model;
   return reason && Object.hasOwn(copy.configurationReason, reason)
     ? copy.configurationReason[reason as ChatConfigurationReason]
@@ -55,7 +55,7 @@ export function noRealConnectionSetupDescription(reason: string | undefined, loc
 
 export function sessionEventErrorMessage(
   event: Extract<SessionEvent, { type: 'error' }>,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): string {
   if (isNoRealConnectionEvent(event)) {
     return noRealConnectionSetupDescription(noRealConnectionReasonFromEvent(event), locale);
@@ -69,7 +69,7 @@ export function sessionEventErrorMessage(
 export function modelSetupToastCopy(
   reason: string | undefined,
   fallback: string,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): { title: string; description: string } {
   const copy = getDesktopConversationCopy(locale).model;
   if (reason === 'connection_missing') {

--- a/apps/desktop/src/renderer/session-error-presentation.ts
+++ b/apps/desktop/src/renderer/session-error-presentation.ts
@@ -25,7 +25,7 @@ import { getDesktopConversationCopy } from './locales/conversation-copy.js';
  * runtime. Unknown reasons intentionally return undefined so callers can use
  * their existing safe fallback instead of displaying raw provider text.
  */
-export function describeSessionErrorReason(reason: string | undefined, locale: UiLocale = 'zh-CN'): string | undefined {
+export function describeSessionErrorReason(reason: string | undefined, locale: UiLocale): string | undefined {
   const copy = getDesktopConversationCopy(locale).turnError;
   switch (reason?.toLowerCase()) {
     case 'context_overflow':

--- a/apps/desktop/src/renderer/session-status-presentation.ts
+++ b/apps/desktop/src/renderer/session-status-presentation.ts
@@ -97,7 +97,7 @@ export function normalizeSessionSummaryForDisplay<T extends SessionSummary>(sess
  * the UI; they just fall through to the catch-all until the mapping
  * is extended.
  */
-export function describeTurnErrorClass(errorClass: string | undefined, locale: UiLocale = 'zh-CN'): string {
+export function describeTurnErrorClass(errorClass: string | undefined, locale: UiLocale): string {
   const copy = getDesktopConversationCopy(locale).turnError;
   if (!errorClass) return copy.unknown;
   const reasonDescription = describeSessionErrorReason(errorClass, locale);
@@ -169,7 +169,7 @@ export interface FailedTurnExecutionState {
  */
 export function describeFailedTurnExecutionState(
   state: FailedTurnExecutionState,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): string | undefined {
   const copy = getDesktopConversationCopy(locale).turnError.executionState;
   if (state.erroredToolCount > 0) return copy.erroredTool;

--- a/apps/desktop/src/renderer/settings/bot-chat-shared.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-shared.tsx
@@ -60,7 +60,7 @@ export const BOT_LABELS: Record<BotProvider, { support: 'runtime' | 'credentials
   slack: { support: 'runtime' },
 };
 
-export function botReadinessCopyForSupport(support: 'runtime' | 'credentials' | 'planned', readiness: BotReadinessState, locale: UiLocale = 'zh-CN') {
+export function botReadinessCopyForSupport(support: 'runtime' | 'credentials' | 'planned', readiness: BotReadinessState, locale: UiLocale) {
   const copy = getBotSettingsCopy(locale);
   if (support === 'planned') return copy.planned;
   return copy.readiness[readiness] ?? copy.readiness.scaffolded;
@@ -98,7 +98,7 @@ export function BotBrandLogo(props: { provider: BotProvider; size?: 'compact' | 
 export type BotPendingActionName = 'test' | 'connect' | 'restart' | 'disconnect';
 export type BotPendingAction = { provider: BotProvider; action: BotPendingActionName };
 
-export function botStatusDetail(status: BotStatus, locale: UiLocale = 'zh-CN'): string {
+export function botStatusDetail(status: BotStatus, locale: UiLocale): string {
   const copy = getBotSettingsCopy(locale).status;
   switch (status.reason) {
     case 'disabled': return copy.disabled;

--- a/apps/desktop/src/renderer/settings/provider-connection-status.ts
+++ b/apps/desktop/src/renderer/settings/provider-connection-status.ts
@@ -62,7 +62,7 @@ export interface ConnectionChipStatus {
  *   readiness, fixed to credential-only language. Matches the doc warning
  *   at SettingsModal `验证通过 ≠ 运行可用`.
  */
-export function connectionChipStatus(connection: LlmConnection, locale: UiLocale = 'zh-CN'): ConnectionChipStatus | null {
+export function connectionChipStatus(connection: LlmConnection, locale: UiLocale): ConnectionChipStatus | null {
   const copy = getProviderSettingsCopy(locale).shared.connectionStatuses;
   // Ahead of every other branch, including needs_reauth: a retired provider
   // has no sign-in left to return to, so any repair-shaped status here would

--- a/apps/desktop/src/renderer/settings/settings-error-copy.ts
+++ b/apps/desktop/src/renderer/settings/settings-error-copy.ts
@@ -22,7 +22,7 @@ import { type UiLocale } from '@maka/core/ui-locale';
 import { redactSecrets } from '@maka/ui';
 import { getSettingsSharedCopy } from '../locales/settings-shared-copy.js';
 
-export function settingsActionErrorMessage(error: unknown, locale: UiLocale = 'zh-CN'): string {
+export function settingsActionErrorMessage(error: unknown, locale: UiLocale): string {
   const raw = error instanceof Error
     ? error.message
     : typeof error === 'string'

--- a/apps/desktop/src/renderer/turn-footer-actions.ts
+++ b/apps/desktop/src/renderer/turn-footer-actions.ts
@@ -99,7 +99,7 @@ export interface TurnFooterContext {
    * / other action types stay clickable.
    */
   pendingActions?: ReadonlySet<TurnFooterActionId>;
-  locale?: UiLocale;
+  locale: UiLocale;
 }
 
 /**
@@ -113,7 +113,7 @@ export interface TurnFooterContext {
  */
 export function deriveTurnFooterActions(input: TurnFooterContext): TurnFooterAction[] {
   const { status, hasContent, alreadyRegenerated, pendingActions, metaSummary } = input;
-  const copyText = getDesktopConversationCopy(input.locale ?? 'zh-CN').footer;
+  const copyText = getDesktopConversationCopy(input.locale).footer;
   const actionLabel = copyText.labels;
   const isPending = (id: TurnFooterActionId) => pendingActions?.has(id) ?? false;
   const PENDING_TOOLTIP = copyText.pending;

--- a/packages/core/src/relative-time.ts
+++ b/packages/core/src/relative-time.ts
@@ -94,7 +94,7 @@ function getAbsoluteFormat(uiLocale: UiLocale): Intl.DateTimeFormat {
  * reading a relative label falls back to and a tooltip shows; `@maka/ui` had
  * its own uncached copy of the same `Intl` options until this became public.
  */
-export function formatAbsoluteTimestamp(ts: number, locale: UiLocale = 'zh-CN'): string {
+export function formatAbsoluteTimestamp(ts: number, locale: UiLocale): string {
   return getAbsoluteFormat(locale).format(new Date(ts));
 }
 
@@ -103,11 +103,7 @@ export function formatAbsoluteTimestamp(ts: number, locale: UiLocale = 'zh-CN'):
  * absolute date string. `now` is injectable so tests pin a deterministic clock;
  * future timestamps (clock skew) snap to the just-now label.
  */
-export function formatRelativeTimestamp(
-  ts: number,
-  now: number = Date.now(),
-  locale: UiLocale = 'zh-CN',
-): string {
+export function formatRelativeTimestamp(ts: number, now: number, locale: UiLocale): string {
   const diffMs = relativeAgeMs(ts, now);
   if (diffMs < JUST_NOW_MS) {
     return JUST_NOW[locale];
@@ -156,11 +152,7 @@ function getCompactFormats(uiLocale: UiLocale): {
  * Compact variant for wider list rows: relative inside the seven-day horizon,
  * then a localized date-only label.
  */
-export function formatCompactTimestamp(
-  ts: number,
-  now: number = Date.now(),
-  locale: UiLocale = 'zh-CN',
-): string {
+export function formatCompactTimestamp(ts: number, now: number, locale: UiLocale): string {
   const diffMs = relativeAgeMs(ts, now);
   if (diffMs <= RELATIVE_HORIZON_MS) return formatRelativeTimestamp(ts, now, locale);
   const { sameYear, otherYear } = getCompactFormats(locale);
@@ -176,11 +168,7 @@ export function formatCompactTimestamp(
  * Unit tokens stay deliberately locale-neutral so the trailing column remains
  * stable across UI languages: "46min", "13h", "17d", "1mo", "1y".
  */
-export function formatSidebarTimestamp(
-  ts: number,
-  now: number = Date.now(),
-  locale: UiLocale = 'zh-CN',
-): string {
+export function formatSidebarTimestamp(ts: number, now: number, locale: UiLocale): string {
   const diffMs = relativeAgeMs(ts, now);
   if (diffMs < JUST_NOW_MS) return JUST_NOW[locale];
   const bucket = sidebarTimeBucket(diffMs);

--- a/packages/core/src/tool-quiet-preview.ts
+++ b/packages/core/src/tool-quiet-preview.ts
@@ -240,7 +240,7 @@ export interface ToolInvocationInput {
  */
 export function formatToolInvocationLine(
   item: ToolInvocationInput,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): string | undefined {
   const s = strings(locale);
   const args = asRecord(item.args);
@@ -528,7 +528,7 @@ export interface QuietPreview {
  * Primary list/text fields become the main body; remaining fields (error, ok,
  * truncated, …) are appended so diagnostics cannot vanish.
  */
-export function formatQuietJsonValue(value: unknown, locale: UiLocale = 'zh-CN'): QuietPreview {
+export function formatQuietJsonValue(value: unknown, locale: UiLocale): QuietPreview {
   const s = strings(locale);
   if (value === null || value === undefined) {
     return { body: s.empty };
@@ -686,8 +686,8 @@ function formatArrayAsBody(values: unknown[], locale: UiLocale): string {
  */
 export function formatAsKeyValueLines(
   record: Record<string, unknown>,
-  depth = 0,
-  locale: UiLocale = 'zh-CN',
+  depth: number,
+  locale: UiLocale,
 ): string {
   const s = strings(locale);
   if (depth > 3) return redactSecrets(String(record));

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -1026,7 +1026,7 @@ describe('tool_result_preview live projection', () => {
         type: 'turn_state', id: 'state-1', turnId: 'turn-1', ts: 3,
         status: 'running', partialOutputRetained: true,
       },
-    ]);
+    ], 'en');
     const started = applyLiveTurnEvent(undefined, {
       type: 'tool_start', id: 'start-1', turnId: 'turn-1', stepId: 'step-1',
       toolUseId: 'tool-1', toolName: 'Read', args: { path: 'README.md' }, ts: 4,

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -75,7 +75,7 @@ describe("steering timeline", () => {
         text: "after",
         modelId: "fixture",
       },
-    ]);
+    ], "en");
 
     assert.deepEqual(timelineText(turn), [
       "text:before",
@@ -85,7 +85,7 @@ describe("steering timeline", () => {
   });
 
   test("renders one live steering message while its persisted row catches up", () => {
-    const settled = materializeTurns([originalUser]);
+    const settled = materializeTurns([originalUser], "en");
     const before = applyLiveTurnEvent(armLiveTurn("t1"), {
       type: "text_complete",
       id: "event-before",
@@ -110,7 +110,7 @@ describe("steering timeline", () => {
       originalUser,
       beforeAssistant,
       { type: "user", id: "steer-1", turnId: "t1", ts: 2, text: "inserted instruction" },
-    ]);
+    ], "en");
     const [deduplicated] = overlayLiveTurn(persisted, live);
     assert.deepEqual(timelineText(deduplicated), ["text:before", "user:inserted instruction"]);
   });
@@ -126,7 +126,7 @@ describe("steering timeline", () => {
         text: "inserted instruction",
         steeringEventId: "event-steer",
       },
-    ]);
+    ], "en");
     const live = applyLiveTurnEvent(armLiveTurn("t1"), {
       type: "text_delta",
       id: "event-before",
@@ -154,7 +154,7 @@ describe("steering timeline", () => {
         args: {},
       },
       steeringUser,
-    ]);
+    ], "en");
     const tool = applyLiveTurnEvent(armLiveTurn("t1"), {
       type: "tool_start",
       id: "tool-event",
@@ -229,8 +229,8 @@ describe("materializeChat message metadata", () => {
         inlineReferences: [],
       },
     ];
-    assert.deepEqual(materializeChat(messages)[0]?.inlineReferences, []);
-    assert.deepEqual(materializeTurns(messages)[0]?.user?.inlineReferences, []);
+    assert.deepEqual(materializeChat(messages, "en")[0]?.inlineReferences, []);
+    assert.deepEqual(materializeTurns(messages, "en")[0]?.user?.inlineReferences, []);
   });
 
   test("preserves Host provenance on a Goal continuation", () => {
@@ -245,11 +245,11 @@ describe("materializeChat message metadata", () => {
       },
     ];
 
-    assert.deepEqual(materializeChat(messages)[0]?.hostOrigin, {
+    assert.deepEqual(materializeChat(messages, "en")[0]?.hostOrigin, {
       kind: "goal",
       goalId: "goal-1",
     });
-    assert.deepEqual(materializeTurns(messages)[0]?.user?.hostOrigin, {
+    assert.deepEqual(materializeTurns(messages, "en")[0]?.user?.hostOrigin, {
       kind: "goal",
       goalId: "goal-1",
     });
@@ -345,7 +345,7 @@ describe("flat timeline under tool projection (#1307 P1 regression)", () => {
         content: shellRunResult(1),
       },
       userMsg("t2", 3, "q"),
-    ]);
+    ], "en");
     const turns = overlayLiveTurn(settled, {
       turnId: "t2",
       phase: "streamed",
@@ -404,7 +404,7 @@ describe("live content over persisted partial rows", () => {
         thinking: { text: "persisted partial" },
         contentOrder: ["thinking"],
       },
-    ]);
+    ], "en");
     const turns = overlayLiveTurn(settled, {
       turnId: "t1",
       phase: "streamed",
@@ -458,7 +458,7 @@ describe("unfinished tools take their status from the turn", () => {
         toolName: "Bash",
         args: { command: "sleep 600" },
       },
-    ]);
+    ], "en");
     assert.equal(turn?.status, "running");
     assert.equal(turn?.tools[0]?.status, "running");
   });
@@ -482,7 +482,7 @@ describe("unfinished tools take their status from the turn", () => {
         toolName: "Bash",
         args: { command: "sleep 600" },
       },
-    ]);
+    ], "en");
     assert.equal(turn?.tools[0]?.status, "interrupted");
   });
 });
@@ -509,7 +509,7 @@ describe("live tool status over persisted", () => {
         toolName: "Bash",
         args: { command: "sleep 60" },
       },
-    ]);
+    ], "en");
     const turns = overlayLiveTurn(settled, {
       turnId: "t1",
       phase: "streamed",
@@ -556,7 +556,7 @@ describe("live tool status over persisted", () => {
         toolName: "Bash",
         args: { command: "sleep 60" },
       },
-    ]);
+    ], "en");
     const turns = overlayLiveTurn(settled, {
       turnId: "t1",
       phase: "streamed",
@@ -620,7 +620,7 @@ describe("live tool status over persisted", () => {
         isError: false,
         content: { kind: "text", text: "unsupported_action" },
       },
-    ]);
+    ], "en");
 
     const live = applyLiveTurnEvent(undefined, {
       type: "tool_start",
@@ -671,7 +671,7 @@ describe("live tool status over persisted", () => {
         toolName: "Bash",
         args: { command: "sleep 60" },
       },
-    ]);
+    ], "en");
     const started = applyLiveTurnEvent(armLiveTurn("t1"), {
       type: "tool_start",
       id: "event-1",

--- a/packages/ui/src/__tests__/shell-run-projection.test.ts
+++ b/packages/ui/src/__tests__/shell-run-projection.test.ts
@@ -53,7 +53,7 @@ describe('ShellRun UI projection', () => {
       }), 4),
     ];
 
-    const turns = materializeTurns(messages);
+    const turns = materializeTurns(messages, 'en');
     const bash = turns[0]?.tools[0];
     const write = turns[1]?.tools[0];
     assert.equal(bash?.toolName, 'Bash');
@@ -86,7 +86,7 @@ describe('ShellRun UI projection', () => {
       { type: 'user', id: 'user-2', turnId: 'turn-2', ts: 3, text: 'next' },
     ];
     const projection = createTranscriptProjection();
-    const unrelatedTurn = projection.project({ messages })[1];
+    const unrelatedTurn = projection.project({ locale: 'en', messages })[1];
     const update: ShellRunUpdate = {
       sessionId: 'session-1',
       ownership: { kind: 'local' },
@@ -94,7 +94,7 @@ describe('ShellRun UI projection', () => {
       sourceToolCallId: 'bash-1',
       result: shellRunSnapshot(3, { status: 'completed', completedAt: 5, exitCode: 0 }),
     };
-    const durable = projection.project({ messages, shellRunUpdates: [update] });
+    const durable = projection.project({ locale: 'en', messages, shellRunUpdates: [update] });
     assert.equal(durable[1], unrelatedTurn);
     assert.equal(durable[0]?.tools[0]?.status, 'completed');
 
@@ -113,7 +113,7 @@ describe('ShellRun UI projection', () => {
         }],
       }],
     };
-    const overlaid = projection.project({ messages, liveTurn: live, shellRunUpdates: [update] });
+    const overlaid = projection.project({ locale: 'en', messages, liveTurn: live, shellRunUpdates: [update] });
     assert.equal(overlaid[1], unrelatedTurn, 'the live overlay must not disturb an unrelated turn');
     const result = overlaid[0]?.tools[0]?.result;
     assert.equal(result?.kind === 'shell_run' ? result.revision : undefined, 3);
@@ -154,7 +154,7 @@ describe('ShellRun UI projection', () => {
     };
 
     const tool = createTranscriptProjection()
-      .project({ messages, liveTurn: live })[0]?.tools[0];
+      .project({ locale: 'en', messages, liveTurn: live })[0]?.tools[0];
     assert.equal(tool?.result?.kind === 'shell_run' ? tool.result.revision : undefined, 2);
     assert.equal(
       tool?.result?.kind === 'shell_run' && tool.result.output?.mode === 'pty'
@@ -189,7 +189,7 @@ describe('ShellRun UI projection', () => {
     };
 
     const turns = createTranscriptProjection()
-      .project({ messages: [], liveTurn: live, shellRunUpdates: [update] });
+      .project({ locale: 'en', messages: [], liveTurn: live, shellRunUpdates: [update] });
     const result = turns[0]?.tools[0]?.result;
     assert.equal(result?.kind, 'shell_run');
     assert.equal(result?.kind === 'shell_run' ? result.output?.mode : undefined, 'pty');
@@ -206,7 +206,7 @@ describe('ShellRun UI projection', () => {
       toolCall('bash-1', 'turn-1', 'Bash', { command: 'job', pty: true }, 1),
       toolResult('bash-1', 'turn-1', shellRun(1), 2),
     ];
-    const turns = createTranscriptProjection().project({ messages, shellRunUpdates: [{
+    const turns = createTranscriptProjection().project({ locale: 'en', messages, shellRunUpdates: [{
       sessionId: 'branch-session',
       ownership: {
         kind: 'source_owned',
@@ -223,7 +223,7 @@ describe('ShellRun UI projection', () => {
       ? turns[0]?.tools[0]?.result?.status
       : undefined, 'running');
 
-    const unavailable = createTranscriptProjection().project({ messages, shellRunUpdates: [{
+    const unavailable = createTranscriptProjection().project({ locale: 'en', messages, shellRunUpdates: [{
       sessionId: 'branch-session',
       ownership: { kind: 'source_unavailable', sourceSessionId: 'source-session' },
       sourceTurnId: 'turn-1',

--- a/packages/ui/src/__tests__/transcript-projection.test.ts
+++ b/packages/ui/src/__tests__/transcript-projection.test.ts
@@ -103,7 +103,7 @@ describe('incremental transcript projection', () => {
   test('a shell-run update whose semantics are unchanged affects nothing', () => {
     const projection = createTranscriptProjection();
     const messages = history();
-    const base = { sessionId: SESSION, messages, liveTurn: streamingTurn('he') };
+    const base = { locale: 'en' as const, sessionId: SESSION, messages, liveTurn: streamingTurn('he') };
     const settled = projection.project({ ...base, shellRunUpdates: [backgroundUpdate] });
 
     // A new update object carrying an already-merged revision says nothing new.
@@ -127,8 +127,8 @@ describe('incremental transcript projection', () => {
 
   test('a turn missing from the durable snapshot is dropped, leaving the rest identical', () => {
     const projection = createTranscriptProjection();
-    const before = projection.project({ sessionId: SESSION, messages: history() });
-    const after = projection.project({ sessionId: SESSION, messages: history().slice(0, 4) });
+    const before = projection.project({ locale: 'en', sessionId: SESSION, messages: history() });
+    const after = projection.project({ locale: 'en', sessionId: SESSION, messages: history().slice(0, 4) });
     assert.notStrictEqual(after, before, 'a dropped turn must move the published list');
     assert.deepEqual(after.map((turn) => turn.turnId), ['turn-1']);
     assert.strictEqual(after[0], before[0]);
@@ -139,6 +139,7 @@ describe('incremental transcript projection', () => {
     // turn is recognised by value, wherever it lands.
     const projection = createTranscriptProjection();
     const before = projection.project({
+      locale: 'en',
       sessionId: SESSION,
       messages: [
         ...history(),
@@ -147,6 +148,7 @@ describe('incremental transcript projection', () => {
       ],
     });
     const after = projection.project({
+      locale: 'en',
       sessionId: SESSION,
       messages: [
         ...history().slice(0, 4),
@@ -161,8 +163,9 @@ describe('incremental transcript projection', () => {
 
   test('an edited-and-resent prompt invalidates its own turn and nothing before it', () => {
     const projection = createTranscriptProjection();
-    const before = projection.project({ sessionId: SESSION, messages: history() });
+    const before = projection.project({ locale: 'en', sessionId: SESSION, messages: history() });
     const after = projection.project({
+      locale: 'en',
       sessionId: SESSION,
       messages: [
         ...history().slice(0, 4),
@@ -178,6 +181,7 @@ describe('incremental transcript projection', () => {
   test('a live step handed off to durable messages rebuilds only its own turn', () => {
     const projection = createTranscriptProjection();
     const live = projection.project({
+      locale: 'en',
       sessionId: SESSION,
       messages: [...history(), { type: 'user', id: 'u3', turnId: 'turn-3', ts: 7, text: 'third' }],
       liveTurn: streamingTurn('half an ans'),
@@ -186,6 +190,7 @@ describe('incremental transcript projection', () => {
 
     // Handoff: the answer lands in messages and the live projection retires.
     const settled = projection.project({
+      locale: 'en',
       sessionId: SESSION,
       messages: [
         ...history(),
@@ -220,12 +225,13 @@ describe('incremental transcript projection', () => {
       sourceToolCallId: 'bash-1',
       result: shellRunSnapshot(1),
     };
-    const before = projection.project({ sessionId: SESSION, messages, shellRunUpdates: [owned] });
+    const before = projection.project({ locale: 'en', sessionId: SESSION, messages, shellRunUpdates: [owned] });
     const bash = before[0]?.tools[0];
     assert.equal(bash?.shellRunSource, 'owned');
     assert.equal(bash?.result?.kind === 'shell_run' ? bash.result.revision : undefined, 1);
 
     const after = projection.project({
+      locale: 'en',
       sessionId: SESSION,
       messages,
       shellRunUpdates: [{
@@ -255,6 +261,7 @@ describe('incremental transcript projection', () => {
       },
     });
     projection.project({
+      locale: 'en',
       sessionId: SESSION,
       messages: counted,
       liveTurn: streamingTurn('h'),
@@ -270,6 +277,7 @@ describe('incremental transcript projection', () => {
     const baseline = reads;
     for (const text of ['he', 'hel', 'hell', 'hello']) {
       projection.project({
+        locale: 'en',
         sessionId: SESSION,
         messages: counted,
         liveTurn: streamingTurn(text),
@@ -286,11 +294,11 @@ describe('incremental transcript projection', () => {
     const projection = createTranscriptProjection();
     const messages = history();
     const updates: ShellRunUpdate[] = [backgroundUpdate];
-    const before = projection.project({ sessionId: SESSION, messages, shellRunUpdates: updates });
+    const before = projection.project({ locale: 'en', sessionId: SESSION, messages, shellRunUpdates: updates });
     assert.equal(revisionOf(before[0]), 9);
 
     updates.push({ ...backgroundUpdate, result: shellRunSnapshot(21) });
-    const after = projection.project({ sessionId: SESSION, messages, shellRunUpdates: updates });
+    const after = projection.project({ locale: 'en', sessionId: SESSION, messages, shellRunUpdates: updates });
     assert.equal(revisionOf(after[0]), 21, 'an update appended to the same array must be applied');
   });
 
@@ -301,8 +309,9 @@ describe('incremental transcript projection', () => {
     // sessionId reset is hygiene, bounding what the projection holds on to
     // rather than standing between the user and a stale transcript.
     const projection = createTranscriptProjection();
-    const first = projection.project({ sessionId: SESSION, messages: history() });
+    const first = projection.project({ locale: 'en', sessionId: SESSION, messages: history() });
     const other = projection.project({
+      locale: 'en',
       sessionId: 'session-2',
       messages: [
         ...history().slice(0, 5),
@@ -313,7 +322,7 @@ describe('incremental transcript projection', () => {
     assert.equal(other[1]?.assistant?.text, 'a different answer');
 
     // Nothing of session-1 survived: re-projecting it rebuilds every turn.
-    const back = projection.project({ sessionId: SESSION, messages: history() });
+    const back = projection.project({ locale: 'en', sessionId: SESSION, messages: history() });
     assert.notStrictEqual(back[0], first[0]);
     assert.notStrictEqual(back[1], first[1]);
   });
@@ -325,8 +334,9 @@ describe('incremental transcript projection', () => {
     // affects — which is why the affected set is derived from the projection's
     // own output rather than passed through from the event.
     const projection = createTranscriptProjection();
-    const before = projection.project({ sessionId: SESSION, messages: history() });
+    const before = projection.project({ locale: 'en', sessionId: SESSION, messages: history() });
     const after = projection.project({
+      locale: 'en',
       sessionId: SESSION,
       messages: [
         ...history(),
@@ -373,6 +383,7 @@ describe('incremental transcript projection', () => {
     // over the live-merged turns, where the live-only tool already exists.
     const projection = createTranscriptProjection();
     const turns = projection.project({
+      locale: 'en',
       sessionId: SESSION,
       messages: [],
       liveTurn: {
@@ -453,10 +464,10 @@ describe('turn identity moves across structural change classes', () => {
   for (const { field, from, refresh } of cases) {
     test(`a refresh that only changes \`${field}\` moves the turn`, () => {
       const projection = createTranscriptProjection();
-      const before = projection.project({ sessionId: SESSION, messages: from ?? base });
+      const before = projection.project({ locale: 'en', sessionId: SESSION, messages: from ?? base });
       // A refresh re-reads the ledger over IPC: all-new objects either way, so
       // identity can only come from the value comparison under test.
-      const after = projection.project({ sessionId: SESSION, messages: refresh });
+      const after = projection.project({ locale: 'en', sessionId: SESSION, messages: refresh });
 
       // Self-check: the row really does move the field it names, so a row that
       // stops isolating its field fails loudly instead of passing vacuously.

--- a/packages/ui/src/artifact-preview-registry.ts
+++ b/packages/ui/src/artifact-preview-registry.ts
@@ -81,7 +81,7 @@ function exceedsImagePayloadCap(base64: string): boolean {
   return base64.length > IMAGE_PAYLOAD_MAX_BASE64_LENGTH;
 }
 
-export function formatPreviewSize(sizeBytes: number | undefined, locale: UiLocale = 'zh-CN'): string {
+export function formatPreviewSize(sizeBytes: number | undefined, locale: UiLocale): string {
   if (sizeBytes === undefined || sizeBytes < 0 || !Number.isFinite(sizeBytes)) return getSharedUiCopy(locale).artifact.unknownSize;
   if (sizeBytes < 1024) return `${sizeBytes} B`;
   if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)} KB`;

--- a/packages/ui/src/chat-model-helpers.ts
+++ b/packages/ui/src/chat-model-helpers.ts
@@ -49,7 +49,7 @@ export type { ChatModelChoice } from '@maka/core/chat-model-choice';
 
 export function modelChoiceDescription(
   choice: Pick<ChatModelChoice, 'description' | 'knowledgeCutoff'>,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): string | undefined {
   const description = choice.description?.trim();
   const knowledge = choice.knowledgeCutoff?.trim();
@@ -85,7 +85,7 @@ export interface ModelMenuGroup {
  * account email `connection.name` carries for `claude-subscription` /
  * `openai-codex`.
  */
-export function modelMenuGroups(choices: ChatModelChoice[], locale: UiLocale = 'zh-CN'): ModelMenuGroup[] {
+export function modelMenuGroups(choices: ChatModelChoice[], locale: UiLocale): ModelMenuGroup[] {
   const copy = getSharedUiCopy(locale).providers;
   const localizedLabels: Partial<Record<ProviderType, string>> = {
     'MiniMax-cn': copy.minimaxChina,

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -189,7 +189,7 @@ function systemNoteLabel(kind: string, data: unknown, locale: UiLocale): string 
 
 export function materializeChat(
   messages: readonly StoredMessage[],
-  locale: UiLocale = "en",
+  locale: UiLocale,
 ): ChatItem[] {
   const items: ChatItem[] = [];
   for (const message of messages) {
@@ -703,7 +703,7 @@ const SHELL_RUN_PRESENTATION_STATUS = {
  */
 export function materializeTurns(
   messages: readonly StoredMessage[],
-  locale: UiLocale = "en",
+  locale: UiLocale,
 ): TurnViewModel[] {
   const turnRecords = deriveTurnRecords(messages);
   const turnRecordById = new Map(

--- a/packages/ui/src/session-status-presentation.ts
+++ b/packages/ui/src/session-status-presentation.ts
@@ -66,7 +66,7 @@ const STATUS_SEMANTIC: Record<SessionStatus, StatusSemantic | undefined> = {
 
 export function presentSessionStatus(
   status: SessionStatus,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): SessionStatusPresentation {
   const semantic = STATUS_SEMANTIC[status];
   return {
@@ -84,7 +84,7 @@ export function presentSessionStatus(
  */
 export function describeBlockedReason(
   reason: SessionBlockedReason | undefined,
-  locale: UiLocale = 'zh-CN',
+  locale: UiLocale,
 ): string {
   const copy = getConversationCopy(locale).sessions.blockedReason;
   return reason ? copy[reason] : copy.unknown;

--- a/packages/ui/src/transcript-projection.ts
+++ b/packages/ui/src/transcript-projection.ts
@@ -60,7 +60,7 @@ export interface TranscriptProjectionInput {
    * turn is only reused when its value matches.
    */
   sessionId?: string;
-  locale?: UiLocale;
+  locale: UiLocale;
   messages: readonly StoredMessage[];
   liveTurn?: LiveTurnProjection;
   shellRunUpdates?: readonly ShellRunUpdate[];

--- a/packages/ui/stories/model-picker.stories.tsx
+++ b/packages/ui/stories/model-picker.stories.tsx
@@ -354,7 +354,7 @@ export const SavingDefaultModel: Story = {
   render: () => (
     <div style={{ width: 260 }}>
       <ModelPicker
-        groups={modelMenuGroups(CHOICES)}
+        groups={modelMenuGroups(CHOICES, useUiLocale())}
         value={modelChoiceValue(CHOICES[4]!.connectionSlug, CHOICES[4]!.model)}
         leadingOption={{ value: '', label: '未设置' }}
         renderProviderMark={providerMark}


### PR DESCRIPTION
## Summary

Presentation helpers across desktop renderer, `@maka/core`, and `@maka/ui` defaulted their `locale` parameter, so a caller that forgot to pass it rendered the wrong language with no type error: `'zh'` defaults showed Chinese to English users, and the `"en"` defaults on `materializeChat` / `materializeTurns` / `contextCompactionNotice` did the reverse. This PR removes every such default (27 helpers) so the locale is a required argument, and makes `TranscriptProjectionInput.locale` required for the same reason. No production caller relied on a default — every one already passed the locale it had in scope — so the runtime behavior is unchanged; only the type-level guarantee is new. Tests that leaned on a default now pass the locale explicitly.

Where a required `locale` now follows an optional parameter (`now` in the three relative-time helpers, `depth` in `formatAsKeyValueLines`), that leading default is dropped too: it became unreachable and every caller already passed it.

The guard for this change is `tsc`, not the tests: restoring a default keeps the existing assertions green. The `'en'` assertions added to the touched test files prove the English path for those helpers only; they are not a per-helper sweep.

The six `@maka/ui` streaming helpers with the same defect are fixed in #4524 and are not touched here; the two OAuth result helpers are fixed in #4551. A lint rule that rejects any future `UiLocale` default is left for a follow-up.

Refs #2672

## Verification

```
workspace typecheck:                    0 errors
packages/core tests (dist):             779 pass / 0 fail
packages/ui tests (dist):               347 pass / 0 fail
desktop main tests (dist):              2029 pass / 0 fail
renderer architecture check:            passed against origin/main
biome (changed files):                  clean
git grep "UiLocale = ['\"](zh|en)['\"]|locale ?? ['\"](zh|en)['\"]" (non-test):
  only the #4524 / #4551 sites and the CLI's optional-input fallback remain
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — implementation, tests, and this description, under the contributor's direction; the commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [ ] Tests cover the change and fail without it (the guard is `tsc`; see Summary)
