### PR TITLE
fix(desktop): use sentence case in trace

### DIFF
--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -867,10 +867,10 @@ const COPY = {
       },
       durationUsage: {
         title: 'Time breakdown',
-        center: 'Recorded Time',
+        center: 'Recorded time',
         segment: {
-          model: (count) => `LLM Calls × ${count}`,
-          tool: (count) => `Tool Runs × ${count}`,
+          model: (count) => `LLM calls × ${count}`,
+          tool: (count) => `Tool runs × ${count}`,
         },
       },
       coveragePartial: (parts) =>


### PR DESCRIPTION
## Summary

Normalize the Time breakdown labels to sentence case so they match the
adjacent Token usage labels.

- `Recorded Time` becomes `Recorded time`
- `LLM Calls` becomes `LLM calls`
- `Tool Runs` becomes `Tool runs`

## Verification

- `npm exec -- biome check apps/desktop/src/renderer/locales/conversation-copy.ts`
- `npm --workspace @maka/desktop run typecheck`
- Verified the hot-reloaded Trace panel in the actual Desktop; all three labels
  render in sentence case without changing the existing layout
- Automated behavioral tests were not added because this is a copy-only change

### Before
<img width="479" height="339" alt="image" src="https://github.com/user-attachments/assets/178b2bf0-78ff-4f41-bcf7-4cb8d67e05d6" />

### After 
<img width="468" height="333" alt="image" src="https://github.com/user-attachments/assets/35eddbcf-71ff-4a9b-ac1f-d728f7d26fec" />



## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with the copy edit, verification,
commit, and PR preparation.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes, the English labels now use sentence case
- [ ] No
