### PR TITLE
fix(desktop): stabilize Windows remote access setup

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-local-operator.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-local-operator.test.ts
@@ -133,6 +133,75 @@ test('local setup forwards the exact development archive evidence', async (t) =>
   assert.equal(environment?.[RUNTIME_HOST_SETUP_SOURCE_PACKAGE_INTEGRITY_ENV], integrity);
 });
 
+test('local setup scratch cleanup cannot replace its framed outcome', async (t) => {
+  const frames = [
+    {
+      schemaVersion: 1 as const,
+      sequence: 0,
+      kind: 'complete' as const,
+      version: '0.2.0',
+      serviceId: 'b'.repeat(64),
+      deploymentId: '00000000-0000-4000-8000-000000000001',
+      operator: OPERATOR,
+      rootPath: '/tmp/maka/root',
+      rootId: 'a'.repeat(64),
+      endpoint: 'ws://127.0.0.1:7443/runtime-host',
+      credentialId: 'credential-1',
+      credential: 'secret-access-token',
+    },
+    {
+      schemaVersion: 1 as const,
+      sequence: 0,
+      kind: 'error' as const,
+      error: { code: 'setup_failed', message: 'primary setup failure' },
+    },
+  ];
+  let invocation = 0;
+  let cleanupCount = 0;
+  const spawnProcess = (() => {
+    const child = new EventEmitter() as ReturnType<typeof spawn>;
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const frame = frames[invocation++];
+    Object.assign(child, { pid: 1234, stdout, stderr, kill: () => true });
+    process.nextTick(() => {
+      stdout.end(encodeRuntimeHostSetupFrame(frame));
+      stderr.end();
+      child.emit('close', frame.kind === 'complete' ? 0 : 1, null);
+    });
+    return child;
+  }) as typeof spawn;
+  const operator = createDesktopRuntimeHostLocalOperator({
+    environment: { PATH: process.env.PATH },
+    spawnProcess,
+    removeSetupWorkingDirectory: async (path) => {
+      cleanupCount += 1;
+      await rm(path, { recursive: true, force: true });
+      throw new Error('scratch cleanup failed');
+    },
+  });
+  t.after(() => operator.close());
+  const setup = {
+    setupPackage: { kind: 'npm' as const, specifier: 'maka-agent@0.2.0' },
+    clientDataRoot: '/tmp/maka/client',
+    rootPath: '/tmp/maka/root',
+    principalId: 'desktop-owner:pairing',
+    expectedTarget: {
+      serviceId: 'b'.repeat(64),
+      rootPath: '/tmp/maka/root',
+      rootId: 'a'.repeat(64),
+    },
+  };
+
+  const complete = await operator.runSetup(setup, () => undefined);
+  assert.equal(complete.kind, 'complete');
+  await assert.rejects(
+    operator.runSetup(setup, () => undefined),
+    /primary setup failure/u,
+  );
+  assert.equal(cleanupCount, 2);
+});
+
 test('Windows npm discovery cannot outlive setup cancellation', async (t) => {
   const originalPlatform = process.platform;
   const fixtureRoot = await mkdtemp(join(tmpdir(), 'maka-windows-npm-lookup-'));

--- a/apps/desktop/src/main/runtime-host-local-operator.ts
+++ b/apps/desktop/src/main/runtime-host-local-operator.ts
@@ -62,6 +62,8 @@ import {
 const SETUP_TIMEOUT_MS = 10 * 60_000;
 const SETUP_FRAME_PENDING_MAX = 20 * 1024;
 const STDERR_MAX_BYTES = 64 * 1024;
+const SETUP_CLEANUP_MAX_RETRIES = 10;
+const SETUP_CLEANUP_RETRY_DELAY_MS = 100;
 const WINDOWS_NPM_RESOLUTION_SCRIPT = String.raw`
 const { statSync } = require('node:fs');
 const path = require('node:path').win32;
@@ -199,6 +201,7 @@ export function createDesktopRuntimeHostLocalOperator(input: {
   readonly spawnProcess?: typeof spawn;
   readonly setupTimeoutMs?: number;
   readonly terminateProcess?: typeof terminateChildProcessTree;
+  readonly removeSetupWorkingDirectory?: (path: string) => Promise<void>;
 } = {}): {
   runSetup(
     setup: DesktopRuntimeHostLocalSetupInput,
@@ -267,6 +270,15 @@ export function createDesktopRuntimeHostLocalOperator(input: {
   let closed = false;
   const closing = new AbortController();
   const terminate = input.terminateProcess ?? terminateChildProcessTree;
+  const removeSetupWorkingDirectory =
+    input.removeSetupWorkingDirectory ??
+    ((path: string) =>
+      rm(path, {
+        recursive: true,
+        force: true,
+        maxRetries: SETUP_CLEANUP_MAX_RETRIES,
+        retryDelay: SETUP_CLEANUP_RETRY_DELAY_MS,
+      }));
 
   return {
     async runSetup(setup, onProgress) {
@@ -302,7 +314,12 @@ export function createDesktopRuntimeHostLocalOperator(input: {
           active,
         });
       } finally {
-        await rm(workingDirectory, { recursive: true, force: true });
+        try {
+          await removeSetupWorkingDirectory(workingDirectory);
+        } catch {
+          // The private scratch directory is not part of the setup transaction.
+          // Its cleanup must not replace the operator's framed result or error.
+        }
       }
     },
     runPeer(command) {

--- a/packages/cli/src/__tests__/runtime-host-setup.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-setup.test.ts
@@ -54,12 +54,19 @@ import {
   acknowledgeRuntimeHostManagedDeploymentCleanup,
   assertRuntimeHostManagedOperatorDeployment,
   convergeRuntimeHostManagedOperator,
+  convergeRuntimeHostManagedWindowsTaskLauncher,
   prepareRuntimeHostManagedPackageDeployment,
   pruneRuntimeHostManagedPackages,
   readRuntimeHostManagedDeploymentCleanupReceipt,
   resolveRuntimeHostManagedControlRoot,
   resolveRuntimeHostManagedDeploymentRoot,
+  verifyRuntimeHostManagedWindowsTaskLauncher,
 } from '../runtime-host-managed-deployment.js';
+import {
+  resolvePackagedRuntimeHostWindowsTaskLauncherPath,
+  resolveRuntimeHostWindowsTaskLauncherPath,
+  runtimeHostManagedWindowsTaskLauncherPath,
+} from '../runtime-host-windows-task-launcher-artifact.js';
 import { runRuntimeHostSetupCli } from '../runtime-host-setup-command.js';
 import { RuntimeHostAccessUnavailableError } from '../runtime-host-access-command.js';
 import { replaceRuntimeHostLifecycle } from '../runtime-host-lifecycle-transaction.js';
@@ -975,6 +982,68 @@ test('managed operator binds its Client Data Root and routes deployment cleanup'
     },
   );
   assert.deepEqual(signalExit, { code: null, signal: 'SIGTERM' });
+});
+
+test('managed Windows task launcher is projected to a stable deployment path', async (t) => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-windows-launcher-'));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const sourcePackageRoot = await createReleasePackage(base, '0.2.0');
+  const sourceLauncher = join(
+    sourcePackageRoot,
+    'native',
+    'runtime-host-windows-task-launcher',
+    'prebuilds',
+    'win32-x64',
+    'maka-runtime-host-task-launcher.exe',
+  );
+  await mkdir(dirname(sourceLauncher), { recursive: true });
+  await writeFile(sourceLauncher, 'launcher-v1');
+  const serviceId = 'a'.repeat(64);
+  const deployment = await prepareRuntimeHostManagedPackageDeployment(
+    {
+      serviceId,
+      clientDataRoot: join(base, 'client'),
+      sourcePackageRoot,
+      version: '0.2.0',
+      packageIntegrity: PACKAGE_INTEGRITY,
+    },
+    {
+      env: { XDG_DATA_HOME: join(base, 'data') },
+      homeDir: join(base, 'home'),
+      platform: 'linux',
+    },
+  );
+  const config: RuntimeHostManagedDeploymentConfig = {
+    schemaVersion: 1,
+    state: 'active',
+    deploymentId: '00000000-0000-4000-8000-000000000001',
+    configRevision: 1,
+    deploymentRoot: deployment.root,
+    root: { id: serviceId, path: join(base, 'state') },
+    projectDirectoryRoots: [],
+    launch: {
+      kind: 'exact_package',
+      nodePath: process.execPath,
+      package: { kind: 'npm_registry', version: '0.2.0', integrity: PACKAGE_INTEGRITY },
+    },
+    listeners: { localIpc: true },
+    lifecycle: { mode: 'supervised', provider: 'windows_task', availability: 'session' },
+    reconciliation: { trigger: 'scheduled', provider: 'windows_task_timer' },
+  };
+
+  await convergeRuntimeHostManagedWindowsTaskLauncher(config);
+  const projected = runtimeHostManagedWindowsTaskLauncherPath(deployment.root);
+  assert.equal(await readFile(projected, 'utf8'), 'launcher-v1');
+  assert.equal(await resolveRuntimeHostWindowsTaskLauncherPath(deployment.cliPath), projected);
+
+  const packaged = await resolvePackagedRuntimeHostWindowsTaskLauncherPath(deployment.cliPath);
+  await writeFile(packaged, 'launcher-v2');
+  await assert.rejects(
+    verifyRuntimeHostManagedWindowsTaskLauncher(config),
+    /does not match its deployment/u,
+  );
+  await convergeRuntimeHostManagedWindowsTaskLauncher(config);
+  await verifyRuntimeHostManagedWindowsTaskLauncher(config);
 });
 
 async function createReleasePackage(base: string, version: string): Promise<string> {

--- a/packages/cli/src/__tests__/runtime-host-setup.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-setup.test.ts
@@ -1032,7 +1032,10 @@ test('managed Windows task launcher is projected to a stable deployment path', a
   };
 
   await convergeRuntimeHostManagedWindowsTaskLauncher(config);
-  const projected = runtimeHostManagedWindowsTaskLauncherPath(deployment.root);
+  const projected = runtimeHostManagedWindowsTaskLauncherPath(
+    deployment.root,
+    Buffer.from('launcher-v1'),
+  );
   assert.equal(await readFile(projected, 'utf8'), 'launcher-v1');
   assert.equal(await resolveRuntimeHostWindowsTaskLauncherPath(deployment.cliPath), projected);
 
@@ -1044,6 +1047,10 @@ test('managed Windows task launcher is projected to a stable deployment path', a
   );
   await convergeRuntimeHostManagedWindowsTaskLauncher(config);
   await verifyRuntimeHostManagedWindowsTaskLauncher(config);
+  assert.notEqual(
+    runtimeHostManagedWindowsTaskLauncherPath(deployment.root, Buffer.from('launcher-v2')),
+    projected,
+  );
 });
 
 async function createReleasePackage(base: string, version: string): Promise<string> {

--- a/packages/cli/src/runtime-host-managed-deployment.ts
+++ b/packages/cli/src/runtime-host-managed-deployment.ts
@@ -41,6 +41,10 @@ import {
   type RuntimeHostManagedDeploymentAuthorityOptions,
   type RuntimeHostManagedDeploymentConfig,
 } from '@maka/runtime-host/operator';
+import {
+  resolvePackagedRuntimeHostWindowsTaskLauncherPath,
+  runtimeHostManagedWindowsTaskLauncherPath,
+} from './runtime-host-windows-task-launcher-artifact.js';
 
 export { RuntimeHostPackageDeploymentError as RuntimeHostManagedDeploymentError } from './runtime-host-package-deployment.js';
 
@@ -63,6 +67,7 @@ interface RuntimeHostManagedDeploymentCleanupReceipt {
 }
 
 const CLEANUP_RECEIPT_FILE = 'cleanup-approved.json';
+const WINDOWS_TASK_LAUNCHER_MAX_BYTES = 1024 * 1024;
 
 export function resolveRuntimeHostManagedPackageCliPath(
   deploymentRoot: string,
@@ -641,15 +646,15 @@ async function writeOperatorLauncher(
     managedRootId,
     deploymentId,
   );
-  await writeStableOperator(path, contents);
+  await writeStableArtifact(path, contents);
 }
 
-async function writeStableOperator(path: string, contents: string): Promise<void> {
+async function writeStableArtifact(path: string, contents: string | Uint8Array): Promise<void> {
   const temporaryPath = `${path}.${randomUUID()}.tmp`;
   try {
     const file = await open(temporaryPath, 'wx', 0o700);
     try {
-      await file.writeFile(contents, 'utf8');
+      await file.writeFile(contents);
       await file.sync();
     } finally {
       await file.close();
@@ -735,6 +740,9 @@ export async function convergeRuntimeHostManagedOperator(
     desired.root.id,
     desired.deploymentId,
   );
+  if (process.platform === 'win32') {
+    await convergeRuntimeHostManagedWindowsTaskLauncher(desired);
+  }
   await forwardLegacyOperatorIfPresent(
     deployment.deploymentRoot,
     desired.launch.nodePath,
@@ -761,7 +769,7 @@ async function forwardLegacyOperatorIfPresent(
     },
   );
   if (exists) {
-    await writeStableOperator(path, legacyOperatorLauncherContents(nodePath, modulePath));
+    await writeStableArtifact(path, legacyOperatorLauncherContents(nodePath, modulePath));
   }
 }
 
@@ -811,6 +819,9 @@ export async function verifyRuntimeHostManagedOperator(
       cause: error,
     });
   });
+  if (process.platform === 'win32') {
+    await verifyRuntimeHostManagedWindowsTaskLauncher(config, { allowAbsent: true });
+  }
   const legacyOperatorPath = join(config.deploymentRoot, 'operator');
   const legacyExpected = legacyOperatorLauncherContents(config.launch.nodePath, operatorPath);
   const legacyExists = await access(legacyOperatorPath, constants.F_OK).then(
@@ -837,6 +848,56 @@ export async function verifyRuntimeHostManagedOperator(
       });
     });
   }
+}
+
+export async function convergeRuntimeHostManagedWindowsTaskLauncher(
+  config: RuntimeHostManagedDeploymentConfig,
+): Promise<void> {
+  const layout = resolveRuntimeHostNpmDeploymentLayout(
+    config.deploymentRoot,
+    config.launch.package.integrity,
+  );
+  const sourcePath = await resolvePackagedRuntimeHostWindowsTaskLauncherPath(layout.cliPath);
+  await writeStableArtifact(
+    runtimeHostManagedWindowsTaskLauncherPath(config.deploymentRoot),
+    await readWindowsTaskLauncher(sourcePath),
+  );
+}
+
+export async function verifyRuntimeHostManagedWindowsTaskLauncher(
+  config: RuntimeHostManagedDeploymentConfig,
+  options: { readonly allowAbsent?: boolean } = {},
+): Promise<void> {
+  const projectedPath = runtimeHostManagedWindowsTaskLauncherPath(config.deploymentRoot);
+  const projectedExists = await access(projectedPath, constants.F_OK).then(
+    () => true,
+    (error: unknown) => {
+      if (isNodeError(error, 'ENOENT')) return false;
+      throw error;
+    },
+  );
+  if (!projectedExists && options.allowAbsent) return;
+
+  const layout = resolveRuntimeHostNpmDeploymentLayout(
+    config.deploymentRoot,
+    config.launch.package.integrity,
+  );
+  const sourcePath = await resolvePackagedRuntimeHostWindowsTaskLauncherPath(layout.cliPath);
+  const [expected, observed] = await Promise.all([
+    readWindowsTaskLauncher(sourcePath),
+    readWindowsTaskLauncher(projectedPath),
+  ]);
+  if (!observed.equals(expected)) {
+    throw new Error('The managed Runtime Host Windows task launcher does not match its deployment');
+  }
+}
+
+function readWindowsTaskLauncher(path: string): Promise<Buffer> {
+  return readStableBoundedFile({
+    path,
+    maxBytes: WINDOWS_TASK_LAUNCHER_MAX_BYTES,
+    invalidFile: () => new Error('The managed Runtime Host Windows task launcher is invalid'),
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/runtime-host-managed-deployment.ts
+++ b/packages/cli/src/runtime-host-managed-deployment.ts
@@ -42,6 +42,7 @@ import {
   type RuntimeHostManagedDeploymentConfig,
 } from '@maka/runtime-host/operator';
 import {
+  readRuntimeHostWindowsTaskLauncher,
   resolvePackagedRuntimeHostWindowsTaskLauncherPath,
   runtimeHostManagedWindowsTaskLauncherPath,
 } from './runtime-host-windows-task-launcher-artifact.js';
@@ -67,8 +68,6 @@ interface RuntimeHostManagedDeploymentCleanupReceipt {
 }
 
 const CLEANUP_RECEIPT_FILE = 'cleanup-approved.json';
-const WINDOWS_TASK_LAUNCHER_MAX_BYTES = 1024 * 1024;
-
 export function resolveRuntimeHostManagedPackageCliPath(
   deploymentRoot: string,
   version: string,
@@ -858,17 +857,8 @@ export async function convergeRuntimeHostManagedWindowsTaskLauncher(
     config.launch.package.integrity,
   );
   const sourcePath = await resolvePackagedRuntimeHostWindowsTaskLauncherPath(layout.cliPath);
-  await writeStableArtifact(
-    runtimeHostManagedWindowsTaskLauncherPath(config.deploymentRoot),
-    await readWindowsTaskLauncher(sourcePath),
-  );
-}
-
-export async function verifyRuntimeHostManagedWindowsTaskLauncher(
-  config: RuntimeHostManagedDeploymentConfig,
-  options: { readonly allowAbsent?: boolean } = {},
-): Promise<void> {
-  const projectedPath = runtimeHostManagedWindowsTaskLauncherPath(config.deploymentRoot);
+  const expected = await readRuntimeHostWindowsTaskLauncher(sourcePath);
+  const projectedPath = runtimeHostManagedWindowsTaskLauncherPath(config.deploymentRoot, expected);
   const projectedExists = await access(projectedPath, constants.F_OK).then(
     () => true,
     (error: unknown) => {
@@ -876,28 +866,42 @@ export async function verifyRuntimeHostManagedWindowsTaskLauncher(
       throw error;
     },
   );
-  if (!projectedExists && options.allowAbsent) return;
+  if (projectedExists) {
+    const observed = await readRuntimeHostWindowsTaskLauncher(projectedPath);
+    if (!observed.equals(expected)) {
+      throw new Error('The managed Runtime Host Windows task launcher is invalid');
+    }
+    return;
+  }
+  await writeStableArtifact(projectedPath, expected);
+}
 
+export async function verifyRuntimeHostManagedWindowsTaskLauncher(
+  config: RuntimeHostManagedDeploymentConfig,
+  options: { readonly allowAbsent?: boolean } = {},
+): Promise<void> {
   const layout = resolveRuntimeHostNpmDeploymentLayout(
     config.deploymentRoot,
     config.launch.package.integrity,
   );
   const sourcePath = await resolvePackagedRuntimeHostWindowsTaskLauncherPath(layout.cliPath);
-  const [expected, observed] = await Promise.all([
-    readWindowsTaskLauncher(sourcePath),
-    readWindowsTaskLauncher(projectedPath),
-  ]);
+  const expected = await readRuntimeHostWindowsTaskLauncher(sourcePath);
+  const projectedPath = runtimeHostManagedWindowsTaskLauncherPath(config.deploymentRoot, expected);
+  const projectedExists = await access(projectedPath, constants.F_OK).then(
+    () => true,
+    (error: unknown) => {
+      if (isNodeError(error, 'ENOENT')) return false;
+      throw error;
+    },
+  );
+  if (!projectedExists) {
+    if (options.allowAbsent) return;
+    throw new Error('The managed Runtime Host Windows task launcher does not match its deployment');
+  }
+  const observed = await readRuntimeHostWindowsTaskLauncher(projectedPath);
   if (!observed.equals(expected)) {
     throw new Error('The managed Runtime Host Windows task launcher does not match its deployment');
   }
-}
-
-function readWindowsTaskLauncher(path: string): Promise<Buffer> {
-  return readStableBoundedFile({
-    path,
-    maxBytes: WINDOWS_TASK_LAUNCHER_MAX_BYTES,
-    invalidFile: () => new Error('The managed Runtime Host Windows task launcher is invalid'),
-  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/runtime-host-package-deployment.ts
+++ b/packages/cli/src/runtime-host-package-deployment.ts
@@ -369,6 +369,7 @@ const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
   await rm(path, { recursive: true, force: true, maxRetries: 100, retryDelay: 100 });
 })().catch(() => { process.exitCode = 1; });`;
   const cleanup = spawn(process.execPath, ['-e', script, path, String(process.pid)], {
+    cwd: dirname(process.execPath),
     detached: true,
     stdio: 'ignore',
     windowsHide: true,

--- a/packages/cli/src/runtime-host-windows-task-launcher-artifact.ts
+++ b/packages/cli/src/runtime-host-windows-task-launcher-artifact.ts
@@ -24,6 +24,16 @@ const LAUNCHER_FILE = 'maka-runtime-host-task-launcher.exe';
 
 export async function resolveRuntimeHostWindowsTaskLauncherPath(cliPath: string): Promise<string> {
   const packageRoot = dirname(dirname(await realpath(cliPath)));
+  const projected = projectedLauncherPath(packageRoot);
+  if (projected && (await isReadable(projected))) return realpath(projected);
+
+  return resolvePackagedRuntimeHostWindowsTaskLauncherPath(cliPath);
+}
+
+export async function resolvePackagedRuntimeHostWindowsTaskLauncherPath(
+  cliPath: string,
+): Promise<string> {
+  const packageRoot = dirname(dirname(await realpath(cliPath)));
   const packaged = join(
     packageRoot,
     'native',
@@ -49,6 +59,17 @@ export async function resolveRuntimeHostWindowsTaskLauncherPath(cliPath: string)
   }
 
   throw new Error('Maka does not include the Windows Runtime Host task launcher');
+}
+
+export function runtimeHostManagedWindowsTaskLauncherPath(deploymentRoot: string): string {
+  return join(deploymentRoot, LAUNCHER_FILE);
+}
+
+function projectedLauncherPath(packageRoot: string): string | undefined {
+  const versionsRoot = dirname(packageRoot);
+  return basename(versionsRoot) === 'versions'
+    ? runtimeHostManagedWindowsTaskLauncherPath(dirname(versionsRoot))
+    : undefined;
 }
 
 async function isReadable(path: string): Promise<boolean> {

--- a/packages/cli/src/runtime-host-windows-task-launcher-artifact.ts
+++ b/packages/cli/src/runtime-host-windows-task-launcher-artifact.ts
@@ -17,17 +17,26 @@
  * under the License.
  */
 
+import { createHash } from 'node:crypto';
 import { access, realpath } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
+import { readStableBoundedFile } from '@maka/storage/stable-storage';
 
 const LAUNCHER_FILE = 'maka-runtime-host-task-launcher.exe';
+const MANAGED_LAUNCHER_PREFIX = 'maka-runtime-host-task-launcher-';
+const WINDOWS_TASK_LAUNCHER_MAX_BYTES = 1024 * 1024;
 
 export async function resolveRuntimeHostWindowsTaskLauncherPath(cliPath: string): Promise<string> {
   const packageRoot = dirname(dirname(await realpath(cliPath)));
-  const projected = projectedLauncherPath(packageRoot);
-  if (projected && (await isReadable(projected))) return realpath(projected);
+  const packaged = await resolvePackagedRuntimeHostWindowsTaskLauncherPath(cliPath);
+  const contents = await readRuntimeHostWindowsTaskLauncher(packaged);
+  const projected = projectedLauncherPath(packageRoot, contents);
+  if (projected) {
+    const observed = await readRuntimeHostWindowsTaskLauncher(projected).catch(() => undefined);
+    if (observed?.equals(contents)) return realpath(projected);
+  }
 
-  return resolvePackagedRuntimeHostWindowsTaskLauncherPath(cliPath);
+  return packaged;
 }
 
 export async function resolvePackagedRuntimeHostWindowsTaskLauncherPath(
@@ -61,14 +70,26 @@ export async function resolvePackagedRuntimeHostWindowsTaskLauncherPath(
   throw new Error('Maka does not include the Windows Runtime Host task launcher');
 }
 
-export function runtimeHostManagedWindowsTaskLauncherPath(deploymentRoot: string): string {
-  return join(deploymentRoot, LAUNCHER_FILE);
+export function runtimeHostManagedWindowsTaskLauncherPath(
+  deploymentRoot: string,
+  contents: Uint8Array,
+): string {
+  const digest = createHash('sha256').update(contents).digest('hex');
+  return join(deploymentRoot, `${MANAGED_LAUNCHER_PREFIX}${digest}.exe`);
 }
 
-function projectedLauncherPath(packageRoot: string): string | undefined {
+export function readRuntimeHostWindowsTaskLauncher(path: string): Promise<Buffer> {
+  return readStableBoundedFile({
+    path,
+    maxBytes: WINDOWS_TASK_LAUNCHER_MAX_BYTES,
+    invalidFile: () => new Error('The managed Runtime Host Windows task launcher is invalid'),
+  });
+}
+
+function projectedLauncherPath(packageRoot: string, contents: Uint8Array): string | undefined {
   const versionsRoot = dirname(packageRoot);
   return basename(versionsRoot) === 'versions'
-    ? runtimeHostManagedWindowsTaskLauncherPath(dirname(versionsRoot))
+    ? runtimeHostManagedWindowsTaskLauncherPath(dirname(versionsRoot), contents)
     : undefined;
 }
 


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

Stabilize Windows Local Runtime Host remote-access setup at the failure boundaries reproduced on a real Windows checkout:

- run deferred package cleanup outside the Desktop-owned scratch directory, so its helper cannot keep that directory locked;
- make scratch cleanup best-effort, preserving the setup operator's primary framed success or error;
- project the native Task Scheduler launcher into the deployment root, keeping `<Command>` below Task Scheduler's path limit while retaining exact-package verification and automatic convergence for existing deployments;
- make projected launchers immutable and content-addressed, so reconciliation never tries to overwrite the executable that a running scheduled task has locked.

Scheduled tasks still execute the native launcher directly. No visible `cmd.exe`/PowerShell trampoline or shell-quoting authority is introduced.

## Root cause

The reported `EBUSY` was secondary: a detached cleanup helper inherited the setup scratch directory as its current working directory, while the Desktop's `finally` cleanup replaced the setup operator's framed result with the directory-removal error. Once that masking was removed, the lifecycle failure was `0x80041318`: the versioned launcher path was 301 characters and Task Scheduler rejected it in `<Command>`. A mutable projected singleton would then fail during a later package change because Windows locks the running executable; content-addressed projection removes that overwrite boundary.

## Verification

- `npx biome check` on all changed files
- Desktop main-process build and focused local-operator suite: 6/6 passed on Linux and Windows
- CLI build and focused setup suite: 7/7 passed on Linux
- New launcher-projection test passed on native Windows; two unrelated existing symlink tests require Windows Developer Mode
- CLI complete compiled suite on Linux: 795 tests, 792 passed, 3 skipped, 0 failed
- Real Windows recovery from the reported `setupPending` state completed as `managed`; Remote access enabled and connection-code creation succeeded
- With the legacy launcher still owned by a running scheduled task, convergence created and verified the immutable content-addressed launcher without overwriting the locked executable
- Setup scratch cleanup left no `EBUSY`; the managed Host remained running after Desktop exited

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the Windows failure chain, implemented the bounded fix, reviewed it, and performed Linux and native Windows verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck, and affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary><strong>中文</strong></summary>

## 摘要

修复在真实 Windows checkout 中复现的本机 Runtime Host 远程访问安装故障边界：

- 延迟包清理进程不再继承 Desktop 的安装临时目录，避免 helper 自己锁住该目录；
- 临时目录清理降为 best-effort，不再覆盖 setup operator 的主要 framed 成功或错误结果；
- 将 Task Scheduler 的原生 launcher 投影到 deployment root，绕开其 `<Command>` 路径长度限制，同时保留 exact-package 校验并让既有部署自动收敛；
- 投影后的 launcher 改为不可变的内容寻址文件，reconciliation 不再覆写正在被计划任务锁定的可执行文件。

计划任务仍直接执行原生 launcher，不引入可见的 `cmd.exe`/PowerShell 中转窗口或 shell quoting authority。

## 根因

日志中的 `EBUSY` 是次生错误：延迟清理 helper 继承了 setup 临时目录作为 cwd，Desktop 的 `finally` 清理又用目录删除错误覆盖了 operator 的 framed 结果。去掉错误覆盖后，真正的 lifecycle 故障是 `0x80041318`：版本目录内的 launcher 路径长达 301 个字符，Task Scheduler 在 `<Command>` 处拒绝该路径。若投影目标仍是可变单例，后续换包又会因 Windows 锁定正在运行的 executable 而失败；内容寻址投影从机制上删除了这个覆写边界。

## 验证

- 所有变更文件通过 `npx biome check`
- Desktop main-process 构建及聚焦 local-operator 测试：Linux、Windows 均 6/6 通过
- CLI 构建及聚焦 setup 测试：Linux 7/7 通过
- 新增 launcher projection 测试在原生 Windows 通过；另两项无关的既有 symlink 测试需要开启 Windows Developer Mode
- Linux CLI 完整编译后测试：795 项，792 通过、3 跳过、0 失败
- Windows 从报告中的 `setupPending` 状态真实恢复为 `managed`；远程访问成功开启并生成连接码
- 旧 launcher 仍被运行中的计划任务占用时，convergence 成功创建并验证不可变的内容寻址 launcher，没有覆写被锁文件
- setup 临时目录清理不再出现 `EBUSY`；Desktop 退出后 managed Host 仍保持运行

## AI 使用

- [ ] 没有生成式工具作出实质贡献
- [x] 生成式工具作出了实质贡献

工具与范围：OpenAI Codex 排查 Windows 故障链、实现并审查修复，并完成 Linux 与原生 Windows 验证。

## 检查清单

- [x] 测试覆盖该变更且在修复前失败
- [x] lint、format、typecheck 和受影响测试均在本地通过

此 PR 是否改变行为？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
