### PR TITLE
fix(desktop): phase-aware update error copy

### DIFF
--- a/apps/desktop/src/main/__tests__/app-update-service.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-service.test.ts
@@ -362,6 +362,63 @@ describe('AppUpdateService', () => {
     assert.equal(updater.quitAndInstallCalls, 0);
   });
 
+  test('can retry a failed provenance verification through the download action', async () => {
+    let verificationCalls = 0;
+    const updater = new FakeUpdater();
+    const { service } = createHarness({
+      updater,
+      verifyDownloadedUpdate: async () => {
+        verificationCalls += 1;
+        if (verificationCalls === 1) throw new Error('release provenance did not match');
+      },
+    });
+    updater.emit('update-downloaded', {
+      ...updateInfo('1.1.0'),
+      downloadedFile: '/tmp/maka-update.zip',
+    });
+    await settleUpdateVerification();
+    assert.equal(service.getStatus().state, 'error');
+
+    updater.checkForUpdates = async () => {
+      updater.checkCalls += 1;
+      updater.emit('checking-for-update');
+      updater.emit('update-available', updateInfo('1.1.0'));
+      updater.emit('update-downloaded', {
+        ...updateInfo('1.1.0'),
+        downloadedFile: '/tmp/maka-update.zip',
+      });
+      return { isUpdateAvailable: true };
+    };
+
+    const retried = await service.retryUpdateDownload();
+    assert.deepEqual(retried, {
+      state: 'downloaded',
+      currentVersion: '1.0.0',
+      latestVersion: '1.1.0',
+    });
+    assert.equal(updater.checkCalls, 1);
+    assert.equal(verificationCalls, 2);
+  });
+
+  test('replaces a stale check error with a later download or provenance failure', async () => {
+    const { service, updater } = createHarness();
+    updater.emit('error', new Error('temporary network failure'));
+    const firstStatus = service.getStatus();
+    assert.equal(firstStatus.state, 'error');
+    assert.equal(firstStatus.state === 'error' ? firstStatus.operation : undefined, 'check');
+
+    updater.emit('update-available', updateInfo('1.1.0'));
+    updater.emit('error', new Error('root was signed by 0/3 keys'));
+
+    assert.deepEqual(service.getStatus(), {
+      state: 'error',
+      currentVersion: '1.0.0',
+      latestVersion: '1.1.0',
+      operation: 'download',
+      message: 'root was signed by 0/3 keys',
+    });
+  });
+
   test('cancels a stalled auto-download before retrying it', async () => {
     const updater = new FakeUpdater();
     const statuses: AppUpdateStatus[] = [];

--- a/apps/desktop/src/main/app-update-service.ts
+++ b/apps/desktop/src/main/app-update-service.ts
@@ -232,6 +232,21 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       ? status.latestVersion
       : updateInfoVersion(latestInfo);
 
+  const resolveErrorOperation = (): Extract<AppUpdateStatus, { state: 'error' }>['operation'] => {
+    if (status.state === 'installing') return 'install';
+    if (
+      activeDownload ||
+      activeVerification ||
+      status.state === 'available' ||
+      status.state === 'downloading' ||
+      status.state === 'verifying' ||
+      status.state === 'downloaded'
+    ) {
+      return 'download';
+    }
+    return 'check';
+  };
+
   const publishError = (
     operation: Extract<AppUpdateStatus, { state: 'error' }>['operation'],
     error: unknown,
@@ -339,11 +354,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       });
   });
   updater.on('error', (error) => {
-    const operation = status.state === 'installing'
-      ? 'install'
-      : status.state === 'available' || status.state === 'downloading' || status.state === 'verifying'
-        ? 'download'
-        : 'check';
+    const operation = resolveErrorOperation();
     if (operation === 'install') rollbackInstallHandoff();
     // A check failure with retry attempts still owed is transient: hold it
     // back and let the scheduled retry produce the final word. Download and
@@ -385,7 +396,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       }
       if (checkAttemptsRemaining <= 0) {
         checkAttemptsRemaining = 0;
-        return status.state === 'error' ? status : publishError('check', error);
+        return status.state === 'error' ? status : publishError(resolveErrorOperation(), error);
       }
       checkAttemptsRemaining -= 1;
       // Back off briefly, then re-check. The 'error' listener holds the
@@ -401,7 +412,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
             return;
           }
           resolve(attempt().catch((retryError) =>
-            status.state === 'error' ? status : publishError('check', retryError),
+            status.state === 'error' ? status : publishError(resolveErrorOperation(), retryError),
           ));
         }, UPDATE_CHECK_RETRY_DELAY_MS);
       });


### PR DESCRIPTION
## Summary

Fixes #4708.

Replace stale update errors with the current failure and preserve the active download/verification/install phase for recovery copy. In particular, after one error changes the visible state to `error`, another error from a still-pending download must remain a download failure.

## Verification

- AppUpdateService: 20/20; About update copy: 5/5. Source tests were bundled with esbuild and run with Node.
- The replacement regression starts a pending `downloadPromise` through `checkForUpdatesNow`, emits two errors, and checks the second message and download phase. Substituting the entire service from base `b06eb02e6` makes this test fail with `operation: check`; the PR service passes.
- Core build and focused strict TypeScript checking of the service test and its imports pass.
- Repository lint, format check, ASF headers, and `git diff --check` pass.
- Full Desktop build/E2E were not rerun for this test-only review follow-up.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex authored the phase handling and regression tests, and updated this description for @seekskyworld. Human review and merge remain with the maintainers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
