### PR TITLE
test(runtime-host): assert owned Host exit against the kernel's shutdown contract

### DIFF
--- a/packages/runtime-host/src/__tests__/fixtures/owned-authority-launcher.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/owned-authority-launcher.ts
@@ -32,7 +32,13 @@ const attempt = await launchOwnedRuntimeHostCandidate({
   rootPath,
   expectedRootId,
   entrypoint: new URL('../../execution-candidate-main.js', import.meta.url),
-  idleGraceMs: 10_000,
+  // The idle grace only has to outlast the test, and it has to stay clear of
+  // any bound a test puts on an owner-loss exit: a Candidate that exits
+  // because it went idle must never be mistaken for one that exited because
+  // its launch owner died. The first-connection deadline stays short so a
+  // Candidate no Client ever reaches still exits on its own.
+  idleGraceMs: 60_000,
+  initialConnectionTimeoutMs: 10_000,
   inheritableAuthorityLeaseFd: leaseFd,
   launchOwnerClientInstanceId: clientInstanceId,
 }).spawned;

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -1916,12 +1916,26 @@ describe('non-serving Runtime Host kernel', () => {
 
       launcher.kill('SIGKILL');
       await waitForExit(launcher);
+      // The process is the only thing that reports the claim. A Client's
+      // `connection.closed` does not: it is that Client's own transport, and
+      // the Client aborts it after its liveness probe goes unanswered for two
+      // seconds. A Host that is merely busy therefore resolves it while still
+      // running, and gating the exit assertion on it starts the exit budget at
+      // a moment that has nothing to do with the Host's shutdown.
+      //
+      // The bound comes from the kernel's contract rather than from an
+      // interval this test could predict. Owner loss cannot close a
+      // composition before its startup settles, and the shutdown that follows
+      // is bounded by `shutdownGraceMs` (10 s), after which the kernel
+      // force-terminates. Twenty seconds therefore sits above every
+      // legitimate exit and below the launcher's 60 s idle grace, so it cannot
+      // be satisfied by a Candidate that merely went idle.
+      await waitForProcessExit(launchedPid, 20_000);
       await withTimeout(
         connected.connection.closed,
         5_000,
-        'authority-supervised Candidate survived its launch owner',
+        'authority-supervised Candidate exited without closing its Client connection',
       );
-      await waitForProcessExit(launchedPid);
       paths.resources.forgetPid(launchedPid);
     });
   });

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -24,6 +24,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import {
+  resolveExistingStorageRoot,
+  resolveExistingStorageRootControlDirectory,
+} from '@maka/storage/root-authority';
+import { readHostRegistration } from '../control/registration.js';
+import {
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
   RUNTIME_HOST_PROTOCOL_VERSION,
 } from '../protocol/index.js';
@@ -257,12 +262,20 @@ test('owned Host exits promptly after its first connection closes', async () => 
 
   assert.equal(result.kind, 'connected', connectFailure(result));
   if (result.kind !== 'connected') return;
+  const controlDirectory = await resolveHostControlDirectory(rootPath, result.connection.rootId);
   await result.connection.close();
-  // Prompt means the owned launch's idleGraceMs of 0, as opposed to the 30 s
-  // default grace, so the bound only has to sit well below that. Shutdown takes
-  // about 30 ms on an idle machine and stretches past 500 ms under a full CI
-  // suite while still exiting cleanly: the Host is starved, not stuck.
-  assert.equal(await result.host.settle(5_000), true);
+  // Promptness is when the Host starts shutting down, not how long shutting
+  // down takes: the owned launch's idleGraceMs is 0 against a 30 s default.
+  // The kernel publishes its draining registration as the first step of
+  // shutdown, so the registration reports the idle grace directly. Reading it
+  // from `settle` alone could not separate the two, which is why a loaded
+  // machine that only made the shutdown itself slow failed this assertion.
+  await waitForHostShutdownStart(controlDirectory, 10_000);
+  // The exit is a second claim with a bound of its own, and the kernel sets
+  // it: shutdown gets `shutdownGraceMs` (10 s) to close every resource before
+  // the kernel force-terminates the process. Anything below that fails a Host
+  // that is starved rather than stuck.
+  assert.equal(await result.host.settle(15_000), true);
 });
 
 test('an exited owned Candidate permits one real successor in the same election', {
@@ -435,6 +448,35 @@ test('pre-cancelled hosted execution does not start a Runtime Host', async () =>
   assert.equal(result.kind, 'indeterminate');
   assert.deepEqual(await readdir(rootPath), []);
 });
+
+async function resolveHostControlDirectory(rootPath: string, rootId: string): Promise<string> {
+  const capability = await resolveExistingStorageRoot({
+    path: rootPath,
+    kind: 'interactive',
+    expectedRootId: rootId,
+  });
+  const { controlDirectory } = await resolveExistingStorageRootControlDirectory(capability);
+  return controlDirectory;
+}
+
+/**
+ * Resolves once the Host has begun shutting down. `draining` is the state the
+ * kernel publishes before it does any shutdown work, and the registration is
+ * removed near the end of that work, so either observation proves shutdown
+ * started; the Host was serving this Client, so its registration existed.
+ */
+async function waitForHostShutdownStart(
+  controlDirectory: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const registration = await readHostRegistration(controlDirectory).catch(() => undefined);
+    if (!registration || registration.state === 'draining') return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('owned Host did not begin shutting down after its first connection closed');
+}
 
 function connectFailure(
   result:


### PR DESCRIPTION
## Summary

Both owned-lifecycle tests assert that a Host process has exited, against a 5 s wall clock that is shorter than the exit the kernel guarantees, and one of them starts that clock from an event the Host does not control. Under suite load they fail on a Host that is working correctly. Each assertion now observes the Host and is bounded by the kernel's own shutdown grace, so it can only fail when the Host really does not exit.

Fixes #4776

## Root cause

**`an authority-supervised Candidate exits if its launch owner is killed` measured from the wrong object.** It waited on `connected.connection.closed`, then gave the process 5 s. That promise is the Client's own transport — `RuntimeHostConnection` assigns `closed` straight from `transport.closed`, and its `#fail` path ends in `transport.abort()`. An unanswered liveness probe (2 s interval, 2 s timeout) therefore resolves it while the Host is still running, and the exit budget starts at a moment unrelated to the Host's shutdown.

The Host also cannot exit as early as that bound assumed. The owner-loss close is armed by `launchOwnerGuard.bind(...)` in `candidate-entry.ts`, which runs only after `startExecutionRuntimeHostCandidate` resolves, so composition startup and recovery must finish before the Candidate can begin closing. Instrumenting the test showed the SIGKILL landing while startup was still in progress even on an idle machine, because `retryConnect` returns as soon as the handshake is admitted and the kernel admits Clients while it is still `recovering`. The shutdown that follows is then bounded by `shutdownGraceMs` (10 s), after which the kernel force-terminates.

**`owned Host exits promptly after its first connection closes` bounded shutdown tighter than the kernel does.** `settle(5_000)` allowed the whole shutdown 5 s against a kernel that allows itself 10 s, and it conflated the two claims in the test's name: that the owned launch's `idleGraceMs` is 0 rather than 30 s, and that the process exits cleanly. `settle` also SIGKILLs on timeout, so a Host that was still shutting down was reported as an unclean exit rather than as a slow one.

### Evidence

I could not reproduce either failure naturally on this machine: 42 focused repetitions and 19 full-suite runs of each test, including runs with two extra suites as background load, produced zero failures. The mechanism was established by fault injection against the built kernel, which reproduces both reported failures exactly.

Stalling the Host's main thread during composition startup — the shape of the synchronous store work profiled in #4032 — reproduces `Error: process <pid> did not exit`, with the merged Client, entry and kernel timeline showing why:

```
     0 ms  test    SIGKILL to launcher
     4 ms  entry   candidate observes IPC disconnect
    62 ms  kernel  composition startup still running (bind has not happened)
  1262 ms  kernel  main thread blocked
  4006 ms  test    connection.closed resolves — Client's liveness timeout; process alive
  9022 ms  test    process <pid> did not exit
```

Stalling composition close for 6.5 s reproduces `false !== true` with `exit: { code: null, signal: 'SIGKILL' }` — `settle`'s own kill of a Host that was mid-shutdown.

## What changed

- The launch-owner test waits for the process, bounded at 20 s: above the kernel's 10 s shutdown grace, below the launcher fixture's idle grace. The connection-closed assertion stays, now after the exit, where it is a consequence rather than a gate.
- The launcher fixture's idle grace goes from 10 s to 60 s, so a Candidate that exits because it went idle can never satisfy an owner-loss bound, with an explicit 10 s first-connection deadline so a Candidate no Client reaches still exits on its own.
- The owned-exit test observes the draining registration the kernel publishes as the first step of shutdown, which is the idle-grace claim directly, then bounds the exit at 15 s.

## Verification

- Under the same fault injection, both tests pass (13.9 s and 7.2 s).
- The bounds still bite. Neutering the owner-loss close (`bind` to a no-op) fails the launch-owner test at 20.5 s. Stalling shutdown past the kernel's own 10 s grace still fails the owned-exit test.
- `@maka/runtime-host` suite, 5 runs at default concurrency: both tests pass in all 5.
- `npm run format:check`, `npm run lint`: clean. `npm run typecheck`: clean once every workspace dependency's `dist` is current (a stale `@maka/ui` build reported 42 errors in `apps/desktop` that a rebuild cleared, none of them in files this PR touches).
- The fault-injection harness is not committed.

Unrelated, and worth its own issue: `WorkHub correction replaces its link without stopping a shared manual Turn` (`execution-composition.test.ts`) failed in 10 of 13 full-suite runs before this change and 2 of 5 after it, on `main` and on this branch alike. It is the flake this machine reproduces, and it is not the one this PR addresses. Filed as #4785: the WorkHub candidate-set identity digests the Session name, so the automatic title commit invalidates the snapshot the delegation was built on.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code read the lifecycle paths, wrote and ran the fault-injection harness and the instrumented timeline, made the test changes, and drafted this PR body. The commit carries a `Generated-by: Claude Code` trailer. I reviewed the diff and the evidence and remain the contributor of record.

## Checklist

- [x] Tests cover the change and fail without it — this PR is the test change; the deterministic seam is the uncommitted fault-injection harness, whose before/after results are above, together with the mutation check that the new bounds still fail a broken guard
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
