### PR TITLE
fix(runtime): preserve cross-step replay chronology

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -3335,6 +3335,133 @@ describe('AiSdkBackend model history', () => {
     assert.match(JSON.stringify(assistant), /Maka shipped the feature/);
   });
 
+  test('preserves pending assistant steps before a following client tool step', async () => {
+    const prompt = await replayPrompt([
+      runtimeTextEvent({
+        id: 'rt-user',
+        turnId: 'turn-prev',
+        role: 'user',
+        author: 'user',
+        text: 'inspect the workspace',
+      }),
+      runtimeEvent({
+        id: 'rt-progress-a',
+        turnId: 'turn-prev',
+        role: 'model',
+        author: 'agent',
+        refs: { providerEventId: 'progress-step-a' },
+        content: { kind: 'text', text: 'I found the relevant package.' },
+      }),
+      runtimeEvent({
+        id: 'rt-progress-b',
+        turnId: 'turn-prev',
+        role: 'model',
+        author: 'agent',
+        refs: { providerEventId: 'progress-step-b' },
+        content: { kind: 'text', text: 'I will inspect its configuration.' },
+      }),
+      clientToolCallEvent('rt-read-call', 'tool-step'),
+      clientToolResultEvent('rt-read-result'),
+    ]);
+
+    assert.deepEqual(
+      prompt.slice(0, 5).map((message) => ({
+        role: message.role,
+        types: message.content.map((part) => part.type),
+        text: message.content.find((part) => part.type === 'text')?.text,
+      })),
+      [
+        { role: 'user', types: ['text'], text: 'inspect the workspace' },
+        {
+          role: 'assistant',
+          types: ['text'],
+          text: 'I found the relevant package.',
+        },
+        {
+          role: 'assistant',
+          types: ['text'],
+          text: 'I will inspect its configuration.',
+        },
+        { role: 'assistant', types: ['tool-call'], text: undefined },
+        { role: 'tool', types: ['tool-result'], text: undefined },
+      ],
+    );
+  });
+
+  test('groups a client tool only with the immediately pending matching step', async () => {
+    const contiguousPrompt = await replayPrompt([
+      runtimeTextEvent({
+        id: 'rt-user',
+        turnId: 'turn-prev',
+        role: 'user',
+        author: 'user',
+        text: 'read the file',
+      }),
+      runtimeEvent({
+        id: 'rt-progress',
+        turnId: 'turn-prev',
+        role: 'model',
+        author: 'agent',
+        refs: { providerEventId: 'shared-step' },
+        content: { kind: 'text', text: 'I will read the file now.' },
+      }),
+      clientToolCallEvent('rt-read-call', 'shared-step'),
+      clientToolResultEvent('rt-read-result'),
+    ]);
+    assert.deepEqual(
+      contiguousPrompt.slice(0, 3).map((message) => ({
+        role: message.role,
+        types: message.content.map((part) => part.type),
+      })),
+      [
+        { role: 'user', types: ['text'] },
+        { role: 'assistant', types: ['text', 'tool-call'] },
+        { role: 'tool', types: ['tool-result'] },
+      ],
+    );
+
+    const interruptedPrompt = await replayPrompt([
+      runtimeTextEvent({
+        id: 'rt-user',
+        turnId: 'turn-prev',
+        role: 'user',
+        author: 'user',
+        text: 'read the file',
+      }),
+      runtimeEvent({
+        id: 'rt-progress-a',
+        turnId: 'turn-prev',
+        role: 'model',
+        author: 'agent',
+        refs: { providerEventId: 'shared-step' },
+        content: { kind: 'text', text: 'I will read the file now.' },
+      }),
+      runtimeEvent({
+        id: 'rt-progress-b',
+        turnId: 'turn-prev',
+        role: 'model',
+        author: 'agent',
+        refs: { providerEventId: 'intervening-step' },
+        content: { kind: 'text', text: 'Another step was persisted.' },
+      }),
+      clientToolCallEvent('rt-read-call', 'shared-step'),
+      clientToolResultEvent('rt-read-result'),
+    ]);
+    assert.deepEqual(
+      interruptedPrompt.slice(0, 5).map((message) => ({
+        role: message.role,
+        types: message.content.map((part) => part.type),
+      })),
+      [
+        { role: 'user', types: ['text'] },
+        { role: 'assistant', types: ['text'] },
+        { role: 'assistant', types: ['text'] },
+        { role: 'assistant', types: ['tool-call'] },
+        { role: 'tool', types: ['tool-result'] },
+      ],
+    );
+  });
+
   test('falls back to grounded text when Open Responses cannot replay a hosted tool pair', async () => {
     const model = completionModel();
     const backend = createTestAiSdkBackend({
@@ -16038,6 +16165,65 @@ function runtimeEvent(input: {
     ...(input.actions ? { actions: input.actions } : {}),
     ...(input.refs ? { refs: input.refs } : {}),
   };
+}
+
+function clientToolCallEvent(id: string, stepId: string): RuntimeEvent {
+  return runtimeEvent({
+    id,
+    turnId: 'turn-prev',
+    role: 'model',
+    author: 'agent',
+    refs: { stepId },
+    content: {
+      kind: 'function_call',
+      id: 'read-1',
+      name: 'Read',
+      args: { path: 'notes.md' },
+    },
+  });
+}
+
+function clientToolResultEvent(id: string): RuntimeEvent {
+  return runtimeEvent({
+    id,
+    turnId: 'turn-prev',
+    role: 'tool',
+    author: 'tool',
+    content: {
+      kind: 'function_response',
+      id: 'read-1',
+      name: 'Read',
+      result: { kind: 'text', text: 'file contents' },
+      isError: false,
+    },
+  });
+}
+
+async function replayPrompt(
+  runtimeContext: RuntimeEvent[],
+): Promise<Array<{ role: string; content: any[] }>> {
+  const model = completionModel();
+  const backend = createTestAiSdkBackend({
+    sessionId: 'session-1',
+    header: header(),
+    appendMessage: async () => {},
+    connection: connection(),
+    apiKey: 'sk-test',
+    modelId: 'mock-model-id',
+    modelFactory: () => model,
+    tools: [],
+    newId: idGenerator(),
+    now: monotonicClock(),
+  });
+  await drain(
+    backend.send({
+      turnId: 'turn-current',
+      text: 'continue',
+      context: [],
+      runtimeContext,
+    }),
+  );
+  return compactPrompt(model) as Array<{ role: string; content: any[] }>;
 }
 
 function compactPrompt(model: MockLanguageModelV4): unknown {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -3899,6 +3899,10 @@ export class AiSdkBackend implements AgentBackend {
     >();
     const reasoningByStep = new Map<string, ThinkingItem[]>();
     const textByStep = new Map<string, TextItem>();
+    const pendingStepOrder = new Set<string>();
+    const rememberPendingStep = (stepId: string) => {
+      pendingStepOrder.add(stepId);
+    };
 
     const replaySupport = this.modelAdapter.runtimeEventReplaySupport();
     const reasoningReplay = (item: ThinkingItem): ReplayReasoning | undefined => {
@@ -4157,6 +4161,7 @@ export class AiSdkBackend implements AgentBackend {
         if (stepId !== undefined) {
           reasoningByStep.delete(stepId);
           textByStep.delete(stepId);
+          pendingStepOrder.delete(stepId);
         }
         await emitStep(reasoning, text, group);
         group = [];
@@ -4173,18 +4178,28 @@ export class AiSdkBackend implements AgentBackend {
       bufferedCalls = [];
       await emitGroupedCalls(calls);
     };
+    const flushPendingStep = async (stepId: string) => {
+      const text = textByStep.get(stepId);
+      const reasoning = reasoningByStep.get(stepId);
+      textByStep.delete(stepId);
+      reasoningByStep.delete(stepId);
+      pendingStepOrder.delete(stepId);
+      await emitStep(reasoning, text, []);
+    };
+    const flushPendingStepsBefore = async (stepId: string | undefined) => {
+      const pendingStepIds = [...pendingStepOrder];
+      const lastPendingStepId = pendingStepIds.at(-1);
+      const earlierStepIds =
+        stepId !== undefined && lastPendingStepId === stepId
+          ? pendingStepIds.slice(0, -1)
+          : pendingStepIds;
+      if (earlierStepIds.length === 0) return;
+      await flushLooseCalls();
+      for (const pendingStepId of earlierStepIds) await flushPendingStep(pendingStepId);
+    };
     const flushPendingSteps = async () => {
       await flushLooseCalls();
-      for (const [stepId, text] of textByStep) {
-        textByStep.delete(stepId);
-        const reasoning = reasoningByStep.get(stepId);
-        reasoningByStep.delete(stepId);
-        await emitStep(reasoning, text, []);
-      }
-      for (const [stepId, reasoning] of reasoningByStep) {
-        reasoningByStep.delete(stepId);
-        await emitStep(reasoning, undefined, []);
-      }
+      for (const stepId of [...pendingStepOrder]) await flushPendingStep(stepId);
     };
 
     for (const item of admitProviderReasoningReplayItems(
@@ -4193,6 +4208,7 @@ export class AiSdkBackend implements AgentBackend {
     )) {
       switch (item.kind) {
         case 'tool_call':
+          await flushPendingStepsBefore(item.stepId);
           if (item.toolName !== 'apply_patch') {
             bufferedCalls.push(item);
             break;
@@ -4248,6 +4264,7 @@ export class AiSdkBackend implements AgentBackend {
                 ts: downgradedCall.ts,
               });
             }
+            rememberPendingStep(downgradedCall.stepId);
           } else {
             await flushPendingSteps();
             push({ role: 'assistant', content: [{ type: 'text', text: replayFact }] }, [
@@ -4262,6 +4279,7 @@ export class AiSdkBackend implements AgentBackend {
             const stepReasoning = reasoningByStep.get(item.stepId) ?? [];
             stepReasoning.push(item);
             reasoningByStep.set(item.stepId, stepReasoning);
+            rememberPendingStep(item.stepId);
           } else {
             // Legacy standalone reasoning (pure-reasoning turn): emit on its own.
             await flushPendingSteps();
@@ -4297,11 +4315,13 @@ export class AiSdkBackend implements AgentBackend {
             if (thisCalls.length > 0) {
               await emitStep(reasoningByStep.get(stepId), item, thisCalls);
               reasoningByStep.delete(stepId);
+              pendingStepOrder.delete(stepId);
             } else {
               // Runtime-owned settlement persists assistant facts before the
               // matching tool calls. Hold the step closer until those calls
               // arrive; a terminal text-only step flushes below.
               textByStep.set(stepId, item);
+              rememberPendingStep(stepId);
             }
           } else {
             // Legacy per-turn assistant text: standalone after any tool block.


### PR DESCRIPTION
## Summary

Fix Runtime event replay so assistant text or reasoning from an earlier distinct step cannot move behind a later client tool call.

The materializer now tracks pending step identities in durable ledger order. Before accepting a new client tool call, it flushes every earlier pending step. It preserves existing same-step grouping only when the matching step is the immediately pending step, so a late matching call cannot jump backward across an intervening step.

Fixes #4749.

## Root cause and history

`AiSdkBackend.materializeRuntimeReplayPlan()` parked assistant text in `textByStep`, while `flushPendingSteps()` emitted buffered tool calls first. A durable sequence such as:

```text
assistant text (step A) -> client tool call (step B) -> result
```

was therefore replayed as:

```text
client tool call (step B) -> result -> assistant text (step A)
```

The calls-before-pending-text order first entered main in #1425 (`a82d4fc090defa3b958ca394f6a1bd5ea044a1a1`, July 24, 2026). #1501 (`b76b60f3a4c14b9e078823b87ec7668cd1e1b513`, July 26, 2026) retained it in the intermediate flush helper. #4270 increased the frequency of cross-step text/tool histories but did not introduce the underlying defect.

## Changes

- Maintain an insertion-ordered set of pending text/reasoning step identities.
- Flush earlier distinct pending steps before a new tool call.
- Keep contiguous text/reasoning and client tools with the same step identity grouped.
- Prevent a late matching tool call from crossing an intervening pending step.
- Add focused chronology and grouping regression coverage.

Provider-executed tool ordering, legacy events without a step identity, prompt policy, provider finish-reason mapping, and CLI completion classification are unchanged.

## Experimental results

All controlled runs used independent Maka CLI sessions with GPT-5.6 Sol. Replay statistics were recomputed from durable `runtime.sqlite` events and captured provider request artifacts.

| Arm | Strict task completion | Comparable replay pairs inverted |
| --- | ---: | ---: |
| Baseline | 6/10 | 789/789 |
| Patched replay | 8/10 | 0/563 |
| Broken replay, progress prompt removed | 3/10 | 138/138 |

Neutral task comparison with the broken replay implementation:

| Arm | Strict task completion | Comparable replay pairs inverted |
| --- | ---: | ---: |
| Progress enabled | 4/5 | 97/97 |
| Progress removed | 5/5 | 71/71 |

Patched stress test:

- 20/20 independent sessions produced and read back the requested artifact.
- 50 client tool calls and 50 matching results were persisted.
- 119 comparable earlier-text/later-tool pairs had 0 replay inversions.
- 0/20 sessions terminated without a tool call.

The experiments show that prompt removal does not repair replay order and that the patch removes the deterministic inversion. They do not claim that replay repair prevents every first-response provider `stop`; that separate prompt/completion question is outside this PR.

## Validation

- Red-green regression check: both new tests failed against the previous calls-first materializer (`0/2`) and passed after restoring this fix (`2/2`).
- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/ai-sdk-backend.test.js` (`223/223`)
- `biome lint` on both changed files
- `biome format` on both changed files
- `git diff --check`

## Scope

This PR repairs faithful replay chronology only. It intentionally does not modify the system prompt or add a semantic task-fulfillment/completion guard.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the replay-order defect, traced its history, implemented the focused repair and regression coverage, and ran the controlled validation. The human contributor remains responsible for review and submission.
