### PR TITLE
fix(cli): repair legacy Host controls before update

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
@@ -43,6 +43,7 @@ import type {
 import { assertRuntimeHostManagedOperatorConfig } from '../runtime-host-managed-deployment.js';
 import {
   applyRuntimeHostLifecycleTransition,
+  convergeRuntimeHostLifecycleControlProjection,
   recoverRuntimeHostLifecycleTransition,
   replaceRuntimeHostLifecycle,
   resolveRecoverableRuntimeHostManagedDeployment,
@@ -55,6 +56,42 @@ import {
 
 const INTEGRITY = `sha512-${Buffer.alloc(64, 7).toString('base64')}`;
 const UPDATED_INTEGRITY = `sha512-${Buffer.alloc(64, 8).toString('base64')}`;
+
+test('control projection repair leaves the running Host supervisor untouched', async () => {
+  const current = config('/workspace', 'a'.repeat(64), 1, 'launch_agent');
+  const calls: string[] = [];
+  const provider = new FakeLifecycleProvider('launch_agent', 'launch_agent_timer');
+  const originalActivate = provider.reconciliationTrigger.activate;
+  provider.reconciliationTrigger.activate = async () => {
+    calls.push('scheduler.activate');
+    await originalActivate();
+  };
+
+  await convergeRuntimeHostLifecycleControlProjection(current, {
+    convergeOperator: async (from, to) => {
+      assert.deepEqual(from, current);
+      assert.deepEqual(to, current);
+      calls.push('operator.converge');
+    },
+    verifyOperator: async () => undefined,
+    resolveProvider: () => ({
+      ...provider,
+      supervisor: {
+        ...provider.supervisor,
+        converge: async () => assert.fail('the running supervisor must not be replaced'),
+      },
+      reconciliationTrigger: {
+        ...provider.reconciliationTrigger,
+        converge: async (definition) => {
+          calls.push('scheduler.converge');
+          await provider.reconciliationTrigger.converge(definition);
+        },
+      },
+    }),
+  });
+
+  assert.deepEqual(calls, ['operator.converge', 'scheduler.converge', 'scheduler.activate']);
+});
 
 test('one authority record recovers provider cutover failures without a journal', async (t) => {
   const stateRoot = await mkdtemp(join(tmpdir(), 'maka-lifecycle-root-'));

--- a/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
@@ -84,6 +84,7 @@ describe('managed Runtime Host selected update', () => {
     let output = '';
     let managedReads = 0;
     let pruned = false;
+    const projection: string[] = [];
     const exitCode = await runManagedRuntimeHostUpdateCli(
       {
         ...OPTIONS,
@@ -106,7 +107,13 @@ describe('managed Runtime Host selected update', () => {
             assert.deepEqual(options?.expectedOwner, expectedHost);
             return { kind: 'active', config: current } as never;
           },
-          verifyProjection: async () => {},
+          convergeControlProjection: async (config) => {
+            assert.equal(config, current);
+            projection.push('converge');
+          },
+          verifyProjection: async () => {
+            projection.push('verify');
+          },
           assertOperatorConfig: () => {},
           manageLifecycle: async () => {
             managedReads += 1;
@@ -130,6 +137,7 @@ describe('managed Runtime Host selected update', () => {
     assert.equal(exitCode, 0);
     assert.equal(managedReads, 2);
     assert.equal(pruned, true);
+    assert.deepEqual(projection, ['converge', 'verify']);
     assert.doesNotMatch(output, /"phase":"staging"/u);
     const result = decodeRuntimeHostServiceManagementFrame(output.trim().split('\n').at(-1) ?? '');
     assert.equal(

--- a/packages/cli/src/runtime-host-lifecycle-transaction.ts
+++ b/packages/cli/src/runtime-host-lifecycle-transaction.ts
@@ -806,6 +806,25 @@ export async function verifyRuntimeHostLifecycleReady(
   );
 }
 
+/** Repairs update-control artifacts without interrupting the running Host supervisor. */
+export async function convergeRuntimeHostLifecycleControlProjection(
+  config: RuntimeHostManagedDeploymentConfig,
+  deps: RuntimeHostLifecycleTransactionDeps,
+): Promise<void> {
+  const canonical = decodeRuntimeHostManagedDeploymentConfig(config);
+  await deps.convergeOperator(canonical, canonical);
+  if (canonical.lifecycle.mode !== 'supervised') return;
+  const provider = deps.resolveProvider(canonical);
+  if (canonical.reconciliation.trigger === 'scheduled') {
+    await provider.reconciliationTrigger.converge(
+      runtimeHostReconciliationTriggerDefinition(canonical),
+    );
+    await provider.reconciliationTrigger.activate();
+  } else {
+    await provider.reconciliationTrigger.uninstall();
+  }
+}
+
 /** Verifies the durable operator and supervisor projection without requiring a compatible Host. */
 export async function verifyRuntimeHostLifecycleProjection(
   config: RuntimeHostManagedDeploymentConfig,

--- a/packages/cli/src/runtime-host-update-command.ts
+++ b/packages/cli/src/runtime-host-update-command.ts
@@ -23,7 +23,6 @@ import { truncateUtf8 } from '@maka/core/diagnostic-log';
 import { activateRuntimeHostManagedDeployment } from '@maka/runtime-host/client';
 import {
   createRuntimeHostLegacyPosixOperatorCommand,
-  runtimeHostManagedOperatorCommand,
   decodeRuntimeHostServiceManagementFrame,
   encodeRuntimeHostServiceManagementFrame,
   RUNTIME_HOST_SERVICE_ERROR_CODE_MAX_BYTES,
@@ -81,6 +80,7 @@ import {
 import type { RuntimeHostExpectedHost, RuntimeHostUpdateSelector } from './runtime-host-cli.js';
 import {
   canDiscardRuntimeHostLifecycleDesiredArtifacts,
+  convergeRuntimeHostLifecycleControlProjection,
   replaceRuntimeHostLifecycle,
   resolveRecoverableRuntimeHostManagedDeployment,
   RuntimeHostLifecycleTransactionError,
@@ -142,6 +142,7 @@ interface RuntimeHostUpdateCliDeps {
     readonly createLifecycleDeps: (rootId: string) => RuntimeHostLifecycleTransactionDeps;
     readonly assertOperatorDeployment: typeof assertRuntimeHostManagedOperatorDeployment;
     readonly recoverDeployment: typeof resolveRecoverableRuntimeHostManagedDeployment;
+    readonly convergeControlProjection: typeof convergeRuntimeHostLifecycleControlProjection;
     readonly verifyProjection: typeof verifyRuntimeHostLifecycleProjection;
     readonly assertOperatorConfig: typeof assertRuntimeHostManagedOperatorConfig;
     readonly manageLifecycle: typeof manageRuntimeHostManagedLifecycle;
@@ -237,6 +238,7 @@ export async function runManagedRuntimeHostUpdateCli(
       }),
       assertOperatorDeployment: assertRuntimeHostManagedOperatorDeployment,
       recoverDeployment: resolveRecoverableRuntimeHostManagedDeployment,
+      convergeControlProjection: convergeRuntimeHostLifecycleControlProjection,
       verifyProjection: verifyRuntimeHostLifecycleProjection,
       assertOperatorConfig: assertRuntimeHostManagedOperatorConfig,
       manageLifecycle: manageRuntimeHostManagedLifecycle,
@@ -651,6 +653,7 @@ async function runCanonicalRuntimeHostUpdate(
           );
         }
         const current = recovered.config;
+        await deps.canonical.convergeControlProjection(current, lifecycleDeps);
         await deps.canonical.verifyProjection(current, lifecycleDeps);
         deps.canonical.assertOperatorConfig(
           current,


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Desktop recovery could not replace a managed Runtime Host installed before #4657: strict projection verification required `operator.mjs` and the current reconciliation scheduler before the updater had a chance to create them.

Repair those update-control artifacts under the deployment lock before strict verification. The running Host supervisor remains untouched until the existing retirement and active-work policy permits replacement.

</details>

<details>
<summary>中文</summary>

在 #4657 之前安装的托管 Runtime Host 仍使用旧的 shell operator 和旧版定时更新配置。Desktop 恢复流程会先按新格式严格校验这些文件，因此还没来得及升级就直接失败，用户点击“停止 Host 并继续”也无法恢复。

本 PR 在 deployment lock 内先修复 operator 和定时更新配置，再做严格校验。这个步骤不会提前停止或替换正在运行的 Host，后续仍由现有的任务保护和退出策略决定何时切换。

</details>

## Verification

- `npm exec -- biome check packages/cli/src/runtime-host-lifecycle-transaction.ts packages/cli/src/runtime-host-update-command.ts packages/cli/src/__tests__/runtime-host-selected-update.test.ts packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts`
- `npm --workspace maka-agent run typecheck`
- `npm --workspace maka-agent run build`
- `node --test packages/cli/dist/__tests__/runtime-host-selected-update.test.js packages/cli/dist/__tests__/runtime-host-lifecycle-transaction.test.js` (18 passed)
- Reproduced with a pre-#4657 macOS launchd deployment, then confirmed Desktop reported `managed Local Host repair result: repaired`; the replacement Host and reconciliation timer were both active afterward.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the legacy projection mismatch, implemented the repair ordering, and added focused regression coverage.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No