### PR TITLE
fix(desktop): show side-conversation message + progress immediately

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-view-optimistic-render.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-view-optimistic-render.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { type ComponentProps, createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  AstryxLocaleProvider,
+  ChatSurfaceLayout,
+  ChatView,
+  LocaleProvider,
+  type TransientUserMessageProjection,
+} from '@maka/ui';
+
+// A side conversation forks lazily: its first send arms the optimistic bubble
+// (and, after the delay, the running-status line) BEFORE the fork commits, so
+// `activeSession` is still undefined. These tests pin that `ChatView` renders
+// that optimistic content in its no-session branch — the render-layer half of
+// #4654 that the hook-only tests could not prove. The panel wires it up:
+// `activeSession={companion.companionSession}` (undefined pre-fork) and
+// `transientMessages`/`runningStatus` from the same hook.
+function renderNoSessionChatView(
+  props: Partial<ComponentProps<typeof ChatView>>,
+): string {
+  const view = createElement(ChatView, {
+    messages: [],
+    activeSession: undefined,
+    onNew: () => {},
+    // A marker standing in for the empty-state content a caller supplies (the
+    // side panel's placeholder, the main chat's onboarding surface / hero). It
+    // must render when there is no optimistic content, and be suppressed when a
+    // bubble/running turn takes over — the ChatMessageList shows `emptyState`
+    // only while it has no children, so empty optimistic fragments must not
+    // count as children (regression: onboarding stopped rendering otherwise).
+    emptyOverride: createElement('div', { 'data-testid': 'empty-state-marker' }),
+    ...props,
+  } as ComponentProps<typeof ChatView>);
+  const layout = createElement(ChatSurfaceLayout, {
+    scrollOwner: 'host',
+    composer: null,
+    children: view,
+  });
+  const astryx = createElement(AstryxLocaleProvider, { children: layout });
+  return renderToStaticMarkup(
+    createElement(LocaleProvider, { locale: 'en', children: astryx }),
+  );
+}
+
+const OPTIMISTIC_BUBBLE: TransientUserMessageProjection = {
+  id: 'turn-1',
+  text: 'why does this fail?',
+  ts: 1,
+  transientPlacement: 'current_turn',
+};
+
+test('ChatView renders the optimistic bubble and running status before a session exists', () => {
+  const markup = renderNoSessionChatView({
+    transientMessages: [OPTIMISTIC_BUBBLE],
+    runningStatus: true,
+  });
+  // The user's question is on screen immediately, before the fork/session lands.
+  assert.match(markup, /why does this fail\?/);
+  // The running-status line rides alongside it (the no-turn bare-turn fallback).
+  assert.match(markup, /data-live-streaming="true"/);
+  // The optimistic content takes over from the empty state.
+  assert.doesNotMatch(markup, /empty-state-marker/);
+});
+
+test('ChatView shows the empty state when there is neither a bubble nor a running turn', () => {
+  const markup = renderNoSessionChatView({
+    transientMessages: [],
+    runningStatus: false,
+  });
+  assert.doesNotMatch(markup, /why does this fail\?/);
+  assert.doesNotMatch(markup, /data-live-streaming="true"/);
+  // The empty state (onboarding surface / hero) must still render — the empty
+  // optimistic fragments must not suppress it.
+  assert.match(markup, /empty-state-marker/);
+});

--- a/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-retry.test.ts
@@ -376,6 +376,83 @@ test('first send after a completed turn forks through the settled turn', async (
   assert.equal(probe.getAttribute('data-error'), '');
 });
 
+test('a first send shows the question bubble immediately but arms Stop only once the fork exists', async () => {
+  // `branchFromTurn` is the Host round trip a first send waits on. Holding it
+  // open lets us observe the panel while the fork is still being created.
+  const branch = deferred<{ ok: true; session: SessionSummary }>();
+  const rendered = await renderOwnershipProbe({
+    listTurns: async () => [settledTurn('done-turn')],
+    branchFromTurn: () => branch.promise,
+    send: async () => ({ ok: true as const, turnId: 'first-turn' }),
+  });
+  const probe = rendered.container.firstElementChild;
+  assert.ok(probe);
+  // Nothing sent yet: no fork, no bubble, not streaming.
+  assert.equal(probe.getAttribute('data-companion-id'), '');
+  assert.equal(probe.getAttribute('data-transient-count'), '0');
+  assert.equal(probe.getAttribute('data-streaming'), 'false');
+
+  // Kick off the send but leave fork creation pending (branch unresolved).
+  let sendResult!: Promise<boolean>;
+  await act(async () => {
+    sendResult = rendered.send('why does this fail?');
+    await Promise.resolve();
+  });
+  await waitUntil(() => probe.getAttribute('data-transient-count') === '1');
+
+  // The fork has NOT committed yet, but the question bubble is already on screen
+  // — the instant feedback #4654 asked for, and what the panel's running-status
+  // line rides on (`streaming || transientMessages.length > 0`) before a turn
+  // exists. Crucially `streaming` is still false, so the Composer does NOT render
+  // a Stop button during the window where `stop()` is a no-op (companionIdRef is
+  // only set at commitFork). Arming the admission early would show a dead Stop.
+  assert.equal(probe.getAttribute('data-companion-id'), '');
+  assert.equal(probe.getAttribute('data-transient-text'), 'why does this fail?');
+  assert.equal(probe.getAttribute('data-streaming'), 'false');
+
+  // Once the fork commits and the send goes in flight, the admission arms:
+  // streaming turns true, so Stop appears exactly when it can act on the turn.
+  await act(async () => {
+    branch.resolve({ ok: true as const, session: session('side-conversation') });
+    assert.equal(await sendResult, true);
+    await Promise.resolve();
+  });
+  await awaitCompanion(rendered.container);
+  await waitUntil(() => probe.getAttribute('data-streaming') === 'true');
+  assert.equal(probe.getAttribute('data-error'), '');
+  assert.equal(probe.getAttribute('data-transient-count'), '1');
+
+  // The running state rides the whole turn and only retires on completion.
+  await act(async () => {
+    rendered.emit(completeEvent('c1', 'first-turn', 2));
+    await Promise.resolve();
+  });
+  await waitUntil(() => probe.getAttribute('data-streaming') === 'false');
+});
+
+test('a failed first send retires the optimistic bubble without ever arming Stop', async () => {
+  // The fork never materializes: `branchFromTurn` throws. The optimistic bubble
+  // must be unwound so nothing is stranded with no turn to reconcile it away, and
+  // Stop must never have appeared (the admission is armed only in onBeforeSend).
+  const rendered = await renderOwnershipProbe({
+    listTurns: async () => [settledTurn('done-turn')],
+    branchFromTurn: async () => {
+      throw new Error('fork setup exploded');
+    },
+  });
+  const probe = rendered.container.firstElementChild;
+  assert.ok(probe);
+
+  await act(async () => {
+    assert.equal(await rendered.send('why does this fail?'), false);
+    await Promise.resolve();
+  });
+  assert.equal(probe.getAttribute('data-companion-id'), '');
+  assert.equal(probe.getAttribute('data-transient-count'), '0');
+  assert.equal(probe.getAttribute('data-streaming'), 'false');
+  assert.equal(probe.getAttribute('data-live-turn-id'), '');
+});
+
 test('dispatches /compact to the committed companion fork without sending model input', async () => {
   const compactCalls: string[] = [];
   let sendCalls = 0;
@@ -1968,6 +2045,8 @@ function QuoteCompanionOwnershipProbe(props: {
     'data-processing': String(companion.processing),
     'data-model-ready': String(companion.modelReady),
     'data-permission-mode': companion.permissionMode ?? '',
+    'data-transient-count': String(companion.transientMessages.length),
+    'data-transient-text': companion.transientMessages[0]?.text ?? '',
   });
 }
 

--- a/apps/desktop/src/renderer/features/workbar/tools/side-chat/quote-companion-panel.tsx
+++ b/apps/desktop/src/renderer/features/workbar/tools/side-chat/quote-companion-panel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { useCallback, useEffect, useRef, type ComponentProps } from 'react';
+import { useCallback, useEffect, useRef, useState, type ComponentProps } from 'react';
 import { Banner } from '@astryxdesign/core/Banner';
 import {
   ChatView,
@@ -58,6 +58,28 @@ import type {
 import type { CompanionForkVisibilityEvent } from './quote-companion-visibility';
 import { readScrollMotionBehavior } from '../../../../scroll-motion-policy';
 import { useWorkbarServices } from '../../services-context.js';
+
+const RUNNING_STATUS_DELAY_MS = 200;
+
+/**
+ * A boolean that turns true only after `condition` has held for `delayMs`, and
+ * false the moment it drops — the rising-edge delay that keeps a fast turn from
+ * flashing the running-status line. A feature-local copy of the shell's
+ * useDelayedFlag: the renderer-legacy original is walled off from feature code
+ * by the architecture budget, and this is only a few lines of timer plumbing.
+ */
+function useDelayedFlag(condition: boolean, delayMs: number): boolean {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    if (!condition) {
+      setVisible(false);
+      return;
+    }
+    const handle = window.setTimeout(() => setVisible(true), delayMs);
+    return () => window.clearTimeout(handle);
+  }, [condition, delayMs]);
+  return visible;
+}
 
 /**
  * The side-conversation workbar tab: a transient read-only fork of the main session.
@@ -171,6 +193,19 @@ export function QuoteCompanionPanel(props: {
   useEffect(() => {
     props.onContentStateChange?.(props.panelId, companion.hasContent);
   }, [companion.hasContent, props.onContentStateChange, props.panelId]);
+  // The transcript's running-status line ("正在琢磨… · Ns"). Like the main chat
+  // (useShellLiveTurn → showRunningStatus) it rides the whole active turn, not
+  // just the pre-first-token wait, with the same rising-edge delay so a fast
+  // turn never flashes it. The companion's `processing` only covers the wait
+  // window, which is why the side panel used to show almost no progress cue.
+  // `transientMessages` covers the first-send window BEFORE the fork commits and
+  // the admission is armed: the optimistic bubble is on screen but `streaming`
+  // is still false, and the cue must already be up (the admission is deliberately
+  // armed late so the Stop button never appears before `stop()` can act on it).
+  const showRunningStatus = useDelayedFlag(
+    companion.streaming || companion.transientMessages.length > 0,
+    RUNNING_STATUS_DELAY_MS,
+  );
   useEffect(() => {
     props.onActivityStateChange?.(
       props.panelId,
@@ -381,9 +416,10 @@ export function QuoteCompanionPanel(props: {
       >
         <ChatView
           messages={companion.messages}
+          transientMessages={companion.transientMessages}
           scrollBehavior={readScrollMotionBehavior()}
           liveTurn={companion.liveTurn}
-          runningStatus={companion.processing}
+          runningStatus={showRunningStatus}
           activeSession={companion.companionSession}
           onReadAttachmentBytes={attachments.readBytes}
           deriveTurnPresentation={deriveTurnPresentation}

--- a/apps/desktop/src/renderer/features/workbar/tools/side-chat/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/features/workbar/tools/side-chat/use-quote-companion.ts
@@ -27,6 +27,7 @@ import {
   useSessionSettingIntent,
   type InteractionQueues,
   type LiveTurnProjection,
+  type TransientUserMessageProjection,
 } from '@maka/ui';
 import type {
   SandboxBoundaryRequestEvent,
@@ -160,6 +161,10 @@ export interface UseQuoteCompanionResult {
    *  the model but stays hidden from this side transcript (separate transcript,
    *  like Codex /side), so the panel isn't a duplicate of the main conversation. */
   messages: StoredMessage[];
+  /** Optimistic, renderer-only user bubbles shown the instant a send dispatches,
+   *  before the durable transcript echoes them back. Reconciled away once the
+   *  durable message with the same id lands. Pass straight to `ChatView`. */
+  transientMessages: readonly TransientUserMessageProjection[];
   liveTurn: LiveTurnProjection | undefined;
   streaming: boolean;
   processing: boolean;
@@ -269,6 +274,15 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   const compactionTurnIdRef = useRef<string | null>(null);
   const pendingCompactionTerminalRef = useRef<PendingCompactionTerminal | null>(null);
   const [allMessages, setAllMessages] = useState<StoredMessage[]>([]);
+  // Renderer-only user bubble shown the instant a send dispatches. The durable
+  // transcript only echoes the just-sent question back mid-turn on a single
+  // best-effort refresh (and otherwise not until the turn settles), so without
+  // this the user's message stays invisible until the whole answer completes.
+  // Mirrors the main chat's optimistic `transientMessages`; reconciled away once
+  // the durable message with the same id lands in `allMessages`.
+  const [pendingUserMessages, setPendingUserMessages] = useState<
+    TransientUserMessageProjection[]
+  >([]);
   const [liveTurn, setLiveTurn] = useState<LiveTurnProjection | undefined>(undefined);
   const liveTurnRef = useRef(liveTurn);
   liveTurnRef.current = liveTurn;
@@ -346,6 +360,16 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   // there is no state to keep in sync.
   const setSubmitLocked = useCallback((locked: boolean) => {
     submitLockRef.current = locked;
+  }, []);
+
+  // Retire the optimistic bubble for a message id. Called when a send is
+  // retracted/abandoned; the success path retires it implicitly by reconciling
+  // against the durable transcript (see the `transientMessages` derivation).
+  const dropOptimisticUserMessage = useCallback((messageId: string) => {
+    setPendingUserMessages((current) => {
+      const next = current.filter((message) => message.id !== messageId);
+      return next.length === current.length ? current : next;
+    });
   }, []);
 
   const applyOwnedEvent = useCallback(
@@ -478,11 +502,14 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
     (admission: PendingAdmission, message?: string) => {
       if (pendingAdmissionRef.current !== admission) return;
       setPendingAdmission(null);
+      // The send is being abandoned (retracted / failed): the optimistic bubble
+      // would otherwise linger with no turn to reconcile it away.
+      dropOptimisticUserMessage(admission.messageId);
       if (stopRequestRef.current === admission.stopPromise) stopRequestRef.current = null;
       if (!activeTurnIdRef.current) setLiveTurn(undefined);
       if (message) setError(message);
     },
-    [setPendingAdmission],
+    [dropOptimisticUserMessage, setPendingAdmission],
   );
 
   const resolveAdmission = useCallback(
@@ -843,9 +870,46 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       const turnId = crypto.randomUUID();
       const quoteSnapshot = snapshotCompanionQuotes(panelId, pendingQuotes);
       const label = (quoteSnapshot.quotes[0]?.text ?? trimmed).slice(0, 24);
+      // Show the user's question IMMEDIATELY as an optimistic bubble, before the
+      // fork exists. On a first send `ensureFork` makes a Host round trip, and the
+      // main chat renders the question the instant Send is pressed; the side panel
+      // must match rather than stay blank until the fork materializes. The bubble
+      // ALSO lights the running-status line — the panel derives it from
+      // `streaming || transientMessages.length > 0` — so the "working" cue rises
+      // in this same window WITHOUT arming the admission early. Arming it here
+      // would flip `streaming` on and render the Composer's Stop button while
+      // `stop()` is still a no-op (`companionIdRef` is only set at commitFork): a
+      // visible-but-dead control for the whole fork round trip. So the admission
+      // and live turn are armed in `onBeforeSend`, once the fork can actually be
+      // stopped; the double-submit window stays closed by `submitLockRef`.
+      // `abandonOptimisticSend` retires the bubble if setup fails before the send.
+      const admission: PendingAdmission = {
+        messageId: turnId,
+        events: [],
+        consumeOnAdmission: () => onQuotesConsumed(quoteSnapshot),
+      };
+      setPendingUserMessages((current) => [
+        ...current.filter((message) => message.id !== turnId),
+        {
+          id: turnId,
+          text: trimmed,
+          ts: Date.now(),
+          transientPlacement: 'current_turn',
+          ...(quoteSnapshot.quotes.length > 0 ? { quotes: quoteSnapshot.quotes } : {}),
+        },
+      ]);
+      // Setup can still fail before the send is in flight (fork unavailable,
+      // fail-closed permission write, or a lost subscription). Retire the
+      // optimistic bubble and release the lock so a failed first send never
+      // strands a question with no turn to reconcile it away. The admission and
+      // live turn are not armed until `onBeforeSend`, so nothing else to unwind.
+      const abandonOptimisticSend = () => {
+        dropOptimisticUserMessage(turnId);
+        setSubmitLocked(false);
+      };
       const fork = await ensureFork(`${copyRef.current.namePrefix}${label}`);
       if (fork.status !== 'ready') {
-        setSubmitLocked(false);
+        abandonOptimisticSend();
         return false;
       }
       // A permission mode picked before the fork existed is applied now, before
@@ -866,12 +930,12 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
           applied = false;
         }
         if (!mountedRef.current) {
-          setSubmitLocked(false);
+          abandonOptimisticSend();
           return false;
         }
         if (!applied) {
           setError(copyRef.current.errors.respondFailed);
-          setSubmitLocked(false);
+          abandonOptimisticSend();
           return false;
         }
       }
@@ -885,14 +949,13 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
           subscriptionReadyRef.current = subscribeToFork(fork.session.id);
           setError(copyRef.current.errors.sendFailed);
         }
-        setSubmitLocked(false);
+        abandonOptimisticSend();
         return false;
       }
       if (!mountedRef.current) {
-        setSubmitLocked(false);
+        abandonOptimisticSend();
         return false;
       }
-      let sendAdmission: PendingAdmission | undefined;
       const result = await performCompanionTurn({
         api: sideChat,
         sourceSession,
@@ -911,23 +974,18 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
             sessionId,
           }),
         onForkCommitted: () => {},
-        // Arm the optimistic live turn right before the send.
+        // The send is now in flight against a committed fork, so the Stop button
+        // can finally stop something: arm the admission (flips `streaming` on)
+        // and the live turn, and release the submit lock. The optimistic bubble
+        // is already on screen from before `ensureFork`.
         onBeforeSend: () => {
           stopRequestRef.current = null;
-          const admission: PendingAdmission = {
-            messageId: turnId,
-            events: [],
-            consumeOnAdmission: () => onQuotesConsumed(quoteSnapshot),
-          };
-          sendAdmission = admission;
           setPendingAdmission(admission);
           setSubmitLocked(false);
           setLiveTurn(armLiveTurn(turnId));
         },
       });
       if (result.status === 'sent' || result.status === 'pending') {
-        const admission = sendAdmission;
-        if (!admission) return false;
         if (result.status === 'pending') {
           const outcome = resolveAdmission(result.forkId, admission, result.messageId);
           if (outcome?.kind === 'retracted') {
@@ -943,9 +1001,21 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
         }
         if ((await admission.stopPromise) === 'confirmed') return false;
         setHasContent(true);
-        // Surface the just-sent user message immediately, and reflect any
-        // automatic connection/model rebound in the read-only model label.
-        void sideChat.readSettledMessages(result.forkId)
+        // Surface the just-sent user message, and reflect any automatic
+        // connection/model rebound in the read-only model label. Wait for THIS
+        // message to be durable (requiredAssistantMessageId gates on any message
+        // id) rather than returning the first ready snapshot: on a follow-up the
+        // transcript store is already "ready" from the prior turn, so an
+        // unqualified read returns stale and the new turn never lands in
+        // `messages`. Without the turn, the running-status line ("正在推敲…") has
+        // nothing to attach to and only appears once the answer starts settling.
+        // The Host mints the user message id from the reserved turn id (`const
+        // messageId = turnId`), so a pending/steered `result.messageId` equals
+        // `turnId` — one identity across every path.
+        void sideChat
+          .readSettledMessages(result.forkId, {
+            requiredAssistantMessageId: turnId,
+          })
           .then(({ messages: next }) => {
             if (mountedRef.current) {
               setAllMessages((current) => mergeSettledMessages(current, next));
@@ -975,7 +1045,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
         };
         setError(byCode[result.code]);
         activeTurnIdRef.current = null;
-        if (sendAdmission) releaseAdmission(sendAdmission);
+        releaseAdmission(admission);
         setLiveTurn(undefined);
       }
       // 'disposed' → the panel unmounted mid-create; nothing to update.
@@ -992,6 +1062,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       sideChat,
       bindAdmittedTurn,
       compact,
+      dropOptimisticUserMessage,
       releaseAdmission,
       resolveAdmission,
       setPendingAdmission,
@@ -1219,6 +1290,15 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   const messages = allMessages.filter(
     (message) => message.turnId !== undefined && ownTurnIdsRef.current.has(message.turnId),
   );
+  // Drop the optimistic bubble only once its durable twin will actually RENDER,
+  // i.e. it is in `messages` (own-turn filtered) — not merely settled into
+  // `allMessages`. Building this from `allMessages` could retire the transient on
+  // an `outcome_unknown` settle while the durable message is still filtered out of
+  // the render, blinking the question away until `reconcileUnknownAdmission` binds.
+  const durableMessageIds = new Set(messages.map((message) => message.id));
+  const transientMessages = pendingUserMessages.filter(
+    (message) => !durableMessageIds.has(message.id),
+  );
   // Inherited model (read-only): the fork's once created, else the source's.
   const activeModel = companion
     ? { llmConnectionSlug: companion.llmConnectionSlug, model: companion.model }
@@ -1249,6 +1329,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
     companionSession: companion,
     hasContent,
     messages,
+    transientMessages,
     liveTurn,
     streaming,
     processing,

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -609,6 +609,13 @@ export function ChatView(props: {
 
   if (!props.activeSession) {
     const conversationItems = props.conversationItems ?? [];
+    // A side conversation forks lazily: its first send arms the optimistic
+    // bubble (and, after the rising-edge delay, the running-status line) BEFORE
+    // the fork commits, so there is no session yet. Render that optimistic
+    // content here too — otherwise the first question stays invisible for the
+    // whole fork round trip (#4654). Once the fork commits `activeSession`
+    // arrives and the full transcript below takes over.
+    const hasOptimisticContent = transientMessages.length > 0 || !!props.runningStatus;
     const emptyContent = props.emptyOverride ?? (
       <EmptyChatHero onPromptSuggestion={props.onPromptSuggestion} userLabel={props.userLabel} />
     );
@@ -635,12 +642,45 @@ export function ChatView(props: {
             owns. */}
         <ChatMessageList
           className="maka-chat-message-list maka-chatContent"
-          emptyState={conversationItems.length === 0 ? emptyContent : undefined}
+          emptyState={
+            conversationItems.length === 0 && !hasOptimisticContent ? emptyContent : undefined
+          }
         >
-          {conversationItems.length > 0 ? (
+          {/* Keep this a single `null` child when there is nothing to show, so
+              `ChatMessageList` still renders its `emptyState` (the onboarding
+              surface / empty hero). Rendering empty `transientMessages`/running
+              fragments as separate children would leave the list "non-empty" and
+              suppress that empty state. */}
+          {conversationItems.length > 0 || hasOptimisticContent ? (
             <>
-              {emptyContent}
-              {conversationItems.map((item) => <Fragment key={item.id}>{item.content}</Fragment>)}
+              {conversationItems.length > 0 ? (
+                <>
+                  {emptyContent}
+                  {conversationItems.map((item) => (
+                    <Fragment key={item.id}>{item.content}</Fragment>
+                  ))}
+                </>
+              ) : null}
+              {transientMessages.map((message) => (
+                <TransientUserMessage key={message.id} message={message} />
+              ))}
+              {/* No committed turn yet (the fork is still being created), so
+                  render the running phrase in a bare turn without a clock —
+                  mirrors the #642 fallback in the settled-session branch below. */}
+              {props.runningStatus && (
+                <section className="maka-turn" data-live-streaming="true">
+                  <LocalizedChatMessage
+                    accessibleLabel={conversationCopy.messages.assistantAriaLabel}
+                    sender="assistant"
+                    className="maka-chat-message maka-assistant-answer"
+                  >
+                    <div className="maka-assistant-answer-content">
+                      <TurnRunningStatus />
+                    </div>
+                    <div aria-hidden="true" className="maka-live-turn-footer-placeholder" />
+                  </LocalizedChatMessage>
+                </section>
+              )}
             </>
           ) : null}
         </ChatMessageList>


### PR DESCRIPTION
## Summary

Two parity/UX fixes for the **side conversation** (quote-companion side chat) in the Desktop renderer. The main conversation already behaves this way; this brings the side conversation in line.

1. **Show the user's message immediately on send** — even during the first send's lazy fork. The side conversation renders the submitted message optimistically (`transientMessages`, the same mechanism the main chat uses) instead of only after the turn completes. Because the fork is created lazily, there is no session yet on the first send, so `ChatView`'s no-`activeSession` branch now also renders `transientMessages` (and the running-status line) — otherwise the first question stayed invisible for the whole fork round trip. It is reconciled away once the durable transcript echoes the same message id (matched against the rendered `messages`, so an `outcome_unknown` settle can't briefly blink the bubble away).
2. **Show the "working" progress indicator during the wait.** The running-status line is derived from `streaming || transientMessages.length > 0` with the same rising-edge delay as the main chat's `showRunningStatus`, so it rises in the pre-fork window and rides the whole active turn — not just the brief pre-first-token `processing` window. The admission (and therefore the Composer's Stop button) is armed only in `onBeforeSend`, once the fork exists and `stop()` can act on it, so **Stop never appears while it would be a no-op**. The post-send settled read waits for the just-sent user message so the turn materializes promptly.

**Deferred to its own issue (#4693):** per-session workbar collapse (item 3 of #4654). It needs a product decision — whether the collapse preference persists across restart — and should hold the session key in the layout reducer rather than mirror it in an in-memory map (which would otherwise duplicate, and silently downgrade, the persisted `maka-session-workbar-collapsed-v1` authority). Kept out so this side-chat rendering change can land independently.

Refs #4654 (items 1 & 2; item 3 tracked in #4693)

## Verification

Local (all pass):
- `tsc -p tsconfig.renderer.json --noEmit` / `tsc -p tsconfig.main.json --noEmit`, plus `@maka/ui` `tsc` build — 0 errors.
- `biome check` on the changed files — clean.
- `check:architecture` — renderer snapshot + monotonic-debt ratchet pass.
- Unit (`node --test dist/main/__tests__/…`):
  - **New `chat-view-optimistic-render.test.tsx`** — SSR-renders `ChatView` with no `activeSession` and asserts the optimistic bubble **and** the running-status line appear (and that neither appears when there is no bubble/running turn). Verified it **fails on the pre-fix `ChatView`** (empty branch rendered only the hero) and passes after — this is the render-layer proof the earlier hook-only tests lacked.
  - `quote-companion-retry.test.ts` — the two new cases: *a first send shows the question bubble immediately but arms Stop only once the fork exists* (bubble on screen while `streaming` is still false during fork creation; fails on `main`), and *a failed first send retires the optimistic bubble without ever arming Stop*.
  - Full companion + workbar suites — pass.
- e2e (`playwright test e2e/slash-command-menu.spec.ts e2e/session-workbar.spec.ts`, against a build that resolves this branch's `@maka/ui`) — pass, including `dispatches /side …`, `a collapsed workbar never flashes during the first send`, and `Side Chat survives collapse …`.

Manual (dev app): the side conversation shows the submitted message immediately and the "working" indicator during the pre-first-token wait, matching the main conversation.

Note: this PR touches `@maka/ui` (`ChatView`'s no-session branch) in addition to `apps/desktop`, since that render path is where the first-send content was being dropped.

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — investigation, implementation, and local verification of the change. The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
