### PR TITLE
fix(eval): decode file URLs before launching test wrappers

### DIFF
--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -33,6 +33,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { FileAttemptStore } from '../attempt-store.js';
 import type { ExperimentCell, ExperimentSpec, JsonObject } from '../experiment.js';
@@ -601,7 +602,7 @@ test('the Maka shim projects only a completed subject as a zero exit', async () 
               )},shortCircuit:true}:n(s,c)}`,
             )}",import.meta.url)`,
           )}`,
-          shim.pathname,
+          fileURLToPath(shim),
           Buffer.from(
             JSON.stringify({
               rootPath: join(root, 'state'),
@@ -859,7 +860,9 @@ test('eight-arm spec and wrappers freeze the working provider contracts', async 
       // These subjects run `/usr/bin/true` and never reach the provider, so
       // each one is an infrastructure failure and exits nonzero: the exit code
       // now carries the semantic status for the relay's benefit.
-      const stdout = await execFileAsync(process.execPath, [wrapper.pathname, ...args], { env })
+      const stdout = await execFileAsync(process.execPath, [fileURLToPath(wrapper), ...args], {
+        env,
+      })
         .then((settled) => settled.stdout)
         .catch((error: { stdout?: string }) => {
           assert.equal(typeof error.stdout, 'string');

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -25,6 +25,7 @@ import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { meteringCheckpointMacMatches } from '../metering-checkpoint.js';
 
@@ -76,7 +77,7 @@ test('provider metering checkpoint records admission before the request settles'
   const wrapperProcess = spawn(
     process.execPath,
     [
-      wrapper.pathname,
+      fileURLToPath(wrapper),
       'opencode',
       `http://127.0.0.1:${address.port}`,
       root,
@@ -163,7 +164,7 @@ test('provider failures remain infrastructure failures until inference admission
       const wrapper = new URL('../harbor-external-subject.js', import.meta.url);
       const { stdout, exitCode } = await runWrapper(
         [
-          wrapper.pathname,
+          fileURLToPath(wrapper),
           'opencode',
           `http://127.0.0.1:${address.port}`,
           root,
@@ -292,7 +293,14 @@ async function executePiWithTerminalRecord(contentBytes: number): Promise<{
   try {
     const wrapper = new URL('../harbor-external-subject.js', import.meta.url);
     const { stdout } = await runWrapper(
-      [wrapper.pathname, 'pi', `http://127.0.0.1:${address.port}`, root, process.execPath, child],
+      [
+        fileURLToPath(wrapper),
+        'pi',
+        `http://127.0.0.1:${address.port}`,
+        root,
+        process.execPath,
+        child,
+      ],
       { OPENAI_API_KEY: 'upstream-test-key', MAKA_EVAL_RESULT_TOKEN: RESULT_TOKEN },
     );
     return decodeResultFrame(stdout) as Awaited<ReturnType<typeof executePiWithTerminalRecord>>;
@@ -388,7 +396,7 @@ process.exit(1);
     const wrapper = new URL('../harbor-external-subject.js', import.meta.url);
     const { stdout } = await runWrapper(
       [
-        wrapper.pathname,
+        fileURLToPath(wrapper),
         'opencode',
         `http://127.0.0.1:${address.port}`,
         root,


### PR DESCRIPTION
## Summary

- convert Eval wrapper and shim file URLs with `fileURLToPath()` before passing them to child-process APIs
- preserve paths containing spaces, non-ASCII characters, and other URL-encoded characters
- keep the change limited to the six affected Eval test-harness launch points

The Eval harness previously passed `URL.pathname` directly to `spawn()` and `execFile()`. Because that value remains percent-encoded, a checkout path containing spaces was passed to Node with `%20` instead of the native filesystem path, preventing the wrapper or shim from launching.

This change performs the platform-correct conversion at each affected child-process boundary. Production Runtime behavior is unchanged.

Fixes #4757

## Verification

- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run check:asf-headers`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- complete `@maka/eval` JavaScript and Python test suites
- complete `@maka/runtime` test suite
- `npm run check:release` — 194/194 passed
- reproduced the failure and verified the fix from a checkout path containing spaces

The repository-wide test command was also exercised. Unrelated Runtime Host process-exit/election timing tests remained intermittent; the same class of failure was reproduced on clean `main`, while isolated reruns passed.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with source inspection, implementation, and local verification. The resulting changes and this description were reviewed by me.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — limited to Eval test-harness file URL conversion; production Runtime behavior is unchanged
- [ ] No
