### PR TITLE
fix(runtime): propagate OpenCode Go session identity

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -2852,7 +2852,7 @@ test('Host auxiliary models meter provider usage and abort physical requests', {
       connection: {
         slug: 'goal-evaluator-provider',
         name: 'Goal evaluator provider',
-        providerType: 'moonshot',
+        providerType: 'opencode-go',
         baseUrl: provider.baseUrl,
         enabled: true,
         enabledModelIds: [MODEL_ID],
@@ -2957,6 +2957,7 @@ test('Host auxiliary models meter provider usage and abort physical requests', {
       requestDrain: () => assert.fail('Daily Review telemetry must not drain the Host'),
       newId: () => 'daily-review-call-1',
     });
+    const dailyReviewRequestsBefore = provider.requests.length;
     assert.deepEqual(
       await dailyReview.generate({
         modelKey: `goal-evaluator-provider::${MODEL_ID}`,
@@ -2974,6 +2975,9 @@ test('Host auxiliary models meter provider usage and abort physical requests', {
     assert.ok(dailyReviewLog);
     assert.equal(dailyReviewLog.callId, 'daily_review_daily-review-call-1');
     assert.equal(dailyReviewLog.sessionId, undefined);
+    const dailyReviewRequest = provider.requests[dailyReviewRequestsBefore];
+    assert.ok(dailyReviewRequest);
+    assert.equal(dailyReviewRequest.sessionHeader, 'daily-review-call-1');
 
     const memoryModel = createHostMemoryExtractionModel({
       runtimePolicy: policy,
@@ -3021,6 +3025,8 @@ test('Host auxiliary models meter provider usage and abort physical requests', {
     const [proposalRequest, canonicalizeRequest] = provider.requests.slice(memoryRequestsBefore);
     assert.ok(proposalRequest);
     assert.ok(canonicalizeRequest);
+    assert.equal(proposalRequest.sessionHeader, session.id);
+    assert.equal(canonicalizeRequest.sessionHeader, session.id);
     assert.deepEqual(toolNames(proposalRequest.body), ['memory_remember']);
     assert.match(JSON.stringify(proposalRequest.body), /SOURCE_SYSTEM_SENTINEL/);
     assert.match(JSON.stringify(proposalRequest.body), /SOURCE_USER_SENTINEL/);
@@ -4336,6 +4342,7 @@ interface ProviderRequest {
   readonly url: string;
   readonly authorization: string | undefined;
   readonly customHeader: string | undefined;
+  readonly sessionHeader: string | undefined;
   readonly body: Record<string, unknown>;
 }
 
@@ -4448,6 +4455,7 @@ async function handleProviderRequest(
     url: request.url ?? '',
     authorization: request.headers.authorization,
     customHeader: request.headers['x-maka-test'] as string | undefined,
+    sessionHeader: request.headers['x-opencode-session'] as string | undefined,
     body,
   });
   if (request.url === '/v1/responses') {

--- a/packages/runtime-host/src/server/execution-model-authority.ts
+++ b/packages/runtime-host/src/server/execution-model-authority.ts
@@ -227,11 +227,12 @@ export function createHostDailyReviewModel(
         const header = await readAuxiliaryPreflight(authority, effectiveAbortSignal, () =>
           resolveDailyReviewHeader(authority.runtimePolicy, modelKey),
         );
+        const callId = authority.newId();
         const result = await runHostAuxiliaryModelCall(authority, {
-          transportContextId: 'daily-review',
+          transportContextId: callId,
           header,
           callKind: 'daily_review',
-          callId: `daily_review_${authority.newId()}`,
+          callId: `daily_review_${callId}`,
           abortSignal: effectiveAbortSignal,
           buildRequest: () => ({ prompt, maxOutputTokens: 2_048 }),
         });
@@ -513,6 +514,7 @@ async function runHostAuxiliaryModelCall(
           input.header.thinkingLevel,
         );
         const model = getAIModel({
+          sessionId: input.transportContextId,
           connection: target.connection,
           apiKey,
           modelId: target.model,

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -203,6 +203,7 @@ async function buildHostAiSdkBackend(
     });
   const resolveHistoryCompactModel = () =>
     getAIModel({
+      sessionId: input.context.sessionId,
       connection: target.connection,
       apiKey,
       modelId: target.model,

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -25,6 +25,30 @@ import { ModelAdapter, normalizeAiSdkUsage } from '../model-adapter.js';
 import type { ModelStreamEvent } from '../model-protocol.js';
 
 describe('ModelAdapter stream and error normalization', () => {
+  test('forwards the stable Session identity to the model factory', () => {
+    let observedSessionId: string | undefined;
+    const model = {};
+    const adapter = new ModelAdapter({
+      sessionId: 'session-opencode-go',
+      connection: {
+        slug: 'opencode-go',
+        providerType: 'opencode-go',
+        defaultModel: 'kimi-k2.7-code',
+      },
+      apiKey: 'opencode-go-token',
+      modelId: 'kimi-k2.7-code',
+      modelFactory: (input) => {
+        observedSessionId = (input as { sessionId?: string }).sessionId;
+        return model;
+      },
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    assert.equal(adapter.resolveModel(), model);
+    assert.equal(observedSessionId, 'session-opencode-go');
+  });
+
   test('resolves optional-key LocalAI without fabricating a credential', () => {
     const model = {};
     let observedApiKey: string | undefined;

--- a/packages/runtime/src/__tests__/opencode-session-header.test.ts
+++ b/packages/runtime/src/__tests__/opencode-session-header.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { OPENCODE_SESSION_HEADER, withOpenCodeSessionHeader } from '../opencode-session-header.js';
+
+describe('OpenCode Go session header', () => {
+  test('adds a trimmed stable session identity only for OpenCode Go', () => {
+    assert.deepEqual(withOpenCodeSessionHeader('opencode-go', '  session-a  '), {
+      [OPENCODE_SESSION_HEADER]: 'session-a',
+    });
+    assert.equal(withOpenCodeSessionHeader('opencode', 'session-a'), undefined);
+    assert.equal(withOpenCodeSessionHeader('openai', 'session-a'), undefined);
+  });
+
+  test('preserves an explicitly configured header case-insensitively', () => {
+    const explicitHeaders = {
+      'X-OpenCode-Session': 'operator-selected-session',
+      'X-Maka-Test': 'preserved',
+    };
+
+    assert.equal(
+      withOpenCodeSessionHeader('opencode-go', 'automatic-session', explicitHeaders),
+      explicitHeaders,
+    );
+  });
+
+  test('does not add an empty session identity', () => {
+    const headers = { 'X-Maka-Test': 'preserved' };
+    assert.equal(withOpenCodeSessionHeader('opencode-go', '   ', headers), headers);
+  });
+});

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -962,6 +962,45 @@ describe('models.dev provider conformance', () => {
     assert.deepEqual(requests[2]?.body.contents, [{ role: 'user', parts: [{ text: 'Hi' }] }]);
   });
 
+  test('OpenCode Go connection probes identify every supported wire request', async () => {
+    const requests: Array<{
+      url: string;
+      headers: IncomingMessage['headers'];
+    }> = [];
+    const server = await startJsonServer(async (request, response) => {
+      requests.push({
+        url: request.url ?? '',
+        headers: request.headers,
+      });
+      respondJson(response, 200, {});
+    });
+    const connection: LlmConnection = {
+      slug: 'opencode-go',
+      name: 'OpenCode Go',
+      providerType: 'opencode-go',
+      baseUrl: `${server.url}/zen/go/v1`,
+      defaultModel: 'kimi-k2.7-code',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    for (const modelId of ['kimi-k2.7-code', 'minimax-m3', 'muse-spark-1.2-contributor']) {
+      assert.equal((await testConnection(connection, 'opencode-go-test-key', modelId)).ok, true);
+    }
+
+    assert.deepEqual(
+      requests.map(({ url }) => url),
+      ['/zen/go/v1/chat/completions', '/zen/go/v1/messages', '/zen/go/v1/responses'],
+    );
+    for (const request of requests) {
+      assert.match(
+        String(request.headers['x-opencode-session']),
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      );
+    }
+  });
+
   test('Volcengine Agent Plan connection probes do not retain the synthetic response', async () => {
     let body: Record<string, unknown> | undefined;
     const server = await startJsonServer(async (request, response) => {

--- a/packages/runtime/src/__tests__/responses-wire-contract.test.ts
+++ b/packages/runtime/src/__tests__/responses-wire-contract.test.ts
@@ -164,8 +164,11 @@ describe('responses wire contract', () => {
 
   test('routes OpenCode Go Muse Spark through the Responses endpoint', async () => {
     const urls: string[] = [];
-    const fetch = (async (url: string | URL | Request) => {
-      urls.push(String(url));
+    const sessionHeaders: Array<string | null> = [];
+    const fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const request = new Request(url, init);
+      urls.push(request.url);
+      sessionHeaders.push(request.headers.get('x-opencode-session'));
       return Response.json({
         id: 'r',
         object: 'response',
@@ -179,13 +182,76 @@ describe('responses wire contract', () => {
       apiKey: '[redacted]',
       modelId: 'muse-spark-1.2-contributor',
       fetch,
-    });
+      sessionId: 'session-opencode-go',
+    } as Parameters<typeof getAIModel>[0]);
 
     await model.doGenerate({
       prompt: [{ role: 'user', content: [{ type: 'text', text: 'ping' }] }],
     });
 
     assert.deepEqual(urls, ['https://opencode.ai/zen/go/v1/responses']);
+    assert.deepEqual(sessionHeaders, ['session-opencode-go']);
+  });
+
+  test('sends the OpenCode Go session identity through Chat and Messages adapters', async () => {
+    const requests: Array<{ url: string; sessionHeader: string | null }> = [];
+    const fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const request = new Request(url, init);
+      requests.push({
+        url: request.url,
+        sessionHeader: request.headers.get('x-opencode-session'),
+      });
+      if (request.url.endsWith('/messages')) {
+        return Response.json({
+          id: 'msg-opencode-go',
+          type: 'message',
+          role: 'assistant',
+          model: 'minimax-m3',
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+      }
+      return Response.json({
+        id: 'chatcmpl-opencode-go',
+        object: 'chat.completion',
+        created: 1,
+        model: 'kimi-k2.7-code',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      });
+    }) as typeof globalThis.fetch;
+
+    for (const modelId of ['kimi-k2.7-code', 'minimax-m3']) {
+      const model = getAIModel({
+        connection: conn('opencode-go'),
+        apiKey: '[redacted]',
+        modelId,
+        fetch,
+        sessionId: 'session-opencode-go',
+      });
+      await model.doGenerate({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'ping' }] }],
+      });
+    }
+
+    assert.deepEqual(requests, [
+      {
+        url: 'https://opencode.ai/zen/go/v1/chat/completions',
+        sessionHeader: 'session-opencode-go',
+      },
+      {
+        url: 'https://opencode.ai/zen/go/v1/messages',
+        sessionHeader: 'session-opencode-go',
+      },
+    ]);
   });
 
   test('normalizes the upstream Open Responses endpoint exactly once', () => {

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -210,6 +210,7 @@ export class ModelAdapter {
       throw new Error(`No API key stored for connection "${this.input.connection.slug}"`);
     }
     return this.input.modelFactory({
+      sessionId: this.input.sessionId,
       connection: this.input.connection,
       apiKey: this.input.apiKey,
       modelId: this.input.modelId,

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -62,11 +62,13 @@ import { runtimeProviderName, type RuntimeProviderAdapter } from './provider-run
 import { openAiCodexHeaders } from './subscription-auth.js';
 import { createRequestCustomizationFetch } from './request-customization-fetch.js';
 import { createStreamUsageFallbackFetch } from './stream-usage-fallback-fetch.js';
+import { withOpenCodeSessionHeader } from './opencode-session-header.js';
 
 export interface ModelFactoryInput {
   connection: RuntimeExecutionConnection;
   apiKey: string;
   modelId: string;
+  sessionId?: string;
   fetch?: typeof globalThis.fetch;
   requestHeaders?: Readonly<Record<string, string>>;
   resolvedRuntime?: ResolvedModelRuntime;
@@ -80,6 +82,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
     connection,
     apiKey,
     modelId,
+    sessionId,
     fetch,
     requestHeaders,
     resolvedRuntime,
@@ -88,12 +91,17 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
   } = input;
   const runtime = resolvedRuntime ?? resolveModelRuntime(connection, modelId);
   const { adapter, baseUrl: baseURL, wire, reasoningReplay } = runtime;
+  const effectiveRequestHeaders = withOpenCodeSessionHeader(
+    connection.providerType,
+    sessionId,
+    requestHeaders,
+  );
   const hasRequestCustomization =
-    Object.keys(requestHeaders ?? {}).length > 0 ||
+    Object.keys(effectiveRequestHeaders ?? {}).length > 0 ||
     Object.keys(connection.requestBodyOverlay ?? {}).length > 0;
   const baseFetch = fetch ?? globalThis.fetch;
   const requestCustomization = {
-    headers: requestHeaders,
+    headers: effectiveRequestHeaders,
     bodyOverlay: connection.requestBodyOverlay,
   } as const;
   const requestFetch = createRequestCustomizationFetch(baseFetch, requestCustomization);

--- a/packages/runtime/src/opencode-session-header.ts
+++ b/packages/runtime/src/opencode-session-header.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ProviderType } from '@maka/core/llm-connections';
+
+export const OPENCODE_SESSION_HEADER = 'x-opencode-session';
+
+/** Adds OpenCode Go's session identity without overriding an explicit header. */
+export function withOpenCodeSessionHeader(
+  providerType: ProviderType,
+  sessionId: string | undefined,
+  headers?: Readonly<Record<string, string>>,
+): Readonly<Record<string, string>> | undefined {
+  const normalizedSessionId = sessionId?.trim();
+  if (providerType !== 'opencode-go' || !normalizedSessionId) return headers;
+  if (Object.keys(headers ?? {}).some((name) => name.toLowerCase() === OPENCODE_SESSION_HEADER)) {
+    return headers;
+  }
+  return { ...headers, [OPENCODE_SESSION_HEADER]: normalizedSessionId };
+}

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { randomUUID } from 'node:crypto';
 import {
   PROVIDER_REGISTRY,
   providerDefaultsOf,
@@ -47,6 +48,7 @@ import {
   type ConnectionEffectError,
   type ConnectionTestEffectOutcome,
 } from './connection-effect-outcome.js';
+import { withOpenCodeSessionHeader } from './opencode-session-header.js';
 
 const CONNECTION_TEST_TIMEOUT_MS = 15_000;
 
@@ -157,6 +159,7 @@ async function testConnectionStrict(
   if (!defaults) {
     return { ok: false, errorMessage: `Unknown provider type "${connection.providerType}"` };
   }
+  const sessionId = connection.providerType === 'opencode-go' ? randomUUID() : undefined;
   const auth = defaults.authKind;
   const secret = auth === 'none' ? '' : apiKey;
   const testModel = resolveConnectionTestModel(
@@ -189,6 +192,7 @@ async function testConnectionStrict(
           fetchFn,
           t0,
           attemptTimeoutMs,
+          sessionId,
         );
         if (result.ok) return result;
         lastFailure = result;
@@ -199,7 +203,15 @@ async function testConnectionStrict(
     return lastFailure ?? connectionTestFailure(new ConnectionEffectFetchError('timeout'), t0);
   }
 
-  return await testConnectionModel(connection, secret, testModel, fetchFn, t0, timeoutMs);
+  return await testConnectionModel(
+    connection,
+    secret,
+    testModel,
+    fetchFn,
+    t0,
+    timeoutMs,
+    sessionId,
+  );
 }
 
 async function testConnectionModel(
@@ -209,6 +221,7 @@ async function testConnectionModel(
   fetchFn: ConnectionEffectFetch | undefined,
   t0: number,
   timeoutMs = CONNECTION_TEST_TIMEOUT_MS,
+  sessionId?: string,
 ): Promise<ConnectionTestResult> {
   // Ahead of `resolveModelRuntime`, which throws for an adapter it cannot name.
   // A stored connection can still be opened long after its provider stopped
@@ -218,24 +231,51 @@ async function testConnectionModel(
     return retiredProviderTestResult(connection.providerType);
   }
   const { adapter, baseUrl, wire } = resolveModelRuntime(connection, testModel);
+  const requestHeaders = withOpenCodeSessionHeader(connection.providerType, sessionId);
 
   switch (adapter.kind) {
     case 'anthropic':
-      return await probeAnthropic(connection, baseUrl, secret, testModel, t0, fetchFn);
+      return await probeAnthropic(
+        connection,
+        baseUrl,
+        secret,
+        testModel,
+        t0,
+        fetchFn,
+        requestHeaders,
+      );
     case 'unavailable':
       // Unreachable: the guard above returns first. The arm keeps the switch
       // exhaustive so a newly retired provider cannot slip past it.
       return retiredProviderTestResult(connection.providerType);
     case 'openai':
       return wire === 'openai-responses'
-        ? await probeOpenAIResponses(baseUrl, secret, testModel, t0, fetchFn)
-        : await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn, timeoutMs);
+        ? await probeOpenAIResponses(baseUrl, secret, testModel, t0, fetchFn, requestHeaders)
+        : await probeOpenAI(
+            connection,
+            baseUrl,
+            secret,
+            testModel,
+            t0,
+            fetchFn,
+            timeoutMs,
+            requestHeaders,
+          );
     case 'openai-codex':
       return await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn, timeoutMs);
     case 'openai-compatible':
       return wire === 'openai-responses'
-        ? await probeOpenAIResponses(baseUrl, secret, testModel, t0, fetchFn)
-        : await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn, timeoutMs);
+        ? await probeOpenAIResponses(baseUrl, secret, testModel, t0, fetchFn, requestHeaders)
+        : await probeOpenAI(
+            connection,
+            baseUrl,
+            secret,
+            testModel,
+            t0,
+            fetchFn,
+            timeoutMs,
+            requestHeaders,
+          );
     case 'github-copilot':
       return await probeGitHubCopilot(baseUrl, secret, testModel, t0, fetchFn);
     case 'google':
@@ -275,10 +315,12 @@ async function probeOpenAIResponses(
   model: string,
   t0: number,
   fetchFn: ConnectionEffectFetch | undefined,
+  requestHeaders?: Readonly<Record<string, string>>,
 ): Promise<ConnectionTestResult> {
   const r = await fetchForConnectionEffect(fetchFn, openResponsesUrl(baseUrl), {
     method: 'POST',
     headers: {
+      ...requestHeaders,
       authorization: `Bearer ${apiKey}`,
       'content-type': 'application/json',
     },
@@ -331,8 +373,10 @@ async function probeAnthropic(
   model: string,
   t0: number,
   fetchFn: ConnectionEffectFetch | undefined,
+  requestHeaders?: Readonly<Record<string, string>>,
 ): Promise<ConnectionTestResult> {
   const headers: Record<string, string> = {
+    ...requestHeaders,
     'x-api-key': secret,
     'anthropic-version': '2023-06-01',
     'content-type': 'application/json',
@@ -361,6 +405,7 @@ async function probeOpenAI(
   t0: number,
   fetchFn: ConnectionEffectFetch | undefined,
   timeoutMs = CONNECTION_TEST_TIMEOUT_MS,
+  requestHeaders?: Readonly<Record<string, string>>,
 ): Promise<ConnectionTestResult> {
   if (connection.providerType === 'openai-codex') {
     // Codex Subscription credentials are ChatGPT account-scoped OAuth
@@ -375,6 +420,7 @@ async function probeOpenAI(
   const r = await fetchForConnectionEffect(fetchFn, `${stripTrailing(baseUrl)}/chat/completions`, {
     method: 'POST',
     headers: {
+      ...requestHeaders,
       ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
       'content-type': 'application/json',
     },


### PR DESCRIPTION
## Summary

OpenCode Go requires every inference request to carry an `x-opencode-session` header with a stable conversation identity. Maka omitted the header from both normal model requests and direct Connection Test probes, which may cause those requests to be rejected by the provider.

This change adds the header at the shared request-customization boundary and propagates the existing Maka Session identity through:

- normal model requests and tool-loop steps;
- history compaction;
- session-scoped auxiliary calls such as title, recap, memory extraction, and goal evaluation;
- OpenAI Chat, Anthropic Messages, and Responses wires.

Operations without a Session use one identity per operation: Connection Test generates one UUID and reuses it across its internal attempts, while Daily Review generates one call identity and reuses it for provider retries.

The header is restricted to `opencode-go`. An explicitly configured `x-opencode-session` header takes precedence case-insensitively, and no user content or credential material is included in the generated value.

Fixes #4663

Related upstream report:
https://github.com/vercel/ai/issues/20271

## Verification

- Confirmed RED before the fix:
  - `ModelAdapter` did not forward its Session identity.
  - OpenCode Go Chat, Messages, Responses, and Connection Test requests omitted `x-opencode-session`.
  - Daily Review used the global constant `daily-review` instead of a unique per-operation identity.
- Focused OpenCode Go regression tests: 7 passed, 0 failed.
- Runtime Host model-composition suite: 28 passed, 0 failed.
- `@maka/runtime` full suite: 3,189 passed, 13 skipped, 0 failed.
- Root `build:test` completed successfully after rebasing onto current `main`.
- Full-repository lint and format checks, `git diff --check`, and the ASF license-header audit passed.
- DeepSeek Harness reviewed the patch with `deepseek-v4-pro` at max reasoning. Its shared Daily Review identity finding was reproduced and fixed with a regression test.

A full Runtime Host package run also exposed an unrelated timing failure in `owned Host exits promptly after its first connection closes`: the Host did not settle within its fixed 500 ms local deadline. The affected model-composition suite passes in full after a clean root build.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex reproduced the missing-header paths, implemented the fix, added regression coverage, and ran the local verification. DeepSeek Harness performed an independent read-only review that identified the Daily Review identity collision fixed in the final patch. The commit contains a `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No