### PR TITLE
fix(runtime-host): preserve legacy handoff operator

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-local-remote-access.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-local-remote-access.test.ts
@@ -404,6 +404,7 @@ test('replaces a conflicting supervised Host with the requested active-work poli
     resolveManagedDeploymentAuthority: async () => ({
       kind: 'active',
       lifecycleMode: 'supervised',
+      deploymentRoot: join(base, 'deployment'),
       target: {
         schemaVersion: 2,
         serviceId: rootId,
@@ -513,14 +514,14 @@ test('does not persist recoverable setup authority before Desktop ownership comm
   assert.equal(setupCalls, 0);
 });
 
-test('adopts committed managed authority from a released handoff without replaying setup', async (t) => {
+test('adopts a released handoff through its existing legacy operator', async (t) => {
   const base = await mkdtemp(join(tmpdir(), 'maka-local-remote-access-prestart-'));
   t.after(() => rm(base, { recursive: true, force: true }));
   const clientDataRoot = join(base, 'client');
   const rootPath = join(clientDataRoot, 'workspaces', 'default');
   const rootId = 'a'.repeat(64);
   const deploymentId = '22222222-2222-4222-8222-222222222222';
-  const installedOperator = testOperator(join(base, 'installed', 'operator.mjs'));
+  const deploymentRoot = join(base, 'installed');
   await mkdir(rootPath, { recursive: true });
   await writeFile(
     join(clientDataRoot, 'runtime-host-local-service.json'),
@@ -543,10 +544,11 @@ test('adopts committed managed authority from a released handoff without replayi
     resolveManagedDeploymentAuthority: async () => ({
       kind: 'active',
       lifecycleMode: 'supervised',
+      deploymentRoot,
       target: {
         schemaVersion: 2,
         serviceId: rootId,
-        operator: installedOperator,
+        operator: testOperator(join(deploymentRoot, 'operator.mjs')),
         rootPath,
         rootId,
         deploymentId,
@@ -570,7 +572,10 @@ test('adopts committed managed authority from a released handoff without replayi
       schemaVersion: 2,
       state: 'managed',
       serviceId: rootId,
-      operator: installedOperator,
+      operator: {
+        kind: 'legacy_posix_executable',
+        executablePath: join(deploymentRoot, 'operator'),
+      },
       rootPath,
       rootId,
       deploymentId,

--- a/apps/desktop/src/main/runtime-host-local-remote-access.ts
+++ b/apps/desktop/src/main/runtime-host-local-remote-access.ts
@@ -92,6 +92,7 @@ type LocalManagedDeploymentAuthority =
   | {
       readonly kind: 'active';
       readonly lifecycleMode: 'on_demand' | 'supervised';
+      readonly deploymentRoot: string;
       readonly target: LocalServiceTarget;
     }
   | { readonly kind: 'transition' };
@@ -205,6 +206,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
       return {
         kind: 'active',
         lifecycleMode: authority.record.lifecycle.mode,
+        deploymentRoot: authority.record.deploymentRoot,
         target: requireServiceTarget(
           {
             schemaVersion: 2,
@@ -223,7 +225,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
     });
 
   const adoptCommittedSetup = async (
-    setup: LocalServiceSetupPending,
+    setup: LocalServiceSetupPending | LocalServiceLegacyHandoff,
   ): Promise<
     | { readonly kind: 'absent' | 'transition' }
     | { readonly kind: 'managed'; readonly managed: LocalServiceManaged }
@@ -231,7 +233,16 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
     const authority = await resolveManagedDeploymentAuthority(setup.rootId);
     if (!authority) return { kind: 'absent' };
     if (authority.kind === 'transition') return authority;
-    const managed = managedLifecycle(authority.target);
+    const target =
+      setup.schemaVersion === 1
+        ? {
+            ...authority.target,
+            operator: createRuntimeHostLegacyPosixOperatorCommand(
+              join(authority.deploymentRoot, 'operator'),
+            ),
+          }
+        : authority.target;
+    const managed = managedLifecycle(target);
     await writeDocument(lifecyclePath, managed);
     return { kind: 'managed', managed };
   };
@@ -472,7 +483,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
     | { readonly kind: 'complete'; readonly managed: LocalServiceManaged }
   > => {
     const pending = pendingSetup(legacy);
-    const authority = await adoptCommittedSetup(pending);
+    const authority = await adoptCommittedSetup(legacy);
     if (authority.kind === 'managed') {
       return { kind: 'complete', managed: authority.managed };
     }
@@ -487,7 +498,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
     );
     if (retirement.kind === 'active_tasks') return { kind: 'active_tasks' };
     if (retirement.kind === 'not_owned') {
-      const raced = await adoptCommittedSetup(pending);
+      const raced = await adoptCommittedSetup(legacy);
       if (raced.kind === 'managed') {
         return { kind: 'complete', managed: raced.managed };
       }
@@ -857,7 +868,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
         const pending = await readLifecycle(lifecyclePath, input.rootPath, input.rootId);
         if (pending?.state !== 'setupPending' && pending?.state !== 'handoff') return false;
         const current = pendingSetup(pending);
-        const authority = await adoptCommittedSetup(current);
+        const authority = await adoptCommittedSetup(pending);
         if (authority.kind === 'absent') return false;
         if (authority.kind === 'managed') return true;
         if (pending.state === 'handoff') await writeDocument(lifecyclePath, current);
@@ -882,7 +893,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
           return;
         }
         if (lifecycle.state === 'handoff' || lifecycle.state === 'setupPending') {
-          const committed = await adoptCommittedSetup(pendingSetup(lifecycle));
+          const committed = await adoptCommittedSetup(lifecycle);
           if (committed.kind === 'managed') return;
           if (!supported(input.directPeerAvailable)) return;
           if (lifecycle.state === 'handoff') await recoverLegacyHandoff(lifecycle);


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

Preserve the only operator artifact guaranteed by a released schema-1 Local Runtime Host handoff when Desktop adopts an already-active managed authority. The recovered schema-2 receipt now points to the existing POSIX `operator`, while schema-2 setup recovery continues to use the portable Node `operator.mjs`.

This keeps adoption read-only with respect to the managed deployment: recovery does not replay setup, change the exact package, or mutate lifecycle ownership.

Refs #4657

## Root cause

The operator-command migration converted a released handoff to schema 2 before choosing its operator representation. That erased the fact that the handoff came from a release which only guaranteed `<deploymentRoot>/operator`, allowing recovery to persist a receipt for an `operator.mjs` that had never been converged.

## Verification

- Desktop main TypeScript build
- Biome on the two changed files
- Local Runtime Host remote-access recovery tests: 14/14 passed
- `git diff --check`

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex adjudicated the review finding, implemented the recovery fix, and ran the targeted verification under maintainer direction.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary><strong>中文</strong></summary>

## 摘要

Desktop 在接管已经 active 的 managed authority 时，为已发布的 schema-1 Local Runtime Host handoff 保留该版本唯一保证存在的 operator artifact。恢复后的 schema-2 receipt 现在指向既有 POSIX `operator`；schema-2 setup recovery 仍使用 portable Node `operator.mjs`。

接管过程不会修改 managed deployment：恢复时不重放 setup、不切换 exact package，也不改变 lifecycle ownership。

关联 #4657

## 根因

operator-command 迁移在选择 operator representation 之前先把已发布 handoff 转成了 schema 2，丢失了“该 handoff 所属版本只保证 `<deploymentRoot>/operator`”这一事实，因此可能持久化一个从未 converge 的 `operator.mjs` receipt。

## 验证

- Desktop main TypeScript build
- 对两个变更文件执行 Biome
- Local Runtime Host remote-access recovery 测试：14/14 通过
- `git diff --check`

## AI 使用

- [ ] 没有生成式工具作出实质贡献
- [x] 生成式工具作出实质贡献

工具与范围：OpenAI Codex 在维护者指导下裁决 review finding、实现恢复修复并完成定向验证。

## 检查清单

- [x] 测试覆盖该变更，且没有变更时会失败
- [x] lint、format、typecheck 与受影响测试已在本地通过

该 PR 是否改变行为？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
