### PR TITLE
fix(desktop): persist workbar collapse per session

### DIFF
--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -67,6 +67,35 @@ test('the composer usage action opens Task trace in the right workbar', async ({
   ).toBeVisible();
 });
 
+test('right workbar visibility belongs to each Session and survives reload', async ({
+  window: page,
+}) => {
+  const first = await createSession(page, 'first workbar owner');
+  const panel = page.locator('.maka-session-workbar[data-placement="right"]');
+  await page.getByRole('button', { name: '展开任务工作栏' }).click();
+  await page
+    .getByRole('list', { name: '打开工具' })
+    .getByRole('button', { name: /变更.*查看当前 Git 工作区变化/ })
+    .click();
+  await page.getByRole('button', { name: '打开或关闭工作栏的面' }).click();
+  await page.getByRole('menu').getByRole('menuitem', { name: '追踪', exact: true }).click();
+  await expect(panel).toBeVisible();
+  await first.sidebar.getByRole('button', { name: '新任务', exact: true }).click();
+  const second = await createSession(page, 'second workbar owner');
+  await expect(panel).toBeHidden();
+  await first.sidebar.locator(`[data-session-id=${JSON.stringify(first.sessionId)}]`).click();
+  await expect(panel).toBeVisible();
+  await page.reload();
+  await expect(page.locator(COMPOSER_INPUT)).toBeVisible();
+  const sidebar = page.getByRole('navigation', { name: '任务列表' });
+  const expandSidebar = page.getByRole('button', { name: '展开侧边栏' });
+  if (await expandSidebar.isVisible()) await expandSidebar.click();
+  await sidebar.locator(`[data-session-id=${JSON.stringify(first.sessionId)}]`).click();
+  await expect(panel).toBeVisible();
+  await sidebar.locator(`[data-session-id=${JSON.stringify(second.sessionId)}]`).click();
+  await expect(panel).toBeHidden();
+});
+
 test('a collapsed workbar never flashes during the first send', async ({
   window: page,
 }) => {

--- a/apps/desktop/src/main/__tests__/workbar-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/workbar-controller.test.ts
@@ -20,7 +20,7 @@
 import { deferred } from '@maka/core/test-only/async-primitives';
 import { strict as assert } from 'node:assert';
 import { afterEach, describe, it } from 'node:test';
-import { act, createElement, StrictMode } from 'react';
+import { act, createElement, StrictMode, useLayoutEffect } from 'react';
 import type { ShellRunUpdate } from '@maka/core/events';
 import type { SessionSummary } from '@maka/core/session';
 import { LocaleProvider } from '@maka/ui';
@@ -66,8 +66,14 @@ let controllerRenderSnapshots: Array<{
   terminalOwnerIds: Array<string | undefined>;
 }> = [];
 
-function ControllerProbe(props: UseWorkbarControllerInput) {
-  latestController = useWorkbarController(props);
+type ControllerProbeInput = UseWorkbarControllerInput & { openOnActivation?: boolean };
+
+function ControllerProbe(props: ControllerProbeInput) {
+  const workbar = useWorkbarController(props);
+  latestController = workbar;
+  useLayoutEffect(() => {
+    if (props.openOnActivation) workbar.host.onOpenLauncher('right');
+  }, [props.activeSession?.id, props.openOnActivation]);
   controllerRenderSnapshots.push({
     activeId: latestController.host.activeId,
     terminalOwnerIds: [
@@ -83,7 +89,7 @@ function ControllerProbe(props: UseWorkbarControllerInput) {
 function renderController(
   root: ReturnType<typeof installReactRenderer>['root'],
   services: WorkbarServices,
-  input: UseWorkbarControllerInput,
+  input: ControllerProbeInput,
   strictMode = false,
 ) {
   const probe = createElement(
@@ -131,6 +137,46 @@ describe('useWorkbarController', () => {
     controllerRenderSnapshots = [];
     cleanupFakeDom();
     delete (globalThis as { window?: unknown }).window;
+  });
+
+  it('keeps right-panel visibility independent across Session navigation', async () => {
+    const { root } = installReactRenderer();
+    const services = createFakeWorkbarServices();
+    const authoritativeSessionIds = new Set(['a', 'b']);
+    const show = (id: string | undefined) => renderController(root, services, {
+      ...input(id ? session(id) : undefined),
+      authoritativeSessionIds,
+    });
+
+    await act(async () => show('a'));
+    await act(async () => controller().commands.toggleRight());
+    assert.equal(controller().host.rightCollapsed, false);
+    await act(async () => show(undefined));
+    await act(async () => show('b'));
+    assert.equal(controller().host.rightCollapsed, true);
+    await act(async () => show('a'));
+    assert.equal(controller().host.rightCollapsed, false);
+  });
+
+  it('keeps an open requested in the activation commit bound to the new Session', async () => {
+    const { root } = installReactRenderer();
+    const services = createFakeWorkbarServices();
+    const authoritativeSessionIds = new Set(['a', 'b']);
+    await act(async () => renderController(root, services, {
+      ...input(session('a')), authoritativeSessionIds,
+    }, true));
+    await act(async () => renderController(root, services, {
+      ...input(session('b')), authoritativeSessionIds, openOnActivation: true,
+    }, true));
+    assert.equal(controller().host.rightCollapsed, false);
+    await act(async () => renderController(root, services, {
+      ...input(session('a')), authoritativeSessionIds,
+    }, true));
+    assert.equal(controller().host.rightCollapsed, true);
+    await act(async () => renderController(root, services, {
+      ...input(session('b')), authoritativeSessionIds,
+    }, true));
+    assert.equal(controller().host.rightCollapsed, false);
   });
 
   it('projects the canonical project and absorbed aliases into the host model', async () => {

--- a/apps/desktop/src/main/__tests__/workbar-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/workbar-controller.test.ts
@@ -179,6 +179,33 @@ describe('useWorkbarController', () => {
     assert.equal(controller().host.rightCollapsed, false);
   });
 
+  it("preserves the active Session's visibility while removing the previous Session's Terminal", async () => {
+    const { root } = installReactRenderer();
+    const defaults = createFakeWorkbarServices();
+    const services = createFakeWorkbarServices({
+      terminal: {
+        ...defaults.terminal,
+        start: async (sessionId) => shellUpdate(sessionId, 'terminal-a'),
+      },
+    });
+    const authoritativeSessionIds = new Set(['a', 'b']);
+    const show = (id: string) => renderController(root, services, {
+      ...input(session(id)),
+      authoritativeSessionIds,
+    });
+
+    await act(async () => show('b'));
+    await act(async () => controller().commands.toggleRight());
+    assert.equal(controller().host.rightCollapsed, false);
+    await act(async () => show('a'));
+    await act(async () => controller().commands.openTool('terminal'));
+    assert.equal(controller().host.panelsState.right.tabs.length, 1);
+    await act(async () => show('b'));
+
+    assert.equal(controller().host.panelsState.right.tabs.length, 0);
+    assert.equal(controller().host.rightCollapsed, false);
+  });
+
   it('projects the canonical project and absorbed aliases into the host model', async () => {
     const { root } = installReactRenderer();
     const controllerInput = input(session('a'));

--- a/apps/desktop/src/main/__tests__/workbar-model.test.ts
+++ b/apps/desktop/src/main/__tests__/workbar-model.test.ts
@@ -17,12 +17,15 @@
  * under the License.
  */
 
+import { createSessionCatalogController, selectAuthoritativeSessionIds } from '../../renderer/session-catalog-state.js';
+import { sessionIdSetsEqual } from '../../renderer/live-turn-snapshot.js';
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 import {
   createSessionWorkbarPanelsState,
   createSessionWorkbarTabsState,
   loadWorkbarLayout,
+  isSessionWorkbarCollapsed,
   persistWorkbarLayout,
   persistableSessionWorkbarPanels,
   readSessionWorkbarPanels,
@@ -89,7 +92,8 @@ describe('Workbar topology', () => {
   it('routes panel visibility and dimensions through the layout reducer', () => {
     let state = {
       panels: createSessionWorkbarPanelsState(),
-      rightCollapsed: true,
+      activeSessionId: 'session-a' as string | undefined,
+      collapsedBySession: {} as Record<string, boolean>,
       bottomOpen: false,
       rightWidth: 480,
       bottomHeight: 300,
@@ -99,7 +103,7 @@ describe('Workbar topology', () => {
       placement: 'right',
       tab: { id: 'workbar:review', kind: 'review' },
     });
-    assert.equal(state.rightCollapsed, false);
+    assert.equal(isSessionWorkbarCollapsed(state), false);
     state = reduceWorkbarLayout(state, {
       type: 'resize',
       placement: 'right',
@@ -229,7 +233,8 @@ describe('Workbar topology', () => {
           'workbar:review',
         ),
       ),
-      rightCollapsed: false,
+      activeSessionId: 'session-a',
+      collapsedBySession: { 'session-a': false },
       bottomOpen: true,
       rightWidth: 544,
       bottomHeight: 388,
@@ -248,18 +253,71 @@ describe('Workbar topology', () => {
         focusedPanel: 'right',
       },
     );
-    assert.deepEqual(loadWorkbarLayout(), {
+    assert.deepEqual(loadWorkbarLayout('session-a'), {
       panels: createSessionWorkbarPanelsState(
         createSessionWorkbarTabsState(
           [{ id: 'workbar:review', kind: 'review' }],
           'workbar:review',
         ),
       ),
-      rightCollapsed: false,
+      activeSessionId: 'session-a',
+      collapsedBySession: { 'session-a': false },
       bottomOpen: true,
       rightWidth: 544,
       bottomHeight: 388,
     });
+  });
+
+  it('persists per-Session collapse and retires the ownerless global preference', () => {
+    cleanups.push(installMemoryLocalStorage({ 'maka-session-workbar-collapsed-v1': 'false' }));
+    let state = loadWorkbarLayout('a');
+    assert.equal(isSessionWorkbarCollapsed(state), true);
+    state = reduceWorkbarLayout(state, { type: 'collapse', placement: 'right', collapsed: false });
+    state = reduceWorkbarLayout(state, { type: 'activate-session', sessionId: 'b' });
+    assert.equal(isSessionWorkbarCollapsed(state), true);
+    persistWorkbarLayout(state, 'right-visibility');
+    assert.equal(localStorage.getItem('maka-session-workbar-collapsed-v1'), null);
+    assert.equal(isSessionWorkbarCollapsed(loadWorkbarLayout('a')), false);
+    assert.equal(isSessionWorkbarCollapsed(loadWorkbarLayout('b')), true);
+    assert.equal(isSessionWorkbarCollapsed(loadWorkbarLayout()), true);
+  });
+
+  it('distinguishes an unhydrated catalog from an authoritative empty snapshot', () => {
+    const catalog = createSessionCatalogController();
+    const pending = selectAuthoritativeSessionIds(catalog.getState());
+    assert.equal(pending, undefined);
+    catalog.commitSessions([]);
+    const empty = selectAuthoritativeSessionIds(catalog.getState());
+    assert.deepEqual(empty, new Set());
+    assert.equal(sessionIdSetsEqual(pending, empty), false);
+    assert.equal(sessionIdSetsEqual(empty, pending), false);
+    assert.equal(sessionIdSetsEqual(pending, pending), true);
+    assert.equal(sessionIdSetsEqual(empty, new Set()), true);
+  });
+
+  it('evicts deleted Sessions without dropping an active Session awaiting catalog hydration', () => {
+    cleanups.push(installMemoryLocalStorage({
+      'maka-session-workbar-collapsed-v2': JSON.stringify({ a: false, b: false, deleted: false }),
+    }));
+    let state = loadWorkbarLayout('a');
+    state = reduceWorkbarLayout(state, { type: 'retain-sessions', sessionIds: new Set(['b']) });
+    assert.deepEqual(state.collapsedBySession, { a: false, b: false });
+    state = reduceWorkbarLayout(state, { type: 'activate-session', sessionId: 'b' });
+    state = reduceWorkbarLayout(state, { type: 'retain-sessions', sessionIds: new Set(['b']) });
+    persistWorkbarLayout(state, 'right-visibility');
+    assert.deepEqual(loadWorkbarLayout().collapsedBySession, { b: false });
+  });
+
+  it('ignores malformed collapse entries and treats prototype names as Session keys', () => {
+    cleanups.push(installMemoryLocalStorage({
+      'maka-session-workbar-collapsed-v2': '{"a":"false","b":false,"__proto__":false}',
+    }));
+    assert.equal(isSessionWorkbarCollapsed(loadWorkbarLayout('a')), true);
+    assert.equal(isSessionWorkbarCollapsed(loadWorkbarLayout('b')), false);
+    assert.equal(isSessionWorkbarCollapsed(loadWorkbarLayout('__proto__')), false);
+    assert.equal(isSessionWorkbarCollapsed(loadWorkbarLayout('constructor')), true);
+    localStorage.setItem('maka-session-workbar-collapsed-v2', '{broken');
+    assert.deepEqual(loadWorkbarLayout().collapsedBySession, {});
   });
 
   it('falls back to an empty topology for corrupt v3 storage', () => {

--- a/apps/desktop/src/renderer/features/workbar/controller/use-workbar-controller.ts
+++ b/apps/desktop/src/renderer/features/workbar/controller/use-workbar-controller.ts
@@ -168,7 +168,8 @@ export function useWorkbarController(
   const locale = useUiLocale();
   const terminalCopy = getDesktopConversationCopy(locale).terminalPanel;
   const { browser, sideChat, terminal } = useWorkbarServices();
-  const layout = useWorkbarLayoutState();
+  const activeSessionId = input.activeSession?.id;
+  const layout = useWorkbarLayoutState(activeSessionId, input.authoritativeSessionIds);
   const sideConversations = useSideConversationWorkspace();
   const [pendingSideChatClose, setPendingSideChatClose] = useState<
     Array<{ placement: SessionWorkbarPlacement; tab: SessionWorkbarTab }>
@@ -183,7 +184,6 @@ export function useWorkbarController(
   >(() => new Set());
   const [, setLiveBrowserSessionIds] = useState<readonly string[]>([]);
 
-  const activeSessionId = input.activeSession?.id;
   const activeSessionIdRef = useRef<string | undefined>(undefined);
   const resourceGenerationRef = useRef(0);
   useLayoutEffect(() => {

--- a/apps/desktop/src/renderer/features/workbar/controller/use-workbar-controller.ts
+++ b/apps/desktop/src/renderer/features/workbar/controller/use-workbar-controller.ts
@@ -449,6 +449,7 @@ export function useWorkbarController(
     (
       placement: SessionWorkbarPlacement,
       tabs: readonly SessionWorkbarTab[],
+      options?: { preserveVisibility?: boolean },
     ) => {
       if (tabs.length === 0) return;
       for (const tab of tabs) {
@@ -458,6 +459,7 @@ export function useWorkbarController(
       layout.closeWorkbarTabs(
         placement,
         tabs.map((tab) => tab.id),
+        options,
       );
       const panelIds = new Set(
         tabs
@@ -540,6 +542,7 @@ export function useWorkbarController(
         stale
           .filter((candidate) => candidate.placement === placement)
           .map((candidate) => candidate.tab),
+        { preserveVisibility: true },
       );
     }
   }, [
@@ -566,12 +569,14 @@ export function useWorkbarController(
       )
         ? 'right'
         : 'bottom';
-      layout.closeWorkbarTab(placement, tabId);
+      layout.closeWorkbarTabs(placement, [tabId], {
+        preserveVisibility: true,
+      });
     }
     sideConversations.removePanels(staleIds);
   }, [
     activeSessionId,
-    layout.closeWorkbarTab,
+    layout.closeWorkbarTabs,
     layout.workbarPanelsState,
     sideConversations.panels,
     sideConversations.removePanels,

--- a/apps/desktop/src/renderer/features/workbar/controller/use-workbar-layout-state.ts
+++ b/apps/desktop/src/renderer/features/workbar/controller/use-workbar-layout-state.ts
@@ -28,6 +28,7 @@ import {
 import type { ResizableProps } from '@astryxdesign/core/Resizable';
 import {
   loadWorkbarLayout,
+  isSessionWorkbarCollapsed,
   persistWorkbarLayout,
   reduceWorkbarLayout,
   SESSION_BOTTOM_PANEL_MAX_HEIGHT,
@@ -45,14 +46,28 @@ const LAYOUT_PERSIST_DEBOUNCE_MS = 200;
 
 /**
  * Owns the application-level Workbar topology, dimensions and persistence.
- * Session-owned panel data deliberately lives below this boundary.
+ * Right-panel visibility belongs to each Session; topology and sizes stay global.
  */
-export function useWorkbarLayoutState() {
+export function useWorkbarLayoutState(
+  activeSessionId: string | undefined,
+  authoritativeSessionIds: ReadonlySet<string> | undefined,
+) {
   const [state, dispatch] = useReducer(
     reduceWorkbarLayout,
-    undefined,
+    activeSessionId,
     loadWorkbarLayout,
   );
+  // Bind the owner before this render commits. An effect-based mirror would
+  // briefly show the previous Session's panel and could overwrite an open
+  // action issued by another layout effect in the activation commit.
+  if (state.activeSessionId !== activeSessionId) {
+    dispatch({ type: 'activate-session', sessionId: activeSessionId });
+  }
+  useEffect(() => {
+    if (authoritativeSessionIds) {
+      dispatch({ type: 'retain-sessions', sessionIds: authoritativeSessionIds });
+    }
+  }, [authoritativeSessionIds, activeSessionId]);
   const stateRef = useRef(state);
   stateRef.current = state;
   const rightDragStartRef = useRef(state.rightWidth);
@@ -163,7 +178,7 @@ export function useWorkbarLayoutState() {
   }, [state.rightWidth]);
   useEffect(() => {
     persistWorkbarLayout(stateRef.current, 'right-visibility');
-  }, [state.rightCollapsed]);
+  }, [state.collapsedBySession]);
   useEffect(() => {
     const handle = window.setTimeout(() => {
       persistWorkbarLayout(stateRef.current, 'bottom-size');
@@ -181,7 +196,7 @@ export function useWorkbarLayoutState() {
     (next: SetStateAction<boolean>) => {
       const collapsed =
         typeof next === 'function'
-          ? next(stateRef.current.rightCollapsed)
+          ? next(isSessionWorkbarCollapsed(stateRef.current))
           : next;
       dispatch({ type: 'collapse', placement: 'right', collapsed });
     },
@@ -201,7 +216,7 @@ export function useWorkbarLayoutState() {
   );
 
   return {
-    workbarCollapsed: state.rightCollapsed,
+    workbarCollapsed: isSessionWorkbarCollapsed(state),
     setWorkbarCollapsed,
     bottomPanelOpen: state.bottomOpen,
     setBottomPanelOpen,

--- a/apps/desktop/src/renderer/features/workbar/controller/use-workbar-layout-state.ts
+++ b/apps/desktop/src/renderer/features/workbar/controller/use-workbar-layout-state.ts
@@ -152,8 +152,16 @@ export function useWorkbarLayoutState(
     [],
   );
   const closeWorkbarTabs = useCallback(
-    (placement: SessionWorkbarPlacement, tabIds: readonly string[]) =>
-      dispatch({ type: 'close', placement, tabIds }),
+    (
+      placement: SessionWorkbarPlacement,
+      tabIds: readonly string[],
+      options?: { preserveVisibility?: boolean },
+    ) =>
+      dispatch({
+        type: options?.preserveVisibility ? 'remove-stale' : 'close',
+        placement,
+        tabIds,
+      }),
     [],
   );
   const openWorkbarLauncher = useCallback(

--- a/apps/desktop/src/renderer/features/workbar/model/workbar-layout.ts
+++ b/apps/desktop/src/renderer/features/workbar/model/workbar-layout.ts
@@ -49,7 +49,8 @@ export const SESSION_BOTTOM_PANEL_MAX_HEIGHT = 520;
 
 export interface WorkbarLayoutState {
   panels: SessionWorkbarPanelsState;
-  rightCollapsed: boolean;
+  activeSessionId: string | undefined;
+  collapsedBySession: Record<string, boolean>;
   bottomOpen: boolean;
   rightWidth: number;
   bottomHeight: number;
@@ -57,6 +58,8 @@ export interface WorkbarLayoutState {
 
 export type WorkbarLayoutAction =
   | WorkbarPanelsAction
+  | { type: 'activate-session'; sessionId: string | undefined }
+  | { type: 'retain-sessions'; sessionIds: ReadonlySet<string> }
   | {
       type: 'collapse';
       placement: 'right' | 'bottom';
@@ -90,11 +93,31 @@ export function readSessionWorkbarWidth(): number {
   return Number.isFinite(stored) && stored > 0 ? Math.round(stored) : SESSION_WORKBAR_DEFAULT_WIDTH;
 }
 
-export function readSessionWorkbarCollapsed(): boolean {
-  const stored = safeLocalStorageGet('maka-session-workbar-collapsed-v1');
-  if (stored === 'false') return false;
-  if (stored === 'true') return true;
-  return true;
+const SESSION_COLLAPSE_KEY = 'maka-session-workbar-collapsed-v2';
+
+function readSessionWorkbarCollapsed(): Record<string, boolean> {
+  try {
+    const stored: unknown = JSON.parse(safeLocalStorageGet(SESSION_COLLAPSE_KEY) ?? '{}');
+    if (!stored || typeof stored !== 'object' || Array.isArray(stored)) return {};
+    return Object.fromEntries(
+      Object.entries(stored).filter(([, value]) => typeof value === 'boolean'),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function isSessionWorkbarCollapsed(state: WorkbarLayoutState): boolean {
+  const id = state.activeSessionId;
+  return id !== undefined && Object.hasOwn(state.collapsedBySession, id)
+    ? state.collapsedBySession[id]!
+    : true;
+}
+
+function withRightCollapsed(state: WorkbarLayoutState, collapsed: boolean): WorkbarLayoutState {
+  const id = state.activeSessionId;
+  if (id === undefined || isSessionWorkbarCollapsed(state) === collapsed) return state;
+  return { ...state, collapsedBySession: { ...state.collapsedBySession, [id]: collapsed } };
 }
 
 export function readSessionBottomPanelHeight(): number {
@@ -108,10 +131,11 @@ export function readSessionBottomPanelOpen(): boolean {
   return safeLocalStorageGet('maka-session-bottom-panel-open-v1') === 'true';
 }
 
-export function loadWorkbarLayout(): WorkbarLayoutState {
+export function loadWorkbarLayout(activeSessionId?: string): WorkbarLayoutState {
   return {
     panels: readSessionWorkbarPanels(),
-    rightCollapsed: readSessionWorkbarCollapsed(),
+    activeSessionId,
+    collapsedBySession: readSessionWorkbarCollapsed(),
     bottomOpen: readSessionBottomPanelOpen(),
     rightWidth: clampSize(
       readSessionWorkbarWidth(),
@@ -138,9 +162,16 @@ export function persistWorkbarLayout(
   }
   if (target === 'all' || target === 'right-visibility') {
     safeLocalStorageSet(
-      'maka-session-workbar-collapsed-v1',
-      state.rightCollapsed ? 'true' : 'false',
+      SESSION_COLLAPSE_KEY,
+      JSON.stringify(state.collapsedBySession),
     );
+    // The old global preference has no Session owner and cannot be migrated
+    // without giving an unrelated conversation its expanded state.
+    try {
+      localStorage.removeItem('maka-session-workbar-collapsed-v1');
+    } catch {
+      // Storage may be unavailable in restricted renderer contexts.
+    }
   }
   if (target === 'all' || target === 'bottom-visibility') {
     safeLocalStorageSet(
@@ -166,11 +197,22 @@ export function reduceWorkbarLayout(
   state: WorkbarLayoutState,
   action: WorkbarLayoutAction,
 ): WorkbarLayoutState {
+  if (action.type === 'activate-session') {
+    return state.activeSessionId === action.sessionId
+      ? state
+      : { ...state, activeSessionId: action.sessionId };
+  }
+  if (action.type === 'retain-sessions') {
+    const entries = Object.entries(state.collapsedBySession).filter(
+      ([id]) => id === state.activeSessionId || action.sessionIds.has(id),
+    );
+    return entries.length === Object.keys(state.collapsedBySession).length
+      ? state
+      : { ...state, collapsedBySession: Object.fromEntries(entries) };
+  }
   if (action.type === 'collapse') {
     if (action.placement === 'right') {
-      return state.rightCollapsed === action.collapsed
-        ? state
-        : { ...state, rightCollapsed: action.collapsed };
+      return withRightCollapsed(state, action.collapsed);
     }
     const bottomOpen = !action.collapsed;
     return state.bottomOpen === bottomOpen
@@ -200,7 +242,7 @@ export function reduceWorkbarLayout(
 
   const panels = reduceWorkbarPanels(state.panels, action);
   if (panels === state.panels) return state;
-  let rightCollapsed = state.rightCollapsed;
+  let rightCollapsed = isSessionWorkbarCollapsed(state);
   let bottomOpen = state.bottomOpen;
   if (action.type === 'open' || action.type === 'open-launcher') {
     if (action.placement === 'right') rightCollapsed = false;
@@ -217,5 +259,5 @@ export function reduceWorkbarLayout(
       else bottomOpen = false;
     }
   }
-  return { ...state, panels, rightCollapsed, bottomOpen };
+  return withRightCollapsed({ ...state, panels, bottomOpen }, rightCollapsed);
 }

--- a/apps/desktop/src/renderer/features/workbar/model/workbar-layout.ts
+++ b/apps/desktop/src/renderer/features/workbar/model/workbar-layout.ts
@@ -26,6 +26,7 @@ import {
   readSessionWorkbarPanels,
   reduceWorkbarPanels,
   type SessionWorkbarPanelsState,
+  type SessionWorkbarPlacement,
   type WorkbarPanelsAction,
 } from './workbar-tabs.js';
 
@@ -58,6 +59,11 @@ export interface WorkbarLayoutState {
 
 export type WorkbarLayoutAction =
   | WorkbarPanelsAction
+  | {
+      type: 'remove-stale';
+      placement: SessionWorkbarPlacement;
+      tabIds: readonly string[];
+    }
   | { type: 'activate-session'; sessionId: string | undefined }
   | { type: 'retain-sessions'; sessionIds: ReadonlySet<string> }
   | {
@@ -240,7 +246,12 @@ export function reduceWorkbarLayout(
       : { ...state, bottomHeight };
   }
 
-  const panels = reduceWorkbarPanels(state.panels, action);
+  const panels = reduceWorkbarPanels(
+    state.panels,
+    action.type === 'remove-stale'
+      ? { type: 'close', placement: action.placement, tabIds: action.tabIds }
+      : action,
+  );
   if (panels === state.panels) return state;
   let rightCollapsed = isSessionWorkbarCollapsed(state);
   let bottomOpen = state.bottomOpen;
@@ -250,7 +261,10 @@ export function reduceWorkbarLayout(
   } else if (action.type === 'move-to-panel') {
     if (action.target === 'right') rightCollapsed = false;
     else bottomOpen = true;
-  } else if (action.type === 'close') {
+  } else if (
+    action.type === 'close' ||
+    (action.type === 'remove-stale' && action.placement === 'bottom')
+  ) {
     if (
       state.panels[action.placement].tabs.length > 0 &&
       panels[action.placement].tabs.length === 0

--- a/apps/desktop/src/renderer/live-turn-snapshot.ts
+++ b/apps/desktop/src/renderer/live-turn-snapshot.ts
@@ -109,7 +109,12 @@ export function selectStreamingSessionIds(
   return streaming;
 }
 
-export function sessionIdSetsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+export function sessionIdSetsEqual(
+  a: ReadonlySet<string> | undefined,
+  b: ReadonlySet<string> | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
   if (a.size !== b.size) return false;
   for (const id of a) {
     if (!b.has(id)) return false;

--- a/apps/desktop/src/renderer/session-catalog-state.ts
+++ b/apps/desktop/src/renderer/session-catalog-state.ts
@@ -78,8 +78,11 @@ export const selectActiveSessionId = (state: SessionCatalogState): string | unde
  * selection would re-render every reader that only cares about which sessions
  * exist.
  */
-export const selectAuthoritativeSessionIds = (state: SessionCatalogState): ReadonlySet<string> =>
-  new Set(state.sessions.map(({ id }) => id));
+export const selectAuthoritativeSessionIds = (
+  state: SessionCatalogState,
+): ReadonlySet<string> | undefined =>
+  // The initial empty catalog cannot prove that persisted Sessions were deleted.
+  state.revision > 0 ? new Set(state.sessions.map(({ id }) => id)) : undefined;
 
 /**
  * Owns the controller for the component's lifetime. Deliberately does NOT


### PR DESCRIPTION
## Summary

Fixes #4693

Opening the right workbar in conversation A currently opens it for a new conversation B. Store collapse state by session in the layout reducer so B starts collapsed and returning to A restores its preference, including after renderer reload. Bind the owner before commit so an open requested during activation is not overwritten.

This chooses **persistent per-session visibility**, while keeping panel topology and dimensions global. The old global `maka-session-workbar-collapsed-v1` preference has no session owner and is retired in favor of v2; sessions default to collapsed once on upgrade. Please review that persistence/topology split and migration behavior against the decision requested in the issue.

Prune deleted entries only after the catalog has a committed snapshot. The catalog selector distinguishes “not loaded” from “confirmed empty,” preventing startup from deleting saved preferences.

## Verification

- New Electron regression fails against unchanged baseline `b0255edcb35588b2f24efd386447d9a494c1e395` on Linux ARM64: B's panel is visible when it should be hidden.
- Fixed macOS ARM64 build: the requested A → B → A plus reload E2E passes; the full file has 9 tests, including A open → B collapsed → A open → reload → A open/B collapsed.
- Compiled workbar model/controller tests: 27 passed, covering persistence, old-key retirement, catalog readiness, deleted-session cleanup, malformed storage and activation-commit opening under StrictMode.
- `npm run lint`, `npm run format:check`, `npm run build`, `npm run typecheck`, both Desktop/UI `knip` checks, Desktop architecture validation (including 101 checker tests), and `git diff --check` passed.
- Full Workbar E2E run: 8 passed; one pre-existing narrow-layout test timed out waiting for its fake-backend response before reaching any Workbar assertion, then passed in isolation (1/1).
- Full repository test suite and the final patch on Windows/Linux were not run. Persistence was checked through storage round-trip and renderer reload, not an OS reboot.

Before: unchanged Linux ARM64 baseline, where B inherits A's expanded panel. The fixture image lacks CJK fonts, affecting labels only.

![Before: conversation B inherits the expanded panel](https://raw.githubusercontent.com/DaBestCode/maka/9b89980ce60a92f50bb794f58a87188b56ee4a4c/before.png)

After: fixed macOS ARM64 build, where B stays collapsed after navigating back and reloading.

![After: conversation B keeps its collapsed panel](https://raw.githubusercontent.com/DaBestCode/maka/9b89980ce60a92f50bb794f58a87188b56ee4a4c/after.png)

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with repository/issue investigation, implementation, regression tests, verification, and this PR description. The commit includes `Generated-by: OpenAI Codex`. Human review remains required.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

