### PR TITLE
test(desktop): sink the slash-command submit rule to its routing function

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { FAKE_HOLD_OPEN_PROMPT } from '@maka/runtime/test-only/fake-backend';
 import { expect, test, COMPOSER_INPUT } from './fixtures';
 
 test('shows only slash commands executable in the current session state', async ({
@@ -206,34 +205,6 @@ test('opens the slash menu after a DOM block break', async ({
     'first line\n/',
   );
   await expect(menu).toBeVisible();
-});
-
-test('dispatches /side instead of steering it into a running turn', async ({
-  invocableSkillsWindow: page,
-}) => {
-  const composer = page.locator(COMPOSER_INPUT);
-  const runningPrompt = FAKE_HOLD_OPEN_PROMPT;
-  await composer.fill(runningPrompt);
-  await composer.press('Enter');
-  await expect(page.locator('.maka-user-message', { hasText: runningPrompt })).toBeVisible();
-  await expect(page.getByRole('button', { name: '停止' })).toBeVisible();
-
-  await composer.click();
-  await composer.pressSequentially('/');
-  const menu = page.getByRole('listbox', { name: '命令和技能' });
-  const commands = menu.getByRole('group', { name: '命令' });
-  const side = commands.getByRole('option', { name: /打开侧聊.*\/side/ });
-  await expect(side).toBeVisible();
-  await expect(commands.getByRole('option', { name: /\/compact/ })).toHaveCount(0);
-  await side.click();
-  await expect.poll(() => composer.textContent()).toBe('/side ');
-  await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(0);
-
-  await composer.fill('/side discuss separately');
-  await composer.press('Enter');
-
-  await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(1);
-  await page.getByRole('button', { name: '停止' }).click();
 });
 
 test('an open menu keeps its container and skills group across projection refreshes', async ({

--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -891,7 +891,7 @@
           "react": 1
         },
         "importSpecifiers": 148,
-        "nonTriviaTokens": 15620
+        "nonTriviaTokens": 15617
       },
       "src/renderer/use-app-shell-composer-quotes.ts": {
         "importDeclarations": 2,

--- a/apps/desktop/src/main/__tests__/follow-up-submit-routing.test.ts
+++ b/apps/desktop/src/main/__tests__/follow-up-submit-routing.test.ts
@@ -50,6 +50,7 @@ describe('follow-up submit routing', () => {
     assert.equal(
       resolveFollowUpModeAtSubmit({
         hasActiveTurn: true,
+        slashCommand: null,
       }),
       'queue',
     );
@@ -57,6 +58,7 @@ describe('follow-up submit routing', () => {
       resolveFollowUpModeAtSubmit({
         requestedMode: 'steer',
         hasActiveTurn: true,
+        slashCommand: null,
       }),
       'steer',
     );
@@ -66,6 +68,27 @@ describe('follow-up submit routing', () => {
     assert.equal(
       resolveFollowUpModeAtSubmit({
         hasActiveTurn: false,
+        slashCommand: null,
+      }),
+      undefined,
+    );
+  });
+
+  it('dispatches a slash command mid-turn instead of steering it into the Turn', () => {
+    assert.equal(
+      resolveFollowUpModeAtSubmit({
+        hasActiveTurn: true,
+        slashCommand: { kind: 'side' },
+      }),
+      undefined,
+    );
+    // An explicit steer request loses to the command too: Shift+Enter on
+    // `/side` still opens the side chat.
+    assert.equal(
+      resolveFollowUpModeAtSubmit({
+        requestedMode: 'steer',
+        hasActiveTurn: true,
+        slashCommand: { kind: 'side' },
       }),
       undefined,
     );

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1919,12 +1919,11 @@ function AppShellContent({
     const runningTurnIds = sessionId
       ? sessionsRef.current.find((session) => session.id === sessionId)?.runningTurnIds
       : undefined;
-    const followUpAtSubmit = !slashCommand
-      ? resolveFollowUpModeAtSubmit({
-          requestedMode: metadata?.followUpMode,
-          hasActiveTurn: hasActiveTurnAtSubmit({ liveTurn, runningTurnIds }),
-        })
-      : undefined;
+    const followUpAtSubmit = resolveFollowUpModeAtSubmit({
+      requestedMode: metadata?.followUpMode,
+      hasActiveTurn: hasActiveTurnAtSubmit({ liveTurn, runningTurnIds }),
+      slashCommand,
+    });
     if (sessionId && followUpAtSubmit) {
       const queued = await enqueueFollowUp(sessionId, text, followUpAtSubmit, {
         ...metadata,

--- a/apps/desktop/src/renderer/follow-up-submit-routing.ts
+++ b/apps/desktop/src/renderer/follow-up-submit-routing.ts
@@ -35,7 +35,12 @@ export function hasActiveTurnAtSubmit(input: {
 export function resolveFollowUpModeAtSubmit(input: {
   requestedMode?: FollowUpMode;
   hasActiveTurn: boolean;
+  /** The parsed command, if the text was one. Only its presence matters here. */
+  slashCommand: object | null;
 }): FollowUpMode | undefined {
+  // A slash command tells the app to do something; it is not text for the
+  // Turn that happens to be running. Dispatch it instead of queueing it.
+  if (input.slashCommand) return undefined;
   if (input.requestedMode) return input.requestedMode;
   // Mid-turn submits always queue; Shift+Enter carries the one-shot steer as
   // the requested mode.


### PR DESCRIPTION
## Summary

`dispatches /side instead of steering it into a running turn` (`slash-command-menu.spec.ts:211`) timed out on #4748's CI, on a branch that changes nothing it touches — `locator.click: Timeout 30000ms exceeded`.

Unlike the specs #4741 removed, this one is not asserting geometry. It guards a single rule:

> A slash command submitted while a Turn is running is dispatched, not queued as follow-up text.

That rule lived as an inline ternary at the call site:

```ts
const followUpAtSubmit = !slashCommand
  ? resolveFollowUpModeAtSubmit({ requestedMode, hasActiveTurn: hasActiveTurnAtSubmit({ ... }) })
  : undefined;
```

Nothing short of a full Electron run could reach it — while the two functions it wrapped already live in `follow-up-submit-routing.ts` and already have `main/__tests__/follow-up-submit-routing.test.ts`. The seam was there; the rule was just outside it.

This moves the condition into `resolveFollowUpModeAtSubmit`, where the rest of the submit routing is decided, and asserts it in that module's existing test file. A browser, a fake backend and a real running Turn become three lines.

The parameter takes the parsed command rather than a boolean derived from it, and it is required rather than optional: there is exactly one call site, and a caller that forgets it should not compile. `slashCommand` passes as shorthand, which leaves `app-shell.tsx` three tokens lighter than the ternary it replaces — #4581 turned the renderer ledger into a one-way ratchet mid-review, and a `isSlashCommand: slashCommand !== null` spelling was one token heavier than what it removed.

The E2E test goes with the move, and takes two assertions with it.

`/side` being offered mid-turn is still covered by `shows only slash commands executable in the current session state`. **`/compact` being withheld mid-turn is not.** That guard is `!(streaming && id === 'compact')` (`app-shell.tsx:1331`), and it only hides the command while a Turn streams — but the surviving spec waits for `Fake backend received: seed session` before opening the menu, so `streaming` is false there and its `toHaveCount(4)` counts `/compact` as present. The rule now has no automated coverage in any tier. This PR neither broke it nor caught it; it belongs to the same tier-three move, per #4727.

The deleted spec also ended by asserting `.maka-quote-workbar-panel` reached count 1 — the side chat actually opened. The unit test pins the routing decision, which is that outcome's precondition, not the outcome. The early return at `if (sessionId && followUpAtSubmit)` is the only thing that could have prevented dispatch, so the moved assertion covers where the rule can break, but the residue is real.

This is the first case of the tier-three move discussed in #4727, and the cheapest possible one: the target module and its test file already existed.

Refs #4727, #4741

## Verification

- `node --test dist/main/__tests__/follow-up-submit-routing.test.js` — 6 passed, including the new `dispatches a slash command mid-turn instead of steering it into the Turn`.
- Fails without the change: with `if (input.isSlashCommand) return undefined;` removed, the new test fails and the rest still pass.
- `playwright test --list` — 87 tests in 35 files, down from 88.
- `node scripts/check-renderer-architecture.mjs --base fde5fb07` — passes against the rebase target. The ledger records app-shell.tsx three tokens lighter (15620 → 15617).
- `npm run build`, `npm run format`, `npm run lint` — clean.
- `npm run typecheck -w @maka/desktop` reports three pre-existing errors in `packages/ui/src` (Astryx `ChatLayoutProps` / `MarkdownProps` / `SideNavItemProps`) that are present without this change and do not involve either file it touches. CI is the authority here.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code located the rule behind the flaking E2E test, moved it onto the existing routing seam, and wrote the assertion.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
