### PR TITLE
fix(desktop): forget a Host-removed Session registration on reconnect restore

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -30,6 +30,7 @@ import type {
   ConnectOrSpawnRuntimeHostInput,
   RuntimeHostConnection,
 } from '@maka/runtime-host/client';
+import { RuntimeHostOperationError } from '@maka/runtime-host/client';
 import {
   SESSION_CONTINUITY_SCHEMA_VERSION,
   type ClientCapabilityCallFrame,
@@ -892,6 +893,69 @@ test('drops a stale shared Session observation when Guest access is gone', async
   assert.deepEqual(observations.trackedSessionIds(), []);
   assert.deepEqual(changes, [{ reason: 'deleted', sessionId: 'session-1' }]);
   await candidate.close();
+  await observations.close();
+});
+
+test('forgets an observed Session the Host no longer serves instead of blocking every reconnect', async () => {
+  const observations = new RuntimeHostSessionObservationRegistry();
+  const firstIpc = ipcHarness();
+  const firstHost = connectionHarness('missing-session-source', {
+    sessionId: 'session-1',
+    subscriptionSnapshot: continuitySnapshot(),
+  });
+  const firstCandidate = await createDesktopRuntimeHostCandidate(
+    firstHost.connection,
+    deps(firstIpc),
+    observations,
+  );
+  await firstIpc.invoke('sessions:observe', 'session-1', 'observer-1');
+  await firstCandidate.close();
+
+  // The replacement Host no longer serves session-1: subscription.open
+  // deterministically answers not_found.
+  const changes: Array<{ reason: string; sessionId?: string }> = [];
+  const missingHost = connectionHarness('missing-session-host', {
+    sessionId: 'session-1',
+    subscriptionError: new RuntimeHostOperationError(
+      'subscription.open',
+      'not_found',
+      'Runtime Host Session was not found',
+    ),
+  });
+  const secondCandidate = await createDesktopRuntimeHostCandidate(
+    missingHost.connection,
+    {
+      ...deps(ipcHarness()),
+      emitSessionsChanged: (_scope, reason, sessionId) => {
+        changes.push({ reason, ...(sessionId === undefined ? {} : { sessionId }) });
+      },
+    },
+    observations,
+  );
+
+  // The stale active registration is forgotten instead of failing the
+  // candidate start, and the renderer is told to drop the Session view.
+  assert.deepEqual(observations.observedSessionIds(), []);
+  assert.ok(
+    changes.some(
+      ({ reason, sessionId }) => reason === 'deleted' && sessionId === 'session-1',
+    ),
+  );
+  await secondCandidate.close();
+
+  // A later reconnect observes new Sessions on the same registry.
+  const thirdIpc = ipcHarness();
+  const thirdHost = connectionHarness('missing-session-recovered', {
+    sessionId: 'session-2',
+  });
+  const thirdCandidate = await createDesktopRuntimeHostCandidate(
+    thirdHost.connection,
+    deps(thirdIpc),
+    observations,
+  );
+  await thirdIpc.invoke('sessions:observe', 'session-2', 'observer-2');
+  assert.deepEqual(observations.observedSessionIds(), ['session-2']);
+  await thirdCandidate.close();
   await observations.close();
 });
 

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -703,11 +703,14 @@ export async function createDesktopRuntimeHostCandidate(
         once: target.once.bind(target),
         off: target.off.bind(target),
       }),
+      (missingSessionId) => emitSessionsChanged("deleted", missingSessionId),
     );
     const restoredSessionIdSet = new Set(restoredSessionIds);
-    const failedSessionIds = observedSessionIds.filter(
-      (sessionId) => !restoredSessionIdSet.has(sessionId),
-    );
+    // Attach forgets Sessions the Host no longer serves, so only Sessions
+    // that are still registered but failed to restore count as failures.
+    const failedSessionIds = sessionObservations
+      .observedSessionIds()
+      .filter((sessionId) => !restoredSessionIdSet.has(sessionId));
     if (failedSessionIds.length > 0) {
       throw new Error(
         `Failed to restore Session observations: ${failedSessionIds.join(', ')}`,

--- a/apps/desktop/src/main/runtime-host-session-observation-registry.ts
+++ b/apps/desktop/src/main/runtime-host-session-observation-registry.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { RuntimeHostOperationError } from "@maka/runtime-host/client";
 import type {
   RuntimeHostSessionObserver,
   RuntimeHostRendererTarget,
@@ -72,6 +73,20 @@ function requireTranscriptSource(
     throw new Error('Runtime Host transcript source is unavailable');
   }
   return source as SessionObservationSource & TranscriptSource;
+}
+
+/**
+ * A `subscription.open`/`not_found` answer is deterministic: the Host no
+ * longer serves this Session (Host restart with ephemeral state, Session GC,
+ * or deletion by another client). Unlike `session.transcript.page`/`not_found`
+ * (see `isRecoverableSubscriptionFailure` in the subscription owner), there is
+ * nothing to retry — the registration must be forgotten instead of blocking
+ * every reconnect.
+ */
+function isMissingRuntimeHostSessionError(error: unknown): boolean {
+  if (!(error instanceof RuntimeHostOperationError)) return false;
+  if (error.operation !== "subscription.open") return false;
+  return error.code === "not_found";
 }
 
 interface SessionObservationRegistration {
@@ -139,6 +154,7 @@ export class RuntimeHostSessionObservationRegistry {
   async attach(
     source: SessionObservationSource,
     bindTarget: ObservationTargetBinding = (target) => target,
+    onSessionMissing?: (sessionId: string) => void,
   ): Promise<string[]> {
     this.#assertOpen();
     if (this.#source && this.#source !== source) {
@@ -176,6 +192,15 @@ export class RuntimeHostSessionObservationRegistry {
             this.#source === source &&
             this.#registrations.get(observerId) === registration
           ) {
+            if (isMissingRuntimeHostSessionError(error)) {
+              // The Host no longer serves this Session. Forget the
+              // registration regardless of lifecycle so the stale entry
+              // cannot fail every future reconnect, and let the upper layer
+              // drop the Session view.
+              onSessionMissing?.(registration.sessionId);
+              this.#deleteRegistration(observerId, registration);
+              return undefined;
+            }
             if (registration.lifecycle === "pending") {
               this.#deleteRegistration(observerId, registration);
             }


### PR DESCRIPTION
## Problem

Fixes #4758.

When the desktop main process reconnects to the Runtime Host after an IPC drop, `desktop-manager` hands the surviving observation registry (`target.observations`) to each replacement candidate, whose `attach()` replays every registration through `subscription.open`. If a previously observed Session no longer exists on the Host (Host restart with ephemeral state, Session GC, deletion by another client), the server deterministically answers `subscription.open` / `not_found` ("Session was not found").

The registry's `attach()` failure cleanup only deleted **pending** registrations, so a stale **active** registration stayed in the map forever. The candidate then computed `failedSessionIds = observedSessionIds − restoredSessionIds` from the pre-attach snapshot, threw `Failed to restore Session observations: <id>`, and aborted the candidate start. Because the reconnect lifecycle only stops on `RuntimeHostPermanentReconnectError`, this plain error just fed the backoff loop — every new candidate failed on the same stale registration, and renderer IPC surfaced `RuntimeHostHandlerUnavailableError` the whole time.

## Fix

- `runtime-host-session-observation-registry.ts`: recognize `RuntimeHostOperationError` with `operation === "subscription.open"` and `code === "not_found"` as "the Host no longer serves this Session" (`isMissingRuntimeHostSessionError`). In `attach()`'s catch path, forget the registration regardless of lifecycle and report it through a new optional `onSessionMissing` callback. All other failures keep the existing behavior (pending-only cleanup + error reporting), so genuinely transient restore failures still fail the candidate and get retried — see the existing `retries candidate startup when a restored observation cannot seed` test, which still passes unchanged.
- `runtime-host-desktop-candidate.ts`: pass `onSessionMissing` to emit a `deleted` sessions-changed event (the renderer already handles `deleted` safely by refreshing the catalog and retiring the Session view), and compute `failedSessionIds` from the registrations that **survive** attach so forgotten Sessions no longer fail the candidate start.

This mirrors the deliberate asymmetry in `isRecoverableSubscriptionFailure`: `session.transcript.page` / `not_found` is transient and retryable, while `subscription.open` / `not_found` at attach time is terminal.

## Tests

- New regression test `forgets an observed Session the Host no longer serves instead of blocking every reconnect`: the second candidate's Host answers `subscription.open`/`not_found` for the previously observed Session; the candidate starts (no throw), the registry forgets the stale entry, a `deleted` change is emitted, and a later candidate can observe new Sessions on the same registry. The test fails without the fix.
- `npm run build:main` clean; the 6 runtime-host desktop suites pass 132/132. (Full main-process suite: 2085/2090; the 5 failures are pre-existing `browser-message-box` environment failures on a display-less Linux box, reproduced on pristine `origin/main`.)

Real-environment follow-up (not done here): restart a Host / expire a Session with the desktop running and confirm the `Failed to restore Session observations` loop no longer appears.
