### PR TITLE
fix(workhub): admit quoted Session names and spoken Chinese stops

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
@@ -100,7 +100,6 @@ test('resolves WorkHub coordination through the dedicated Host operation', async
     { sessionId: 'maka_workhub_coordination' },
     { candidateSetId: `sha256:${'a'.repeat(64)}`, candidates: [] },
     { disposition: 'answer_here', coordinationTurnId: 'action-turn' },
-    { turnId: 'answer-turn' },
     { turnId: 'summary-turn' },
   ]);
 
@@ -120,10 +119,6 @@ test('resolves WorkHub coordination through the dedicated Host operation', async
     { disposition: 'answer_here', coordinationTurnId: 'action-turn' },
   );
   assert.deepEqual(
-    await client.answerWorkHubCoordination({ turnId: 'answer-turn', text: 'Question' }),
-    { turnId: 'answer-turn' },
-  );
-  assert.deepEqual(
     await client.recordWorkHubCoordination({
       turnId: 'summary-turn',
       userText: 'Request',
@@ -141,10 +136,6 @@ test('resolves WorkHub coordination through the dedicated Host operation', async
         userText: 'Question',
         proposal: { disposition: 'answer_here' },
       },
-    },
-    {
-      operation: 'workhub.coordination.answer',
-      input: { turnId: 'answer-turn', text: 'Question' },
     },
     {
       operation: 'workhub.coordination.record',

--- a/apps/desktop/src/main/__tests__/runtime-host-workhub-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-workhub-ipc-main.test.ts
@@ -25,7 +25,6 @@ import { registerRuntimeHostWorkHubIpc } from '../runtime-host-workhub-ipc-main.
 test('projects WorkHub coordination resolution through its dedicated IPC domain', async () => {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
   let resolveCalls = 0;
-  const answers: unknown[] = [];
   const records: unknown[] = [];
   const actions: unknown[] = [];
   const changes: unknown[] = [];
@@ -35,10 +34,6 @@ test('projects WorkHub coordination resolution through its dedicated IPC domain'
       resolveWorkHubCoordinationSession: async () => {
         resolveCalls += 1;
         return { sessionId: 'maka_workhub_coordination' };
-      },
-      answerWorkHubCoordination: async (input: { turnId: string; text: string }) => {
-        answers.push(input);
-        return { turnId: input.turnId };
       },
       recordWorkHubCoordination: async (input: {
         turnId: string;
@@ -80,10 +75,6 @@ test('projects WorkHub coordination resolution through its dedicated IPC domain'
   assert.deepEqual(await handler({}), { sessionId: 'maka_workhub_coordination' });
   assert.equal(resolveCalls, 1);
   assert.deepEqual(
-    await handlers.get('workhub:answer')?.({}, { turnId: 'answer', text: 'Question' }),
-    { turnId: 'answer' },
-  );
-  assert.deepEqual(
     await handlers.get('workhub:record')?.({}, {
       turnId: 'record',
       userText: 'Request',
@@ -91,7 +82,6 @@ test('projects WorkHub coordination resolution through its dedicated IPC domain'
     }),
     { turnId: 'record' },
   );
-  assert.deepEqual(answers, [{ turnId: 'answer', text: 'Question' }]);
   assert.deepEqual(records, [{
     turnId: 'record',
     userText: 'Request',

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -977,11 +977,7 @@ export class DesktopRuntimeHostClient {
     return this.request("workhub.coordination.act", input);
   }
 
-  answerWorkHubCoordination(
-    input: OperationInput<"workhub.coordination.answer">,
-  ): Promise<OperationOutput<"workhub.coordination.answer">> {
-    return this.request("workhub.coordination.answer", input);
-  }
+
 
   recordWorkHubCoordination(
     input: OperationInput<"workhub.coordination.record">,

--- a/apps/desktop/src/main/runtime-host-workhub-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-workhub-ipc-main.ts
@@ -31,7 +31,6 @@ import type { ReconnectableReadIpcMain } from './ipc-reconnect-policy.js';
 type RuntimeHostWorkHubClient = Pick<
   DesktopRuntimeHostClient,
   | 'actWorkHubCoordination'
-  | 'answerWorkHubCoordination'
   | 'listWorkHubCoordinationCandidates'
   | 'recordWorkHubCoordination'
   | 'resolveWorkHubCoordinationSession'
@@ -52,9 +51,6 @@ export function registerRuntimeHostWorkHubIpc(
 ): void {
   ipcMain.handle('workhub:resolveCoordinationSession', () =>
     client.resolveWorkHubCoordinationSession(),
-  );
-  ipcMain.handle('workhub:answer', (_event, input) =>
-    client.answerWorkHubCoordination(input),
   );
   ipcMain.handle('workhub:record', (_event, input) =>
     client.recordWorkHubCoordination(input),

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -1035,11 +1035,6 @@ export interface MakaBridge {
   workHub: {
     /** Resolve the active Runtime Host's stable coordination conversation. */
     resolveCoordinationSession(): Promise<string>;
-    /** Answer an ordinary question inside the persistent Coordination Session. */
-    answer(
-      coordinationSessionId: string,
-      input: { turnId: string; text: string },
-    ): Promise<{ turnId: string }>;
     /** Persist one deterministic clarification or routing summary. */
     record(
       coordinationSessionId: string,
@@ -1054,11 +1049,6 @@ export interface MakaBridge {
       coordinationSessionId: string,
       input: Omit<OperationInput<'workhub.coordination.act'>, 'create'>,
     ): Promise<OperationOutcome<'workhub.coordination.act'>>;
-    /** Create an ordinary Session on the exact Host owning the resolved conversation. */
-    createSession(
-      coordinationSessionId: string,
-      input: { name: string },
-    ): Promise<DesktopSessionSummary>;
   };
   sessions: {
     list(filter?: SessionListFilter): Promise<DesktopSessionSummary[]>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1897,16 +1897,6 @@ const makaBridge = {
         (scope) => ipcRenderer.invoke('workhub:resolveCoordinationSession', scope),
       );
     },
-    async answer(
-      coordinationSessionId: string,
-      input: { turnId: string; text: string },
-    ): Promise<{ turnId: string }> {
-      const scope = await resolveDesktopWorkHubCoordinationCreateScope(
-        coordinationSessionId,
-        runtimeHostSessionRef,
-      );
-      return ipcRenderer.invoke('workhub:answer', scope, input) as Promise<{ turnId: string }>;
-    },
     async record(
       coordinationSessionId: string,
       input: { turnId: string; userText: string; assistantText: string },
@@ -1961,16 +1951,6 @@ const makaBridge = {
           targetSessionId: recordRuntimeHostSessionScope(scope, result.result.targetSessionId),
         },
       };
-    },
-    async createSession(
-      coordinationSessionId: string,
-      input: { name: string },
-    ): Promise<DesktopSessionSummary> {
-      const scope = await resolveDesktopWorkHubCoordinationCreateScope(
-        coordinationSessionId,
-        runtimeHostSessionRef,
-      );
-      return createDesktopSessionOnScope(scope, input);
     },
   },
   sessions: {

--- a/packages/core/src/__tests__/workhub-creation-intent.test.ts
+++ b/packages/core/src/__tests__/workhub-creation-intent.test.ts
@@ -1066,3 +1066,30 @@ test('requires a direct, explicitly named command for WorkHub stop authority', (
     );
   }
 });
+
+test('a quoted Session name is a title, not a reason to refuse the request', () => {
+  // The literal mask blanks quoted spans so a quoted word can never be read as
+  // a command. That is right for commands and wrong for the one place the
+  // quotes mark the object itself: naming a Session. Quoting the name is the
+  // natural way to write it, and it used to be the one way that did not work.
+  for (const [quoted, bare] of [
+    ['Create a new Session called "Payments"', 'Create a new Session called Payments'],
+    ['请创建一个新会话名为"支付任务"', '请创建一个新会话名为支付任务'],
+  ] as const) {
+    const quotedIntent = intentFor(quoted);
+    const bareIntent = intentFor(bare);
+    assert.equal(quotedIntent.execution, 'imperative', quoted);
+    assert.equal(quotedIntent.execution, bareIntent.execution, quoted);
+    assert.deepEqual(quotedIntent.creation.naming, bareIntent.creation.naming, quoted);
+  }
+
+  // The mask still decides everything else. None of these may be promoted.
+  for (const text of [
+    'Should we create a new Session called "Payments"?',
+    'Maybe create a new Session called "Payments" later',
+    'Do not create a new Session called "Payments"',
+    'Create a new Session called "',
+  ]) {
+    assert.notEqual(intentFor(text).execution, 'imperative', text);
+  }
+});

--- a/packages/core/src/__tests__/workhub-creation-intent.test.ts
+++ b/packages/core/src/__tests__/workhub-creation-intent.test.ts
@@ -1093,3 +1093,36 @@ test('a quoted Session name is a title, not a reason to refuse the request', () 
     assert.notEqual(intentFor(text).execution, 'imperative', text);
   }
 });
+
+test('a spoken Chinese stop is a stop, in the same range English already covers', () => {
+  // `停掉` and `停下` are how the request is usually spoken. Without them
+  // `停掉支付任务` carried no stop cue at all, so the sentence was routed as
+  // ordinary work and delivered to Payments — asking to stop it started more.
+  for (const text of ['停掉支付任务', '停下支付任务', '请停掉支付任务']) {
+    assert.deepEqual(
+      readWorkHubRequestIntent(text).stop,
+      { cue: true, imperative: true, target: '支付任务' },
+      text,
+    );
+  }
+
+  // Anaphora is a stop that names nothing, exactly as `Stop it` is: the cue is
+  // read so the user can be asked which work, and no target is claimed.
+  for (const text of ['停掉它', '停下它']) {
+    assert.deepEqual(readWorkHubRequestIntent(text).stop, { cue: true, imperative: false }, text);
+    // Same shape English gives `Stop it`: a stop was asked for, and no target
+    // was claimed, so the surface asks which work rather than guessing.
+    assert.deepEqual(
+      readWorkHubRequestIntent(text).stop,
+      readWorkHubRequestIntent('Stop it').stop,
+      text,
+    );
+  }
+
+  // Nothing here widens what counts as a stop. `关掉` reads as "switch off",
+  // which is usually work to do inside a Session, and English admits no
+  // equivalent; questions and negations stay refused.
+  for (const text of ['关掉调试日志', '不要停掉支付任务', '怎么停掉支付任务？']) {
+    assert.equal(readWorkHubRequestIntent(text).stop.cue, false, text);
+  }
+});

--- a/packages/core/src/workhub-creation-intent.ts
+++ b/packages/core/src/workhub-creation-intent.ts
@@ -101,8 +101,15 @@ const NAMED_CREATION_TITLE_INTRODUCER =
 const LEADING_CORRECTION_SEPARATOR = /^[\s,.;:!?，。；：！？—–-]+/u;
 const DIRECT_STOP_REQUEST =
   /^\s*(?:(?:please|kindly)\s+)?(?:stop|cancel|terminate|halt)\s+(?:(?:the|this)\s+)?(?:(?:session|work|task|job)\s+)?(.+?)\s*[.!。！]?\s*$/iu;
+// `停掉` and `停下` are the spoken forms of `停止`, as ordinary as the written
+// one. Without them `停掉支付任务` was not a stop at all, so the words were
+// delivered to Payments as new work — the opposite of what was asked. English
+// covers its own colloquial range with stop/cancel/terminate/halt; this is the
+// same range, not a wider claim. `关掉` stays out: it reads as "switch off",
+// which is usually work to do inside a Session, and English admits no
+// equivalent either.
 const DIRECT_CHINESE_STOP_REQUEST =
-  /^\s*(?:(?:请|请帮我|帮我|麻烦你?)\s*)?(?:停止|取消|终止|中止)\s*(?:(?:这个|该)?(?:会话|工作|任务)\s*)?(.+?)\s*[。！]?\s*$/iu;
+  /^\s*(?:(?:请|请帮我|帮我|麻烦你?)\s*)?(?:停止|停掉|停下|取消|终止|中止)\s*(?:(?:这个|该)?(?:会话|工作|任务)\s*)?(.+?)\s*[。！]?\s*$/iu;
 const UNSAFE_STOP_TARGET =
   /^(?:it|this|that|one|everything|all|current|session|work|task|job|(?:this|that|current)\s+(?:session|work|task|job)|它|这个|那个|全部|当前|会话|工作|任务|(?:这个|那个|当前)(?:会话|工作|任务))$/iu;
 

--- a/packages/core/src/workhub-creation-intent.ts
+++ b/packages/core/src/workhub-creation-intent.ts
@@ -248,15 +248,23 @@ function hasNegatedWorkHubCreationRequest(value: string): boolean {
 }
 
 /** Whether already-normalized, literal-masked text is an executable instruction. */
-function isImperativeWorkHubNewTopicRequest(normalized: string): boolean {
+/**
+ * `naming` is resolved from the unmasked text by the caller. A quoted title is
+ * a literal span, so the mask blanks it, and re-deriving the title from masked
+ * text would read every quoted name as an unusable one — the reason
+ * `Create a new Session called "Payments"` was refused while the same sentence
+ * without quotes was admitted. The mask still decides everything else here: it
+ * exists so quoted words cannot be read as commands, and that is unchanged.
+ */
+function isImperativeWorkHubNewTopicRequest(
+  normalized: string,
+  naming: WorkHubCreationNaming,
+): boolean {
   const actions = allMatches(normalized, EXECUTION_ACTION);
   if (isDeliberative(normalized) || hasUnquotedTerminalWithdrawal(normalized)) {
     return false;
   }
-  if (
-    hasWorkHubNamedCreationClause(normalized) &&
-    !affirmativeWorkHubNamedCreationTitle(normalized)
-  ) {
+  if (naming.kind === 'unusable') {
     return false;
   }
   const explicitCreation = isExplicitWorkHubCreationRequest(normalized);
@@ -309,7 +317,7 @@ export function readWorkHubRequestIntent(value: string): WorkHubRequestIntent {
       ? 'non_executable'
       : hasAmbiguousAdvisoryCommand(masked, actions)
         ? 'ambiguous'
-        : isImperativeWorkHubNewTopicRequest(masked)
+        : isImperativeWorkHubNewTopicRequest(masked, naming)
           ? 'imperative'
           : 'non_executable';
   return {


### PR DESCRIPTION
## Summary

Three independent WorkHub fixes, each self-contained.

**Two of them are user-facing bugs where a request was not just missed but acted on as something else.**

### 1. A quoted Session name refused the request

`Create a new Session called "Payments"` resolved as non-executable, while the same sentence without quotes was admitted. Quoting the name is the natural way to write it, so naming a Session by quoting it did not work at all, in either language.

The intent reader masks quoted spans before the text is read for commands, so a quoted word can never be mistaken for one. The title is the one place quotes mark the object rather than hide a command, and the caller already resolves it from the unmasked source; the imperative check was re-deriving it from masked text, where every quoted title reads as unusable, and refusing on that. It now takes the caller's verdict. The mask still decides everything else — a question, a hedge, a negation and an unterminated quote are all refused as before, which the test pins alongside the four sentences that now work.

### 2. A spoken Chinese stop was not read as a stop

`停掉支付任务` carried no stop cue at all. The Chinese pattern matched only the written verbs 停止 / 取消 / 终止 / 中止, so the most ordinary spoken form fell through to routing and was delivered to Payments as new work: **asking to stop it started more of it.**

`停掉` and `停下` are the spoken forms of `停止`. English already covers its own range with stop / cancel / terminate / halt, so this restores the same range rather than claiming a wider one. `关掉` stays out — it reads as "switch off", which is usually work to do inside a Session, and English admits no equivalent. Anaphora now behaves as it does in English: `停掉它` reads the cue and claims no target, so the surface asks which work instead of guessing. The test pins that against `Stop it` rather than restating the shape, so the two languages cannot drift apart. A cue alone still stops nothing — the reference must resolve to a real Session, which is what keeps `停掉这个定时器` ordinary work.

### 3. Bridge surface with no callers

`workHub.answer` and `workHub.createSession` are declared on the Desktop bridge, implemented in preload, and handled in the main process, and no renderer code calls either. Answering happens through `act({ disposition: 'answer_here' })` and Session creation through the `create_new` disposition, both served by the Action Gate.

This removes the bridge members, their preload implementations, the `workhub:answer` IPC handler and the Host client method behind it. **The `workhub.coordination.answer` operation stays**: it is a Host protocol contract with a live server implementation, and retiring it is a wire change with its own epoch, not a consequence of the renderer being silent.

## Verification

Each fix carries a regression that fails on the old behaviour: reverting the production change turns the corresponding test red, verified for both bugs.

Run locally, all green:

- `npm run build`, `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run check:asf-headers`
- `@maka/core` 801 pass / 0 fail
- Desktop WorkHub controller 72 pass / 0 fail
- Runtime Host WorkHub suites 65 pass / 0 fail

## Compatibility

No wire change and no schema change. The removed bridge members had no callers, and the Host protocol surface is untouched.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code wrote the changes and tests in this PR under human direction and review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — two refused requests are now admitted, and one unused bridge surface is removed
- [ ] No

---

> **Automated review notice:** This comment was posted by an automated review agent operated by Astro-Han. It is not an independent human review and does not replace one.
