### PR TITLE
refactor(desktop): register Workbar surface descriptors

### DIFF
--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -349,6 +349,61 @@ test('titlebar workbar action restores an existing tool instead of the picker', 
   expect(Math.abs(restoredToggleBox!.x - safeAreaToggleBox!.x)).toBeLessThanOrEqual(1);
 });
 
+test('registered Workbar descriptors render singleton and dynamic panels', async ({
+  window: page,
+}) => {
+  await createSession(page, 'create descriptor registry session');
+  await page.getByRole('button', { name: '展开任务工作栏' }).click();
+
+  const launcher = page.getByRole('list', { name: '打开工具' });
+  const openLauncher = async () => {
+    await page.getByRole('button', { name: '打开工作栏标签' }).first().click();
+    await expect(launcher).toBeVisible();
+  };
+  const registeredActions = [
+    /侧边对话.*在不打断主任务的情况下追问和只读探索/,
+    /变更.*查看当前 Git 工作区变化/,
+    /终端.*查看当前任务的终端运行和实时输出/,
+    /浏览器.*打开内置浏览器并保留当前页面/,
+    /生成文件.*浏览当前任务生成的文件/,
+    /待办.*查看和维护这个任务的待办台账/,
+    /工作看板.*记录和管理暂缓事项/,
+    /追踪.*检查任务调用、工具与耗时记录/,
+  ] as const;
+  await expect(launcher).toBeVisible();
+  await expect(launcher.getByRole('button')).toHaveCount(registeredActions.length);
+  for (const name of registeredActions) {
+    await expect(launcher.getByRole('button', { name })).toBeVisible();
+  }
+
+  await launcher.getByRole('button', { name: registeredActions[5] }).click();
+  await expect(page.getByRole('region', { name: '任务待办' })).toBeVisible();
+  await openLauncher();
+  await launcher.getByRole('button', { name: registeredActions[5] }).click();
+  await expect(page.getByRole('tab', { name: '待办' })).toHaveCount(1);
+
+  await openLauncher();
+  await launcher.getByRole('button', { name: registeredActions[2] }).click();
+  const firstTerminal = page.getByRole('region', { name: '任务终端' });
+  await expect(firstTerminal).toBeVisible();
+  const firstTerminalRef = await firstTerminal.getAttribute('data-terminal-ref');
+  expect(firstTerminalRef).toBeTruthy();
+  await openLauncher();
+  await launcher.getByRole('button', { name: registeredActions[2] }).click();
+  const secondTerminal = page.locator('.maka-session-terminal-panel:visible');
+  await expect(secondTerminal).toBeVisible();
+  await expect(page.getByRole('tab', { name: /^终端(?: \d+)?$/ })).toHaveCount(2);
+  expect(await secondTerminal.getAttribute('data-terminal-ref')).not.toBe(firstTerminalRef);
+
+  await openLauncher();
+  await launcher.getByRole('button', { name: registeredActions[0] }).click();
+  await expect(page.locator('.maka-quote-companion')).toBeVisible();
+  await openLauncher();
+  await launcher.getByRole('button', { name: registeredActions[0] }).click();
+  await expect(page.getByRole('tab', { name: /^侧边对话(?: \d+)?$/ })).toHaveCount(2);
+  await expect(page.locator('.maka-quote-companion')).toHaveCount(2);
+});
+
 test('Git changes re-read the workspace after the app regains focus', async ({
   gitReviewWindow,
 }) => {

--- a/apps/desktop/src/main/__tests__/workbar-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/workbar-boundary.test.ts
@@ -22,6 +22,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { WORKBAR_TOOL_DEFINITIONS } from '../../renderer/features/workbar/testing.js';
 
 const desktopRoot = resolve(
   fileURLToPath(new URL('../../../', import.meta.url)),
@@ -43,6 +44,37 @@ function sourceFiles(root: string): string[] {
 }
 
 describe('Workbar feature boundary', () => {
+  it('registers one exhaustive surface descriptor for every Workbar tab kind', () => {
+    const surface = readFileSync(
+      join(featureRoot, 'ui', 'workbar-surface.tsx'),
+      'utf8',
+    );
+    const registeredKinds = [...surface.matchAll(
+      /\n  (?:'[^']+'|[a-z]+): defineWorkbarSurfaceDescriptor\(\s*'([^']+)',\s*\{/g,
+    )].map((match) => match[1]);
+
+    assert.deepEqual(
+      registeredKinds,
+      WORKBAR_TOOL_DEFINITIONS.map((definition) => definition.kind),
+    );
+    assert.equal(
+      surface.includes(
+        'const WORKBAR_SURFACE_DESCRIPTOR_BY_KIND: WorkbarSurfaceDescriptorsByKind',
+      ),
+      true,
+    );
+    assert.equal(
+      surface.includes(
+        'WORKBAR_TOOL_DEFINITIONS.map(\n    (definition) => WORKBAR_SURFACE_DESCRIPTOR_BY_KIND[definition.kind]',
+      ),
+      true,
+    );
+    assert.equal(
+      surface.includes('const descriptor = workbarSurfaceDescriptor(tab.kind);'),
+      true,
+    );
+  });
+
   it('contains no Desktop global bridge or shell/process imports', () => {
     const violations: string[] = [];
     for (const path of sourceFiles(featureRoot)) {

--- a/apps/desktop/src/renderer/features/workbar/model/workbar-tool-definitions.ts
+++ b/apps/desktop/src/renderer/features/workbar/model/workbar-tool-definitions.ts
@@ -27,6 +27,7 @@ export interface WorkbarToolDefinition {
   readonly labelKey: SessionWorkbarTabKind;
   readonly icon:
     | 'activity'
+    | 'clipboard'
     | 'folder'
     | 'git-branch'
     | 'globe'
@@ -102,7 +103,7 @@ const WORKBAR_TOOL_DEFINITION_BY_KIND = {
   'work-board': {
     kind: 'work-board',
     labelKey: 'work-board',
-    icon: 'list-todo',
+    icon: 'clipboard',
     persisted: true,
     singleton: true,
     defaultPlacement: 'right',

--- a/apps/desktop/src/renderer/features/workbar/ui/workbar-surface.tsx
+++ b/apps/desktop/src/renderer/features/workbar/ui/workbar-surface.tsx
@@ -86,6 +86,11 @@ import {
   sessionWorkbarTabsToRight,
   terminalRefFromWorkbarTab,
 } from '../model/workbar-tabs';
+import {
+  WORKBAR_TOOL_DEFINITIONS,
+  workbarToolDefinition,
+  type WorkbarToolDefinition,
+} from '../model/workbar-tool-definitions';
 import { useSessionTodo } from '../tools/tasks/use-session-todo';
 import { WorkbarToggle } from './workbar-toggle';
 import { WorkBoardPanel } from '../../../work-board-panel.js';
@@ -118,6 +123,104 @@ const SessionTerminalPanel = lazy(() =>
     default: module.SessionTerminalPanel,
   })),
 );
+
+type WorkbarCopy = ReturnType<typeof getDesktopConversationCopy>['workbar'];
+
+export interface WorkbarSurfaceProps {
+  sessionId: string;
+  projectId?: string | null;
+  projectAliases?: readonly string[];
+  hidden: boolean;
+  onDismissPanel: (placement: SessionWorkbarPlacement) => void;
+  panelsState: SessionWorkbarPanelsState;
+  rightCollapsed: boolean;
+  bottomOpen: boolean;
+  onActivateTab: (placement: SessionWorkbarPlacement, tabId: string) => void;
+  onCloseTab: (placement: SessionWorkbarPlacement, tab: SessionWorkbarTab) => void;
+  onCloseTabs: (
+    placement: SessionWorkbarPlacement,
+    tabs: readonly SessionWorkbarTab[],
+  ) => void;
+  onReorderTab: (
+    placement: SessionWorkbarPlacement,
+    tabId: string,
+    targetTabId: string,
+  ) => void;
+  onMoveTab: (
+    placement: SessionWorkbarPlacement,
+    tabId: string,
+    direction: 'left' | 'right',
+  ) => void;
+  onMoveTabToPanel: (tabId: string, target: SessionWorkbarPlacement) => void;
+  onPinTab: (tabId: string) => void;
+  onOpenLauncher: (placement: SessionWorkbarPlacement) => void;
+  onRequestOpenTab: (
+    placement: SessionWorkbarPlacement,
+    kind: SessionWorkbarTabKind,
+  ) => void;
+  quotes?: readonly QuoteCompanionPanelState[];
+  onQuotesConsumed?: (snapshot: CompanionQuoteSnapshot) => void;
+  onRemoveQuote?: (target: CompanionQuoteTarget) => void;
+  onForkVisibilityChange?: (event: CompanionForkVisibilityEvent) => void;
+  onContentStateChange?: (panelId: string, hasContent: boolean) => void;
+  onInitialPromptStarted?: (panelId: string) => void;
+  onPromptAccepted?: (panelId: string, prompt: string) => void;
+  onActivityStateChange?: (panelId: string, active: boolean) => void;
+  activeSideChatPanelIds?: ReadonlySet<string>;
+  sourceSession?: SessionSummary;
+  modelChoices?: readonly ChatModelChoice[];
+  confirmBypass: () => Promise<boolean>;
+}
+
+interface WorkbarSurfaceRenderContext {
+  active: boolean;
+  copy: WorkbarCopy;
+  placement: SessionWorkbarPlacement;
+  props: WorkbarSurfaceProps;
+  sessionTodo: ReturnType<typeof useSessionTodo>;
+  setArtifactCount: (count: number) => void;
+  tab: SessionWorkbarTab;
+}
+
+interface WorkbarSurfaceDescriptor<Kind extends SessionWorkbarTabKind> {
+  readonly kind: Kind;
+  readonly icon: typeof Activity;
+  readonly label: (
+    tab: SessionWorkbarTab,
+    tabs: readonly SessionWorkbarTab[],
+    copy: WorkbarCopy,
+  ) => string;
+  readonly launcherLabel: (copy: WorkbarCopy) => string;
+  readonly launcherDescription: (copy: WorkbarCopy) => string;
+  readonly panelClassName?: string;
+  readonly render: (context: WorkbarSurfaceRenderContext) => ReactNode;
+}
+
+type WorkbarSurfaceDescriptorsByKind = {
+  readonly [Kind in SessionWorkbarTabKind]: WorkbarSurfaceDescriptor<Kind>;
+};
+
+const WORKBAR_ICON_BY_NAME = {
+  activity: Activity,
+  clipboard: Clipboard,
+  folder: FolderOpen,
+  'git-branch': GitBranch,
+  globe: Globe,
+  'list-todo': ListTodo,
+  'message-circle-question': MessageCircleQuestion,
+  terminal: Terminal,
+} satisfies Record<WorkbarToolDefinition['icon'], typeof Activity>;
+
+function defineWorkbarSurfaceDescriptor<Kind extends SessionWorkbarTabKind>(
+  kind: Kind,
+  descriptor: Omit<WorkbarSurfaceDescriptor<Kind>, 'icon' | 'kind'>,
+): WorkbarSurfaceDescriptor<Kind> {
+  return {
+    ...descriptor,
+    kind,
+    icon: WORKBAR_ICON_BY_NAME[workbarToolDefinition(kind).icon],
+  };
+}
 
 function WorkbarPanelLoading(props: { label: string }) {
   return (
@@ -171,39 +274,160 @@ function TabCount(props: { count: number }) {
   return <Badge variant="neutral" label={props.count} data-maka-contract="session-workbar-count" />;
 }
 
+const WORKBAR_SURFACE_DESCRIPTOR_BY_KIND: WorkbarSurfaceDescriptorsByKind = {
+  'side-chat': defineWorkbarSurfaceDescriptor('side-chat', {
+    label: (tab, tabs, copy) => {
+      if (tab.title?.trim()) return tab.title.trim();
+      const index =
+        tab.ordinal ??
+        tabs.filter((candidate) => candidate.kind === 'side-chat').findIndex(
+          (candidate) => candidate.id === tab.id,
+        ) + 1;
+      return index <= 1 ? copy.sideChat : copy.sideChatNumbered(index);
+    },
+    launcherLabel: (copy) => copy.sideChat,
+    launcherDescription: (copy) => copy.launcher.sideChat,
+    panelClassName: 'maka-quote-workbar-panel',
+    render: ({ active, props, tab }) => {
+      const panelId = tab.id.slice('side-chat:'.length);
+      const quote = props.quotes?.find((candidate) => candidate.id === panelId);
+      if (!quote) return null;
+      return (
+        <QuoteCompanionPanel
+          panelId={quote.id}
+          active={!props.hidden && active}
+          quotes={quote.quotes}
+          initialPrompt={quote.initialPrompt}
+          sourceSession={props.sourceSession}
+          modelChoices={props.modelChoices ?? []}
+          confirmBypass={props.confirmBypass}
+          onQuotesConsumed={props.onQuotesConsumed ?? (() => {})}
+          onRemoveQuote={props.onRemoveQuote}
+          onForkVisibilityChange={props.onForkVisibilityChange}
+          onContentStateChange={props.onContentStateChange}
+          onInitialPromptStarted={props.onInitialPromptStarted}
+          onPromptAccepted={props.onPromptAccepted}
+          onActivityStateChange={props.onActivityStateChange}
+        />
+      );
+    },
+  }),
+  review: defineWorkbarSurfaceDescriptor('review', {
+    label: (_tab, _tabs, copy) => copy.review,
+    launcherLabel: (copy) => copy.review,
+    launcherDescription: (copy) => copy.launcher.review,
+    render: ({ active, copy, props }) => (
+      <Suspense fallback={<WorkbarPanelLoading label={copy.review} />}>
+        <SessionReviewPanel
+          sessionId={props.sessionId}
+          active={!props.hidden && active}
+        />
+      </Suspense>
+    ),
+  }),
+  terminal: defineWorkbarSurfaceDescriptor('terminal', {
+    label: (tab, _tabs, copy) =>
+      tab.ordinal && tab.ordinal > 1
+        ? copy.terminalNumbered(tab.ordinal)
+        : copy.terminal,
+    launcherLabel: (copy) => copy.terminal,
+    launcherDescription: (copy) => copy.launcher.terminal,
+    render: ({ active, copy, props, tab }) => (
+      <Suspense fallback={<WorkbarPanelLoading label={copy.terminal} />}>
+        <SessionTerminalPanel
+          sessionId={tab.ownerSessionId ?? props.sessionId}
+          terminalRef={terminalRefFromWorkbarTab(tab)}
+          active={!props.hidden && active}
+        />
+      </Suspense>
+    ),
+  }),
+  browser: defineWorkbarSurfaceDescriptor('browser', {
+    label: (_tab, _tabs, copy) => copy.browser,
+    launcherLabel: (copy) => copy.browser,
+    launcherDescription: (copy) => copy.launcher.browser,
+    render: ({ active, copy, props }) => (
+      <Suspense fallback={<WorkbarPanelLoading label={copy.browser} />}>
+        <BrowserPanel
+          sessionId={props.sessionId}
+          hidden={props.hidden || !active}
+        />
+      </Suspense>
+    ),
+  }),
+  files: defineWorkbarSurfaceDescriptor('files', {
+    label: (_tab, _tabs, copy) => copy.files,
+    launcherLabel: (copy) => copy.files,
+    launcherDescription: (copy) => copy.launcher.files,
+    render: ({ copy, placement, props, setArtifactCount }) => (
+      <Suspense fallback={<WorkbarPanelLoading label={copy.files} />}>
+        <ArtifactPane
+          sessionId={props.sessionId}
+          onCountChange={setArtifactCount}
+          onDismiss={() => props.onDismissPanel(placement)}
+        />
+      </Suspense>
+    ),
+  }),
+  tasks: defineWorkbarSurfaceDescriptor('tasks', {
+    label: (_tab, _tabs, copy) => copy.tasks,
+    launcherLabel: (copy) => copy.tasks,
+    launcherDescription: (copy) => copy.launcher.tasks,
+    render: ({ sessionTodo }) => (
+      <SessionTodoPanel
+        items={sessionTodo.items}
+        loading={sessionTodo.loading}
+        error={sessionTodo.error}
+        onRetry={sessionTodo.retry}
+      />
+    ),
+  }),
+  'work-board': defineWorkbarSurfaceDescriptor('work-board', {
+    label: (_tab, _tabs, copy) => copy.workBoard,
+    launcherLabel: (copy) => copy.workBoard,
+    launcherDescription: (copy) => copy.launcher.workBoard,
+    render: ({ props }) => (
+      <WorkBoardPanel
+        projectId={props.projectId ?? null}
+        projectAliases={props.projectAliases}
+      />
+    ),
+  }),
+  inspector: defineWorkbarSurfaceDescriptor('inspector', {
+    label: (_tab, _tabs, copy) => copy.inspector,
+    launcherLabel: (copy) => copy.inspector,
+    launcherDescription: (copy) => copy.launcher.inspector,
+    render: ({ active, copy, props }) => (
+      <Suspense fallback={<WorkbarPanelLoading label={copy.inspector} />}>
+        <SessionInspectorPanel
+          sessionId={props.sessionId}
+          active={!props.hidden && active}
+        />
+      </Suspense>
+    ),
+  }),
+};
+
+type RegisteredWorkbarSurfaceDescriptor =
+  (typeof WORKBAR_SURFACE_DESCRIPTOR_BY_KIND)[SessionWorkbarTabKind];
+
+const WORKBAR_SURFACE_DESCRIPTORS: readonly RegisteredWorkbarSurfaceDescriptor[] =
+  WORKBAR_TOOL_DEFINITIONS.map(
+    (definition) => WORKBAR_SURFACE_DESCRIPTOR_BY_KIND[definition.kind],
+  );
+
+function workbarSurfaceDescriptor(
+  kind: SessionWorkbarTabKind,
+): RegisteredWorkbarSurfaceDescriptor {
+  return WORKBAR_SURFACE_DESCRIPTOR_BY_KIND[kind];
+}
+
 function tabLabel(
   tab: SessionWorkbarTab,
   tabs: readonly SessionWorkbarTab[],
-  copy: ReturnType<typeof getDesktopConversationCopy>['workbar'],
+  copy: WorkbarCopy,
 ): string {
-  switch (tab.kind) {
-    case 'review':
-      return copy.review;
-    case 'terminal':
-      return tab.ordinal && tab.ordinal > 1
-        ? copy.terminalNumbered(tab.ordinal)
-        : copy.terminal;
-    case 'tasks':
-      return copy.tasks;
-    case 'work-board':
-      return copy.workBoard;
-    case 'browser':
-      return copy.browser;
-    case 'files':
-      return copy.files;
-    case 'inspector':
-      return copy.inspector;
-    case 'side-chat':
-      {
-        if (tab.title?.trim()) return tab.title.trim();
-        const index =
-          tab.ordinal ??
-          tabs.filter((candidate) => candidate.kind === 'side-chat').findIndex(
-            (candidate) => candidate.id === tab.id,
-          ) + 1;
-        return index <= 1 ? copy.sideChat : copy.sideChatNumbered(index);
-      }
-  }
+  return workbarSurfaceDescriptor(tab.kind).label(tab, tabs, copy);
 }
 
 function tabIcon(tab: SessionWorkbarTab, active: boolean): ReactNode {
@@ -216,22 +440,7 @@ function tabIcon(tab: SessionWorkbarTab, active: boolean): ReactNode {
       />
     );
   }
-  const Icon =
-    tab.kind === 'review'
-      ? GitBranch
-      : tab.kind === 'terminal'
-        ? Terminal
-        : tab.kind === 'tasks'
-          ? ListTodo
-          : tab.kind === 'work-board'
-            ? Clipboard
-          : tab.kind === 'browser'
-            ? Globe
-            : tab.kind === 'files'
-              ? FolderOpen
-              : tab.kind === 'inspector'
-                ? Activity
-                : MessageCircleQuestion;
+  const Icon = workbarSurfaceDescriptor(tab.kind).icon;
   return <Icon size={ICON_SIZE.control} aria-hidden="true" className="maka-workbar-tab-icon" />;
 }
 
@@ -557,69 +766,6 @@ function WorkbarLauncher(props: {
   sideChatAvailable: boolean;
 }) {
   const copy = getDesktopConversationCopy(useUiLocale()).workbar;
-  const actions: Array<{
-    kind: SessionWorkbarTabKind;
-    label: string;
-    description: string;
-    icon: typeof Activity;
-    shortcut?: string;
-    disabled?: boolean;
-  }> = [
-    {
-      kind: 'side-chat',
-      label: copy.sideChat,
-      description: copy.launcher.sideChat,
-      icon: MessageCircleQuestion,
-      shortcut: 'mod+alt+s',
-      disabled: !props.sideChatAvailable,
-    },
-    {
-      kind: 'review',
-      label: copy.review,
-      description: copy.launcher.review,
-      icon: GitBranch,
-      shortcut: 'ctrl+shift+g',
-    },
-    {
-      kind: 'terminal',
-      label: copy.terminal,
-      description: copy.launcher.terminal,
-      icon: Terminal,
-      shortcut: 'ctrl+`',
-    },
-    {
-      kind: 'browser',
-      label: copy.browser,
-      description: copy.launcher.browser,
-      icon: Globe,
-      shortcut: 'mod+t',
-    },
-    {
-      kind: 'files',
-      label: copy.files,
-      description: copy.launcher.files,
-      icon: FolderOpen,
-      shortcut: 'mod+p',
-    },
-    {
-      kind: 'tasks',
-      label: copy.tasks,
-      description: copy.launcher.tasks,
-      icon: ListTodo,
-    },
-    {
-      kind: 'work-board',
-      label: copy.workBoard,
-      description: copy.launcher.workBoard,
-      icon: Clipboard,
-    },
-    {
-      kind: 'inspector',
-      label: copy.inspector,
-      description: copy.launcher.inspector,
-      icon: Activity,
-    },
-  ];
   return (
     <div className="maka-workbar-launcher">
       <div className="maka-workbar-launcher-frame">
@@ -628,72 +774,33 @@ function WorkbarLauncher(props: {
           density="compact"
           header={<Heading level={4}>{copy.openTools}</Heading>}
         >
-          {actions.map((action) => (
-            <ListItem
-              key={action.kind}
-              startContent={<Icon icon={action.icon} size="sm" color="secondary" />}
-              label={action.label}
-              description={action.description}
-              endContent={
-                action.shortcut ? (
-                  <Kbd keys={action.shortcut} />
-                ) : undefined
-              }
-              isDisabled={action.disabled}
-              onClick={() => props.onOpen(action.kind)}
-            />
-          ))}
+          {WORKBAR_SURFACE_DESCRIPTORS.map((descriptor) => {
+            const definition = workbarToolDefinition(descriptor.kind);
+            const shortcut =
+              'shortcut' in definition ? definition.shortcut : undefined;
+            return (
+              <ListItem
+                key={descriptor.kind}
+                startContent={<Icon icon={descriptor.icon} size="sm" color="secondary" />}
+                label={descriptor.launcherLabel(copy)}
+                description={descriptor.launcherDescription(copy)}
+                endContent={
+                  shortcut ? (
+                    <Kbd keys={shortcut} />
+                  ) : undefined
+                }
+                isDisabled={descriptor.kind === 'side-chat' && !props.sideChatAvailable}
+                onClick={() => props.onOpen(descriptor.kind)}
+              />
+            );
+          })}
         </List>
       </div>
     </div>
   );
 }
 
-export function WorkbarSurface(props: {
-  sessionId: string;
-  projectId?: string | null;
-  projectAliases?: readonly string[];
-  hidden: boolean;
-  onDismissPanel: (placement: SessionWorkbarPlacement) => void;
-  panelsState: SessionWorkbarPanelsState;
-  rightCollapsed: boolean;
-  bottomOpen: boolean;
-  onActivateTab: (placement: SessionWorkbarPlacement, tabId: string) => void;
-  onCloseTab: (placement: SessionWorkbarPlacement, tab: SessionWorkbarTab) => void;
-  onCloseTabs: (
-    placement: SessionWorkbarPlacement,
-    tabs: readonly SessionWorkbarTab[],
-  ) => void;
-  onReorderTab: (
-    placement: SessionWorkbarPlacement,
-    tabId: string,
-    targetTabId: string,
-  ) => void;
-  onMoveTab: (
-    placement: SessionWorkbarPlacement,
-    tabId: string,
-    direction: 'left' | 'right',
-  ) => void;
-  onMoveTabToPanel: (tabId: string, target: SessionWorkbarPlacement) => void;
-  onPinTab: (tabId: string) => void;
-  onOpenLauncher: (placement: SessionWorkbarPlacement) => void;
-  onRequestOpenTab: (
-    placement: SessionWorkbarPlacement,
-    kind: SessionWorkbarTabKind,
-  ) => void;
-  quotes?: readonly QuoteCompanionPanelState[];
-  onQuotesConsumed?: (snapshot: CompanionQuoteSnapshot) => void;
-  onRemoveQuote?: (target: CompanionQuoteTarget) => void;
-  onForkVisibilityChange?: (event: CompanionForkVisibilityEvent) => void;
-  onContentStateChange?: (panelId: string, hasContent: boolean) => void;
-  onInitialPromptStarted?: (panelId: string) => void;
-  onPromptAccepted?: (panelId: string, prompt: string) => void;
-  onActivityStateChange?: (panelId: string, active: boolean) => void;
-  activeSideChatPanelIds?: ReadonlySet<string>;
-  sourceSession?: SessionSummary;
-  modelChoices?: readonly ChatModelChoice[];
-  confirmBypass: () => Promise<boolean>;
-}) {
+export function WorkbarSurface(props: WorkbarSurfaceProps) {
   const locale = useUiLocale();
   const copy = getDesktopConversationCopy(locale).workbar;
   const sessionTodo = useSessionTodo(props.sessionId, {
@@ -777,95 +884,16 @@ export function WorkbarSurface(props: {
           placement === 'right' ? !props.rightCollapsed : props.bottomOpen;
         const active =
           panelVisible && !showingLauncher && activeTab?.id === tab.id;
-        let content: ReactNode = null;
-        if (tab.kind === 'review') {
-          content = (
-            <Suspense fallback={<WorkbarPanelLoading label={copy.review} />}>
-              <SessionReviewPanel
-                sessionId={props.sessionId}
-                active={!props.hidden && active}
-              />
-            </Suspense>
-          );
-        } else if (tab.kind === 'terminal') {
-          const terminalRef = terminalRefFromWorkbarTab(tab);
-          content = (
-            <Suspense fallback={<WorkbarPanelLoading label={copy.terminal} />}>
-              <SessionTerminalPanel
-                sessionId={tab.ownerSessionId ?? props.sessionId}
-                terminalRef={terminalRef}
-                active={!props.hidden && active}
-              />
-            </Suspense>
-          );
-        } else if (tab.kind === 'tasks') {
-          content = (
-            <SessionTodoPanel
-              items={sessionTodo.items}
-              loading={sessionTodo.loading}
-              error={sessionTodo.error}
-              onRetry={sessionTodo.retry}
-            />
-          );
-        } else if (tab.kind === 'work-board') {
-          content = (
-            <WorkBoardPanel
-              projectId={props.projectId ?? null}
-              projectAliases={props.projectAliases}
-            />
-          );
-        } else if (tab.kind === 'browser') {
-          content = (
-            <Suspense fallback={<WorkbarPanelLoading label={copy.browser} />}>
-              <BrowserPanel
-                sessionId={props.sessionId}
-                hidden={props.hidden || !active}
-              />
-            </Suspense>
-          );
-        } else if (tab.kind === 'files') {
-          content = (
-            <Suspense fallback={<WorkbarPanelLoading label={copy.files} />}>
-              <ArtifactPane
-                sessionId={props.sessionId}
-                onCountChange={setArtifactCount}
-                onDismiss={() => props.onDismissPanel(placement)}
-              />
-            </Suspense>
-          );
-        } else if (tab.kind === 'inspector') {
-          content = (
-            <Suspense fallback={<WorkbarPanelLoading label={copy.inspector} />}>
-              <SessionInspectorPanel
-                sessionId={props.sessionId}
-                active={!props.hidden && active}
-              />
-            </Suspense>
-          );
-        } else {
-          const panelId = tab.id.slice('side-chat:'.length);
-          const quote = props.quotes?.find((candidate) => candidate.id === panelId);
-          if (quote) {
-            content = (
-              <QuoteCompanionPanel
-                panelId={quote.id}
-                active={!props.hidden && active}
-                quotes={quote.quotes}
-                initialPrompt={quote.initialPrompt}
-                sourceSession={props.sourceSession}
-                modelChoices={props.modelChoices ?? []}
-                confirmBypass={props.confirmBypass}
-                onQuotesConsumed={props.onQuotesConsumed ?? (() => {})}
-                onRemoveQuote={props.onRemoveQuote}
-                onForkVisibilityChange={props.onForkVisibilityChange}
-                onContentStateChange={props.onContentStateChange}
-                onInitialPromptStarted={props.onInitialPromptStarted}
-                onPromptAccepted={props.onPromptAccepted}
-                onActivityStateChange={props.onActivityStateChange}
-              />
-            );
-          }
-        }
+        const descriptor = workbarSurfaceDescriptor(tab.kind);
+        const content = descriptor.render({
+          active,
+          copy,
+          placement,
+          props,
+          sessionTodo,
+          setArtifactCount,
+          tab,
+        });
         return content ? (
           <WorkbarPanel
             key={tab.id}
@@ -874,9 +902,7 @@ export function WorkbarSurface(props: {
             overlay
             preview={tab.preview}
             onPin={() => props.onPinTab(tab.id)}
-            className={
-              tab.kind === 'side-chat' ? 'maka-quote-workbar-panel' : undefined
-            }
+            className={descriptor.panelClassName}
           >
             {content}
           </WorkbarPanel>


### PR DESCRIPTION
## Summary

- Register every first-party Workbar tab kind in one exhaustive internal surface descriptor map.
- Route localized labels, icons, launcher rows, and panel rendering through the descriptors while retaining the existing topology registry as the persistence, singleton, shortcut, and ordering authority.
- Preserve lazy panel loading, tab identity and placement behavior, preview/pin/focus/close/reorder actions, and Side Conversation/Terminal resource state.
- Add a structural completeness ratchet plus a real Electron regression for singleton and dynamic tab rendering.

Fixes #4744

## Verification

- `node --test apps/desktop/dist/main/__tests__/workbar-boundary.test.js apps/desktop/dist/main/__tests__/workbar-model.test.js` — 14/14 passed after the base sync.
- `npx playwright test --config e2e/playwright.config.ts e2e/session-workbar.spec.ts --grep "registered Workbar descriptors"` — 1/1 passed in a real Electron fixture after the base sync.
- `npm --workspace @maka/desktop run typecheck` — passed after the base sync.
- `npm --workspace @maka/desktop run check:architecture -- --base apache/main` — 71/71 checker fixtures passed; renderer architecture check passed against `apache/main`.
- `npm --workspace @maka/desktop run build` — passed, including renderer entry and third-party notice checks.
- `npm run lint` and `npm run format:check` — passed across the repository.
- `git diff --check` — passed.

Built and launched current head `b67c360ce` in a visible local Electron App and ran the registered-descriptor journey: the launcher exposed every registered first-party tool, singleton Todo stayed single, and Terminal and Side Conversation opened as distinct dynamic tabs.

## Real App screenshot

This direct capture comes from that locally running Electron test; it is not a mockup or generated image.

![Real Maka Workbar registered tool launcher](https://raw.githubusercontent.com/testikun/maka/f3945e1c76136e06f7011c7a63feb07e816d214d/pr-4747/workbar-descriptor-launcher.png)

## Base sync

Rebased the single feature commit without conflict onto `apache/main` at `a6fd57ba8`, including #4741, which removes the unrelated layout-tier E2E that failed the first CI attempt. No functional Workbar code changed during the rebase.

## Review focus

The registry remains private to the Workbar feature. It does not introduce a plugin API or move Side Conversation/Terminal lifecycle ownership into the surface layer.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex audited the existing Workbar boundaries, implemented the descriptor refactor and regression coverage, rebased the single feature commit onto the updated base, and ran the listed verification. The human contributor remains responsible for review and submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
