### PR TITLE
test(desktop): wait for the prompt-rail fixture session

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -41,6 +41,7 @@ import { closeElectronApplication } from '../../../scripts/electron-lifecycle.mj
 
 const DESKTOP_ROOT = process.cwd();
 const execFileAsync = promisify(execFile);
+const PROMPT_RAIL_READY_SELECTOR = '[data-turn-id^="turn-prompt-rail-"]';
 
 /**
  * The composer's text surface. It is Astryx's `ChatComposerInput`, so the
@@ -557,7 +558,7 @@ async function resetPromptRailWindow(worker: PromptRailWorker): Promise<void> {
   });
   await worker.page.setViewportSize(worker.viewport);
   await worker.page.reload();
-  await worker.page.waitForSelector('[data-turn-id]', { timeout: 20_000 });
+  await worker.page.waitForSelector(PROMPT_RAIL_READY_SELECTOR, { timeout: 20_000 });
 }
 
 type E2eTestFixtures = {
@@ -725,11 +726,11 @@ export const test = base.extend<E2eTestFixtures, E2eWorkerFixtures>({
   promptRailWorker: [async ({}, use) => {
     await withE2eWindow({
       seed: false,
-      // A rendered turn, deliberately not the rail: Playwright treats a
-      // zero-area element as hidden, so gating readiness on a tick would turn
-      // every rail regression into a 20s cold-start timeout instead of the
-      // assertion that names it.
-      readinessSelector: '[data-turn-id]',
+      // The fixture always seeds the default Session too, and that Session can
+      // render before the async fixture state selects the prompt-rail Session.
+      // A turn from the target Session proves both selection and transcript
+      // readiness without relying on a rail tick's nonzero geometry.
+      readinessSelector: PROMPT_RAIL_READY_SELECTOR,
       e2eFixtureScenario: 'chat-prompt-rail',
       // Every other fixture window names its locale; without one the renderer
       // takes the host's, so any test that reaches a control by its label


### PR DESCRIPTION
## Summary

- Keep the pinned-tail regression test: it protects the real contract that layout changes must not request earlier history while the reader is following the tail.
- Fix the test harness race instead. The prompt-rail fixture used `[data-turn-id]` as its readiness gate, so the default fixture Session could satisfy it before the asynchronous E2E state selected the prompt-rail Session.
- Gate both worker startup and per-test reloads on a prompt-rail Turn. Assertions now start only after the intended Session and transcript are active.

Fixes #4707

## Verification

- `npm --workspace @maka/desktop run build:with-deps`
- Target regression with `--repeat-each=5`: 5/5 passed on the final head (15/15 across the investigation)
- `e2e/prompt-rail.spec.ts`: 11/11 passed
- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm run check:renderer-architecture -- --base origin/main`: 71/71 passed

An additional full `transcript-scroll.spec.ts` run passed all six cases that use the changed prompt-rail fixture. Three separate cases using the ordinary `window` fixture hit existing scroll-state failures; one passed on an isolated rerun, while two reproduced. They do not traverse `promptRailWorker` or `resetPromptRailWindow` and are outside this fix.

## Root cause

The retained CI trace shows the generic readiness wait completing on `turn-fixture-1`, which belongs to the default Session. The final assertion then observed `turn-prompt-rail-111`, the first Turn in the intended Session's active range. That was a normal Session switch, not an earlier-history load.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the CI trace and authored the fixture readiness fix.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
