### PR TITLE
fix(runtime): reach the standalone compaction call site with the retreat

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -4378,6 +4378,82 @@ describe('AiSdkBackend model history', () => {
     assert.equal(prompt.includes(oldResult.body), false);
   });
 
+  test('manual compactHistory retreats to a span this route has accepted', async () => {
+    // The retreat needs the run headers and the route to find the newest reply
+    // this model produced. The planner tests hand those in directly, so they
+    // would stay green if the call site stopped passing them; this drives the
+    // entry `/compact` actually uses.
+    const attemptedCoverage: string[][] = [];
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: { ...header(), llmConnectionId: 'test-connection-id', model: 'mock-model-id' },
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => completionModel(),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: { name: 'standalone-retreat-test', charsPerToken: 1 },
+      summarizeHistoryCompact: async ({ source }) => {
+        attemptedCoverage.push(source.foldedRuntimeEvents.map((event) => event.id));
+        if (attemptedCoverage.length === 1) {
+          throw new HistoryCompactSummarizerError('input_too_large');
+        }
+        return structuredSummary('STANDALONE_RETREAT_SENTINEL');
+      },
+      recordHistoryCompactCheckpoint: () => {},
+    });
+
+    const result = await backend.compactHistory({
+      turnId: 'turn-compact',
+      runId: 'run-1',
+      runtimeContextRunHeaders: [
+        priorModelRunHeader({ connectionId: 'test-connection-id', modelId: 'mock-model-id' }),
+      ],
+      runtimeContext: [
+        runtimeTextEvent({
+          id: 'old-user',
+          turnId: 'turn-old',
+          role: 'user',
+          author: 'user',
+          text: 'old alpha '.repeat(100),
+        }),
+        runtimeTextEvent({
+          id: 'old-model',
+          turnId: 'turn-old',
+          role: 'model',
+          author: 'agent',
+          text: 'old beta '.repeat(100),
+        }),
+        runtimeTextEvent({
+          id: 'recent-user',
+          turnId: 'turn-recent',
+          role: 'user',
+          author: 'user',
+          text: 'recent alpha '.repeat(100),
+        }),
+        runtimeTextEvent({
+          id: 'recent-model',
+          turnId: 'turn-recent',
+          role: 'model',
+          author: 'agent',
+          text: 'recent beta '.repeat(100),
+        }),
+      ],
+    });
+
+    assert.equal(result.outcome.kind, 'compacted');
+    // The first attempt covers everything; the retreat stops where the newest
+    // reply this route produced begins. Without the route reaching the planner
+    // there is no second attempt at all.
+    assert.deepEqual(attemptedCoverage, [
+      ['old-user', 'old-model', 'recent-user', 'recent-model'],
+      ['old-user', 'old-model', 'recent-user'],
+    ]);
+  });
+
   test('manual compactHistory writes a V2 checkpoint without the legacy artifact writer', async () => {
     const recorded: HistoryCompactCheckpoint[] = [];
     let memoryDispatches = 0;

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -366,6 +366,13 @@ export class AiSdkCompaction {
         sessionId: this.sessionId,
         phase: 'standalone',
         orderedEvents: runtimeContext,
+        ...(input.runtimeContextRunHeaders ? { runHeaders: input.runtimeContextRunHeaders } : {}),
+        acceptedRoute: {
+          modelId: this.input.modelId,
+          ...(this.targetConnectionId !== undefined
+            ? { connectionId: this.targetConnectionId }
+            : {}),
+        },
         reserveTailEvents: 0,
         charsPerToken,
         now: this.now(),


### PR DESCRIPTION
## Summary

Follow-up to #4667, reported by @Astro-Han there. That PR wired the proven-boundary retreat into the mid-turn and pre-turn call site and missed the standalone one, which is the site manual compaction uses.

Without `runHeaders` and `acceptedRoute`, `acceptedInputBoundary` returns nothing on its first line, so the first `input_too_large` fails open with no retreat at all. That path retreated before: its coverage gate admitted every halving step, so the loop walked down until a span was accepted. So this is a regression #4667 introduced, not a pre-existing gap.

Four entries reach the standalone site — CLI `/compact`, Desktop `sessions:compact`, sub-agent compaction from supervisor wake, and the pre-turn fallback in `ai-sdk-backend.ts`. The first three end as failed with a `context_compaction_failed_open` note; the fourth sends the oversized history and the turn dies with `context_overflow`. Its first attempt covers the whole prior session with no reserved tail, which is the span most likely to be rejected, so the regression lands on the ordinary long session rather than an edge.

Both values are already in hand at that call site: `input.runtimeContextRunHeaders` is used ten lines below, and the route is the same one the mid-turn site passes.

Refs #4559, #4667

## Verification

The test drives `compactHistory`, not `planHistoryCompaction`. That distinction is the point: the planner tests hand `acceptedRoute` in directly, so they would have stayed green with both call sites deleted, which is exactly how this got through. "manual compactHistory retreats to a span this route has accepted" asserts both attempts — the full span, then the retreat stopping where the newest reply this route produced begins — and fails on the previous commit, where there is no second attempt.

`ai-sdk-backend` 214/214, `history-compaction` 24/24, `mid-turn-capacity-backend` 73/73; typecheck, lint and format clean.

## Self-review

- @Astro-Han also noted that mid-turn cannot reach a retreat, because `priorRunHeaders` excludes the current turn so the proven index lands at or below `headAnchorIndex` while the gate wants it above. I confirmed that reading. It is a pre-existing limit rather than something #4667 changed (halving usually undershot the same gate), and it needs its own change to the gate, so it is not in this PR.
- The fix is deliberately the same two values the other call site passes, not a new derivation, so there is one rule and two call sites rather than two rules.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — implementation; reviewed and verified by the author.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

https://claude.ai/code/session_014ajaRxC4jydavY9nYUFj5J
