### PR TITLE
test(desktop): wait for restored focus

### DIFF
--- a/apps/desktop/stories/settings/provider-settings.stories.tsx
+++ b/apps/desktop/stories/settings/provider-settings.stories.tsx
@@ -903,7 +903,7 @@ export const OAuthCreateAdoptsExactConnection: Story = {
       '[data-connection-id="connection-openai-codex-4"]',
     );
     await expect(createdRow).not.toBeNull();
-    await expect(within(createdRow!).getByRole('button')).toHaveFocus();
+    await waitFor(() => expect(within(createdRow!).getByRole('button')).toHaveFocus());
   },
 };
 


### PR DESCRIPTION
## Summary

The OAuth connection story could check focus before the next-frame focus restoration completed. Wait for the new connection row to receive focus.

Production behavior is unchanged.

## Verification

- `npm run build`
- `npm run typecheck`
- Biome lint and format on all tracked files
- Desktop and UI knip checks
- Storybook build and smoke — 257 stories, 262 theme renders

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the test fix, reviewed it, ran verification, and drafted this PR.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

