### PR TITLE
fix(runtime): preserve billing classification in durable diagnostics

### DIFF
--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -69,6 +69,7 @@ describe('Provider error classification', () => {
       data: { error: { code: 'insufficient_quota' } },
     });
     assert.equal(classifyError(quotaOn401), 'ProviderBilling');
+    assert.equal(providerFailureDiagnostic(quotaOn401).errorClass, 'ProviderBilling');
 
     const balanceOn403 = Object.assign(new Error('request failed'), {
       name: 'AI_APICallError',
@@ -76,6 +77,7 @@ describe('Provider error classification', () => {
       data: { error: { code: 'insufficient_balance' } },
     });
     assert.equal(classifyError(balanceOn403), 'ProviderBilling');
+    assert.equal(providerFailureDiagnostic(balanceOn403).errorClass, 'ProviderBilling');
 
     // Explicit provider evidence outranks the numeric HTTP fallback: an
     // exhausted quota is a closed window, not a transient throttle to retry.
@@ -86,6 +88,7 @@ describe('Provider error classification', () => {
     });
     assert.equal(classifyError(quotaOn429), 'ProviderBilling');
     assert.equal(providerRetryMetadata(quotaOn429).retryable, false);
+    assert.equal(providerFailureDiagnostic(quotaOn429).errorClass, 'ProviderBilling');
   });
 
   test('plan-window wording on a credential-shaped status projects to billing', () => {
@@ -100,6 +103,7 @@ describe('Provider error classification', () => {
     });
     assert.equal(classifyError(planWindow), 'ProviderBilling');
     assert.equal(providerRetryMetadata(planWindow).retryable, false);
+    assert.equal(providerFailureDiagnostic(planWindow).errorClass, 'ProviderBilling');
 
     const exhaustedCredits = Object.assign(new Error('Request failed with status code 403'), {
       name: 'AI_APICallError',
@@ -109,6 +113,7 @@ describe('Provider error classification', () => {
       }),
     });
     assert.equal(classifyError(exhaustedCredits), 'ProviderBilling');
+    assert.equal(providerFailureDiagnostic(exhaustedCredits).errorClass, 'ProviderBilling');
   });
 
   test('genuine credential and permission failures stay auth on 401/403', () => {

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -455,11 +455,12 @@ function durableProviderErrorClass(
   classified: string,
   httpStatus: number | undefined,
 ): string {
-  // Structured context-overflow and capacity evidence can legitimately arrive
+  // Structured context-overflow, capacity, and billing evidence can legitimately arrive
   // behind a generic 4xx/5xx proxy response and remains stronger than the wrapper code.
   if (
     classified === 'ContextLength' ||
     classified === 'ProviderCapacity' ||
+    classified === 'ProviderBilling' ||
     (classified === 'ProviderUnavailable' && isTrustedCodexEdgeRejection(facts))
   ) {
     return classified;


### PR DESCRIPTION
## Summary

Keep durable provider diagnostics consistent with the runtime's canonical
provider-error classification.

`classifyProviderFacts()` already recognizes billing failures from structured
provider codes such as `insufficient_quota` and `insufficient_balance`, as well
as explicit plan-limit wording behind HTTP 401/403 responses. However,
`durableProviderErrorClass()` subsequently remapped those failures from their
HTTP status alone:

- HTTP 401/403 became `Auth`
- HTTP 429 became `RateLimit`

As a result, the runtime could report `ProviderBilling` while Usage and Trace
persisted a different error class for the same provider failure.

This change treats the upstream `ProviderBilling` classification as
authoritative, matching the existing handling of `ContextLength` and
`ProviderCapacity`. Regression assertions cover structured billing codes
behind HTTP 401/403/429 and plan-limit wording behind HTTP 401/403.

## Verification

Passed:

- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/provider-error-classification.test.js packages/runtime/dist/__tests__/model-adapter.test.js`
  - 54 tests passed
- `npm --workspace @maka/runtime run typecheck`
- `npx biome format packages/runtime/src/provider-error-classification.ts packages/runtime/src/__tests__/provider-error-classification.test.ts`
- `npx biome lint packages/runtime/src/provider-error-classification.ts packages/runtime/src/__tests__/provider-error-classification.test.ts`
- `git diff --check`

The full Runtime suite was also attempted locally. Five unrelated
`filesystem-worker-smoke` tests could not start the worker because the macOS
sandbox blocked the Nix Node binary from loading `libz.dylib`; the remaining
3,218 tests passed.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Codex reviewed the provider classification paths, identified the inconsistent
durable remapping, implemented the focused fix, added regression assertions,
and ran the reported verification commands.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
