### PR TITLE
fix(desktop): collapse completed Agent Graph on reopen

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
@@ -696,3 +696,81 @@ describe('AgentGraphPanel dismiss', () => {
     await act(async () => harness.root.unmount());
   });
 });
+
+describe('AgentGraphPanel collapse initialization', () => {
+  it('collapses a completed graph each time its session is opened', async () => {
+    const sessionA = snapshot({
+      rootSessionId: 'session-a',
+      graphId: 'graph-a',
+      status: 'completed',
+    });
+    const sessionB = snapshot({
+      rootSessionId: 'session-b',
+      graphId: 'graph-b',
+      status: 'active',
+    });
+    const harness = installGraphRenderer(sessionA, [sessionB]);
+
+    await harness.renderSession('session-a');
+    assert.equal(
+      harness.container.querySelector('.maka-agent-graph-panel')?.getAttribute('data-collapsed'),
+      'true',
+    );
+
+    await harness.renderSession('session-b');
+    assert.equal(
+      harness.container.querySelector('.maka-agent-graph-panel')?.getAttribute('data-collapsed'),
+      'false',
+    );
+
+    await harness.renderSession('session-a');
+    assert.equal(
+      harness.container.querySelector('.maka-agent-graph-panel')?.getAttribute('data-collapsed'),
+      'true',
+    );
+    await act(async () => harness.root.unmount());
+  });
+
+  it('keeps non-completed graphs expanded on open', async () => {
+    for (const status of ['active', 'waiting', 'closing', 'failed', 'stopped'] as const) {
+      const harness = await renderPanel(snapshot({ graphId: `graph-${status}`, status }));
+      assert.equal(
+        harness.container.querySelector('.maka-agent-graph-panel')?.getAttribute('data-collapsed'),
+        'false',
+        status,
+      );
+      await act(async () => harness.root.unmount());
+    }
+  });
+
+  it('does not auto-collapse when the open graph completes', async () => {
+    const active = snapshot({ graphId: 'graph-1', status: 'active' });
+    const harness = await renderPanel(active);
+
+    await harness.setSnapshot({ ...active, status: 'completed' });
+
+    assert.equal(
+      harness.container.querySelector('.maka-agent-graph-panel')?.getAttribute('data-collapsed'),
+      'false',
+    );
+    await act(async () => harness.root.unmount());
+  });
+
+  it('preserves a manual expansion across completed snapshot refreshes', async () => {
+    const completed = snapshot({ graphId: 'graph-1', status: 'completed' });
+    const harness = await renderPanel(completed);
+    const toggle = harness.container.querySelector('.maka-agent-graph-collapse-toggle');
+    assert.ok(toggle);
+
+    await act(async () => {
+      (toggle as HTMLElement).click();
+    });
+    await harness.setSnapshot({ ...completed, scheduleRevision: 2 });
+
+    assert.equal(
+      harness.container.querySelector('.maka-agent-graph-panel')?.getAttribute('data-collapsed'),
+      'false',
+    );
+    await act(async () => harness.root.unmount());
+  });
+});

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -192,7 +192,7 @@ export function AgentGraphPanel(props: {
     pending: false,
     error: false,
   });
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState<boolean>();
   const [dismissedBySession, setDismissedBySession] = useState<AgentGraphPanelDismissals>({});
   const contentId = useId();
   const refreshRef = useRef<AgentGraphRefreshScheduler>(noopAgentGraphRefreshScheduler);
@@ -220,7 +220,7 @@ export function AgentGraphPanel(props: {
       pending: false,
       error: false,
     });
-    setCollapsed(false);
+    setCollapsed(undefined);
     setLoading(props.enabled);
     let cachedDirectory: AgentGraphEpochDirectory | undefined;
 
@@ -256,6 +256,7 @@ export function AgentGraphPanel(props: {
           setEpochs(nextEpochs);
           setEpochsTruncated(directory.truncated);
           setSelectedGraphId(graphId);
+          setCollapsed((current) => current ?? next.status === 'completed');
           setSnapshot(next);
           setError(false);
         }


### PR DESCRIPTION
## Summary

Collapse a completed Agent Graph by default when its Session is entered or reopened. Keep in-flight and abnormal terminal graphs expanded, and preserve live/manual collapse state for the rest of the visit.

Add regression coverage for completed and non-completed initial states, live completion, and manual expansion across snapshot refreshes.

Fixes #4721

## Verification

- `npm run build:test && node scripts/run-workspace-tests-parallel.mjs --concurrency=1` — all workspace tests passed.
- `npm run check:renderer-architecture -- --base 0f4d20e3117ab3bbdedee26296b2c1bff445ba5b` — passed.
- `npm --workspace @maka/desktop run typecheck` — passed.
- `npx biome check apps/desktop/src/renderer/agent-graph-panel.tsx apps/desktop/src/main/__tests__/agent-graph-panel.test.ts` — passed.
- `git diff --check` — passed.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the change, added regression tests, ran verification, and drafted the Issue and PR.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
