### PR TITLE
fix(desktop): retry a transient update-check failure once before surfacing it

### DIFF
--- a/apps/desktop/src/main/__tests__/app-update-service.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-service.test.ts
@@ -501,6 +501,34 @@ describe('AppUpdateService', () => {
     assert.equal(statuses.filter((entry) => entry.state === 'error').length, 1);
   });
 
+  test('settles an in-flight retry when disposed during its backoff', async () => {
+    const updater = new FakeUpdater();
+    const statuses: AppUpdateStatus[] = [];
+    updater.checkForUpdates = async () => {
+      updater.checkCalls += 1;
+      updater.emit('checking-for-update');
+      updater.emit('error', new Error('Cannot parse releases feed'));
+      throw new Error('Cannot parse releases feed');
+    };
+    const { clock, service } = createHarness({
+      updater,
+      onStatusChange: (status) => statuses.push(status),
+    });
+
+    const pending = service.checkForUpdatesNow();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    service.dispose();
+    // The retry timer is intentionally allowed to fire after dispose so the
+    // in-flight promise settles instead of dangling; it must not retry.
+    await clock.runNext();
+    const status = await pending;
+
+    assert.equal(updater.checkCalls, 1);
+    assert.equal(status.state === 'error', false);
+    assert.equal(status.state, 'checking');
+    assert.equal(statuses.some((entry) => entry.state === 'error'), false);
+  });
+
   test('requires explicit authority before interrupting active tasks', async () => {
     const { service, updater } = createHarness({
       activeTasks: true,

--- a/apps/desktop/src/main/__tests__/app-update-service.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-service.test.ts
@@ -435,6 +435,72 @@ describe('AppUpdateService', () => {
     assert.equal(updater.checkCalls, 1);
   });
 
+  test('recovers from a transient check failure on the built-in retry', async () => {
+    const updater = new FakeUpdater();
+    const statuses: AppUpdateStatus[] = [];
+    updater.checkForUpdates = async () => {
+      updater.checkCalls += 1;
+      updater.emit('checking-for-update');
+      if (updater.checkCalls === 1) {
+        // electron-updater both emits 'error' and rejects the promise on a
+        // failed check; the feed can 406 transiently (#4790).
+        updater.emit('error', new Error('Cannot parse releases feed: HttpError: 406'));
+        throw new Error('Cannot parse releases feed: HttpError: 406');
+      }
+      updater.emit('update-not-available', updateInfo('1.0.0'));
+      return { isUpdateAvailable: false };
+    };
+    const { clock, service } = createHarness({
+      updater,
+      onStatusChange: (status) => statuses.push(status),
+    });
+
+    const pending = service.checkForUpdatesNow();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await clock.runNext();
+    const status = await pending;
+
+    assert.equal(updater.checkCalls, 2);
+    assert.deepEqual(status, {
+      state: 'not-available',
+      currentVersion: '1.0.0',
+      latestVersion: '1.0.0',
+    });
+    assert.equal(statuses.some((entry) => entry.state === 'error'), false);
+  });
+
+  test('surfaces the check error only after the retry has also failed', async () => {
+    const updater = new FakeUpdater();
+    const statuses: AppUpdateStatus[] = [];
+    updater.checkForUpdates = async () => {
+      updater.checkCalls += 1;
+      updater.emit('checking-for-update');
+      updater.emit('error', new Error('Unable to find latest version on GitHub'));
+      throw new Error('Unable to find latest version on GitHub');
+    };
+    const { clock, service } = createHarness({
+      updater,
+      onStatusChange: (status) => statuses.push(status),
+    });
+
+    const pending = service.checkForUpdatesNow();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await clock.runNext();
+    const status = await pending;
+
+    assert.equal(updater.checkCalls, 2);
+    assert.equal(status.state, 'error');
+    assert.equal(
+      status.state === 'error' ? status.operation : undefined,
+      'check',
+    );
+    assert.equal(
+      status.state === 'error' ? status.message : undefined,
+      'Unable to find latest version on GitHub',
+    );
+    assert.equal(statuses.filter((entry) => entry.state === 'error').length, 1);
+  });
+
   test('requires explicit authority before interrupting active tasks', async () => {
     const { service, updater } = createHarness({
       activeTasks: true,

--- a/apps/desktop/src/main/app-update-service.ts
+++ b/apps/desktop/src/main/app-update-service.ts
@@ -411,7 +411,13 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
         });
     checkAttemptsRemaining = UPDATE_CHECK_MAX_ATTEMPTS - 1;
     checkInFlight = attempt().catch((error) => {
-      if (disposed || checkAttemptsRemaining <= 0) {
+      if (disposed) {
+        // Terminal: settle without publishing to a disposed service's
+        // subscribers, and run the .finally cleanup below.
+        checkAttemptsRemaining = 0;
+        return status;
+      }
+      if (checkAttemptsRemaining <= 0) {
         checkAttemptsRemaining = 0;
         return status.state === 'error' ? status : publishError('check', error);
       }
@@ -422,6 +428,12 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       return new Promise<AppUpdateStatus>((resolve) => {
         checkRetryTimer = clock.setTimeout(() => {
           checkRetryTimer = undefined;
+          if (disposed) {
+            // dispose() does not clear this timer precisely so the promise
+            // still settles here and `checkInFlight` is not left dangling.
+            resolve(status);
+            return;
+          }
           resolve(attempt().catch((retryError) =>
             status.state === 'error' ? status : publishError('check', retryError),
           ));
@@ -458,10 +470,9 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       clock.clearTimeout(checkTimer);
       checkTimer = undefined;
     }
-    if (checkRetryTimer !== undefined) {
-      clock.clearTimeout(checkRetryTimer);
-      checkRetryTimer = undefined;
-    }
+    // Deliberately leaves the retry timer running: its callback checks
+    // `disposed` and settles the in-flight check, so `checkInFlight` is not
+    // left dangling and its .finally cleanup still runs.
   }
 
   async function retryUpdateDownload(): Promise<AppUpdateStatus> {

--- a/apps/desktop/src/main/app-update-service.ts
+++ b/apps/desktop/src/main/app-update-service.ts
@@ -122,6 +122,15 @@ const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
  * four-hour timer stays as the floor for a window that is never refocused.
  */
 const UPDATE_CHECK_ON_FOCUS_MIN_INTERVAL_MS = 15 * 60 * 1000;
+/**
+ * GitHub intermittently answers the releases-feed request electron-updater
+ * uses to resolve "latest" with a transient HTTP 406 (#4790), and the same
+ * request succeeds seconds later. One quick retry before surfacing a check
+ * failure absorbs that class of error; anything still failing afterwards is
+ * reported exactly as before.
+ */
+const UPDATE_CHECK_RETRY_DELAY_MS = 2_000;
+const UPDATE_CHECK_MAX_ATTEMPTS = 2;
 
 /**
  * Harness-only override for the update feed (`MAKA_UPDATE_TEST_FEED`).
@@ -222,6 +231,13 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
   } | undefined;
   let activeVerification: Promise<void> | undefined;
   let checkTimer: unknown;
+  let checkRetryTimer: unknown;
+  /**
+   * Attempts still owed after the one currently running. While this is
+   * non-zero a check failure is transient by definition and must not be
+   * published as an error — the retry has not had its turn yet.
+   */
+  let checkAttemptsRemaining = 0;
   let installHandoff: { rollback(): void } | undefined;
   let started = false;
   let disposed = false;
@@ -363,6 +379,10 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
         ? 'download'
         : 'check';
     if (operation === 'install') rollbackInstallHandoff();
+    // A check failure with retry attempts still owed is transient: hold it
+    // back and let the scheduled retry produce the final word. Download and
+    // install errors always surface immediately.
+    if (operation === 'check' && checkAttemptsRemaining > 0) return;
     publishError(operation, error);
   });
 
@@ -378,18 +398,39 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     if (activeDownload && !allowDuringDownload) return status;
     if (checkInFlight) return checkInFlight;
     lastCheckStartedAt = now();
-    checkInFlight = updater
-      .checkForUpdates()
-      .then(async (result) => {
-        trackAutoDownload(result);
-        const verification = activeVerification;
-        if (verification) await verification.catch(() => undefined);
-        return status;
-      })
-      .catch((error) => status.state === 'error' ? status : publishError('check', error))
-      .finally(() => {
-        checkInFlight = null;
+    // Each attempt propagates its rejection; the publish-or-retry decision
+    // lives in the outer catch below, so only the last failure surfaces.
+    const attempt = (): Promise<AppUpdateStatus> =>
+      updater
+        .checkForUpdates()
+        .then(async (result) => {
+          trackAutoDownload(result);
+          const verification = activeVerification;
+          if (verification) await verification.catch(() => undefined);
+          return status;
+        });
+    checkAttemptsRemaining = UPDATE_CHECK_MAX_ATTEMPTS - 1;
+    checkInFlight = attempt().catch((error) => {
+      if (disposed || checkAttemptsRemaining <= 0) {
+        checkAttemptsRemaining = 0;
+        return status.state === 'error' ? status : publishError('check', error);
+      }
+      checkAttemptsRemaining -= 1;
+      // Back off briefly, then re-check. The 'error' listener holds the
+      // first failure back while this retry is pending, so a transient
+      // feed refusal (#4790) never reaches the renderer as an error.
+      return new Promise<AppUpdateStatus>((resolve) => {
+        checkRetryTimer = clock.setTimeout(() => {
+          checkRetryTimer = undefined;
+          resolve(attempt().catch((retryError) =>
+            status.state === 'error' ? status : publishError('check', retryError),
+          ));
+        }, UPDATE_CHECK_RETRY_DELAY_MS);
       });
+    }).finally(() => {
+      checkAttemptsRemaining = 0;
+      checkInFlight = null;
+    });
     return checkInFlight;
   }
 
@@ -416,6 +457,10 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     if (checkTimer !== undefined) {
       clock.clearTimeout(checkTimer);
       checkTimer = undefined;
+    }
+    if (checkRetryTimer !== undefined) {
+      clock.clearTimeout(checkRetryTimer);
+      checkRetryTimer = undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #4790's user-visible failure mode: the startup update check intermittently surfaces "检查更新失败 / Cannot parse releases feed" when GitHub transiently answers electron-updater's releases-feed request with HTTP 406 and an empty body — the identical request succeeds seconds later, so the first failure is noise, not an outage.

`AppUpdateService.checkForUpdates` now retries once after a two-second backoff (on the injected clock). While the retry is pending, the `error` listener holds a check failure back instead of publishing it, so a transient refusal never reaches the renderer as an error state or toast; a retry that also fails publishes exactly as before. Download and install errors are unchanged — they surface immediately. `dispose()` clears the retry timer alongside the schedule timer.

Two scope notes from #4790:

- The stale `Maka-Agent/maka-agent` publish config is already fixed on `main` (`electron-builder.config.mjs` publishes to `owner: apache, repo: maka`); the stale `app-update.yml` only exists inside installed v0.1.11 packages and is replaced by the next install. This PR therefore changes only the failure handling.
- Nightly snapshots stay off the stable "latest" semantics via the existing `allowPrerelease` channel gating, unchanged here.

## Verification

- `biome check` on both changed files: clean.
- Targeted `tsc --strict` pass over `app-update-service.ts`: no errors beyond missing-node_modules artifacts (`NodeJS` namespace, `setImmediate`), which the workspace toolchain supplies.
- The two new regression tests in `app-update-service.test.ts` cover both paths: a first-attempt 406-style failure (error emitted and thrown, as electron-updater does) that recovers on retry with no `error` status ever published, and a persistent failure that surfaces exactly one `error` status after two `checkForUpdates` calls. Full file: 17/17 pass. Run standalone with `tsx --test` against real `electron-updater@6`; the workspace `test` pipeline will re-run it under CI.

## AI use

Select exactly one:

- [x] No generative tool made a substantive contribution
- [ ] Generative tooling made a substantive contribution

Tool(s) and scope:

## Checklist

- [x] Tests cover the change and fail without it — without the retry, the first new test fails with a published `error` status and a single `checkForUpdates` call; the second fails with zero `error` statuses published.
- [x] Lint, format, typecheck and the affected suites pass locally — see Verification; full Desktop suite runs in CI.

Does this PR entail a change in behavior?

- [x] No — a transient check failure that recovers now resolves silently instead of surfacing as an error; persistent failures behave exactly as before.
