### PR TITLE
test(desktop): sink the /compact menu rule to a tested predicate

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -891,7 +891,7 @@
           "react": 1
         },
         "importSpecifiers": 148,
-        "nonTriviaTokens": 15617
+        "nonTriviaTokens": 15602
       },
       "src/renderer/use-app-shell-composer-quotes.ts": {
         "importDeclarations": 2,

--- a/apps/desktop/src/main/__tests__/desktop-slash-command.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-slash-command.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { slashCommandsForSurface } from '@maka/core/slash-command-catalog';
+import { desktopSlashCommandAvailability } from '../../renderer/desktop-slash-command.js';
+
+const offered = (state: { hasSession: boolean; streaming: boolean }): readonly string[] =>
+  slashCommandsForSurface('desktop')
+    .filter(desktopSlashCommandAvailability(state))
+    .map(({ id }) => id);
+
+describe('desktop slash command availability', () => {
+  it('withholds /compact while the Turn streams, and nothing else', () => {
+    const idle = offered({ hasSession: true, streaming: false });
+    assert.ok(idle.includes('compact'), 'an idle Session can compact its context');
+    assert.deepEqual(
+      offered({ hasSession: true, streaming: true }),
+      idle.filter((id) => id !== 'compact'),
+    );
+  });
+
+  it('offers only the commands that need no Session before one exists', () => {
+    // Spelled out rather than derived from the catalog: a new Desktop command
+    // reaching an empty composer is a decision, not a default.
+    assert.deepEqual(offered({ hasSession: false, streaming: false }), ['graph', 'swarm']);
+    assert.deepEqual(offered({ hasSession: false, streaming: true }), ['graph', 'swarm']);
+  });
+});

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -65,7 +65,6 @@ import {
   activeInteractionFor,
   deriveComposerModelSwitchAvailability,
   deriveTitlebarProjectName,
-  enqueueInteraction,
   reconcileInteractions,
 } from '@maka/ui';
 import type { ConnectionEvent } from '@maka/core/connections';
@@ -106,7 +105,10 @@ import { useNewTaskChoice } from './use-new-task-choice';
 import { SessionCollaborationDialog } from './session-collaboration-dialog';
 import * as SessionCollaboration from './features/session-collaboration';
 import { NEW_TASK_PENDING_KEY } from './pending-items';
-import { parseDesktopSlashCommand } from './desktop-slash-command';
+import {
+  desktopSlashCommandAvailability,
+  parseDesktopSlashCommand,
+} from './desktop-slash-command';
 import {
   hasActiveTurnAtSubmit,
   mergeWorkspaceReferences,
@@ -1324,11 +1326,11 @@ function AppShellContent({
       : undefined;
   const desktopSlashCommands = useMemo<readonly ComposerSlashCommandOption[]>(
     () => {
-      const streaming = turnActive || activeStreamingLive;
       const availableCommands = slashCommandsForSurface('desktop').filter(
-        ({ id, session }) =>
-          (session === 'none' || Boolean(activeId))
-          && !(streaming && id === 'compact'),
+        desktopSlashCommandAvailability({
+          hasSession: Boolean(activeId),
+          streaming: turnActive || activeStreamingLive,
+        }),
       );
       const presentation: Record<
         SlashCommandIdForSurface<'desktop'>,

--- a/apps/desktop/src/renderer/desktop-slash-command.ts
+++ b/apps/desktop/src/renderer/desktop-slash-command.ts
@@ -18,6 +18,7 @@
  */
 
 import { parseGraphCommand, type ParsedGraphCommand } from '@maka/core/graph-command';
+import type { SlashCommandSpec } from '@maka/core/slash-command-catalog';
 import { parseSwarmCommand, type ParsedSwarmCommand } from '@maka/core/swarm-command';
 import { parseSideChatCommand, type SideChatCommand } from './side-chat-command.js';
 
@@ -36,4 +37,18 @@ export function parseDesktopSlashCommand(input: string): DesktopSlashCommand | n
   if (graph) return { kind: 'graph', command: graph };
   const swarm = parseSwarmCommand(input);
   return swarm ? { kind: 'swarm', command: swarm } : null;
+}
+
+/**
+ * Which catalog commands the Desktop composer offers in the state it is in.
+ * `/compact` rewrites the context the running Turn is still reading from, so it
+ * is withheld while a stream is live; every other command only needs a Session
+ * to act on.
+ */
+export function desktopSlashCommandAvailability(state: {
+  hasSession: boolean;
+  streaming: boolean;
+}): (command: Pick<SlashCommandSpec, 'id' | 'session'>) => boolean {
+  return ({ id, session }) =>
+    (session === 'none' || state.hasSession) && !(state.streaming && id === 'compact');
 }


### PR DESCRIPTION
## Summary

The Desktop composer withholds `/compact` while a Turn streams — compacting the context the running Turn is still reading from is not something the menu should offer. #4741 deleted the only case that covered that rule, and the surviving slash-command spec opens the menu after the Turn ends, where `streaming` is false. So the rule has no coverage in any tier right now; #4752 said as much and left it as the next tier-three move.

The rule lived inside the array filter that builds the menu, reachable only by rendering AppShell. It moves to `desktop-slash-command.ts`, next to the parser that owns the same four commands, and `node:test` asserts both halves: an idle Session is offered `/compact`, a streaming one is offered everything else and nothing less. This is a move, not a rewrite — behavior is unchanged.

Two things worth naming:

- The catalog query stays in AppShell. Moving `@maka/core/slash-command-catalog` into the smaller module reads better, but the debt ratchet counts dependencies per file, so that books a new dependency in `desktop-slash-command.ts` instead of retiring one.
- The predicate needs an import specifier in AppShell, and the ratchet counts those per file too. `enqueueInteraction` was imported from `@maka/ui` and never used, so it pays for it.

Refs #4727 #4752

## Verification

- `npm run test:dist --workspace @maka/desktop` — 2115 pass, 0 fail
- Mutation check: deleting `&& !(state.streaming && id === 'compact')` from the predicate turns the new test red
- `npm run typecheck --workspace @maka/desktop`, `npm run format`, `npm run lint` — clean
- `node scripts/check-renderer-architecture.mjs --base 3f4ac8c9dd` — passes; `app-shell.tsx` `nonTriviaTokens` 15617 → 15602
- No e2e run: this PR adds no e2e and changes no rendered output

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — located the uncovered rule, moved the predicate, wrote the test, ran the checks above.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
