### PR TITLE
fix(desktop): make Runtime Host quit intentional

### DIFF
--- a/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
@@ -26,7 +26,7 @@ describe('app quit coordinator', () => {
     let resumeQuitCount = 0;
     let preventedCount = 0;
     const coordinator = createAppQuitCoordinator({
-      prepareToQuit: async () => {},
+      prepareToQuit: async () => 'ready' as const,
       cleanup: async () => {},
       focusOrCreateWindow: () => {},
       onPreparationError: () => {},
@@ -64,7 +64,7 @@ describe('app quit coordinator', () => {
       releaseCleanup = resolve;
     });
     const coordinator = createAppQuitCoordinator({
-      prepareToQuit: async () => {},
+      prepareToQuit: async () => 'ready',
       cleanup: async () => {
         cleanupCount += 1;
         await cleanupPending;
@@ -113,7 +113,7 @@ describe('app quit coordinator', () => {
     let focusOrCreateCount = 0;
     let windowCreationSignal: AbortSignal | undefined;
     const coordinator = createAppQuitCoordinator({
-      prepareToQuit: async () => {},
+      prepareToQuit: async () => 'ready',
       cleanup: () => new Promise<void>(() => {}),
       focusOrCreateWindow: (signal) => {
         focusOrCreateCount += 1;
@@ -133,11 +133,39 @@ describe('app quit coordinator', () => {
     assert.equal(windowCreationSignal?.aborted, true);
   });
 
+  it('restores the running app when quit preparation is cancelled', async () => {
+    let cleanupCount = 0;
+    let focusOrCreateCount = 0;
+    let resumeQuitCount = 0;
+    const coordinator = createAppQuitCoordinator({
+      prepareToQuit: async () => 'cancelled',
+      cleanup: async () => {
+        cleanupCount += 1;
+      },
+      focusOrCreateWindow: () => {
+        focusOrCreateCount += 1;
+      },
+      onPreparationError: () => {},
+      onCleanupError: () => {},
+      onWindowCreationError: () => {},
+      resumeQuit: () => {
+        resumeQuitCount += 1;
+      },
+    });
+
+    coordinator.handleBeforeQuit({ preventDefault: () => {} });
+    await flushQuitCoordinator();
+
+    assert.equal(cleanupCount, 0);
+    assert.equal(resumeQuitCount, 0);
+    assert.equal(focusOrCreateCount, 1);
+  });
+
   it('reports window creation failure without leaking an unhandled rejection', async () => {
     const failure = new Error('window load failed');
     const reportedErrors: unknown[] = [];
     const coordinator = createAppQuitCoordinator({
-      prepareToQuit: async () => {},
+      prepareToQuit: async () => 'ready',
       cleanup: async () => {},
       focusOrCreateWindow: async () => {
         throw failure;
@@ -166,6 +194,7 @@ describe('app quit coordinator', () => {
       prepareToQuit: async () => {
         preparationCount += 1;
         if (preparationCount === 1) throw preparationError;
+        return 'ready';
       },
       cleanup: async () => {
         cleanupCount += 1;
@@ -203,7 +232,7 @@ describe('app quit coordinator', () => {
     let focusOrCreateCount = 0;
     let resumeQuitCount = 0;
     const deps = {
-      prepareToQuit: async () => {},
+      prepareToQuit: async () => 'ready' as const,
       cleanup: async () => {
         throw cleanupError;
       },

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -454,7 +454,12 @@ test('preserves Host facts when authorized retirement is refused', async () => {
 
 test('fences replacement launches while force-terminating the exact failed retirement', async () => {
   const events: string[] = [];
-  const current = candidateHarness();
+  const current = candidateHarness({
+    ownedProcess: {
+      pid: 42,
+      exited: new Promise(() => {}),
+    },
+  });
   const owner = await startRuntimeHostDesktopManager({
     rootPath: '/test-root',
     candidateLaunchBarrier: {
@@ -468,13 +473,14 @@ test('fences replacement launches while force-terminating the exact failed retir
     },
   } as unknown as DesktopRuntimeHostCandidateStartInput, {
     startCandidate: async () => ready(current.candidate),
-    forceTerminateHost: async (identity) => {
+    forceTerminateHost: async (identity, stillOwnsProcess) => {
       assert.deepEqual(identity, {
         rootPath: '/test-root',
         rootId: 'test-host',
         hostEpoch: 'test-host-epoch',
         pid: 42,
       });
+      assert.equal(stillOwnsProcess(), true);
       events.push('terminate');
       return true;
     },
@@ -487,6 +493,7 @@ test('fences replacement launches while force-terminating the exact failed retir
       lifecycleMode: 'ephemeral',
       rootPath: '/test-root',
       pid: 42,
+      forceTerminationAvailable: true,
     }),
     true,
   );

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -215,6 +215,65 @@ test('waits through a reconnect gap before quiescing Host retirement', async () 
   await owner.close();
 });
 
+test('does not treat an in-flight replacement as retired after admission times out', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const first = candidateHarness({
+    ownedProcess: {
+      pid: 42,
+      exited: Promise.resolve({ code: 1, signal: null, stderr: '', stderrTruncated: false }),
+    },
+  });
+  const replacement = candidateHarness();
+  let starts = 0;
+  let reportReconnectStart!: () => void;
+  let releaseReconnect!: () => void;
+  const reconnectStarted = new Promise<void>((resolve) => {
+    reportReconnectStart = resolve;
+  });
+  const reconnectReleased = new Promise<void>((resolve) => {
+    releaseReconnect = resolve;
+  });
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (input) => {
+      starts += 1;
+      if (starts === 1) return ready(first.candidate);
+      reportReconnectStart();
+      const signal = input.signal;
+      assert.ok(signal);
+      await Promise.race([
+        reconnectReleased,
+        new Promise<never>((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }),
+      ]);
+      return ready(replacement.candidate);
+    },
+    reconnectBackoff: { minMs: 0, maxMs: 0 },
+    waitForHostExit: async () => {},
+  });
+
+  first.disconnect();
+  await reconnectStarted;
+  const retirement = owner.retireOwnedLocalHost('interrupt_active_work');
+  t.mock.timers.tick(5_000);
+  await assert.rejects(
+    retirement,
+    (error: unknown) =>
+      error instanceof DesktopLocalHostRetirementError &&
+      error.facts.pid === undefined &&
+      !error.facts.forceTerminationAvailable,
+  );
+
+  releaseReconnect();
+  await owner.waitUntilReady('local');
+  assert.equal(
+    (await owner.retireOwnedLocalHost('interrupt_active_work')).kind,
+    'retired',
+  );
+  assert.equal(replacement.prepareRetirementCalls, 1);
+  await owner.close();
+});
+
 test('retires the owned ephemeral Host before Desktop quit', async () => {
   const events: string[] = [];
   const current = candidateHarness({

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -452,6 +452,50 @@ test('preserves Host facts when authorized retirement is refused', async () => {
   await owner.close();
 });
 
+test('fences replacement launches while force-terminating the exact failed retirement', async () => {
+  const events: string[] = [];
+  const current = candidateHarness();
+  const owner = await startRuntimeHostDesktopManager({
+    rootPath: '/test-root',
+    candidateLaunchBarrier: {
+      connect: async () => assert.fail('mocked candidate startup bypasses the barrier'),
+      pause: () => events.push('pause'),
+      retireExcept: async (pid: number) => {
+        events.push(`retire:${pid}`);
+      },
+      resume: () => events.push('resume'),
+      release: () => events.push('release'),
+    },
+  } as unknown as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async () => ready(current.candidate),
+    forceTerminateHost: async (identity) => {
+      assert.deepEqual(identity, {
+        rootPath: '/test-root',
+        rootId: 'test-host',
+        hostEpoch: 'test-host-epoch',
+        pid: 42,
+      });
+      events.push('terminate');
+      return true;
+    },
+  });
+
+  assert.equal(
+    await owner.forceTerminateOwnedLocalHost({
+      hostId: 'test-host',
+      hostEpoch: 'test-host-epoch',
+      lifecycleMode: 'ephemeral',
+      rootPath: '/test-root',
+      pid: 42,
+    }),
+    true,
+  );
+  assert.deepEqual(events, ['pause', 'retire:42', 'terminate']);
+  assert.equal((await owner.retireOwnedLocalHost('refuse_active_work')).kind, 'retired');
+  await owner.close();
+  assert.equal(events.at(-1), 'release');
+});
+
 test('resumes candidate launches when candidate retirement fails', async () => {
   const events: string[] = [];
   const current = candidateHarness();

--- a/apps/desktop/src/main/__tests__/runtime-host-quit-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-quit-copy.test.ts
@@ -32,13 +32,18 @@ const failure = new DesktopLocalHostRetirementError(
     lifecycleMode: 'ephemeral',
     rootPath: '/state/root',
     pid: 4242,
+    forceTerminationAvailable: true,
   },
   { cause: new Error('writer release timed out') },
+);
+const manualFailure = new DesktopLocalHostRetirementError(
+  { ...failure.facts, forceTerminationAvailable: false },
+  { cause: failure.cause },
 );
 
 for (const locale of ['en', 'zh'] as const) {
   test(`quit failure copy exposes actionable Host facts in ${locale}`, () => {
-    const dialog = buildRuntimeHostQuitFailureDialog(failure, locale, false);
+    const dialog = buildRuntimeHostQuitFailureDialog(manualFailure, locale);
 
     assert.match(dialog.options.detail ?? '', /4242/);
     assert.match(dialog.options.detail ?? '', /host-epoch/);
@@ -48,8 +53,8 @@ for (const locale of ['en', 'zh'] as const) {
 }
 
 test('manual recovery copy names a cross-platform process-management concept', () => {
-  const english = buildRuntimeHostQuitFailureDialog(failure, 'en', false).options.detail ?? '';
-  const chinese = buildRuntimeHostQuitFailureDialog(failure, 'zh', false).options.detail ?? '';
+  const english = buildRuntimeHostQuitFailureDialog(manualFailure, 'en').options.detail ?? '';
+  const chinese = buildRuntimeHostQuitFailureDialog(manualFailure, 'zh').options.detail ?? '';
 
   assert.match(english, /operating system's process-management tool/);
   assert.match(chinese, /操作系统的进程管理工具/);
@@ -58,7 +63,7 @@ test('manual recovery copy names a cross-platform process-management concept', (
 
 test('quit dialogs default to preserving background work', () => {
   const active = buildRuntimeHostActiveQuitDialog('en');
-  const recovery = buildRuntimeHostQuitFailureDialog(failure, 'en', true);
+  const recovery = buildRuntimeHostQuitFailureDialog(failure, 'en');
 
   assert.equal(active.decisions[active.options.defaultId ?? -1], 'cancel');
   assert.equal(recovery.decisions[recovery.options.defaultId ?? -1], 'cancel');

--- a/apps/desktop/src/main/__tests__/runtime-host-quit-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-quit-copy.test.ts
@@ -20,7 +20,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { DesktopLocalHostRetirementError } from '../runtime-host-desktop-manager.js';
-import { buildRuntimeHostQuitFailureDialog } from '../runtime-host-quit-copy.js';
+import {
+  buildRuntimeHostActiveQuitDialog,
+  buildRuntimeHostQuitFailureDialog,
+} from '../runtime-host-quit-copy.js';
 
 const failure = new DesktopLocalHostRetirementError(
   {
@@ -35,20 +38,29 @@ const failure = new DesktopLocalHostRetirementError(
 
 for (const locale of ['en', 'zh'] as const) {
   test(`quit failure copy exposes actionable Host facts in ${locale}`, () => {
-    const dialog = buildRuntimeHostQuitFailureDialog(failure, locale);
+    const dialog = buildRuntimeHostQuitFailureDialog(failure, locale, false);
 
-    assert.match(dialog.detail ?? '', /4242/);
-    assert.match(dialog.detail ?? '', /host-epoch/);
-    assert.match(dialog.detail ?? '', /\/state\/root/);
-    assert.match(dialog.detail ?? '', /writer release timed out/);
+    assert.match(dialog.options.detail ?? '', /4242/);
+    assert.match(dialog.options.detail ?? '', /host-epoch/);
+    assert.match(dialog.options.detail ?? '', /\/state\/root/);
+    assert.match(dialog.options.detail ?? '', /writer release timed out/);
   });
 }
 
 test('manual recovery copy names a cross-platform process-management concept', () => {
-  const english = buildRuntimeHostQuitFailureDialog(failure, 'en').detail ?? '';
-  const chinese = buildRuntimeHostQuitFailureDialog(failure, 'zh').detail ?? '';
+  const english = buildRuntimeHostQuitFailureDialog(failure, 'en', false).options.detail ?? '';
+  const chinese = buildRuntimeHostQuitFailureDialog(failure, 'zh', false).options.detail ?? '';
 
   assert.match(english, /operating system's process-management tool/);
   assert.match(chinese, /操作系统的进程管理工具/);
   assert.doesNotMatch(`${english}\n${chinese}`, /Activity Monitor|Task Manager|活动监视器|任务管理器/);
+});
+
+test('quit dialogs default to preserving background work', () => {
+  const active = buildRuntimeHostActiveQuitDialog('en');
+  const recovery = buildRuntimeHostQuitFailureDialog(failure, 'en', true);
+
+  assert.equal(active.decisions[active.options.defaultId ?? -1], 'cancel');
+  assert.equal(recovery.decisions[recovery.options.defaultId ?? -1], 'cancel');
+  assert.deepEqual(recovery.decisions, ['retry', 'force', 'cancel']);
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-quit.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-quit.test.ts
@@ -20,6 +20,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { RuntimeHostRetirementMode } from '@maka/runtime-host/client';
+import { DesktopLocalHostRetirementError } from '../runtime-host-desktop-manager.js';
 import { prepareRuntimeHostQuit } from '../runtime-host-quit.js';
 
 test('background work requires consent before interruption', async () => {
@@ -31,15 +32,73 @@ test('background work requires consent before interruption', async () => {
         ? ({ kind: 'active_tasks' } as const)
         : ({ kind: 'retired', resume: () => {} } as const);
     },
+    forceTerminateOwnedLocalHost: async () => assert.fail('force termination is not expected'),
   };
+  const recoverFailure = async () => assert.fail('recovery is not expected');
 
-  assert.equal(await prepareRuntimeHostQuit(owner, async () => false), 'cancelled');
+  assert.equal(
+    await prepareRuntimeHostQuit(owner, {
+      confirmInterrupt: async () => false,
+      recoverFailure,
+    }),
+    'cancelled',
+  );
   assert.deepEqual(modes, ['refuse_active_work']);
 
-  assert.equal(await prepareRuntimeHostQuit(owner, async () => true), 'ready');
+  assert.equal(
+    await prepareRuntimeHostQuit(owner, {
+      confirmInterrupt: async () => true,
+      recoverFailure,
+    }),
+    'ready',
+  );
   assert.deepEqual(modes, [
     'refuse_active_work',
     'refuse_active_work',
     'interrupt_active_work',
+  ]);
+});
+
+test('failed force termination stays inside the quit recovery decision', async () => {
+  const retirement = new DesktopLocalHostRetirementError(
+    {
+      hostId: 'root-id',
+      hostEpoch: 'host-epoch',
+      lifecycleMode: 'ephemeral',
+      rootPath: '/state/root',
+      pid: 4242,
+      forceTerminationAvailable: true,
+    },
+    { cause: new Error('graceful retirement timed out') },
+  );
+  const recovery: Array<{ canForceTerminate: boolean; cause: string | undefined }> = [];
+  const owner = {
+    retireOwnedLocalHost: async () => Promise.reject(retirement),
+    forceTerminateOwnedLocalHost: async () => {
+      throw new Error('process access denied');
+    },
+  };
+
+  assert.equal(
+    await prepareRuntimeHostQuit(owner, {
+      confirmInterrupt: async () => assert.fail('active-work consent is not expected'),
+      recoverFailure: async (error) => {
+        const canForceTerminate =
+          error instanceof DesktopLocalHostRetirementError &&
+          error.facts.forceTerminationAvailable;
+        recovery.push({
+          canForceTerminate,
+          cause: error instanceof Error && error.cause instanceof Error
+            ? error.cause.message
+            : undefined,
+        });
+        return canForceTerminate ? 'force' : 'cancel';
+      },
+    }),
+    'cancelled',
+  );
+  assert.deepEqual(recovery, [
+    { canForceTerminate: true, cause: 'graceful retirement timed out' },
+    { canForceTerminate: false, cause: 'process access denied' },
   ]);
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-quit.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-quit.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { RuntimeHostRetirementMode } from '@maka/runtime-host/client';
+import { prepareRuntimeHostQuit } from '../runtime-host-quit.js';
+
+test('background work requires consent before interruption', async () => {
+  const modes: RuntimeHostRetirementMode[] = [];
+  const owner = {
+    retireOwnedLocalHost: async (mode: RuntimeHostRetirementMode) => {
+      modes.push(mode);
+      return mode === 'refuse_active_work'
+        ? ({ kind: 'active_tasks' } as const)
+        : ({ kind: 'retired', resume: () => {} } as const);
+    },
+  };
+
+  assert.equal(await prepareRuntimeHostQuit(owner, async () => false), 'cancelled');
+  assert.deepEqual(modes, ['refuse_active_work']);
+
+  assert.equal(await prepareRuntimeHostQuit(owner, async () => true), 'ready');
+  assert.deepEqual(modes, [
+    'refuse_active_work',
+    'refuse_active_work',
+    'interrupt_active_work',
+  ]);
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-ssh-terminal.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-ssh-terminal.test.ts
@@ -1093,7 +1093,7 @@ function createHarness(
     terminateProcessTree: async ({ pid, signal, fallback, hasExited, beforeSignal }) => {
       terminatedProcesses.push({ pid, signal });
       await Promise.resolve();
-      if (hasExited?.() || beforeSignal?.() === false) return false;
+      if (hasExited?.() || (beforeSignal && !(await beforeSignal()))) return false;
       fallback?.();
       return true;
     },

--- a/apps/desktop/src/main/app-quit-coordinator.ts
+++ b/apps/desktop/src/main/app-quit-coordinator.ts
@@ -27,7 +27,7 @@ export interface AppQuitCoordinator {
 }
 
 export interface AppQuitCoordinatorDeps {
-  prepareToQuit(): Promise<void>;
+  prepareToQuit(): Promise<'ready' | 'cancelled'>;
   cleanup(): Promise<void>;
   focusOrCreateWindow(signal: AbortSignal): void | Promise<void>;
   onPreparationError(error: unknown): void;
@@ -75,7 +75,13 @@ export function createAppQuitCoordinator(deps: AppQuitCoordinatorDeps): AppQuitC
       void Promise.resolve()
         .then(() => deps.prepareToQuit())
         .then(
-          () => {
+          (preparation) => {
+            if (preparation === 'cancelled') {
+              phase = 'running';
+              windowCreationAbort = new AbortController();
+              focusOrCreateWindow();
+              return;
+            }
             phase = 'cleaning';
             return Promise.resolve()
               .then(() => deps.cleanup())

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -183,6 +183,7 @@ import type {
   DesktopRuntimeHostTargetPolicy,
 } from "./runtime-host-desktop-candidate.js";
 import {
+  DesktopLocalHostRetirementError,
   RuntimeHostUpgradeCancelledError,
   startRuntimeHostDesktopManager,
   type RuntimeHostDesktopManager,
@@ -192,7 +193,11 @@ import {
   DesktopRuntimeHostStartupRecoveryCancelledError,
   startDesktopRuntimeHostWithRecovery,
 } from "./runtime-host-startup-recovery.js";
-import { buildRuntimeHostQuitFailureDialog } from "./runtime-host-quit-copy.js";
+import {
+  buildRuntimeHostActiveQuitDialog,
+  buildRuntimeHostQuitFailureDialog,
+} from "./runtime-host-quit-copy.js";
+import { prepareRuntimeHostQuit } from "./runtime-host-quit.js";
 import { createRuntimeHostUpgradePrompts } from "./runtime-host-upgrade-dialog.js";
 import { registerRuntimeHostMemoryIpc } from "./runtime-host-memory-ipc-main.js";
 import {
@@ -1929,19 +1934,54 @@ function wireLifecycle(): void {
   quitCoordinator.focusOrCreateWindow();
 }
 
-async function prepareRuntimeHostDesktopQuit(): Promise<void> {
-  mainWindowController.browserWindow()?.destroy();
-  const retirement = await runtimeHostManager?.retireOwnedLocalHost(
-    "interrupt_active_work",
-  );
-  if (retirement?.kind === "active_tasks") {
-    throw new Error("Runtime Host refused authorized quit retirement");
-  }
+async function prepareRuntimeHostDesktopQuit(): Promise<'ready' | 'cancelled'> {
+  const preparation = await prepareRuntimeHostQuit(runtimeHostManager, async () => {
+    const locale = await desktopLocale.resolve();
+    const dialog = buildRuntimeHostActiveQuitDialog(locale);
+    const { response } = await showDesktopMessageBox(dialog.options, { locale });
+    return dialog.decisions[response] === 'quit';
+  });
+  if (preparation === 'ready') mainWindowController.browserWindow()?.destroy();
+  return preparation;
 }
 
 async function showRuntimeHostQuitFailure(error: unknown): Promise<void> {
-  const locale = await desktopLocale.resolve();
-  await showDesktopMessageBox(buildRuntimeHostQuitFailureDialog(error, locale), { locale });
+  let currentError = error;
+  let canForceTerminate =
+    runtimeHostManager !== undefined &&
+    currentError instanceof DesktopLocalHostRetirementError &&
+    currentError.facts.pid !== undefined;
+  for (;;) {
+    const locale = await desktopLocale.resolve();
+    const dialog = buildRuntimeHostQuitFailureDialog(
+      currentError,
+      locale,
+      canForceTerminate,
+    );
+    const { response } = await showDesktopMessageBox(dialog.options, { locale });
+    const decision = dialog.decisions[response] ?? 'cancel';
+    if (decision === 'cancel') return;
+    if (decision === 'retry') {
+      app.quit();
+      return;
+    }
+    const retirement = currentError instanceof DesktopLocalHostRetirementError
+      ? currentError
+      : undefined;
+    if (
+      retirement &&
+      await runtimeHostManager?.forceTerminateOwnedLocalHost(retirement.facts)
+    ) {
+      app.quit();
+      return;
+    }
+    canForceTerminate = false;
+    currentError = retirement
+      ? new DesktopLocalHostRetirementError(retirement.facts, {
+          cause: new Error('The Runtime Host identity changed or forced termination failed'),
+        })
+      : currentError;
+  }
 }
 
 async function closeRuntimeHostDesktop(): Promise<void> {

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -183,7 +183,6 @@ import type {
   DesktopRuntimeHostTargetPolicy,
 } from "./runtime-host-desktop-candidate.js";
 import {
-  DesktopLocalHostRetirementError,
   RuntimeHostUpgradeCancelledError,
   startRuntimeHostDesktopManager,
   type RuntimeHostDesktopManager,
@@ -1902,9 +1901,6 @@ function wireLifecycle(): void {
     },
     onPreparationError: (error) => {
       console.error("[runtime-host] quit retirement failed:", error);
-      void showRuntimeHostQuitFailure(error).catch((dialogError) =>
-        console.error("[runtime-host] quit failure dialog failed:", dialogError),
-      );
     },
     onCleanupError: (error) =>
       console.error("[runtime-host] shutdown failed:", error),
@@ -1935,53 +1931,22 @@ function wireLifecycle(): void {
 }
 
 async function prepareRuntimeHostDesktopQuit(): Promise<'ready' | 'cancelled'> {
-  const preparation = await prepareRuntimeHostQuit(runtimeHostManager, async () => {
-    const locale = await desktopLocale.resolve();
-    const dialog = buildRuntimeHostActiveQuitDialog(locale);
-    const { response } = await showDesktopMessageBox(dialog.options, { locale });
-    return dialog.decisions[response] === 'quit';
+  const preparation = await prepareRuntimeHostQuit(runtimeHostManager, {
+    confirmInterrupt: async () => {
+      const locale = await desktopLocale.resolve();
+      const dialog = buildRuntimeHostActiveQuitDialog(locale);
+      const { response } = await showDesktopMessageBox(dialog.options, { locale });
+      return dialog.decisions[response] === 'quit';
+    },
+    recoverFailure: async (error) => {
+      const locale = await desktopLocale.resolve();
+      const dialog = buildRuntimeHostQuitFailureDialog(error, locale);
+      const { response } = await showDesktopMessageBox(dialog.options, { locale });
+      return dialog.decisions[response] ?? 'cancel';
+    },
   });
   if (preparation === 'ready') mainWindowController.browserWindow()?.destroy();
   return preparation;
-}
-
-async function showRuntimeHostQuitFailure(error: unknown): Promise<void> {
-  let currentError = error;
-  let canForceTerminate =
-    runtimeHostManager !== undefined &&
-    currentError instanceof DesktopLocalHostRetirementError &&
-    currentError.facts.pid !== undefined;
-  for (;;) {
-    const locale = await desktopLocale.resolve();
-    const dialog = buildRuntimeHostQuitFailureDialog(
-      currentError,
-      locale,
-      canForceTerminate,
-    );
-    const { response } = await showDesktopMessageBox(dialog.options, { locale });
-    const decision = dialog.decisions[response] ?? 'cancel';
-    if (decision === 'cancel') return;
-    if (decision === 'retry') {
-      app.quit();
-      return;
-    }
-    const retirement = currentError instanceof DesktopLocalHostRetirementError
-      ? currentError
-      : undefined;
-    if (
-      retirement &&
-      await runtimeHostManager?.forceTerminateOwnedLocalHost(retirement.facts)
-    ) {
-      app.quit();
-      return;
-    }
-    canForceTerminate = false;
-    currentError = retirement
-      ? new DesktopLocalHostRetirementError(retirement.facts, {
-          cause: new Error('The Runtime Host identity changed or forced termination failed'),
-        })
-      : currentError;
-  }
 }
 
 async function closeRuntimeHostDesktop(): Promise<void> {

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -159,6 +159,7 @@ const decodeStoredMessage = (value: unknown): StoredMessage =>
 const MAX_OPTIMISTIC_ATTEMPTS = 3;
 const MAX_SESSION_REVISION_ATTEMPTS = 8;
 const MAX_PRICING_SNAPSHOT_ATTEMPTS = 3;
+const RUNTIME_HOST_RETIREMENT_TIMEOUT_MS = 5_000;
 
 export type DesktopSessionConfigurationPatch = SessionConfigurationPatch;
 
@@ -1326,7 +1327,11 @@ export class DesktopRuntimeHostClient {
   prepareHostRetirement(
     mode: RuntimeHostRetirementMode,
   ): Promise<RuntimeHostRetirementPreparation> {
-    return prepareConnectedRuntimeHostRetirement(this.connection, mode);
+    return prepareConnectedRuntimeHostRetirement(
+      this.connection,
+      mode,
+      RUNTIME_HOST_RETIREMENT_TIMEOUT_MS,
+    );
   }
 
   stopTurn(

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -186,6 +186,7 @@ export class RuntimeHostPairingFinalizationInterruptedError extends Error {
 export type RuntimeHostGuestAccessFinalization = 'ready' | 'reconnecting';
 
 const DEFAULT_PAIRING_FINALIZATION_TIMEOUT_MS = 30_000;
+const LOCAL_HOST_RETIREMENT_ADMISSION_TIMEOUT_MS = 5_000;
 
 export type RuntimeHostRestartableConflict = Extract<
   DesktopRuntimeHostCandidateStartResult,
@@ -811,12 +812,22 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     let quiescence: Awaited<
       ReturnType<RuntimeHostReconnectLifecycle<DesktopRuntimeHostCandidate>['quiesce']>
     >;
+    const admissionAbort = new AbortController();
+    const admissionTimeout = setTimeout(
+      () => admissionAbort.abort(new Error('Runtime Host did not reconnect before retirement')),
+      LOCAL_HOST_RETIREMENT_ADMISSION_TIMEOUT_MS,
+    );
     try {
-      quiescence = await lifecycle.quiesce();
+      quiescence = await lifecycle.quiesce(admissionAbort.signal);
     } catch (error) {
       const terminal = this.#unavailableLocalHostRetirement(target, error);
       if (terminal) return terminal;
+      if (admissionAbort.signal.aborted) {
+        throw this.#localHostRetirementError(target, error) ?? error;
+      }
       throw error;
+    } finally {
+      clearTimeout(admissionTimeout);
     }
     let hostPid = quiescence.current.hostPid;
     let launchBarrierPaused = false;
@@ -879,10 +890,27 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     cause: unknown = target.state.readiness === 'unavailable' ? target.state.error : undefined,
   ): DesktopLocalHostRetirement | undefined {
     if (target.state.readiness !== 'unavailable') return undefined;
+    return this.#retirementWithoutCurrentHost(target, cause);
+  }
+
+  #retirementWithoutCurrentHost(
+    target: DesktopRuntimeHostTargetGeneration,
+    cause: unknown,
+  ): DesktopLocalHostRetirement {
+    const failure = this.#localHostRetirementError(target, cause);
+    if (!failure || target.lastCandidate?.ownedProcess?.state === 'exited') {
+      return { kind: 'not_owned' };
+    }
+    throw failure;
+  }
+
+  #localHostRetirementError(
+    target: DesktopRuntimeHostTargetGeneration,
+    cause: unknown,
+  ): DesktopLocalHostRetirementError | undefined {
     const last = target.lastCandidate;
-    if (!last || last.ownership !== 'owned_ephemeral') return { kind: 'not_owned' };
-    if (last.ownedProcess?.state === 'exited') return { kind: 'not_owned' };
-    throw new DesktopLocalHostRetirementError(
+    if (!last || last.ownership !== 'owned_ephemeral') return undefined;
+    return new DesktopLocalHostRetirementError(
       {
         hostId: last.hostId,
         hostEpoch: last.hostEpoch,

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -21,6 +21,7 @@ import { randomUUID } from 'node:crypto';
 import type { BotIncomingMessage } from '@maka/runtime/bots';
 import {
   abortable,
+  forceTerminateRegisteredRuntimeHost,
   RuntimeHostOperationError,
   RuntimeHostPermanentReconnectError,
   RuntimeHostRequestInterruptedError,
@@ -95,6 +96,7 @@ export interface RuntimeHostDesktopManager {
   runManagedLocalHostChange<T>(change: () => Promise<T>): Promise<T>;
   setDefaultProfile(profileId: string): void;
   retireOwnedLocalHost(mode: RuntimeHostRetirementMode): Promise<DesktopLocalHostRetirement>;
+  forceTerminateOwnedLocalHost(facts: DesktopLocalHostRetirementFacts): Promise<boolean>;
   close(): Promise<void>;
 }
 
@@ -241,6 +243,7 @@ export async function startRuntimeHostDesktopManager(
     onFatalError?: (error: Error, target: ResolvedRuntimeHostProfile) => void;
     upgradePrompts?: RuntimeHostUpgradePrompts;
     waitForHostExit?: (pid: number) => Promise<void>;
+    forceTerminateHost?: typeof forceTerminateRegisteredRuntimeHost;
     waitForHostRetirement?: (
       registration: HostRegistration,
       signal: AbortSignal,
@@ -264,6 +267,7 @@ export async function startRuntimeHostDesktopManager(
     options.onFatalError ?? ((error) => console.error('[runtime-host] reconnect failed:', error)),
     options.upgradePrompts,
     options.waitForHostExit ?? waitForProcessExit,
+    options.forceTerminateHost ?? forceTerminateRegisteredRuntimeHost,
     options.waitForHostRetirement ?? waitForProcessRetirement,
     options.resolveLocalHostReplacement,
     options.recoverLocalHost,
@@ -302,6 +306,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     ) => void,
     private readonly upgradePrompts: RuntimeHostUpgradePrompts | undefined,
     private readonly waitForHostExit: (pid: number) => Promise<void>,
+    private readonly forceTerminateHost: typeof forceTerminateRegisteredRuntimeHost,
     private readonly waitForHostRetirement: (
       registration: HostRegistration,
       signal: AbortSignal,
@@ -738,6 +743,45 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     });
     this.#localHostRetirementTask = { mode, result };
     return result;
+  }
+
+  async forceTerminateOwnedLocalHost(
+    facts: DesktopLocalHostRetirementFacts,
+  ): Promise<boolean> {
+    if (this.#localHostRetirement) return true;
+    const target = this.#targets.get(LOCAL_RUNTIME_HOST_PROFILE.id);
+    const last = target?.lastCandidate;
+    if (
+      !last ||
+      last.hostId !== facts.hostId ||
+      last.hostEpoch !== facts.hostEpoch ||
+      last.ownership !== 'owned_ephemeral' ||
+      facts.pid === undefined ||
+      (last.ownedProcess && last.ownedProcess.pid !== facts.pid)
+    ) {
+      return false;
+    }
+    const barrier = this.#baseInput.candidateLaunchBarrier;
+    let paused = false;
+    let retained = false;
+    try {
+      barrier?.pause();
+      paused = barrier !== undefined;
+      await barrier?.retireExcept(facts.pid);
+      const terminated = await this.forceTerminateHost({
+        rootPath: facts.rootPath,
+        rootId: facts.hostId,
+        hostEpoch: facts.hostEpoch,
+        pid: facts.pid,
+      });
+      if (!terminated) return false;
+      target.lastCandidate = undefined;
+      this.#completeLocalHostRetirement(() => barrier?.resume());
+      retained = true;
+      return true;
+    } finally {
+      if (paused && !retained) barrier?.resume();
+    }
   }
 
   async #retireOwnedLocalHost(
@@ -1368,7 +1412,9 @@ async function waitForProcessRetirement(
 }
 
 async function waitForProcessExit(pid: number): Promise<void> {
-  const deadline = Date.now() + 10_000;
+  // The Host owns a 10-second graceful-shutdown deadline. Keep a separate
+  // observation margin so Desktop cannot race the Host's final process.exit.
+  const deadline = Date.now() + 12_000;
   while (isProcessAlive(pid)) {
     if (Date.now() >= deadline) throw new Error('Runtime Host did not exit before retirement');
     await new Promise<void>((resolve) => setTimeout(resolve, 50));

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -145,6 +145,7 @@ export interface DesktopLocalHostRetirementFacts {
   readonly lifecycleMode: 'ephemeral';
   readonly rootPath: string;
   readonly pid?: number;
+  readonly forceTerminationAvailable: boolean;
 }
 
 export class DesktopLocalHostRetirementError extends Error {
@@ -751,16 +752,25 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     if (this.#localHostRetirement) return true;
     const target = this.#targets.get(LOCAL_RUNTIME_HOST_PROFILE.id);
     const last = target?.lastCandidate;
+    const ownedProcess = last?.ownedProcess;
     if (
+      !facts.forceTerminationAvailable ||
       !last ||
       last.hostId !== facts.hostId ||
       last.hostEpoch !== facts.hostEpoch ||
       last.ownership !== 'owned_ephemeral' ||
       facts.pid === undefined ||
-      (last.ownedProcess && last.ownedProcess.pid !== facts.pid)
+      !ownedProcess ||
+      ownedProcess.pid !== facts.pid ||
+      ownedProcess.state === 'unknown'
     ) {
       return false;
     }
+    const stillOwnsProcess = () =>
+      !this.#closed &&
+      target?.lastCandidate === last &&
+      last.ownedProcess === ownedProcess &&
+      ownedProcess.state === 'running';
     const barrier = this.#baseInput.candidateLaunchBarrier;
     let paused = false;
     let retained = false;
@@ -768,13 +778,20 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       barrier?.pause();
       paused = barrier !== undefined;
       await barrier?.retireExcept(facts.pid);
-      const terminated = await this.forceTerminateHost({
-        rootPath: facts.rootPath,
-        rootId: facts.hostId,
-        hostEpoch: facts.hostEpoch,
-        pid: facts.pid,
-      });
-      if (!terminated) return false;
+      const terminated =
+        ownedProcess.state === 'exited' ||
+        await this.forceTerminateHost(
+          {
+            rootPath: facts.rootPath,
+            rootId: facts.hostId,
+            hostEpoch: facts.hostEpoch,
+            pid: facts.pid,
+          },
+          stillOwnsProcess,
+        );
+      if (!terminated && (target.lastCandidate !== last || ownedProcess.state !== 'exited')) {
+        return false;
+      }
       target.lastCandidate = undefined;
       this.#completeLocalHostRetirement(() => barrier?.resume());
       retained = true;
@@ -834,6 +851,14 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       target.lastCandidate = undefined;
       return this.#completeLocalHostRetirement(resume);
     } catch (error) {
+      const last = target.lastCandidate;
+      const forceTerminationAvailable =
+        hostPid !== undefined &&
+        last?.hostId === quiescence.current.client.hostId &&
+        last.hostEpoch === quiescence.current.client.hostEpoch &&
+        last.ownership === 'owned_ephemeral' &&
+        last.ownedProcess?.pid === hostPid &&
+        last.ownedProcess.state === 'running';
       resume();
       throw new DesktopLocalHostRetirementError(
         {
@@ -842,6 +867,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
           lifecycleMode: 'ephemeral',
           rootPath: this.#baseInput.rootPath,
           ...(hostPid === undefined ? {} : { pid: hostPid }),
+          forceTerminationAvailable,
         },
         { cause: error },
       );
@@ -865,6 +891,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
         ...(last.ownedProcess?.state === 'running'
           ? { pid: last.ownedProcess.pid }
           : {}),
+        forceTerminationAvailable: last.ownedProcess?.state === 'running',
       },
       { cause: cause instanceof Error ? cause : new Error(String(cause)) },
     );

--- a/apps/desktop/src/main/runtime-host-quit-copy.ts
+++ b/apps/desktop/src/main/runtime-host-quit-copy.ts
@@ -20,6 +20,7 @@
 import type { UiLocale } from '@maka/core/ui-locale';
 import type { MessageBoxOptions } from 'electron';
 import { DesktopLocalHostRetirementError } from './runtime-host-desktop-manager.js';
+import type { RuntimeHostQuitFailureDecision } from './runtime-host-quit.js';
 
 export interface RuntimeHostQuitDialog<Decision extends string> {
   readonly options: MessageBoxOptions;
@@ -27,7 +28,6 @@ export interface RuntimeHostQuitDialog<Decision extends string> {
 }
 
 export type RuntimeHostActiveQuitDecision = 'quit' | 'cancel';
-export type RuntimeHostQuitFailureDecision = 'retry' | 'force' | 'cancel';
 
 export function buildRuntimeHostActiveQuitDialog(
   locale: UiLocale,
@@ -51,9 +51,9 @@ export function buildRuntimeHostActiveQuitDialog(
 export function buildRuntimeHostQuitFailureDialog(
   error: unknown,
   locale: UiLocale,
-  canForceTerminate: boolean,
 ): RuntimeHostQuitDialog<RuntimeHostQuitFailureDecision> {
   const retirement = error instanceof DesktopLocalHostRetirementError ? error : undefined;
+  const canForceTerminate = retirement?.facts.forceTerminationAvailable === true;
   const copy = COPY[locale];
   const details: string[] = [copy.detail];
   if (retirement) {

--- a/apps/desktop/src/main/runtime-host-quit-copy.ts
+++ b/apps/desktop/src/main/runtime-host-quit-copy.ts
@@ -21,10 +21,38 @@ import type { UiLocale } from '@maka/core/ui-locale';
 import type { MessageBoxOptions } from 'electron';
 import { DesktopLocalHostRetirementError } from './runtime-host-desktop-manager.js';
 
+export interface RuntimeHostQuitDialog<Decision extends string> {
+  readonly options: MessageBoxOptions;
+  readonly decisions: readonly Decision[];
+}
+
+export type RuntimeHostActiveQuitDecision = 'quit' | 'cancel';
+export type RuntimeHostQuitFailureDecision = 'retry' | 'force' | 'cancel';
+
+export function buildRuntimeHostActiveQuitDialog(
+  locale: UiLocale,
+): RuntimeHostQuitDialog<RuntimeHostActiveQuitDecision> {
+  const copy = COPY[locale];
+  return {
+    options: {
+      type: 'warning',
+      title: copy.activeTitle,
+      message: copy.activeMessage,
+      detail: copy.activeDetail,
+      buttons: [copy.stopAndQuit, copy.keepRunning],
+      defaultId: 1,
+      cancelId: 1,
+      noLink: true,
+    },
+    decisions: ['quit', 'cancel'],
+  };
+}
+
 export function buildRuntimeHostQuitFailureDialog(
   error: unknown,
   locale: UiLocale,
-): MessageBoxOptions {
+  canForceTerminate: boolean,
+): RuntimeHostQuitDialog<RuntimeHostQuitFailureDecision> {
   const retirement = error instanceof DesktopLocalHostRetirementError ? error : undefined;
   const copy = COPY[locale];
   const details: string[] = [copy.detail];
@@ -32,7 +60,8 @@ export function buildRuntimeHostQuitFailureDialog(
     details.push(`State Root: ${retirement.facts.rootPath}`);
     details.push(`Host epoch: ${retirement.facts.hostEpoch}`);
     if (retirement.facts.pid !== undefined) {
-      details.push(copy.process(retirement.facts.pid), copy.manual);
+      details.push(copy.process(retirement.facts.pid));
+      details.push(canForceTerminate ? copy.forceWarning : copy.manual);
     }
   }
   const cause = error instanceof Error && error.cause instanceof Error
@@ -41,35 +70,59 @@ export function buildRuntimeHostQuitFailureDialog(
       ? error.message
       : String(error);
   details.push(`${copy.cause}: ${cause}`);
+  const decisions: RuntimeHostQuitFailureDecision[] = canForceTerminate
+    ? ['retry', 'force', 'cancel']
+    : ['retry', 'cancel'];
   return {
-    type: 'error',
-    title: copy.title,
-    message: copy.message,
-    detail: details.join('\n'),
-    buttons: [copy.button],
-    defaultId: 0,
-    noLink: true,
+    options: {
+      type: 'error',
+      title: copy.title,
+      message: copy.message,
+      detail: details.join('\n'),
+      buttons: canForceTerminate
+        ? [copy.retry, copy.forceQuit, copy.keepRunning]
+        : [copy.retry, copy.keepRunning],
+      defaultId: decisions.length - 1,
+      cancelId: decisions.length - 1,
+      noLink: true,
+    },
+    decisions,
   };
 }
 
 const COPY = {
   en: {
+    activeTitle: 'Maka is still working',
+    activeMessage: 'Background work is still running.',
+    activeDetail:
+      'Quitting now stops the Runtime Host and may interrupt active executions or scheduled background work.',
+    stopAndQuit: 'Stop Work and Quit',
+    keepRunning: 'Keep Maka Running',
     title: 'Unable to quit Maka safely',
     message: 'The local Runtime Host could not stop safely. Maka is still running.',
     detail: 'Quit was cancelled. Try again, or inspect diagnostics if the problem persists.',
     process: (pid: number) => `Runtime Host process PID: ${pid}`,
     manual:
       "If retry still fails, confirm that no execution must be preserved before stopping this PID with the operating system's process-management tool.",
+    forceWarning: 'Force quitting can discard in-flight external work that has not settled.',
     cause: 'Cause',
-    button: 'OK',
+    retry: 'Retry Quit',
+    forceQuit: 'Force Quit Maka',
   },
   zh: {
+    activeTitle: 'Maka 正在后台工作',
+    activeMessage: '仍有后台工作正在运行。',
+    activeDetail: '现在退出会停止 Runtime Host，并可能中断正在执行或等待运行的后台任务。',
+    stopAndQuit: '停止任务并退出',
+    keepRunning: '继续运行 Maka',
     title: '无法安全退出 Maka',
     message: '本地 Runtime Host 未能安全停止，Maka 仍在运行。',
     detail: '退出已取消。请重试；如果问题持续存在，请查看诊断信息。',
     process: (pid: number) => `Runtime Host 进程 PID：${pid}`,
     manual: '如果重试仍然失败，请先确认没有需要保留的执行，再通过操作系统的进程管理工具停止该 PID。',
+    forceWarning: '强制退出可能丢弃尚未完成的外部工作。',
     cause: '原因',
-    button: '好',
+    retry: '重试退出',
+    forceQuit: '强制退出 Maka',
   },
 } as const;

--- a/apps/desktop/src/main/runtime-host-quit.ts
+++ b/apps/desktop/src/main/runtime-host-quit.ts
@@ -17,21 +17,85 @@
  * under the License.
  */
 
-import type { RuntimeHostDesktopManager } from './runtime-host-desktop-manager.js';
+import {
+  DesktopLocalHostRetirementError,
+  type RuntimeHostDesktopManager,
+} from './runtime-host-desktop-manager.js';
 
-type RetirementOwner = Pick<RuntimeHostDesktopManager, 'retireOwnedLocalHost'>;
+type RetirementOwner = Pick<
+  RuntimeHostDesktopManager,
+  'retireOwnedLocalHost' | 'forceTerminateOwnedLocalHost'
+>;
+
+export type RuntimeHostQuitFailureDecision = 'retry' | 'force' | 'cancel';
+
+export interface RuntimeHostQuitPrompts {
+  confirmInterrupt(): Promise<boolean>;
+  recoverFailure(error: unknown): Promise<RuntimeHostQuitFailureDecision>;
+}
 
 export async function prepareRuntimeHostQuit(
   owner: RetirementOwner | undefined,
-  confirmInterrupt: () => Promise<boolean>,
+  prompts: RuntimeHostQuitPrompts,
 ): Promise<'ready' | 'cancelled'> {
   if (!owner) return 'ready';
-  const guarded = await owner.retireOwnedLocalHost('refuse_active_work');
-  if (guarded.kind !== 'active_tasks') return 'ready';
-  if (!(await confirmInterrupt())) return 'cancelled';
-  const authorized = await owner.retireOwnedLocalHost('interrupt_active_work');
-  if (authorized.kind === 'active_tasks') {
-    throw new Error('Runtime Host refused authorized quit retirement');
+  for (;;) {
+    try {
+      const guarded = await owner.retireOwnedLocalHost('refuse_active_work');
+      if (guarded.kind !== 'active_tasks') return 'ready';
+      if (!(await prompts.confirmInterrupt())) return 'cancelled';
+      const authorized = await owner.retireOwnedLocalHost('interrupt_active_work');
+      if (authorized.kind === 'active_tasks') {
+        throw new Error('Runtime Host refused authorized quit retirement');
+      }
+      return 'ready';
+    } catch (error) {
+      const recovery = await recoverRuntimeHostQuit(owner, prompts, error);
+      if (recovery !== 'retry') return recovery;
+    }
   }
-  return 'ready';
+}
+
+async function recoverRuntimeHostQuit(
+  owner: RetirementOwner,
+  prompts: RuntimeHostQuitPrompts,
+  error: unknown,
+): Promise<'ready' | 'retry' | 'cancelled'> {
+  let currentError = error;
+  for (;;) {
+    const retirement = forceTerminableRetirement(currentError);
+    const decision = await prompts.recoverFailure(currentError);
+    if (decision === 'cancel') return 'cancelled';
+    if (decision === 'retry') return 'retry';
+    if (!retirement) throw new Error('Force termination was selected without Host authority');
+    try {
+      if (await owner.forceTerminateOwnedLocalHost(retirement.facts)) return 'ready';
+      currentError = forceTerminationError(
+        retirement,
+        new Error('The Runtime Host identity changed or forced termination failed'),
+      );
+    } catch (cause) {
+      currentError = forceTerminationError(retirement, cause);
+    }
+  }
+}
+
+function forceTerminableRetirement(
+  error: unknown,
+): DesktopLocalHostRetirementError | undefined {
+  return error instanceof DesktopLocalHostRetirementError &&
+    error.facts.pid !== undefined &&
+    error.facts.forceTerminationAvailable
+    ? error
+    : undefined;
+}
+
+function forceTerminationError(
+  retirement: DesktopLocalHostRetirementError,
+  cause: unknown,
+): DesktopLocalHostRetirementError {
+  return new DesktopLocalHostRetirementError(
+    { ...retirement.facts, forceTerminationAvailable: false },
+    { cause: cause instanceof Error ? cause : new Error(String(cause)) },
+  );
 }

--- a/apps/desktop/src/main/runtime-host-quit.ts
+++ b/apps/desktop/src/main/runtime-host-quit.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { RuntimeHostDesktopManager } from './runtime-host-desktop-manager.js';
+
+type RetirementOwner = Pick<RuntimeHostDesktopManager, 'retireOwnedLocalHost'>;
+
+export async function prepareRuntimeHostQuit(
+  owner: RetirementOwner | undefined,
+  confirmInterrupt: () => Promise<boolean>,
+): Promise<'ready' | 'cancelled'> {
+  if (!owner) return 'ready';
+  const guarded = await owner.retireOwnedLocalHost('refuse_active_work');
+  if (guarded.kind !== 'active_tasks') return 'ready';
+  if (!(await confirmInterrupt())) return 'cancelled';
+  const authorized = await owner.retireOwnedLocalHost('interrupt_active_work');
+  if (authorized.kind === 'active_tasks') {
+    throw new Error('Runtime Host refused authorized quit retirement');
+  }
+  return 'ready';
+}

--- a/packages/runtime-host/src/__tests__/registered-host-termination.test.ts
+++ b/packages/runtime-host/src/__tests__/registered-host-termination.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  prepareStorageRootControlDirectory,
+  resolveStorageRoot,
+} from '@maka/storage/root-authority';
+import { forceTerminateRegisteredRuntimeHostWithDependencies } from '../client/registered-host-termination.js';
+import { writeHostRegistration } from '../control/registration.js';
+import {
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
+  type HostRegistration,
+} from '../protocol/index.js';
+
+test('forced termination remains bound to the registered Host identity', async (t) => {
+  const rootPath = await mkdtemp(join(tmpdir(), 'maka-host-termination-'));
+  t.after(() => rm(rootPath, { recursive: true, force: true }));
+  const capability = await resolveStorageRoot({ path: rootPath, kind: 'interactive' });
+  const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
+  const identity = {
+    rootPath,
+    rootId: capability.rootId,
+    hostEpoch: 'expected-epoch',
+    pid: 4242,
+  };
+  const registration: HostRegistration = {
+    kind: 'maka-runtime-host',
+    schemaVersion: RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
+    rootId: capability.rootId,
+    hostEpoch: identity.hostEpoch,
+    endpoint: join(rootPath, 'runtime-host.sock'),
+    protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
+    protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+    compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+    compositionId: 'maka.interactive',
+    compositionRevision: 'test',
+    lifecycleMode: 'ephemeral',
+    state: 'ready',
+    pid: identity.pid,
+    createdAt: new Date(0).toISOString(),
+  };
+  let alive = true;
+  let terminated = 0;
+  let replaceBeforeSignal = false;
+  const dependencies = {
+    isProcessAlive: () => alive,
+    settleMs: 0,
+    terminateProcess: async (options: { beforeSignal?: () => boolean | Promise<boolean> }) => {
+      if (replaceBeforeSignal) {
+        await writeHostRegistration(controlDirectory, { ...registration, hostEpoch: 'successor' });
+      }
+      if (options.beforeSignal && !(await options.beforeSignal())) return false;
+      terminated += 1;
+      alive = false;
+      return true;
+    },
+  };
+
+  await writeHostRegistration(controlDirectory, registration);
+  replaceBeforeSignal = true;
+  assert.equal(
+    await forceTerminateRegisteredRuntimeHostWithDependencies(identity, dependencies),
+    false,
+  );
+  assert.equal(terminated, 0);
+
+  await writeHostRegistration(controlDirectory, registration);
+  replaceBeforeSignal = false;
+  assert.equal(
+    await forceTerminateRegisteredRuntimeHostWithDependencies(identity, dependencies),
+    true,
+  );
+  assert.equal(terminated, 1);
+});

--- a/packages/runtime-host/src/__tests__/registered-host-termination.test.ts
+++ b/packages/runtime-host/src/__tests__/registered-host-termination.test.ts
@@ -65,6 +65,8 @@ test('forced termination remains bound to the registered Host identity', async (
   let alive = true;
   let terminated = 0;
   let replaceBeforeSignal = false;
+  let stillOwnsProcess = true;
+  let releaseOwnershipBeforeSignal = false;
   const dependencies = {
     isProcessAlive: () => alive,
     settleMs: 0,
@@ -72,6 +74,7 @@ test('forced termination remains bound to the registered Host identity', async (
       if (replaceBeforeSignal) {
         await writeHostRegistration(controlDirectory, { ...registration, hostEpoch: 'successor' });
       }
+      if (releaseOwnershipBeforeSignal) stillOwnsProcess = false;
       if (options.beforeSignal && !(await options.beforeSignal())) return false;
       terminated += 1;
       alive = false;
@@ -82,15 +85,36 @@ test('forced termination remains bound to the registered Host identity', async (
   await writeHostRegistration(controlDirectory, registration);
   replaceBeforeSignal = true;
   assert.equal(
-    await forceTerminateRegisteredRuntimeHostWithDependencies(identity, dependencies),
+    await forceTerminateRegisteredRuntimeHostWithDependencies(
+      identity,
+      () => stillOwnsProcess,
+      dependencies,
+    ),
     false,
   );
   assert.equal(terminated, 0);
 
   await writeHostRegistration(controlDirectory, registration);
   replaceBeforeSignal = false;
+  releaseOwnershipBeforeSignal = true;
   assert.equal(
-    await forceTerminateRegisteredRuntimeHostWithDependencies(identity, dependencies),
+    await forceTerminateRegisteredRuntimeHostWithDependencies(
+      identity,
+      () => stillOwnsProcess,
+      dependencies,
+    ),
+    false,
+  );
+  assert.equal(terminated, 0);
+
+  stillOwnsProcess = true;
+  releaseOwnershipBeforeSignal = false;
+  assert.equal(
+    await forceTerminateRegisteredRuntimeHostWithDependencies(
+      identity,
+      () => stillOwnsProcess,
+      dependencies,
+    ),
     true,
   );
   assert.equal(terminated, 1);

--- a/packages/runtime-host/src/client/host-retirement.ts
+++ b/packages/runtime-host/src/client/host-retirement.ts
@@ -33,9 +33,14 @@ export type RuntimeHostRetirementPreparation = OperationOutput<'host.upgrade.pre
 export function prepareConnectedRuntimeHostRetirement(
   connection: RuntimeHostConnection,
   mode: RuntimeHostRetirementMode,
+  timeoutMs?: number,
 ): Promise<RuntimeHostRetirementPreparation> {
-  return connection.request('host.upgrade.prepare', {
-    expectedHostEpoch: connection.hostEpoch,
-    allowInterruptActiveTasks: mode === 'interrupt_active_work',
-  });
+  return connection.request(
+    'host.upgrade.prepare',
+    {
+      expectedHostEpoch: connection.hostEpoch,
+      allowInterruptActiveTasks: mode === 'interrupt_active_work',
+    },
+    timeoutMs,
+  );
 }

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -45,6 +45,10 @@ export {
   type RuntimeHostRetirementPreparation,
 } from './host-retirement.js';
 export {
+  forceTerminateRegisteredRuntimeHost,
+  type RegisteredRuntimeHostIdentity,
+} from './registered-host-termination.js';
+export {
   LOCAL_RUNTIME_HOST_PROFILE,
   RUNTIME_HOST_ACCESS_CREDENTIAL_MAX_BYTES,
   createClientRuntimeHostCredentialStore,

--- a/packages/runtime-host/src/client/launcher.ts
+++ b/packages/runtime-host/src/client/launcher.ts
@@ -139,7 +139,7 @@ export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): 
         const result = await within(exited, timeoutMs);
         if (result) return result.code === 0 && result.signal === null;
         child.kill('SIGKILL');
-        await exited;
+        await within(exited, timeoutMs);
         return false;
       },
     })),

--- a/packages/runtime-host/src/client/reconnect-lifecycle.ts
+++ b/packages/runtime-host/src/client/reconnect-lifecycle.ts
@@ -51,7 +51,7 @@ export interface RuntimeHostReconnectLifecycle<T extends RuntimeHostReconnectRes
   subscribe(listener: (current: T | undefined) => void): () => void;
   wake(): void;
   suspend(): Promise<RuntimeHostReconnectSuspension<T>>;
-  quiesce(): Promise<RuntimeHostReconnectQuiescence<T>>;
+  quiesce(signal?: AbortSignal): Promise<RuntimeHostReconnectQuiescence<T>>;
   close(): Promise<void>;
 }
 
@@ -251,7 +251,8 @@ class RuntimeHostReconnectLifecycleImpl<T extends RuntimeHostReconnectResource>
     return this.#suspension(this.#current);
   }
 
-  async quiesce(): Promise<RuntimeHostReconnectQuiescence<T>> {
+  async quiesce(signal?: AbortSignal): Promise<RuntimeHostReconnectQuiescence<T>> {
+    signal?.throwIfAborted();
     while (!this.#current) {
       if (this.#closed || this.#terminalError) {
         throw new Error('Runtime Host reconnect lifecycle is closed');
@@ -259,8 +260,9 @@ class RuntimeHostReconnectLifecycleImpl<T extends RuntimeHostReconnectResource>
       if (this.#quiesced) {
         throw new Error('Runtime Host reconnect lifecycle is already quiesced');
       }
-      await this.waitForCurrent();
+      await this.waitForCurrent(undefined, signal);
     }
+    signal?.throwIfAborted();
     if (this.#closed || this.#terminalError) {
       throw new Error('Runtime Host reconnect lifecycle is closed');
     }

--- a/packages/runtime-host/src/client/registered-host-termination.ts
+++ b/packages/runtime-host/src/client/registered-host-termination.ts
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { terminateProcessTree } from '@maka/runtime/process-tree-terminator';
+import {
+  prepareStorageRootControlDirectory,
+  resolveStorageRoot,
+} from '@maka/storage/root-authority';
+import { readHostRegistration } from '../control/registration.js';
+import type { HostRegistration } from '../protocol/index.js';
+
+const TERMINATION_SETTLE_MS = 2_000;
+
+export interface RegisteredRuntimeHostIdentity {
+  readonly rootPath: string;
+  readonly rootId: string;
+  readonly hostEpoch: string;
+  readonly pid: number;
+}
+
+interface RegisteredRuntimeHostTerminationDependencies {
+  readonly terminateProcess: typeof terminateProcessTree;
+  readonly isProcessAlive: (pid: number) => boolean;
+  readonly settleMs: number;
+}
+
+const defaultDependencies: RegisteredRuntimeHostTerminationDependencies = {
+  terminateProcess: terminateProcessTree,
+  isProcessAlive,
+  settleMs: TERMINATION_SETTLE_MS,
+};
+
+/**
+ * Force-terminates only the exact local ephemeral Host still registered for
+ * the expected State Root. Callers must reserve this for explicit recovery
+ * after graceful retirement fails.
+ */
+export function forceTerminateRegisteredRuntimeHost(
+  identity: RegisteredRuntimeHostIdentity,
+): Promise<boolean> {
+  return forceTerminateRegisteredRuntimeHostWithDependencies(identity, defaultDependencies);
+}
+
+export async function forceTerminateRegisteredRuntimeHostWithDependencies(
+  identity: RegisteredRuntimeHostIdentity,
+  dependencies: RegisteredRuntimeHostTerminationDependencies,
+): Promise<boolean> {
+  const capability = await resolveStorageRoot({ path: identity.rootPath, kind: 'interactive' });
+  if (capability.rootId !== identity.rootId) return false;
+  const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
+  const registered = await readHostRegistration(controlDirectory);
+  if (!registered) return true;
+  if (!matchesIdentity(registered, identity)) return false;
+  if (!dependencies.isProcessAlive(identity.pid)) return true;
+
+  let signalTarget: HostRegistration | undefined = registered;
+  const signaled = await dependencies.terminateProcess({
+    pid: identity.pid,
+    signal: 'SIGKILL',
+    hasExited: () => !dependencies.isProcessAlive(identity.pid),
+    beforeSignal: async () => {
+      // This runs after asynchronous process-tree discovery and immediately
+      // before the OS signal, so a successor cannot inherit stale intent.
+      signalTarget = await readHostRegistration(controlDirectory);
+      return matchesIdentity(signalTarget, identity);
+    },
+    fallback: () => {
+      try {
+        process.kill(identity.pid, 'SIGKILL');
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+  if (!signalTarget) return true;
+  if (!matchesIdentity(signalTarget, identity)) return false;
+  if (!signaled && dependencies.isProcessAlive(identity.pid)) return false;
+  return waitForExit(identity.pid, dependencies);
+}
+
+function matchesIdentity(
+  registration: HostRegistration | undefined,
+  identity: RegisteredRuntimeHostIdentity,
+): boolean {
+  return (
+    registration?.rootId === identity.rootId &&
+    registration.hostEpoch === identity.hostEpoch &&
+    registration.pid === identity.pid &&
+    registration.lifecycleMode === 'ephemeral'
+  );
+}
+
+async function waitForExit(
+  pid: number,
+  dependencies: RegisteredRuntimeHostTerminationDependencies,
+): Promise<boolean> {
+  const deadline = Date.now() + dependencies.settleMs;
+  while (dependencies.isProcessAlive(pid)) {
+    if (Date.now() >= deadline) return false;
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
+  return true;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !(
+      error instanceof Error &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ESRCH'
+    );
+  }
+}

--- a/packages/runtime-host/src/client/registered-host-termination.ts
+++ b/packages/runtime-host/src/client/registered-host-termination.ts
@@ -53,14 +53,21 @@ const defaultDependencies: RegisteredRuntimeHostTerminationDependencies = {
  */
 export function forceTerminateRegisteredRuntimeHost(
   identity: RegisteredRuntimeHostIdentity,
+  stillOwnsProcess: () => boolean,
 ): Promise<boolean> {
-  return forceTerminateRegisteredRuntimeHostWithDependencies(identity, defaultDependencies);
+  return forceTerminateRegisteredRuntimeHostWithDependencies(
+    identity,
+    stillOwnsProcess,
+    defaultDependencies,
+  );
 }
 
 export async function forceTerminateRegisteredRuntimeHostWithDependencies(
   identity: RegisteredRuntimeHostIdentity,
+  stillOwnsProcess: () => boolean,
   dependencies: RegisteredRuntimeHostTerminationDependencies,
 ): Promise<boolean> {
+  if (!stillOwnsProcess()) return false;
   const capability = await resolveStorageRoot({ path: identity.rootPath, kind: 'interactive' });
   if (capability.rootId !== identity.rootId) return false;
   const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
@@ -76,9 +83,10 @@ export async function forceTerminateRegisteredRuntimeHostWithDependencies(
     hasExited: () => !dependencies.isProcessAlive(identity.pid),
     beforeSignal: async () => {
       // This runs after asynchronous process-tree discovery and immediately
-      // before the OS signal, so a successor cannot inherit stale intent.
+      // before the OS signal, so neither a successor nor a reused PID can
+      // inherit stale intent.
       signalTarget = await readHostRegistration(controlDirectory);
-      return matchesIdentity(signalTarget, identity);
+      return matchesIdentity(signalTarget, identity) && stillOwnsProcess();
     },
     fallback: () => {
       try {

--- a/packages/runtime/src/process-tree-terminator.ts
+++ b/packages/runtime/src/process-tree-terminator.ts
@@ -32,7 +32,7 @@ interface ProcessTreeTerminationOptions {
   fallback?: () => boolean | void;
   hasExited?: () => boolean;
   /** Runs after asynchronous topology discovery and before the first OS action. */
-  beforeSignal?: () => boolean;
+  beforeSignal?: () => boolean | Promise<boolean>;
 }
 
 interface PosixProcess {
@@ -69,7 +69,7 @@ export async function terminateProcessTree(
   const { pid, signal, fallback, hasExited, beforeSignal } = options;
   if (hasExited?.()) return false;
   if (process.platform === 'win32') {
-    if (beforeSignal && !beforeSignal()) return false;
+    if (beforeSignal && !(await beforeSignal())) return false;
     if (await killWindowsTree(pid)) return true;
     if (hasExited?.()) return false;
     return invokeFallback(fallback);
@@ -77,7 +77,7 @@ export async function terminateProcessTree(
 
   const processes = await readPosixProcesses();
   if (hasExited?.()) return false;
-  if (beforeSignal && !beforeSignal()) return false;
+  if (beforeSignal && !(await beforeSignal())) return false;
 
   const escapedDescendantSignaled = forceKillEscapedDescendants(pid, processes);
   if (hasExited?.()) return escapedDescendantSignaled;


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Make Desktop shutdown express user intent instead of treating every close as an unconditional Runtime Host interruption.

- Retire an idle local Runtime Host immediately and quit without a prompt.
- If work is active, ask whether to stop it; cancelling restores the Desktop and leaves the work running.
- Let Desktop observe the Host's graceful shutdown deadline instead of racing the same deadline.
- If graceful retirement genuinely fails, offer Retry, Keep Running, or an explicit Force Quit recovery. Force Quit revalidates the exact State Root, Host epoch, and PID immediately before signalling, while preventing a replacement candidate from starting during shutdown.
- Keep the existing 30-second true-idle policy unchanged. It serves reconnect and on-demand lifecycle semantics and is no longer on the explicit Desktop quit path.

The mechanism has one authority: the Runtime Host still decides whether active work exists and performs normal retirement. Desktop only supplies user intent and owns the narrowly scoped, identity-bound recovery path when graceful retirement has already failed.

### Before

![Before: Desktop reported a false Runtime Host retirement timeout](https://github.com/user-attachments/assets/8822c561-cf96-4c0c-8cb4-fedb9fb89487)

### After

![After: Desktop asks before stopping active Runtime Host work](https://github.com/user-attachments/assets/0740e0dc-a19d-415f-8525-f237026eec81)

## Verification

- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm run typecheck` — passed for every workspace.
- Targeted Runtime Host and Desktop main-process suites — 101 tests passed at the latest head, including quit cancellation, candidate fencing, and registration-swap protection.
- Windows build: `npm.cmd --workspace @maka/desktop run build:with-deps` — passed.
- Windows Electron smoke test through CDP:
  - idle close exited in 477 ms without a dialog;
  - closing during a streaming task showed the confirmation dialog;
  - Esc restored the app and the task continued;
  - confirming stopped the task and exited without a residual Maka Electron process;
  - no retirement-timeout or unhandled-error entry appeared in the quit log.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the lifecycle/UX change, added focused tests, and performed local and Windows Electron verification. The commit includes a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

让 Desktop 退出流程表达用户意图，不再把每次关闭都视为无条件中断 Runtime Host。

- 本地 Runtime Host 空闲时立即优雅退役并退出，不弹确认框。
- 存在后台工作时询问是否停止；取消后恢复 Desktop，任务继续运行。
- Desktop 的退出观察窗口覆盖 Host 自身的优雅关闭期限，不再与同一个期限竞争并产生假超时。
- 优雅退役确实失败时，提供“重试”“继续运行”和明确的“强制退出”。强制退出只会在发信号前重新核验 State Root、Host epoch 和 PID 完全一致，并在关机期间阻止替代 candidate 启动。
- 保留既有 30 秒 true-idle 策略；它仍服务于重连和 on-demand 生命周期，但不再参与 Desktop 的显式退出路径。

机制上仍只有一个 authority：Runtime Host 判断是否存在活动工作并负责正常退役；Desktop 只传递用户意图，并仅在优雅退役已经失败时拥有范围严格、身份绑定的恢复路径。

### 修改前

![修改前：Desktop 将 Runtime Host 退役误报为超时](https://github.com/user-attachments/assets/8822c561-cf96-4c0c-8cb4-fedb9fb89487)

### 修改后

![修改后：Desktop 会在停止 Runtime Host 后台工作前确认](https://github.com/user-attachments/assets/0740e0dc-a19d-415f-8525-f237026eec81)

## 验证

- `npm run lint`：通过。
- `npm run format:check`：通过。
- `npm run typecheck`：所有 workspace 通过。
- Runtime Host 与 Desktop 主进程定向测试：最新 head 上 101 项通过，覆盖退出取消、candidate fencing 和 registration 替换竞态。
- Windows 构建：`npm.cmd --workspace @maka/desktop run build:with-deps`：通过。
- 通过 CDP 完成 Windows Electron 真实交互测试：
  - 空闲关闭在 477 ms 内退出且不弹窗；
  - 流式任务期间关闭会出现确认框；
  - 按 Esc 后应用恢复且任务继续；
  - 确认停止任务后应用退出，没有残留 Maka Electron 进程；
  - 退出日志中没有退役超时或未处理异常。

## AI 使用

- [ ] 生成式工具没有作出实质贡献
- [x] 生成式工具作出了实质贡献

工具与范围：Codex 实现生命周期与 UX 修改，补充聚焦测试，并完成本地及 Windows Electron 验证。提交包含 `Generated-by: Codex` trailer。

## 检查清单

- [x] 测试覆盖该变更，且没有实现时会失败
- [x] lint、format、typecheck 和受影响测试在本地通过

该 PR 是否改变行为？

- [x] 是——已在概要中说明
- [ ] 否

</details>


