### PR TITLE
fix(storage): ignore invalid ancestor Git markers

### DIFF
--- a/packages/storage/src/__tests__/fixtures/git-repository.ts
+++ b/packages/storage/src/__tests__/fixtures/git-repository.ts
@@ -24,6 +24,36 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
+export const BROKEN_GIT_SHAPES = [
+  'head-directory',
+  'head-garbage',
+  'gitfile-garbage-head',
+  'missing-objects-and-refs',
+] as const;
+
+export type BrokenGitShape = (typeof BROKEN_GIT_SHAPES)[number];
+
+/** Writes structurally broken Git metadata (a `.git` entry or its target) into root. */
+export async function createBrokenGitMetadata(root: string, shape: BrokenGitShape): Promise<void> {
+  switch (shape) {
+    case 'head-directory':
+      await mkdir(join(root, '.git', 'HEAD'), { recursive: true });
+      return;
+    case 'head-garbage':
+      await mkdir(join(root, '.git'), { recursive: true });
+      await writeFile(join(root, '.git', 'HEAD'), 'gk\n', 'utf8');
+      return;
+    case 'gitfile-garbage-head':
+      await writeFile(join(root, '.git'), 'gitdir: stub\n', 'utf8');
+      await mkdir(join(root, 'stub'), { recursive: true });
+      await writeFile(join(root, 'stub', 'HEAD'), 'gk\n', 'utf8');
+      return;
+    case 'missing-objects-and-refs':
+      await mkdir(join(root, '.git'), { recursive: true });
+      await writeFile(join(root, '.git', 'HEAD'), `ref: refs/heads/${'a'.repeat(40)}\n`, 'utf8');
+  }
+}
+
 export async function createGitRepositoryWithWorktree(
   repository: string,
   linkedWorktree: string,

--- a/packages/storage/src/__tests__/fixtures/git-repository.ts
+++ b/packages/storage/src/__tests__/fixtures/git-repository.ts
@@ -18,7 +18,7 @@
  */
 
 import { execFile } from 'node:child_process';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
@@ -36,29 +36,28 @@ export type BrokenGitShape = (typeof BROKEN_GIT_SHAPES)[number];
 
 /** Writes structurally broken Git metadata (a `.git` entry or its target) into root. */
 export async function createBrokenGitMetadata(root: string, shape: BrokenGitShape): Promise<void> {
+  await execFileAsync('git', ['init', '--quiet'], { cwd: root });
   switch (shape) {
     case 'head-directory':
-      await mkdir(join(root, '.git', 'HEAD'), { recursive: true });
+      await rm(join(root, '.git', 'HEAD'));
+      await mkdir(join(root, '.git', 'HEAD'));
       return;
     case 'head-garbage':
-      await mkdir(join(root, '.git'), { recursive: true });
       await writeFile(join(root, '.git', 'HEAD'), 'gk\n', 'utf8');
       return;
     case 'gitfile-garbage-head':
+      await rm(join(root, '.git'), { recursive: true });
       await writeFile(join(root, '.git'), 'gitdir: stub\n', 'utf8');
-      await mkdir(join(root, 'stub'), { recursive: true });
+      await mkdir(join(root, 'stub'));
+      await execFileAsync('git', ['init', '--bare', '--quiet', join(root, 'stub')]);
       await writeFile(join(root, 'stub', 'HEAD'), 'gk\n', 'utf8');
       return;
     case 'head-symref-no-refs-prefix':
-      // Valid objects/ and refs/ plus a symref whose target is not under
-      // refs/: passes naive checks but git rev-parse exits 128.
-      await mkdir(join(root, '.git', 'objects'), { recursive: true });
-      await mkdir(join(root, '.git', 'refs'), { recursive: true });
       await writeFile(join(root, '.git', 'HEAD'), 'ref: gk\n', 'utf8');
       return;
     case 'missing-objects-and-refs':
-      await mkdir(join(root, '.git'), { recursive: true });
-      await writeFile(join(root, '.git', 'HEAD'), `ref: refs/heads/${'a'.repeat(40)}\n`, 'utf8');
+      await rm(join(root, '.git', 'objects'), { recursive: true });
+      await rm(join(root, '.git', 'refs'), { recursive: true });
   }
 }
 

--- a/packages/storage/src/__tests__/fixtures/git-repository.ts
+++ b/packages/storage/src/__tests__/fixtures/git-repository.ts
@@ -27,6 +27,7 @@ const execFileAsync = promisify(execFile);
 export const BROKEN_GIT_SHAPES = [
   'head-directory',
   'head-garbage',
+  'head-symref-no-refs-prefix',
   'gitfile-garbage-head',
   'missing-objects-and-refs',
 ] as const;
@@ -47,6 +48,13 @@ export async function createBrokenGitMetadata(root: string, shape: BrokenGitShap
       await writeFile(join(root, '.git'), 'gitdir: stub\n', 'utf8');
       await mkdir(join(root, 'stub'), { recursive: true });
       await writeFile(join(root, 'stub', 'HEAD'), 'gk\n', 'utf8');
+      return;
+    case 'head-symref-no-refs-prefix':
+      // Valid objects/ and refs/ plus a symref whose target is not under
+      // refs/: passes naive checks but git rev-parse exits 128.
+      await mkdir(join(root, '.git', 'objects'), { recursive: true });
+      await mkdir(join(root, '.git', 'refs'), { recursive: true });
+      await writeFile(join(root, '.git', 'HEAD'), 'ref: gk\n', 'utf8');
       return;
     case 'missing-objects-and-refs':
       await mkdir(join(root, '.git'), { recursive: true });

--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -99,6 +99,58 @@ test('a plain folder resolves without requiring the Git executable', async () =>
   }
 });
 
+test('an incomplete enclosing .git directory does not turn a nested folder into a repository', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-folder-invalid-git-'));
+  try {
+    const folder = join(base, 'folder');
+    await mkdir(join(base, '.git', 'gk'), { recursive: true });
+    await mkdir(folder);
+
+    assert.deepEqual(await resolveProjectLocationWithoutGit(folder), {
+      canonicalPath: await realpath(folder),
+      identity: `folder:${await realpath(folder)}`,
+      kind: 'folder',
+    });
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('a folder nested inside a repository resolves to that repository', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-nested-in-repo-'));
+  try {
+    const repository = join(base, 'repository');
+    const nested = join(repository, 'sub', 'dir');
+    await mkdir(nested, { recursive: true });
+    await execFileAsync('git', ['init', '--quiet'], { cwd: repository });
+
+    const resolved = await resolveProjectLocation({ path: nested });
+
+    assert.equal(resolved.kind, 'git');
+    assert.equal(resolved.git?.worktreeRoot, await realpath(repository));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('a folder nested inside a linked worktree resolves to that repository', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-nested-in-worktree-'));
+  try {
+    const repository = join(base, 'repository');
+    const linkedWorktree = join(base, 'linked');
+    await createGitRepositoryWithWorktree(repository, linkedWorktree, 'nested-linked');
+    const nested = join(linkedWorktree, 'nested');
+    await mkdir(nested);
+
+    const resolved = await resolveProjectLocation({ path: nested });
+
+    assert.equal(resolved.kind, 'git');
+    assert.equal(resolved.git?.isWorktree, true);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test('a Git probe failure cannot persistently downgrade a repository to a folder', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-project-repository-no-git-'));
   try {

--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -35,7 +35,11 @@ import {
   resolveProjectLocation,
 } from '../project-catalog.js';
 import { createSessionStore } from '../session-store.js';
-import { createGitRepositoryWithWorktree } from './fixtures/git-repository.js';
+import {
+  BROKEN_GIT_SHAPES,
+  createBrokenGitMetadata,
+  createGitRepositoryWithWorktree,
+} from './fixtures/git-repository.js';
 
 const execFileAsync = promisify(execFile);
 const trackedCatalogs = new Map<ProjectCatalog, string>();
@@ -111,6 +115,30 @@ test('an incomplete enclosing .git directory does not turn a nested folder into 
       identity: `folder:${await realpath(folder)}`,
       kind: 'folder',
     });
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('broken ancestor Git metadata does not turn a nested folder into a repository', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-invalid-ancestor-'));
+  try {
+    for (const shape of BROKEN_GIT_SHAPES) {
+      const root = join(base, shape);
+      const folder = join(root, 'folder');
+      await mkdir(folder, { recursive: true });
+      await createBrokenGitMetadata(root, shape);
+
+      assert.deepEqual(
+        await resolveProjectLocation({ path: folder }),
+        {
+          canonicalPath: await realpath(folder),
+          identity: `folder:${await realpath(folder)}`,
+          kind: 'folder',
+        },
+        shape,
+      );
+    }
   } finally {
     await rm(base, { recursive: true, force: true });
   }

--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -110,7 +110,7 @@ test('an incomplete enclosing .git directory does not turn a nested folder into 
     await mkdir(join(base, '.git', 'gk'), { recursive: true });
     await mkdir(folder);
 
-    assert.deepEqual(await resolveProjectLocationWithoutGit(folder), {
+    assert.deepEqual(await resolveProjectLocation({ path: folder }), {
       canonicalPath: await realpath(folder),
       identity: `folder:${await realpath(folder)}`,
       kind: 'folder',
@@ -138,6 +138,14 @@ test('broken ancestor Git metadata does not turn a nested folder into a reposito
         },
         shape,
       );
+      const catalog = createProjectCatalog(join(root, 'state'));
+      const project = await catalog.register(folder);
+      assert.deepEqual(
+        project.locations,
+        [{ path: await realpath(folder), isWorktree: false }],
+        shape,
+      );
+      assert.deepEqual(await catalog.list(), [project]);
     }
   } finally {
     await rm(base, { recursive: true, force: true });
@@ -156,6 +164,7 @@ test('a folder nested inside a repository resolves to that repository', async ()
 
     assert.equal(resolved.kind, 'git');
     assert.equal(resolved.git?.worktreeRoot, await realpath(repository));
+    await assert.rejects(resolveProjectLocationWithoutGit(nested));
   } finally {
     await rm(base, { recursive: true, force: true });
   }

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -31,6 +31,7 @@ import {
   WORKSPACE_MARKER_FILE,
   WorkspaceIdentityError,
 } from '../workspace-identity.js';
+import { BROKEN_GIT_SHAPES, createBrokenGitMetadata } from './fixtures/git-repository.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -210,6 +211,23 @@ test('a malformed ancestor .git directory does not block a workspace marker', as
     await resolveWorkspaceIdentityWithoutGit(workspace);
 
     await access(join(workspace, WORKSPACE_MARKER_FILE));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('broken ancestor Git metadata does not block a workspace marker', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-workspace-invalid-ancestor-'));
+  try {
+    for (const shape of BROKEN_GIT_SHAPES) {
+      const root = join(base, shape);
+      const workspace = join(root, 'workspace');
+      await mkdir(workspace, { recursive: true });
+      await createBrokenGitMetadata(root, shape);
+
+      await resolveWorkspaceIdentity({ path: workspace });
+      await access(join(workspace, WORKSPACE_MARKER_FILE));
+    }
   } finally {
     await rm(base, { recursive: true, force: true });
   }

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -19,7 +19,7 @@
 
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -200,10 +200,46 @@ test('a full Git exclude does not grow when resolving workspace identity', async
   }
 });
 
+test('a malformed ancestor .git directory does not block a workspace marker', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-workspace-git-malformed-ancestor-'));
+  try {
+    const workspace = join(base, 'workspace');
+    await mkdir(join(base, '.git', 'gk'), { recursive: true });
+    await mkdir(workspace);
+
+    await resolveWorkspaceIdentityWithoutGit(workspace);
+
+    await access(join(workspace, WORKSPACE_MARKER_FILE));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test('a malformed enclosing Git repository prevents publishing a new marker', async () => {
   const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-malformed-'));
   try {
     await writeFile(join(workspace, '.git'), 'gitdir: /missing/maka-git-dir\n', 'utf8');
+
+    await assert.rejects(
+      () => resolveWorkspaceIdentity({ path: workspace }),
+      (error: unknown) =>
+        error instanceof WorkspaceIdentityError && error.code === 'workspace_io_failed',
+    );
+    await assert.rejects(access(join(workspace, WORKSPACE_MARKER_FILE)), { code: 'ENOENT' });
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('a dangling .git symlink in the workspace itself blocks marker publication', {
+  skip:
+    process.platform === 'win32'
+      ? 'Windows symlink creation requires elevated privileges or Developer Mode'
+      : false,
+}, async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-dangling-'));
+  try {
+    await symlink(join(workspace, 'missing-target'), join(workspace, '.git'));
 
     await assert.rejects(
       () => resolveWorkspaceIdentity({ path: workspace }),

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -208,7 +208,7 @@ test('a malformed ancestor .git directory does not block a workspace marker', as
     await mkdir(join(base, '.git', 'gk'), { recursive: true });
     await mkdir(workspace);
 
-    await resolveWorkspaceIdentityWithoutGit(workspace);
+    await resolveWorkspaceIdentity({ path: workspace });
 
     await access(join(workspace, WORKSPACE_MARKER_FILE));
   } finally {

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -19,7 +19,17 @@
 
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { access, chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -228,6 +238,80 @@ test('broken ancestor Git metadata does not block a workspace marker', async () 
       await resolveWorkspaceIdentity({ path: workspace });
       await access(join(workspace, WORKSPACE_MARKER_FILE));
     }
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('a valid outer repository owns exclusion for a workspace below broken ancestor metadata', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-workspace-git-outer-'));
+  try {
+    const repository = join(base, 'repository');
+    const broken = join(repository, 'broken');
+    const workspace = join(broken, 'workspace');
+    await mkdir(workspace, { recursive: true });
+    await execFileAsync('git', ['init', '--quiet'], { cwd: repository });
+    await createBrokenGitMetadata(broken, 'head-garbage');
+
+    await resolveWorkspaceIdentity({ path: workspace });
+    await access(join(workspace, WORKSPACE_MARKER_FILE));
+
+    // Git itself still selects the outer repository from the nested workspace;
+    // the marker must be ignored through that repository's local exclude.
+    const repoRoot = await realpath(repository);
+    const { stdout: toplevel } = await execFileAsync(
+      'git',
+      ['-C', workspace, 'rev-parse', '--show-toplevel'],
+      { encoding: 'utf8' },
+    );
+    assert.equal(toplevel.trim(), repoRoot);
+    const { stdout: exclude } = await execFileAsync(
+      'git',
+      ['-C', workspace, 'rev-parse', '--path-format=absolute', '--git-path', 'info/exclude'],
+      { encoding: 'utf8' },
+    );
+    assert.equal(exclude.trim(), join(repoRoot, '.git', 'info', 'exclude'));
+    const { stdout } = await execFileAsync(
+      'git',
+      ['status', '--porcelain=v1', '--untracked-files=all'],
+      { cwd: repository, encoding: 'utf8' },
+    );
+    assert.equal(stdout, '');
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('an unreadable ancestor Git repository fails closed until permissions return', {
+  skip:
+    process.platform === 'win32'
+      ? 'POSIX permissions are required for an unreadable HEAD fixture'
+      : false,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-workspace-git-unreadable-ancestor-'));
+  try {
+    const repository = join(base, 'repository');
+    const workspace = join(repository, 'nested', 'workspace');
+    await mkdir(workspace, { recursive: true });
+    await execFileAsync('git', ['init', '--quiet'], { cwd: repository });
+    await chmod(join(repository, '.git', 'HEAD'), 0o000);
+
+    await assert.rejects(
+      () => resolveWorkspaceIdentity({ path: workspace }),
+      (error: unknown) =>
+        error instanceof WorkspaceIdentityError && error.code === 'workspace_io_failed',
+    );
+    await assert.rejects(access(join(workspace, WORKSPACE_MARKER_FILE)), { code: 'ENOENT' });
+
+    await chmod(join(repository, '.git', 'HEAD'), 0o644);
+    await resolveWorkspaceIdentity({ path: workspace });
+    await access(join(workspace, WORKSPACE_MARKER_FILE));
+    const { stdout } = await execFileAsync(
+      'git',
+      ['status', '--porcelain=v1', '--untracked-files=all'],
+      { cwd: repository, encoding: 'utf8' },
+    );
+    assert.equal(stdout, '');
   } finally {
     await rm(base, { recursive: true, force: true });
   }

--- a/packages/storage/src/git-entry.ts
+++ b/packages/storage/src/git-entry.ts
@@ -17,21 +17,47 @@
  * under the License.
  */
 
-import { lstat } from 'node:fs/promises';
-import { join, parse } from 'node:path';
+import { lstat, readFile, stat } from 'node:fs/promises';
+import { join, parse, resolve } from 'node:path';
+
+const GITDIR_PREFIX = 'gitdir: ';
 
 export async function hasEnclosingGitEntry(path: string): Promise<boolean> {
   let current = path;
   while (true) {
+    const gitPath = join(current, '.git');
     try {
-      await lstat(join(current, '.git'));
-      return true;
+      // lstat does not follow symlinks, so a dangling `.git` symlink still
+      // counts as an existing entry. The selected directory fails closed
+      // downstream when its own Git metadata is damaged; an ancestor only
+      // counts when it is structurally valid.
+      const entry = await lstat(gitPath);
+      if (current === path) return true;
+      const gitStat = entry.isSymbolicLink() ? await stat(gitPath) : entry;
+      if (gitStat.isDirectory()) return pathExists(join(gitPath, 'HEAD'));
+      if (gitStat.isFile()) {
+        const content = (await readFile(gitPath, 'utf8')).trim();
+        if (!content.startsWith(GITDIR_PREFIX)) return false;
+        const target = content.slice(GITDIR_PREFIX.length).trim();
+        if (!target) return false;
+        return pathExists(join(resolve(current, target), 'HEAD'));
+      }
+      return false;
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT' && code !== 'ENOTDIR') throw error;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') return current === path;
     }
     const parent = parse(current).dir;
     if (parent === current) return false;
     current = parent;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/packages/storage/src/git-entry.ts
+++ b/packages/storage/src/git-entry.ts
@@ -21,6 +21,9 @@ import { lstat, readFile, stat } from 'node:fs/promises';
 import { join, parse, resolve } from 'node:path';
 
 const GITDIR_PREFIX = 'gitdir: ';
+const HEAD_REF_PREFIX = 'ref: ';
+// HEAD holds a 40-char SHA-1 object id, or 64 chars for SHA-256 repositories.
+const HEAD_OBJECT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 
 export async function hasEnclosingGitEntry(path: string): Promise<boolean> {
   let current = path;
@@ -34,13 +37,13 @@ export async function hasEnclosingGitEntry(path: string): Promise<boolean> {
       const entry = await lstat(gitPath);
       if (current === path) return true;
       const gitStat = entry.isSymbolicLink() ? await stat(gitPath) : entry;
-      if (gitStat.isDirectory()) return pathExists(join(gitPath, 'HEAD'));
+      if (gitStat.isDirectory()) return isGitDirectory(gitPath);
       if (gitStat.isFile()) {
         const content = (await readFile(gitPath, 'utf8')).trim();
         if (!content.startsWith(GITDIR_PREFIX)) return false;
         const target = content.slice(GITDIR_PREFIX.length).trim();
         if (!target) return false;
-        return pathExists(join(resolve(current, target), 'HEAD'));
+        return isGitDirectory(resolve(current, target));
       }
       return false;
     } catch (error) {
@@ -53,10 +56,44 @@ export async function hasEnclosingGitEntry(path: string): Promise<boolean> {
   }
 }
 
-async function pathExists(path: string): Promise<boolean> {
+/**
+ * Checks the minimum Git directory contract git-rev-parse relies on: a
+ * readable regular HEAD holding either a symref or an object id, plus the
+ * objects and refs directories. Anything else would make the downstream Git
+ * commands fail closed instead of being treated as an enclosing repository.
+ */
+async function isGitDirectory(gitDir: string): Promise<boolean> {
   try {
-    await stat(path);
-    return true;
+    // readFile fails closed on a missing, unreadable, or directory HEAD.
+    const head = (await readFile(join(gitDir, 'HEAD'), 'utf8')).trim();
+    const validHead = head.startsWith(HEAD_REF_PREFIX)
+      ? head.slice(HEAD_REF_PREFIX.length).trim() !== ''
+      : HEAD_OBJECT_ID.test(head);
+    if (!validHead) return false;
+  } catch {
+    return false;
+  }
+  // Linked worktrees keep HEAD locally but share objects/refs with the
+  // common dir named by their commondir file.
+  return (
+    (await hasGitSubdirectory(gitDir, 'objects')) && (await hasGitSubdirectory(gitDir, 'refs'))
+  );
+}
+
+async function hasGitSubdirectory(gitDir: string, name: string): Promise<boolean> {
+  if (await isDirectory(join(gitDir, name))) return true;
+  try {
+    const commonDir = (await readFile(join(gitDir, 'commondir'), 'utf8')).trim();
+    return commonDir !== '' && (await isDirectory(resolve(gitDir, commonDir, name)));
+  } catch {
+    // No commondir file: a plain Git directory.
+    return false;
+  }
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
   } catch {
     return false;
   }

--- a/packages/storage/src/git-entry.ts
+++ b/packages/storage/src/git-entry.ts
@@ -17,38 +17,25 @@
  * under the License.
  */
 
-import { lstat, readFile, stat } from 'node:fs/promises';
-import { join, parse, resolve } from 'node:path';
+import { execFile } from 'node:child_process';
+import { lstat } from 'node:fs/promises';
+import { join, parse } from 'node:path';
+import { promisify } from 'node:util';
 
-const GITDIR_PREFIX = 'gitdir: ';
-const HEAD_REF_PREFIX = 'ref: ';
-// HEAD holds a 40-char SHA-1 object id, or 64 chars for SHA-256 repositories.
-const HEAD_OBJECT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
+const execFileAsync = promisify(execFile);
 
 export async function hasEnclosingGitEntry(path: string): Promise<boolean> {
   let current = path;
   while (true) {
     const gitPath = join(current, '.git');
     try {
-      // lstat does not follow symlinks, so a dangling `.git` symlink still
-      // counts as an existing entry. The selected directory fails closed
-      // downstream when its own Git metadata is damaged; an ancestor only
-      // counts when it is structurally valid.
-      const entry = await lstat(gitPath);
+      await lstat(gitPath);
+      // Keep failures in the selected directory's own metadata visible.
       if (current === path) return true;
-      const gitStat = entry.isSymbolicLink() ? await stat(gitPath) : entry;
-      if (gitStat.isDirectory()) return isGitDirectory(gitPath);
-      if (gitStat.isFile()) {
-        const content = (await readFile(gitPath, 'utf8')).trim();
-        if (!content.startsWith(GITDIR_PREFIX)) return false;
-        const target = content.slice(GITDIR_PREFIX.length).trim();
-        if (!target) return false;
-        return isGitDirectory(resolve(current, target));
-      }
-      return false;
+      return isGitEntry(gitPath);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT' && code !== 'ENOTDIR') return current === path;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') throw error;
     }
     const parent = parse(current).dir;
     if (parent === current) return false;
@@ -56,47 +43,26 @@ export async function hasEnclosingGitEntry(path: string): Promise<boolean> {
   }
 }
 
-/**
- * Checks the minimum Git directory contract git-rev-parse relies on: a
- * readable regular HEAD holding either a symref or an object id, plus the
- * objects and refs directories. Anything else would make the downstream Git
- * commands fail closed instead of being treated as an enclosing repository.
- */
-async function isGitDirectory(gitDir: string): Promise<boolean> {
+async function isGitEntry(gitPath: string): Promise<boolean> {
+  const env: NodeJS.ProcessEnv = { ...process.env, GIT_OPTIONAL_LOCKS: '0' };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_COMMON_DIR;
   try {
-    // readFile fails closed on a missing, unreadable, or directory HEAD.
-    const head = (await readFile(join(gitDir, 'HEAD'), 'utf8')).trim();
-    // A symref must target a ref under refs/; git itself rejects any other
-    // target (e.g. `ref: gk`) with exit 128 even when objects/ and refs/ exist.
-    const validHead = head.startsWith(HEAD_REF_PREFIX)
-      ? head.slice(HEAD_REF_PREFIX.length).trim().startsWith('refs/')
-      : HEAD_OBJECT_ID.test(head);
-    if (!validHead) return false;
-  } catch {
-    return false;
-  }
-  // Linked worktrees keep HEAD locally but share objects/refs with the
-  // common dir named by their commondir file.
-  return (
-    (await hasGitSubdirectory(gitDir, 'objects')) && (await hasGitSubdirectory(gitDir, 'refs'))
-  );
-}
-
-async function hasGitSubdirectory(gitDir: string, name: string): Promise<boolean> {
-  if (await isDirectory(join(gitDir, name))) return true;
-  try {
-    const commonDir = (await readFile(join(gitDir, 'commondir'), 'utf8')).trim();
-    return commonDir !== '' && (await isDirectory(resolve(gitDir, commonDir, name)));
-  } catch {
-    // No commondir file: a plain Git directory.
-    return false;
-  }
-}
-
-async function isDirectory(path: string): Promise<boolean> {
-  try {
-    return (await stat(path)).isDirectory();
-  } catch {
-    return false;
+    // Let Git validate directories and gitfiles, including linked worktrees.
+    await execFileAsync('git', ['rev-parse', '--resolve-git-dir', gitPath], {
+      env,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024,
+      timeout: 3_000,
+      windowsHide: true,
+    });
+    return true;
+  } catch (error) {
+    // This probe exits 128 for invalid Git metadata. Execution failures must
+    // still surface so a missing Git executable cannot downgrade a repository.
+    if ((error as { code?: unknown }).code === 128) return false;
+    throw error;
   }
 }

--- a/packages/storage/src/git-entry.ts
+++ b/packages/storage/src/git-entry.ts
@@ -18,8 +18,9 @@
  */
 
 import { execFile } from 'node:child_process';
-import { lstat } from 'node:fs/promises';
-import { join, parse } from 'node:path';
+import { constants as fsConstants, type Stats } from 'node:fs';
+import { access, lstat, readFile } from 'node:fs/promises';
+import { dirname, join, parse, resolve } from 'node:path';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
@@ -28,15 +29,22 @@ export async function hasEnclosingGitEntry(path: string): Promise<boolean> {
   let current = path;
   while (true) {
     const gitPath = join(current, '.git');
+    let present: boolean;
     try {
       await lstat(gitPath);
-      // Keep failures in the selected directory's own metadata visible.
-      if (current === path) return true;
-      return isGitEntry(gitPath);
+      present = true;
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
       if (code !== 'ENOENT' && code !== 'ENOTDIR') throw error;
+      present = false;
     }
+    if (present) {
+      // Keep failures in the selected directory's own metadata visible.
+      if (current === path) return true;
+      if (await isGitEntry(gitPath)) return true;
+    }
+    // An ancestor Git rejected despite readable metadata is confirmed invalid;
+    // Git itself skips it and keeps searching outward, so continue the walk.
     const parent = parse(current).dir;
     if (parent === current) return false;
     current = parent;
@@ -60,9 +68,55 @@ async function isGitEntry(gitPath: string): Promise<boolean> {
     });
     return true;
   } catch (error) {
-    // This probe exits 128 for invalid Git metadata. Execution failures must
-    // still surface so a missing Git executable cannot downgrade a repository.
-    if ((error as { code?: unknown }).code === 128) return false;
+    // Exit 128 is Git rejecting the entry, but it conflates an invalid format
+    // with unreadable metadata; execution failures must still surface so a
+    // missing Git executable cannot downgrade a repository.
+    if ((error as { code?: unknown }).code === 128) {
+      await assertGitMetadataReadable(gitPath);
+      return false;
+    }
     throw error;
+  }
+}
+
+/**
+ * Git's 128 verdict is trusted format interpretation only when Git could read
+ * the metadata: an unreadable repository is not evidence of an ordinary
+ * directory, so permission and I/O failures surface instead of taking the
+ * no-repository path.
+ */
+async function assertGitMetadataReadable(gitPath: string): Promise<void> {
+  let entryStat: Stats;
+  try {
+    entryStat = await lstat(gitPath);
+    await access(
+      gitPath,
+      entryStat.isDirectory() ? fsConstants.R_OK | fsConstants.X_OK : fsConstants.R_OK,
+    );
+  } catch (error) {
+    throw new Error(`Git metadata is not readable: ${gitPath}`, { cause: error });
+  }
+  if (entryStat.isDirectory()) {
+    await assertGitDirectoryReadable(gitPath);
+    return;
+  }
+  // A gitfile's target is the directory Git actually validated.
+  const pointer = /^gitdir: (.+)$/m.exec(await readFile(gitPath, 'utf8'));
+  if (pointer) {
+    await assertGitDirectoryReadable(resolve(dirname(gitPath), pointer[1].trim()));
+  }
+}
+
+async function assertGitDirectoryReadable(gitDir: string): Promise<void> {
+  for (const name of ['HEAD', 'objects', 'refs']) {
+    const path = join(gitDir, name);
+    try {
+      await access(path, fsConstants.R_OK);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      // Missing members are Git's format call; unreadable ones are ours.
+      if (code === 'ENOENT' || code === 'ENOTDIR') continue;
+      throw new Error(`Git metadata is not readable: ${path}`, { cause: error });
+    }
   }
 }

--- a/packages/storage/src/git-entry.ts
+++ b/packages/storage/src/git-entry.ts
@@ -66,8 +66,10 @@ async function isGitDirectory(gitDir: string): Promise<boolean> {
   try {
     // readFile fails closed on a missing, unreadable, or directory HEAD.
     const head = (await readFile(join(gitDir, 'HEAD'), 'utf8')).trim();
+    // A symref must target a ref under refs/; git itself rejects any other
+    // target (e.g. `ref: gk`) with exit 128 even when objects/ and refs/ exist.
     const validHead = head.startsWith(HEAD_REF_PREFIX)
-      ? head.slice(HEAD_REF_PREFIX.length).trim() !== ''
+      ? head.slice(HEAD_REF_PREFIX.length).trim().startsWith('refs/')
       : HEAD_OBJECT_ID.test(head);
     if (!validHead) return false;
   } catch {


### PR DESCRIPTION
## Summary

`hasEnclosingGitEntry` treated a folder as "inside a repository" whenever it could `lstat` a `.git` entry, without checking that the entry was a repository Git can actually use. A structurally invalid ancestor `.git` — for example a `.git/` holding only unrelated subdirectories, or a `HEAD` that is not a valid symref under `refs/` — therefore marked every nested plain folder as a repository. Classification passed that corrupted ancestor state to the downstream Git probe, which exits 128, and the add-folder action surfaced as `project.catalog.mutate → commit_outcome_unknown`.

This changes ancestor classification to defer to Git instead of trusting the filesystem entry:

- A `.git` entry in a strict ancestor is accepted only when Git itself accepts it (`git rev-parse --resolve-git-dir`). When Git rejects the entry, the walk continues outward, matching how Git's own discovery skips markers it cannot use. Valid Git directories, `gitdir:` indirection files, repositories, and linked worktrees continue to resolve as before.
- A `.git` entry in the selected folder itself still returns `true` without consulting Git, preserving the existing fail-closed behavior for a malformed marker in the directory being classified.
- Git's exit code 128 conflates "this is not a valid repository" with "I could not read the metadata", so an unreadable entry — `HEAD`, `objects`, `refs`, or a gitfile's target — raises instead of being downgraded to an ordinary folder. Execution failures propagate for the same reason, so a missing Git executable cannot silently turn a repository into a plain folder.

Regression coverage adds a shared fixture that writes broken Git metadata in several shapes (`HEAD` replaced by a directory, garbage `HEAD`, a `ref:` symref outside `refs/`, a gitfile pointing at a bare repo with a broken `HEAD`, and a repository missing `objects` and `refs`), together with tests for Project Catalog classification, workspace identity marker publication, and fail-closed behavior while an ancestor repository's metadata is unreadable.

Fixes #4806

## Review focus

Classification of strict ancestors now depends on the Git executable, so the tests exercise real `git` rather than a stub and the suite needs Git on `PATH` (the unreadable-metadata test uses POSIX permissions and is skipped on Windows). The exit-128 handling in `isGitEntry` is the subtle part: review that an invalid format and an unreadable repository stay distinguishable, since collapsing the two is what produced the original bug.

## Verification

- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/storage run typecheck`
- `npm --workspace @maka/storage run test:dist` — 1,112 passed, 8 skipped, 0 failed
- `npx biome check packages/storage/src/git-entry.ts packages/storage/src/__tests__/project-catalog.test.ts packages/storage/src/__tests__/workspace-identity.test.ts`
- `npm run check:asf-headers`
- Verified the affected real-world folder now resolves with `kind: 'folder'`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex — root-cause analysis, implementation, regression tests, verification, and PR drafting.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
