### PR TITLE
fix(runtime): reject non-boolean goal evaluation flags

### DIFF
--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -671,6 +671,38 @@ describe('GoalContinuationCoordinator settlement', () => {
     assert.equal(admitted.length, 1);
   });
 
+  for (const field of ['met', 'impossible', 'progress', 'waiting']) {
+    test(`invalid ${field} cannot settle a Goal or change its stall counter`, async (t) => {
+      const { manager, coordinator, deps, admitted } = setup({
+        evaluations: [{ progress: false }],
+      });
+      t.after(() => coordinator.dispose());
+      manager.create(SESSION, 'ship', { blockCap: 2 });
+      await settleExternal(coordinator, SESSION, { kind: 'completed', turnId: 'turn-1' });
+      await waitFor(() => admitted.length === 1);
+      assert.equal(manager.get(SESSION)?.consecutiveNoProgress, 1);
+
+      // Exercise the raw evaluator response through the real continuation path.
+      deps.evaluator.evaluate = async () =>
+        JSON.stringify({
+          met: false,
+          impossible: false,
+          progress: false,
+          waiting: false,
+          [field]: 'false',
+        });
+      const owned = admitted[0]!;
+      owned.completion.resolve({ kind: 'completed', turnId: owned.turnId });
+      await waitFor(
+        () => manager.get(SESSION)?.status !== 'active' || manager.get(SESSION)?.iterations === 2,
+      );
+
+      assert.equal(manager.get(SESSION)?.status, 'active');
+      assert.equal(manager.get(SESSION)?.consecutiveNoProgress, 1);
+      await waitFor(() => admitted.length === 2);
+    });
+  }
+
   test('context failure pauses the exact Goal with a visible reason', async () => {
     const { manager, coordinator, deps, admitted } = setup();
     deps.getRecentContext = async () => {

--- a/packages/runtime/src/__tests__/goal-evaluator.test.ts
+++ b/packages/runtime/src/__tests__/goal-evaluator.test.ts
@@ -46,6 +46,44 @@ describe('parseGoalEvaluation', () => {
     assert.equal(r.reason, 'No reason provided');
   });
 
+  for (const field of ['met', 'impossible', 'progress', 'waiting']) {
+    for (const value of ['false', 'true', '', 0, 1, null, []]) {
+      test(`rejects ${field}=${JSON.stringify(value)} as a neutral evaluator failure`, () => {
+        const r = parseGoalEvaluation(
+          JSON.stringify({
+            met: false,
+            impossible: false,
+            progress: false,
+            waiting: false,
+            [field]: value,
+          }),
+        );
+        assert.equal(r.evaluatorFailed, true);
+        assert.equal(r.met, false);
+        assert.equal(r.impossible, false);
+        assert.equal(r.progress, false);
+        assert.equal(r.waiting, false);
+      });
+    }
+  }
+
+  test('rejects the whole judgment when a true verdict accompanies an invalid field', () => {
+    const r = parseGoalEvaluation('{"met":true,"progress":"false"}');
+    assert.equal(r.evaluatorFailed, true);
+    assert.equal(r.met, false);
+  });
+
+  test('accepts boolean false as a real no-progress judgment', () => {
+    const r = parseGoalEvaluation(
+      '{"met":false,"impossible":false,"progress":false,"waiting":false}',
+    );
+    assert.equal(r.evaluatorFailed, false);
+    assert.equal(r.met, false);
+    assert.equal(r.impossible, false);
+    assert.equal(r.progress, false);
+    assert.equal(r.waiting, false);
+  });
+
   test('unparseable output → neutral evaluator failure (not real no-progress)', () => {
     const r = parseGoalEvaluation('I cannot determine this');
     assert.equal(r.met, false);

--- a/packages/runtime/src/goal-evaluator.ts
+++ b/packages/runtime/src/goal-evaluator.ts
@@ -150,11 +150,17 @@ export function parseGoalEvaluation(raw: string): GoalEvaluation {
   if (!jsonMatch) return fallback;
   try {
     const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+    // Missing flags keep their defaults; invalid flags are not a real judgment.
+    for (const field of ['met', 'impossible', 'progress', 'waiting']) {
+      if (parsed[field] !== undefined && typeof parsed[field] !== 'boolean') {
+        return { ...fallback, reason: `Evaluator returned a non-boolean ${field}` };
+      }
+    }
     return {
-      met: Boolean(parsed.met),
-      impossible: Boolean(parsed.impossible),
-      progress: Boolean(parsed.progress),
-      waiting: Boolean(parsed.waiting),
+      met: parsed.met === true,
+      impossible: parsed.impossible === true,
+      progress: parsed.progress === true,
+      waiting: parsed.waiting === true,
       evaluatorFailed: false,
       reason:
         typeof parsed.reason === 'string' && parsed.reason.trim()


### PR DESCRIPTION
## Summary

Fixes #4736

`Boolean("false")` currently turns an invalid judge response into a valid Goal verdict. Reject non-boolean `met`, `impossible`, `progress`, or `waiting` fields as a neutral evaluator failure. Missing flags still default to `false`, and valid boolean judgments are unchanged.

This keeps malformed evaluations from terminating or waiting a Goal, or changing its no-progress counter. The change adds no dependencies, model calls, or state. JSON extraction, prompts, and Todo behavior are unchanged.

## Verification

- Rebuilt the runtime before testing. The evaluator/continuation regression run was **68 passed, 33 failed before the fix → 101 passed, 0 failed after it**.
- The regressions feed raw synthetic judge output through the real continuation coordinator, checking that the Goal stays active, keeps its existing no-progress count, and admits the next turn.
- Full runtime suite: **3,243 passed, 0 failed, 13 skipped**. This PR adds no skips.
- Runtime Host Goal coordinator/root-authority/protocol tests: **23 passed**.
- `npm run lint`, `npm run format:check`, `npm run build`, `npm run typecheck`: passed.
- Both documented Knip workspace checks passed. ASF header check passed on a clean worktree of the proposed commits.
- Evaluator coverage: **95.77% lines, 92.11% branches, 90% functions**.

Minimal reproduction output for a string `"false"` flag:

```text
Before: parsedMet=true,  evaluatorFailed=false
After:  parsedMet=false, evaluatorFailed=true
```

Not run: the full all-workspace test matrix or live-provider E2E. The issue contains the standalone reproduction command; no API credentials are needed.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex assisted with investigation, implementation, regression tests, and local verification. AI-authored commits include `Generated-by: Codex`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
