### PR TITLE
fix(desktop): keep node:crypto out of the renderer's protocol barrel import graph

### DIFF
--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -64,7 +64,8 @@ import {
   openRuntimeHostPeerEndpointOwner,
   type RuntimeHostPeerEndpointOwner,
 } from '@maka/runtime-host/peer-reachability';
-import { clientCapabilityEntityId, type WorkspaceTarget } from "@maka/runtime-host/protocol";
+import { clientCapabilityEntityId } from "@maka/runtime-host/capability-entity-id";
+import { type WorkspaceTarget } from "@maka/runtime-host/protocol";
 import { runtimeHostProfileUsesHostWorkspace } from "@maka/runtime-host/profile-kind";
 import { createCredentialMcpOAuthStorage, McpClientManager } from "@maka/mcp";
 import { createWorkBoardStore } from "@maka/storage/work-board-store";

--- a/apps/desktop/src/main/runtime-host-native-capabilities.ts
+++ b/apps/desktop/src/main/runtime-host-native-capabilities.ts
@@ -30,7 +30,6 @@ import {
   CLIENT_CAPABILITY_MAX_OFFERS,
   CLIENT_CAPABILITY_MAX_TOOLS,
   CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER,
-  clientCapabilityEntityId,
   decodeClientCapabilityReplaceInput,
   decodeClientCapabilityToolDescriptor,
   type ClientCapabilityCallFrame,
@@ -42,6 +41,7 @@ import {
   type ClientCapabilityServiceOffer,
   type ClientCapabilityToolDescriptor,
 } from "@maka/runtime-host/protocol";
+import { clientCapabilityEntityId } from "@maka/runtime-host/capability-entity-id";
 import { toJSONSchema, z } from "zod";
 import { withBrowserOriginAdmission } from './browser/browser-origin-admission.js';
 import type { DesktopTargetScope } from '../shared/runtime-host-identity.js';

--- a/packages/cli/src/mcp-capability-provider.ts
+++ b/packages/cli/src/mcp-capability-provider.ts
@@ -24,11 +24,11 @@ import type { ClientCapabilityProvider } from '@maka/runtime-host/client';
 import {
   CLIENT_CAPABILITY_MAX_TOOLS,
   CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER,
-  clientCapabilityEntityId,
   decodeClientCapabilityReplaceInput,
   type ClientCapabilityCallResult,
   type ClientCapabilityOffer,
 } from '@maka/runtime-host/protocol';
+import { clientCapabilityEntityId } from '@maka/runtime-host/capability-entity-id';
 import type { McpCallResult, McpToolDescriptor } from '@maka/core/mcp';
 
 const CAPABILITY_VERSION = '0';

--- a/packages/runtime-host/package.json
+++ b/packages/runtime-host/package.json
@@ -15,6 +15,7 @@
     "./operator": "./dist/operator/index.js",
     "./operator/update-package-evidence": "./dist/operator/update-package-evidence.js",
     "./profile-kind": "./dist/profile-kind.js",
+    "./capability-entity-id": "./dist/capability-entity-id.js",
     "./execution-candidate-main": "./dist/execution-candidate-main.js",
     "./server": "./dist/server/index.js",
     "./test-only/client-capability-host": "./dist/test-only/client-capability-host.js",

--- a/packages/runtime-host/src/__tests__/capability-entity-id.test.ts
+++ b/packages/runtime-host/src/__tests__/capability-entity-id.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { clientCapabilityEntityId } from '../capability-entity-id.js';
+
+test('passes an already wire-safe identity through unchanged', () => {
+  assert.equal(clientCapabilityEntityId('my-server-01'), 'my-server-01');
+  assert.equal(clientCapabilityEntityId('my_server_01'), 'my_server_01');
+});
+
+test('normalizes spaces and punctuation into a readable label plus digest', () => {
+  const id = clientCapabilityEntityId('My Server #01');
+  assert.match(id, /^My_Server_01_[0-9a-f]{24}$/u);
+});
+
+test('truncates an over-long identity to a bounded label with a digest', () => {
+  const value = 'x'.repeat(300);
+  const id = clientCapabilityEntityId(value);
+  assert.ok(id.length <= 128, `expected <=128, got ${id.length}`);
+  assert.match(id, /_[0-9a-f]{24}$/u);
+});
+
+test('distinct over-long values produce distinct digests', () => {
+  const a = clientCapabilityEntityId('a'.repeat(300));
+  const b = clientCapabilityEntityId('b'.repeat(300));
+  assert.notEqual(a, b);
+});
+
+test('honors an explicit max length', () => {
+  const id = clientCapabilityEntityId('server name here', 40);
+  assert.ok(id.length <= 40, `expected <=40, got ${id.length}`);
+});

--- a/packages/runtime-host/src/capability-entity-id.ts
+++ b/packages/runtime-host/src/capability-entity-id.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Node-only helper for turning an MCP server/tool identity into a wire-safe
+ * capability entity id.
+ *
+ * This lives outside `protocol/` on purpose: `clientCapabilityEntityId` uses
+ * `node:crypto`, and the protocol barrel is re-exported by the Desktop
+ * renderer's startup graph. A value import from the barrel evaluates every
+ * `export *` module in the browser, so a Node builtin anywhere in that
+ * closure silently breaks `vite dev`. Keeping the hashing helper in its own
+ * Node-only module — the same shape as `profile-kind` — lets the renderer keep
+ * importing browser-safe values from the barrel without ever loading this one.
+ */
+
+import { createHash } from 'node:crypto';
+
+export function clientCapabilityEntityId(value: string, maxLength = 128): string {
+  if (/^[A-Za-z0-9_-]+$/u.test(value) && value.length <= maxLength) return value;
+  const label = value.replace(/[^A-Za-z0-9_-]+/gu, '_').slice(0, maxLength - 25) || 'mcp';
+  const digest = createHash('sha256').update(value).digest('hex').slice(0, 24);
+  return `${label}_${digest}`;
+}

--- a/packages/runtime-host/src/protocol/client-capability.ts
+++ b/packages/runtime-host/src/protocol/client-capability.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { createHash } from 'node:crypto';
 import { TOOL_ACTIVITY_KINDS, type ToolActivityKind } from '@maka/core/events';
 import {
   decodeInteractionAnswer,
@@ -85,18 +84,6 @@ export const CLIENT_CAPABILITY_MAX_OFFERS = 32;
 export const CLIENT_CAPABILITY_MAX_SERVICES = 32;
 export const CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER = 64;
 
-/**
- * Normalize an arbitrary Client Capability identity (an MCP server id or tool
- * name from user configuration) into a wire-safe entity id: identities that
- * already fit pass through unchanged, anything else becomes a readable label
- * plus a collision-proof digest of the original value.
- */
-export function clientCapabilityEntityId(value: string, maxLength = 128): string {
-  if (/^[A-Za-z0-9_-]+$/u.test(value) && value.length <= maxLength) return value;
-  const label = value.replace(/[^A-Za-z0-9_-]+/gu, '_').slice(0, maxLength - 25) || 'mcp';
-  const digest = createHash('sha256').update(value).digest('hex').slice(0, 24);
-  return `${label}_${digest}`;
-}
 export const CLIENT_CAPABILITY_MAX_TOOLS = 256;
 export const CLIENT_CAPABILITY_MAX_MANIFEST_BYTES = 56 * 1024;
 export const CLIENT_CAPABILITY_MAX_RESULT_BYTES = 24 * 1024 * 1024;


### PR DESCRIPTION
## Summary

The Desktop renderer stays on the `index.html` preload skeleton forever when launched with `vite dev`. The renderer startup graph imports a value (`MESSAGE_QUEUE_MAX_ENTRIES`) from `@maka/runtime-host/protocol`, whose barrel `export *` re-exports `client-capability.js`. That module imported `node:crypto` for `clientCapabilityEntityId`. Vite dev does no tree-shaking, so evaluating the barrel evaluates `client-capability.js` in the browser, where the top-level `node:crypto` destructure throws and kills the renderer import graph before React mounts — with no terminal error.

The fix moves `clientCapabilityEntityId` (and its `node:crypto` import) out of `protocol/client-capability.ts` into a Node-only module `packages/runtime-host/src/capability-entity-id.ts`, re-exported as `@maka/runtime-host/capability-entity-id` (the same standalone-subpath shape as `profile-kind`). The three call sites (two Desktop main-process, one CLI) import it from there. The protocol barrel and every module it re-exports are now free of `node:` builtins, so the renderer can keep importing browser-safe values without evaluating `node:crypto`.

`clientCapabilityEntityId` had no unit test before; one is added so the moved behavior is pinned.

Verification of the root cause against the current tree:

- `packages/runtime-host/src/protocol/client-capability.ts:20` imported `node:crypto`, the only Node builtin in the barrel's `export *` closure.
- A grep of every `export * from './*.js'` target in `packages/runtime-host/src/protocol/index.ts` confirms no other `node:` builtin remains.
- The renderer imports `MESSAGE_QUEUE_MAX_ENTRIES` (value) from the barrel in `session-workspace-actions.ts:38`, which is what triggers module evaluation.

Fixes #4706

## Verification

- New unit test for `clientCapabilityEntityId` (5 cases): wire-safe passthrough, space/punctuation normalization, over-length truncation, digest distinction, explicit max length — all pass with `node --test --experimental-strip-types` (Node v24.20.0).
- `clientCapabilityEntityId` references now point only at the new module and the three call sites; no call site still imports it from `@maka/runtime-host/protocol`.
- `client-capability.ts` has no remaining `node:crypto` / `createHash` reference.
- `tsconfig.json` (`include: ['src']`, `rootDir: src`, `outDir: dist`) compiles `src/capability-entity-id.ts` to `dist/capability-entity-id.js`, matching the added `exports["./capability-entity-id"]` — same pattern as the existing `profile-kind` subpath.

Not run: the full Desktop dev launch (`npm run dev`) and the runtime-host `test:dist`/typecheck, because a full workspace `npm ci` does not complete from this network. The change is a pure relocation with no logic change and a pinned unit test; a maintainer with the workspace installed can confirm `npm run dev` renders past the skeleton, and `npm --workspace @maka/runtime-host run typecheck`.

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — traced the import chain to the `node:crypto` source, relocated `clientCapabilityEntityId`, updated the call sites and exports, and wrote the unit test. The commit carries a `Generated-by: Claude (Claude Code)` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

(The runtime-host typecheck/test suites are not runnable from this environment as noted under Verification; the new unit test passes locally via type-stripping.)

Does this PR entail a change in behavior?

- [x] Yes — the renderer can once again mount under `vite dev`, which it could not before.
