### PR TITLE
ci(dependabot): label npm and actions updates with dependencies only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
     groups:
       minor-and-patch:
         patterns:
@@ -45,6 +47,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
     groups:
       official-actions:
         patterns:


### PR DESCRIPTION
## Summary

Dependabot applies its default labels to every update PR because neither block in `.github/dependabot.yml` sets `labels`: `dependencies` plus a language label, `javascript` for npm and `github_actions` for github-actions. The `javascript` label exists only because of this default. It appears on dependabot PRs (36 PRs, 2 issues) and nothing else: no workflow filters on it and no maintainer uses it. The `github_actions` label does not exist in the repository at all.

This PR sets `labels: [dependencies]` on both the npm and github-actions blocks so dependabot stops applying language labels. `ignore`, `groups` and everything else are untouched.

The config change has to land first: deleting the `javascript` label today would only get it recreated by dependabot on its next update.

## Follow-up after merge

- [ ] A maintainer deletes the `javascript` label from the repository.

## Verification

- `npm run format` and `npm run lint` run clean (YAML is outside Biome's scope, so this only confirms no side effects).
- Dependabot behavior cannot be exercised locally. The `labels` key follows the documented `dependabot.yml` schema.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code authored the entire change (config edit, commit message, PR description).

## Checklist

- [ ] Tests cover the change and fail without it (not applicable: dependabot configuration has no test surface)
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
