### PR TITLE
fix(desktop): persist edited context windows

### DIFF
--- a/apps/desktop/e2e/context-window-save.spec.ts
+++ b/apps/desktop/e2e/context-window-save.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect, test } from './fixtures';
+import { getProviderSettingsCopy } from '../src/renderer/features/connection-settings';
+
+const copy = getProviderSettingsCopy('zh').detail;
+const MODEL_ID = 'custom-reasoner';
+
+test('one save persists a context window that is still focused', async ({
+  requestHeaderRowWindow: page,
+}) => {
+  await page.locator('[data-connection-slug="no-models"] button').first().click();
+  await page.getByRole('button', { name: copy.addModel }).click();
+  await page.getByRole('textbox', { name: copy.addModelIdField }).fill(MODEL_ID);
+  await page.getByRole('spinbutton', { name: copy.addModelContextWindow }).fill('128000');
+  await page.getByRole('button', { name: copy.addModelConfirm, exact: true }).click();
+  await expect(
+    page.getByRole('button', { name: copy.declareCapabilitiesAria(MODEL_ID) }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: copy.declareCapabilitiesAria(MODEL_ID) }).click();
+
+  const contextWindow = page.getByRole('spinbutton', {
+    name: `${copy.contextWindow} — ${MODEL_ID}`,
+  });
+  await contextWindow.fill('258000');
+  const save = page.getByRole('button', { name: copy.save, exact: true });
+  await expect(save).toBeDisabled();
+  // Keep the field focused and exercise the physical gesture: Save is below
+  // the scroll viewport, so scroll it into view without letting Playwright's
+  // locator click wait for the blur-driven enabled state.
+  await save.scrollIntoViewIfNeeded();
+  const saveBox = await save.boundingBox();
+  expect(saveBox).not.toBeNull();
+  await page.mouse.click(saveBox!.x + saveBox!.width / 2, saveBox!.y + saveBox!.height / 2);
+
+  await expect
+    .poll(async () =>
+      page.evaluate(async (modelId) => {
+        const snapshot = await window.maka.connections.getSnapshot();
+        return snapshot.connections
+          .find((connection) => connection.slug === 'no-models')
+          ?.relayModelProfiles?.[modelId]?.contextWindow;
+      }, MODEL_ID),
+    )
+    .toBe(258_000);
+});

--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -3086,11 +3086,11 @@
         "environmentCapabilities": {},
         "hookCalls": {
           "useConnectionDetail": 1,
-          "useEffect": 2,
+          "useEffect": 1,
           "useMountedRef": 2,
           "useOAuthLoginFlow": 1,
           "useRuntimeHostSettingsErrorReporter": 2,
-          "useState": 8,
+          "useState": 7,
           "useToast": 2,
           "useUiLocale": 3
         },

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -1072,38 +1072,28 @@ function CapabilityField(props: { label: string; description: string; children: 
   );
 }
 
-// A context-window draft commits on blur/Enter only: NumberInput fires
-// onChange per *valid* keystroke, and "128000" must arrive as one draft edit,
-// not six. The committed draft stays local until the row's 保存 — nothing
-// here writes the connection itself. The draft resyncs from the controller's
-// draft whenever it changes (seed, save round-trip, or an unrelated field).
+// NumberInput already owns the text draft and calls onChange only when the
+// whole value commits on blur/Enter. Forward that commit directly to the
+// row-level draft: adding another local draft here creates a second commit
+// boundary, so the first blur only updates this component and Save can write
+// the previous value.
 function DeclaredContextWindowField(props: {
   declared: number | undefined;
   disabled: boolean;
   label: string;
   onCommit: (value: number | null) => void;
 }) {
-  const [draft, setDraft] = useState<number | null>(props.declared ?? null);
-  useEffect(() => {
-    setDraft(props.declared ?? null);
-  }, [props.declared]);
-  function commit() {
-    if ((draft ?? undefined) === props.declared) return;
-    props.onCommit(draft);
-  }
   return (
     <NumberInput
       size="sm"
       width={200}
       label={props.label}
       isLabelHidden
-      value={draft}
+      value={props.declared ?? null}
       hasClear
       isIntegerOnly
       min={1}
-      onChange={setDraft}
-      onBlur={commit}
-      onEnter={commit}
+      onChange={props.onCommit}
       isDisabled={props.disabled}
     />
   );


### PR DESCRIPTION
## Summary

Persist the context-window value currently shown for a custom model on the first Save click. `NumberInput` already owns and commits its text draft on blur/Enter, so the model field now forwards that commit directly to the connection draft instead of adding a second stale draft boundary.

Adds an Electron regression test that changes only the context window, keeps the field focused, performs one physical Save click, and verifies the persisted connection snapshot.

Fixes #4755

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npm --workspace @maka/desktop run check:architecture`
- `npx knip --workspace apps/desktop`
- `npx playwright test --config e2e/playwright.config.ts e2e/context-window-save.spec.ts e2e/request-header-row-contract.spec.ts`

The regression test failed against the old implementation with `128000` persisted instead of `258000`, and passes with this change.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex helped diagnose the nested-draft bug, implement the fix, add the Electron regression test, and run review/verification. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
