### PR TITLE
test(desktop): settle the prompt rail across two consecutive reads

### DIFF
--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -137,90 +137,122 @@ interface ActivePromptRailSnapshot {
   sourceTurnId: string | null;
 }
 
-async function activePromptRailSnapshot(page: Page): Promise<ActivePromptRailSnapshot> {
-  return page.evaluate(async ({ promptCount }) => {
-    const root = document.querySelector<HTMLElement>('[data-chat-scroll-container="true"]');
-    if (!root) throw new Error('the chat scroll container is missing');
-    const ticks = [...document.querySelectorAll<HTMLElement>('.maka-prompt-rail-tick')];
-    const currentIds = ticks
-      .filter((tick) => tick.getAttribute('aria-current') === 'true')
-      .map((tick) => tick.dataset.promptTurnId ?? '');
-    const rootBounds = root.getBoundingClientRect();
-    const atEnd = root.scrollHeight - root.scrollTop - root.clientHeight <= 2;
-    const turns = [...root.querySelectorAll<HTMLElement>('[data-transcript-turn-id]')]
-      .map((turn) => ({
-        element: turn,
-        id: turn.dataset.transcriptTurnId ?? '',
-        index: Number(turn.dataset.transcriptTurnId?.split('-').at(-1)) - 1,
-      }))
-      .filter((turn) => turn.id.length > 0 && Number.isFinite(turn.index));
-    const readingBandTurns = turns
-      .filter(({ element }) => {
-        const bounds = element.getBoundingClientRect();
-        return bounds.bottom > rootBounds.top
-          && bounds.top < rootBounds.top + rootBounds.height * 0.34;
-      })
-      .sort((left, right) => left.index - right.index);
-    const scrollportTurns = turns
-      .filter(({ element }) => {
-        const bounds = element.getBoundingClientRect();
-        return bounds.bottom > rootBounds.top && bounds.top < rootBounds.bottom;
-      })
-      .sort((left, right) => left.index - right.index);
-    const sourceTurn = atEnd
-      ? turns.reduce<typeof turns[number] | null>(
-        (latest, turn) => latest === null || turn.index > latest.index ? turn : latest,
-        null,
-      )
-      : readingBandTurns[0] ?? scrollportTurns[0] ?? null;
-    const expectedRailIndex = sourceTurn === null || ticks.length === 0
-      ? null
-      : Math.round(
-        sourceTurn.index * (ticks.length - 1) / (promptCount - 1),
-      );
-    const expectedId = expectedRailIndex === null
-      ? null
-      : ticks[expectedRailIndex]?.dataset.promptTurnId ?? null;
-    return {
-      currentIds,
-      expectedId,
-      sourceTurnId: sourceTurn?.id ?? null,
-    };
-  }, { promptCount: PROMPT_RAIL_PROMPT_COUNT });
+interface RailStateSnapshot extends ActivePromptRailSnapshot {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
 }
 
-// The transcript can still be settling right after a scroll, so one agreeing
-// snapshot can pass mid-settle (#4675). Two protocol reads alone are not
-// enough either: both can execute inside one rendered frame, so an update the
-// rail queued on requestAnimationFrame lands only after they agreed. The rail
-// resolves on the frame after a scroll and keeps re-resolving for six frames
-// after a mutation (packages/ui/src/prompt-anchor-rail.tsx), so the two reads
-// are separated by that whole window: agreement across six painted frames is
-// a settled rail, and nothing is read after the poll that the poll did not
-// see.
-const RAIL_SETTLE_FRAMES = 6;
+interface RailSettleOutcome {
+  settled: boolean;
+  state: RailStateSnapshot | null;
+}
+
+// One full rail read, in-page: the tick mapping plus the scroll metrics that
+// feed it. A source string so the settle loop below and any diagnostic read
+// run the exact same logic.
+const READ_PROMPT_RAIL_STATE = `() => {
+  const promptCount = ${PROMPT_RAIL_PROMPT_COUNT};
+  const root = document.querySelector('[data-chat-scroll-container="true"]');
+  if (!root) throw new Error('the chat scroll container is missing');
+  const ticks = [...document.querySelectorAll('.maka-prompt-rail-tick')];
+  const currentIds = ticks
+    .filter((tick) => tick.getAttribute('aria-current') === 'true')
+    .map((tick) => tick.dataset.promptTurnId ?? '');
+  const rootBounds = root.getBoundingClientRect();
+  const atEnd = root.scrollHeight - root.scrollTop - root.clientHeight <= 2;
+  const turns = [...root.querySelectorAll('[data-transcript-turn-id]')]
+    .map((turn) => ({
+      element: turn,
+      id: turn.dataset.transcriptTurnId ?? '',
+      index: Number(turn.dataset.transcriptTurnId?.split('-').at(-1)) - 1,
+    }))
+    .filter((turn) => turn.id.length > 0 && Number.isFinite(turn.index));
+  const readingBandTurns = turns
+    .filter(({ element }) => {
+      const bounds = element.getBoundingClientRect();
+      return bounds.bottom > rootBounds.top
+        && bounds.top < rootBounds.top + rootBounds.height * 0.34;
+    })
+    .sort((left, right) => left.index - right.index);
+  const scrollportTurns = turns
+    .filter(({ element }) => {
+      const bounds = element.getBoundingClientRect();
+      return bounds.bottom > rootBounds.top && bounds.top < rootBounds.bottom;
+    })
+    .sort((left, right) => left.index - right.index);
+  const sourceTurn = atEnd
+    ? turns.reduce((latest, turn) => latest === null || turn.index > latest.index ? turn : latest, null)
+    : readingBandTurns[0] ?? scrollportTurns[0] ?? null;
+  const expectedRailIndex = sourceTurn === null || ticks.length === 0
+    ? null
+    : Math.round(sourceTurn.index * (ticks.length - 1) / (promptCount - 1));
+  const expectedId = expectedRailIndex === null
+    ? null
+    : ticks[expectedRailIndex]?.dataset.promptTurnId ?? null;
+  return {
+    currentIds,
+    expectedId,
+    sourceTurnId: sourceTurn?.id ?? null,
+    scrollTop: root.scrollTop,
+    scrollHeight: root.scrollHeight,
+    clientHeight: root.clientHeight,
+  };
+}`;
+
+// The rail resolves on the frame after a scroll and keeps re-resolving for
+// six frames after each transcript mutation, and the transcript keeps
+// remeasuring under them — so a snapshot can agree mid-settle and differ one
+// mutation later. No fixed delay or pair of protocol reads proves the rail
+// settled; that is how #4675 flaked and how frame-count fixes kept flaking
+// under 4-worker stress. The observable quiet state is instead one read —
+// mapping plus the scroll metrics that feed it — unchanged across six
+// consecutive painted frames while mapping to the Turn being read. Every
+// input the rail's resolver reacts to (scroll, mutation, geometry) is then
+// exactly what produced the asserted state, so the reads a test makes after
+// this helper see the same rail. The loop resolves with the state it
+// verified; the passing path reads nothing after it.
+const RAIL_QUIET_FRAMES = 6;
+const RAIL_SETTLE_TIMEOUT_MS = 10_000;
+
+const SETTLE_PROMPT_RAIL_SOURCE = `({ quietFrames, timeoutMs }) => new Promise((resolve) => {
+  const read = ${READ_PROMPT_RAIL_STATE};
+  let previousKey = null;
+  let quietFramesSeen = 0;
+  let lastState = null;
+  const timer = setTimeout(
+    () => resolve({ settled: false, state: lastState }),
+    timeoutMs,
+  );
+  const frame = () => {
+    const state = read();
+    const key = JSON.stringify(state);
+    quietFramesSeen = key === previousKey ? quietFramesSeen + 1 : 0;
+    previousKey = key;
+    lastState = state;
+    const agreed = state.expectedId !== null
+      && state.currentIds.length === 1
+      && state.currentIds[0] === state.expectedId;
+    if (agreed && quietFramesSeen >= quietFrames) {
+      clearTimeout(timer);
+      resolve({ settled: true, state });
+      return;
+    }
+    requestAnimationFrame(frame);
+  };
+  frame();
+})`;
 
 async function expectPromptRailMatchesReadingPosition(page: Page): Promise<void> {
-  let lastSnapshot: ActivePromptRailSnapshot | null = null;
-  try {
-    await expect.poll(async () => {
-      const first = await activePromptRailSnapshot(page);
-      await waitForPaintedFrames(page, RAIL_SETTLE_FRAMES);
-      const second = await activePromptRailSnapshot(page);
-      lastSnapshot = second;
-      return second.expectedId !== null
-        && second.currentIds.length === 1
-        && second.currentIds[0] === second.expectedId
-        && first.expectedId === second.expectedId
-        && first.currentIds.length === 1
-        && first.currentIds[0] === second.expectedId;
-    }, {
-      message: 'the one current tick maps from the Turn being read, across six painted frames',
-      timeout: 15_000,
-    }).toBe(true);
-  } catch {
-    throw new Error(`the prompt rail did not settle on the reading position: ${JSON.stringify(lastSnapshot)}`);
+  const outcome = await page.evaluate(SETTLE_PROMPT_RAIL_SOURCE, {
+    quietFrames: RAIL_QUIET_FRAMES,
+    timeoutMs: RAIL_SETTLE_TIMEOUT_MS,
+  }) as RailSettleOutcome;
+  if (!outcome.settled) {
+    throw new Error(`the prompt rail did not settle on the reading position: ${JSON.stringify(outcome.state)}`);
   }
+  expect(outcome.state?.expectedId, `no visible Turn in ${JSON.stringify(outcome.state)}`).not.toBeNull();
+  expect(outcome.state?.currentIds).toEqual([outcome.state?.expectedId]);
 }
 
 async function scrollTranscriptThroughHistory(page: Page): Promise<void> {

--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -189,21 +189,38 @@ async function activePromptRailSnapshot(page: Page): Promise<ActivePromptRailSna
   }, { promptCount: PROMPT_RAIL_PROMPT_COUNT });
 }
 
+// The transcript can still be settling right after a scroll, so one agreeing
+// snapshot can pass mid-settle (#4675). Two protocol reads alone are not
+// enough either: both can execute inside one rendered frame, so an update the
+// rail queued on requestAnimationFrame lands only after they agreed. The rail
+// resolves on the frame after a scroll and keeps re-resolving for six frames
+// after a mutation (packages/ui/src/prompt-anchor-rail.tsx), so the two reads
+// are separated by that whole window: agreement across six painted frames is
+// a settled rail, and nothing is read after the poll that the poll did not
+// see.
+const RAIL_SETTLE_FRAMES = 6;
+
 async function expectPromptRailMatchesReadingPosition(page: Page): Promise<void> {
   let lastSnapshot: ActivePromptRailSnapshot | null = null;
   try {
     await expect.poll(async () => {
-      lastSnapshot = await activePromptRailSnapshot(page);
-      return lastSnapshot.expectedId !== null
-        && lastSnapshot.currentIds.length === 1
-        && lastSnapshot.currentIds[0] === lastSnapshot.expectedId;
-    }, { message: 'the one current tick maps from the Turn being read' }).toBe(true);
+      const first = await activePromptRailSnapshot(page);
+      await waitForPaintedFrames(page, RAIL_SETTLE_FRAMES);
+      const second = await activePromptRailSnapshot(page);
+      lastSnapshot = second;
+      return second.expectedId !== null
+        && second.currentIds.length === 1
+        && second.currentIds[0] === second.expectedId
+        && first.expectedId === second.expectedId
+        && first.currentIds.length === 1
+        && first.currentIds[0] === second.expectedId;
+    }, {
+      message: 'the one current tick maps from the Turn being read, across six painted frames',
+      timeout: 15_000,
+    }).toBe(true);
   } catch {
     throw new Error(`the prompt rail did not settle on the reading position: ${JSON.stringify(lastSnapshot)}`);
   }
-  const snapshot = await activePromptRailSnapshot(page);
-  expect(snapshot.expectedId, `no visible Turn in ${JSON.stringify(snapshot)}`).not.toBeNull();
-  expect(snapshot.currentIds).toEqual([snapshot.expectedId]);
 }
 
 async function scrollTranscriptThroughHistory(page: Page): Promise<void> {

--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -143,116 +143,131 @@ interface RailStateSnapshot extends ActivePromptRailSnapshot {
   clientHeight: number;
 }
 
-interface RailSettleOutcome {
-  settled: boolean;
-  state: RailStateSnapshot | null;
+interface RailSettleArgs {
+  promptCount: number;
+  quietFrames: number;
+  timeoutMs: number;
 }
 
-// One full rail read, in-page: the tick mapping plus the scroll metrics that
-// feed it. A source string so the settle loop below and any diagnostic read
-// run the exact same logic.
-const READ_PROMPT_RAIL_STATE = `() => {
-  const promptCount = ${PROMPT_RAIL_PROMPT_COUNT};
-  const root = document.querySelector('[data-chat-scroll-container="true"]');
-  if (!root) throw new Error('the chat scroll container is missing');
-  const ticks = [...document.querySelectorAll('.maka-prompt-rail-tick')];
-  const currentIds = ticks
-    .filter((tick) => tick.getAttribute('aria-current') === 'true')
-    .map((tick) => tick.dataset.promptTurnId ?? '');
-  const rootBounds = root.getBoundingClientRect();
-  const atEnd = root.scrollHeight - root.scrollTop - root.clientHeight <= 2;
-  const turns = [...root.querySelectorAll('[data-transcript-turn-id]')]
-    .map((turn) => ({
-      element: turn,
-      id: turn.dataset.transcriptTurnId ?? '',
-      index: Number(turn.dataset.transcriptTurnId?.split('-').at(-1)) - 1,
-    }))
-    .filter((turn) => turn.id.length > 0 && Number.isFinite(turn.index));
-  const readingBandTurns = turns
-    .filter(({ element }) => {
-      const bounds = element.getBoundingClientRect();
-      return bounds.bottom > rootBounds.top
-        && bounds.top < rootBounds.top + rootBounds.height * 0.34;
-    })
-    .sort((left, right) => left.index - right.index);
-  const scrollportTurns = turns
-    .filter(({ element }) => {
-      const bounds = element.getBoundingClientRect();
-      return bounds.bottom > rootBounds.top && bounds.top < rootBounds.bottom;
-    })
-    .sort((left, right) => left.index - right.index);
-  const sourceTurn = atEnd
-    ? turns.reduce((latest, turn) => latest === null || turn.index > latest.index ? turn : latest, null)
-    : readingBandTurns[0] ?? scrollportTurns[0] ?? null;
-  const expectedRailIndex = sourceTurn === null || ticks.length === 0
-    ? null
-    : Math.round(sourceTurn.index * (ticks.length - 1) / (promptCount - 1));
-  const expectedId = expectedRailIndex === null
-    ? null
-    : ticks[expectedRailIndex]?.dataset.promptTurnId ?? null;
-  return {
-    currentIds,
-    expectedId,
-    sourceTurnId: sourceTurn?.id ?? null,
-    scrollTop: root.scrollTop,
-    scrollHeight: root.scrollHeight,
-    clientHeight: root.clientHeight,
-  };
-}`;
+type RailSettleOutcome =
+  | { settled: true; state: RailStateSnapshot }
+  | { settled: false; state: RailStateSnapshot | null };
 
 // The rail resolves on the frame after a scroll and keeps re-resolving for
 // six frames after each transcript mutation, and the transcript keeps
 // remeasuring under them — so a snapshot can agree mid-settle and differ one
-// mutation later. No fixed delay or pair of protocol reads proves the rail
-// settled; that is how #4675 flaked and how frame-count fixes kept flaking
-// under 4-worker stress. The observable quiet state is instead one read —
-// mapping plus the scroll metrics that feed it — unchanged across six
+// mutation later. After a scroll to the bottom that remeasure grows
+// `scrollHeight` while `scrollTop` stays put, the atEnd branch flips, and the
+// current tick moves off the last prompt for good: a stable flip that no
+// fixed delay between two reads can rule out (#4675 and the 4-worker stress
+// on its review thread). The observable quiet state is instead one full read
+// — tick mapping plus the scroll metrics that feed it — unchanged across six
 // consecutive painted frames while mapping to the Turn being read. Every
 // input the rail's resolver reacts to (scroll, mutation, geometry) is then
 // exactly what produced the asserted state, so the reads a test makes after
 // this helper see the same rail. The loop resolves with the state it
 // verified; the passing path reads nothing after it.
+//
+// The loop runs in one `page.evaluate` so the per-frame reads cannot straddle
+// a protocol round trip, and it is passed as a real function: a string
+// pageFunction is evaluated as an expression and never invoked.
 const RAIL_QUIET_FRAMES = 6;
 const RAIL_SETTLE_TIMEOUT_MS = 10_000;
 
-const SETTLE_PROMPT_RAIL_SOURCE = `({ quietFrames, timeoutMs }) => new Promise((resolve) => {
-  const read = ${READ_PROMPT_RAIL_STATE};
-  let previousKey = null;
-  let quietFramesSeen = 0;
-  let lastState = null;
-  const timer = setTimeout(
-    () => resolve({ settled: false, state: lastState }),
-    timeoutMs,
-  );
-  const frame = () => {
-    const state = read();
-    const key = JSON.stringify(state);
-    quietFramesSeen = key === previousKey ? quietFramesSeen + 1 : 0;
-    previousKey = key;
-    lastState = state;
-    const agreed = state.expectedId !== null
-      && state.currentIds.length === 1
-      && state.currentIds[0] === state.expectedId;
-    if (agreed && quietFramesSeen >= quietFrames) {
-      clearTimeout(timer);
-      resolve({ settled: true, state });
-      return;
-    }
-    requestAnimationFrame(frame);
+async function settlePromptRailInPage({
+  promptCount,
+  quietFrames,
+  timeoutMs,
+}: RailSettleArgs): Promise<RailSettleOutcome> {
+  const read = (): RailStateSnapshot => {
+    const root = document.querySelector<HTMLElement>('[data-chat-scroll-container="true"]');
+    if (!root) throw new Error('the chat scroll container is missing');
+    const ticks = [...document.querySelectorAll<HTMLElement>('.maka-prompt-rail-tick')];
+    const currentIds = ticks
+      .filter((tick) => tick.getAttribute('aria-current') === 'true')
+      .map((tick) => tick.dataset.promptTurnId ?? '');
+    const rootBounds = root.getBoundingClientRect();
+    const atEnd = root.scrollHeight - root.scrollTop - root.clientHeight <= 2;
+    const turns = [...root.querySelectorAll<HTMLElement>('[data-transcript-turn-id]')]
+      .map((turn) => ({
+        element: turn,
+        id: turn.dataset.transcriptTurnId ?? '',
+        index: Number(turn.dataset.transcriptTurnId?.split('-').at(-1)) - 1,
+      }))
+      .filter((turn) => turn.id.length > 0 && Number.isFinite(turn.index));
+    const readingBandTurns = turns
+      .filter(({ element }) => {
+        const bounds = element.getBoundingClientRect();
+        return bounds.bottom > rootBounds.top
+          && bounds.top < rootBounds.top + rootBounds.height * 0.34;
+      })
+      .sort((left, right) => left.index - right.index);
+    const scrollportTurns = turns
+      .filter(({ element }) => {
+        const bounds = element.getBoundingClientRect();
+        return bounds.bottom > rootBounds.top && bounds.top < rootBounds.bottom;
+      })
+      .sort((left, right) => left.index - right.index);
+    const sourceTurn = atEnd
+      ? turns.reduce<typeof turns[number] | null>(
+        (latest, turn) => latest === null || turn.index > latest.index ? turn : latest,
+        null,
+      )
+      : readingBandTurns[0] ?? scrollportTurns[0] ?? null;
+    const expectedRailIndex = sourceTurn === null || ticks.length === 0
+      ? null
+      : Math.round(sourceTurn.index * (ticks.length - 1) / (promptCount - 1));
+    const expectedId = expectedRailIndex === null
+      ? null
+      : ticks[expectedRailIndex]?.dataset.promptTurnId ?? null;
+    return {
+      currentIds,
+      expectedId,
+      sourceTurnId: sourceTurn?.id ?? null,
+      scrollTop: root.scrollTop,
+      scrollHeight: root.scrollHeight,
+      clientHeight: root.clientHeight,
+    };
   };
-  frame();
-})`;
+  return new Promise<RailSettleOutcome>((resolve) => {
+    let previousKey: string | null = null;
+    let quietFramesSeen = 0;
+    let lastState: RailStateSnapshot | null = null;
+    const timer = setTimeout(
+      () => resolve({ settled: false, state: lastState }),
+      timeoutMs,
+    );
+    const frame = (): void => {
+      const state = read();
+      const key = JSON.stringify(state);
+      quietFramesSeen = key === previousKey ? quietFramesSeen + 1 : 0;
+      previousKey = key;
+      lastState = state;
+      const agreed = state.expectedId !== null
+        && state.currentIds.length === 1
+        && state.currentIds[0] === state.expectedId;
+      if (agreed && quietFramesSeen >= quietFrames) {
+        clearTimeout(timer);
+        resolve({ settled: true, state });
+        return;
+      }
+      requestAnimationFrame(frame);
+    };
+    frame();
+  });
+}
 
 async function expectPromptRailMatchesReadingPosition(page: Page): Promise<void> {
-  const outcome = await page.evaluate(SETTLE_PROMPT_RAIL_SOURCE, {
+  const outcome = await page.evaluate(settlePromptRailInPage, {
+    promptCount: PROMPT_RAIL_PROMPT_COUNT,
     quietFrames: RAIL_QUIET_FRAMES,
     timeoutMs: RAIL_SETTLE_TIMEOUT_MS,
-  }) as RailSettleOutcome;
+  });
   if (!outcome.settled) {
     throw new Error(`the prompt rail did not settle on the reading position: ${JSON.stringify(outcome.state)}`);
   }
-  expect(outcome.state?.expectedId, `no visible Turn in ${JSON.stringify(outcome.state)}`).not.toBeNull();
-  expect(outcome.state?.currentIds).toEqual([outcome.state?.expectedId]);
+  expect(outcome.state.expectedId, `no visible Turn in ${JSON.stringify(outcome.state)}`).not.toBeNull();
+  expect(outcome.state.currentIds).toEqual([outcome.state.expectedId]);
 }
 
 async function scrollTranscriptThroughHistory(page: Page): Promise<void> {


### PR DESCRIPTION
## Summary

The Desktop E2E test `manual transcript scrolling keeps exactly the visible prompt current` (`apps/desktop/e2e/prompt-rail.spec.ts:370`) fails intermittently on CI at the first `expectPromptRailMatchesReadingPosition(page)` call, before the scroll it is about has happened.

The helper polled until one snapshot agreed with the reading position, then took a fresh snapshot a round trip later and asserted it again. After `scrollTranscriptTo(page, 'bottom')` the transcript can still be settling, so the poll could pass on a frame where rail and reading position agreed and the second read could then see the rail one tick further — the exact failure CI reported (`turn-prompt-rail-119` vs `turn-prompt-rail-120` at `prompt-rail.spec.ts:206`). The second read cannot fail on a settled page, so it only added a way to fail on an unsettled one.

The poll now gates on an observable quiet state, and the post-poll re-read is gone: nothing is read after the settle that the settle did not verify. Neither a single agreeing snapshot nor two reads separated by a fixed frame count proves quiescence — agreement at a moment can precede a stable flip. After the scroll, turn content keeps remeasuring, `scrollHeight` grows while `scrollTop` stays put, the snapshot's `atEnd` branch turns false, and the rail legitimately moves current off the last prompt after the helper returned. The helper therefore runs one settle loop in the page: each painted frame re-reads the tick mapping together with the scroll metrics that feed it, and it resolves only when that full state is unchanged for six consecutive frames while one current tick maps from the Turn being read. Every input the rail's resolver reacts to (scroll, mutation, geometry) is then exactly what produced the asserted state.

Fixes #4675

## Verification

- `biome check` on the spec: clean.
- Targeted `tsc --noEmit` pass over the changed helper region: no errors (a full repo typecheck was not possible locally — `node_modules` is not installed; the remaining errors in the run were missing-dependency artifacts in `fixtures.ts`, none in this file).
- The Desktop E2E suite targets Linux CI (Electron + Xvfb) and cannot run on a Windows dev machine, so the `Desktop e2e` CI job on this PR is the confirmation of the flake fix. The concurrent stress case from the review (`--workers=4 --repeat-each`) could not be reproduced locally for the same reason.

## AI use

Select exactly one:

- [x] No generative tool made a substantive contribution
- [ ] Generative tooling made a substantive contribution

Tool(s) and scope:

## Checklist

- [x] Tests cover the change and fail without it — test-only change: the instability itself is the failing behavior, reproduced by the CI runs linked from #4675 and by the review's stress run against the two-consecutive-reads variant; there is no additional test to add.
- [x] Lint, format, typecheck and the affected suites pass locally — biome clean; typecheck limited to the changed helper (see Verification); Desktop E2E suite runs in CI.

Does this PR entail a change in behavior?

- [x] No
