### PR TITLE
chore(ci): cap effort/XL at 2500 readable lines and add effort/XXL

### DIFF
--- a/scripts/pr-effort.mjs
+++ b/scripts/pr-effort.mjs
@@ -23,7 +23,7 @@
 // copy fresh. Pull request search has no size qualifier, which leaves reading
 // effort as the one axis a query cannot express.
 
-const EFFORT_LABELS = ['effort/XS', 'effort/S', 'effort/M', 'effort/L', 'effort/XL'];
+const EFFORT_LABELS = ['effort/XS', 'effort/S', 'effort/M', 'effort/L', 'effort/XL', 'effort/XXL'];
 
 // Counted changes should track what a human actually reads. Lockfiles,
 // regenerated artifacts and binaries are verified by their own contracts, so
@@ -40,13 +40,16 @@ const UNREAD_PATTERNS = [
 ];
 
 // Tier boundaries are inclusive upper bounds on readable lines. Test code is
-// not discounted anywhere here; it is reviewed too.
+// not discounted anywhere here; it is reviewed too. Past 2500 lines a pull
+// request is no longer reviewable as one change, so the top tier exists to
+// start the split conversation before the review does.
 const EFFORT_TIERS = [
   { label: 'effort/XS', maxLines: 10 },
   { label: 'effort/S', maxLines: 100 },
   { label: 'effort/M', maxLines: 500 },
   { label: 'effort/L', maxLines: 1000 },
-  { label: 'effort/XL', maxLines: Number.POSITIVE_INFINITY },
+  { label: 'effort/XL', maxLines: 2500 },
+  { label: 'effort/XXL', maxLines: Number.POSITIVE_INFINITY },
 ];
 
 function isUnreadPath(path) {

--- a/scripts/pr-effort.test.mjs
+++ b/scripts/pr-effort.test.mjs
@@ -48,6 +48,8 @@ describe('tier boundaries', () => {
     assert.equal(tier([file('a.ts', 501)]), 'effort/L');
     assert.equal(tier([file('a.ts', 1000)]), 'effort/L');
     assert.equal(tier([file('a.ts', 1001)]), 'effort/XL');
+    assert.equal(tier([file('a.ts', 2500)]), 'effort/XL');
+    assert.equal(tier([file('a.ts', 2501)]), 'effort/XXL');
   });
 
   it('counts additions and deletions together', () => {


### PR DESCRIPTION
## Summary

`effort/XL` has no upper bound. Measured with the label's own readable-line rule (lockfiles, generated files and binaries excluded), it currently holds 75 of the last 300 merged pull requests and 57 of the 157 open ones, ranging from 1000 to over 10000 lines under one label. That is the largest tier by count and the only one whose members are handled differently from each other: up to roughly 2500 lines a change is still read as one unit; past that, the first review question is whether it splits.

This caps `effort/XL` at 2500 readable lines and adds `effort/XXL` above it. On the same data the split is 45 XL / 30 XXL for merged and 31 / 26 for open, so both halves stay populated. Nothing else in the ladder moves.

Refs #3949

## Verification

- `node --test --test-concurrency=1 scripts/pr-effort.test.mjs`: 13 pass, including the new 2500 / 2501 boundary cases
- `biome check` on both files: clean

Not run: the labeling workflow itself. It reads `scripts/pr-effort.mjs` from `main` on `pull_request_target`, so this branch cannot exercise it before merge.

## Rollout

The `effort/XXL` label needs to exist in the repository before the workflow first assigns it, and the `effort/XL` description should read "Under 2500 readable lines". I will create and update the labels when this merges; the next scheduled or triggered run then relabels the open pull requests above 2500.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code measured the current tier distribution, made the change and wrote the tests. The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes: pull requests above 2500 readable lines receive `effort/XXL` instead of `effort/XL`
- [ ] No
