### PR TITLE
fix(peer): preserve Host sessions across path changes

### DIFF
--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -82,13 +82,16 @@ const LISTENER_ADDRESS_QUIET_PERIOD: Duration = Duration::from_millis(250);
 const COORDINATION_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const TRANSIT_HOLE_PUNCH_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 const AUTOMATIC_RELAY_COOLDOWN: Duration = Duration::from_secs(30);
-const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
+const PING_INTERVAL: Duration = Duration::from_secs(2);
+const PING_TIMEOUT: Duration = Duration::from_secs(3);
+const MAX_CONSECUTIVE_PING_FAILURES: u8 = 3;
 const TARGET_COORDINATION_RESERVATIONS: usize = 2;
 const MAX_AUTOMATIC_RELAY_CANDIDATES: usize = 8;
 const MAX_REMEMBERED_RELAY_FAILURES: u8 = 3;
 const MAX_RELAY_ADDRESSES_PER_PEER: usize = 4;
 const MAX_PUBLISHED_COORDINATION_RELAY_ADDRESSES: usize = 16;
-const TRANSIT_FALLBACK_DELAY: Duration = Duration::from_secs(3);
+const TRANSIT_FALLBACK_DELAY: Duration = Duration::from_millis(250);
 const MAX_TRANSIT_RESERVATIONS: usize = 32;
 const MAX_TRANSIT_CIRCUITS: usize = 8;
 const MAX_TRANSIT_CIRCUITS_PER_PEER: usize = 2;
@@ -178,6 +181,16 @@ pub enum EngineCommand {
     Stop {
         result: oneshot::Sender<()>,
     },
+    #[cfg(test)]
+    HasDirectConnection {
+        peer_id: PeerId,
+        result: oneshot::Sender<bool>,
+    },
+    #[cfg(test)]
+    CloseDirectConnections {
+        peer_id: PeerId,
+        result: oneshot::Sender<()>,
+    },
 }
 
 pub struct TransitPolicy {
@@ -250,7 +263,8 @@ struct Behaviour {
 struct PendingConnect {
     attempt_id: ConnectAttemptId,
     peer_id: PeerId,
-    result: oneshot::Sender<Result<PeerStream, PeerError>>,
+    // None keeps route discovery alive after a transit stream was delivered.
+    result: Option<oneshot::Sender<Result<PeerStream, PeerError>>>,
     stream_kind: StreamKind,
     deadline: Instant,
     opening: Option<PendingStreamOpen>,
@@ -343,6 +357,27 @@ struct DirectConnectState {
     pending: HashMap<u32, PendingConnect>,
     active: HashMap<ConnectionId, usize>,
     retiring_connections: HashSet<ConnectionId>,
+    health: HashMap<ConnectionId, ConnectionHealth>,
+}
+
+#[derive(Default)]
+struct ConnectionHealth {
+    failures: u8,
+    rtt: Option<Duration>,
+}
+
+impl ConnectionHealth {
+    fn observe(&mut self, result: Result<Duration, ping::Failure>) -> bool {
+        match result {
+            Ok(rtt) => {
+                self.failures = 0;
+                self.rtt = Some(self.rtt.map_or(rtt, |previous| (previous * 3 + rtt) / 4));
+            }
+            Err(ping::Failure::Unsupported) => return false,
+            Err(_) => self.failures = self.failures.saturating_add(1),
+        }
+        self.failures >= MAX_CONSECUTIVE_PING_FAILURES
+    }
 }
 
 enum PendingAttemptAdmission {
@@ -692,21 +727,18 @@ async fn run_endpoint_async(
     };
 
     let listen_addresses = if options.listen_addresses.is_empty() {
-        vec![
-            "/ip4/0.0.0.0/udp/0/quic-v1"
-                .parse()
-                .expect("constant multiaddr"),
-        ]
+        default_listen_addresses()
     } else {
         options.listen_addresses
     };
     let mut pending_listeners = HashSet::new();
+    let mut configured_listeners = HashMap::new();
     for address in &listen_addresses {
-        pending_listeners.insert(
-            swarm
-                .listen_on(address.clone())
-                .map_err(|error| PeerError::new("peer_native_failed", error.to_string()))?,
-        );
+        let listener = swarm
+            .listen_on(address.clone())
+            .map_err(|error| PeerError::new("peer_native_failed", error.to_string()))?;
+        pending_listeners.insert(listener);
+        configured_listeners.insert(listener, address.clone());
     }
     let mut coordination_relays = HashMap::new();
     for relay in &options.coordination_relays {
@@ -735,7 +767,6 @@ async fn run_endpoint_async(
 
     let startup_deadline = Instant::now() + Duration::from_secs(10);
     let mut address_quiet_deadline = None;
-    let mut bound_addresses = HashSet::new();
     loop {
         let deadline = address_quiet_deadline
             .unwrap_or(startup_deadline)
@@ -747,7 +778,6 @@ async fn run_endpoint_async(
                 address,
             }) if !is_relayed_address(&address) => {
                 pending_listeners.remove(&listener_id);
-                bound_addresses.insert(address_with_peer(address, local_peer_id));
                 if pending_listeners.is_empty() {
                     address_quiet_deadline = Some(Instant::now() + LISTENER_ADDRESS_QUIET_PERIOD);
                 }
@@ -764,7 +794,12 @@ async fn run_endpoint_async(
             }
         }
     }
-    let mut bound_addresses = bound_addresses.into_iter().collect::<Vec<_>>();
+    let mut bound_addresses = swarm
+        .listeners()
+        .filter(|address| !is_relayed_address(address))
+        .cloned()
+        .map(|address| address_with_peer(address, local_peer_id))
+        .collect::<Vec<_>>();
     bound_addresses.sort_unstable_by_key(ToString::to_string);
     transit.listen_addresses.clone_from(&bound_addresses);
     if webrtc_stun_urls.is_some() {
@@ -776,7 +811,7 @@ async fn run_endpoint_async(
         &mut coordination_relays,
         &reachability,
         &mut relay_anchors,
-        &bound_addresses,
+        &transit.listen_addresses,
     );
     publish_connectivity(&swarm, &connectivity);
     let _ = ready_tx.send(Ok(local_peer_id));
@@ -785,6 +820,12 @@ async fn run_endpoint_async(
     let (stream_completed_tx, mut stream_completed_rx) =
         mpsc::channel::<CompletedStream>(MAX_ESTABLISHED_CONNECTIONS as usize);
     let mut direct = DirectConnectState::default();
+    direct.health.extend(
+        mesh_control
+            .connection_ids()
+            .into_iter()
+            .map(|id| (id, ConnectionHealth::default())),
+    );
     let mut deadline_tick = tokio::time::interval(Duration::from_millis(100));
     deadline_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut discovered_relays = options
@@ -793,13 +834,27 @@ async fn run_endpoint_async(
     let webrtc_cancellation = CancellationToken::new();
     let mut incoming_webrtc_upgrades = JoinSet::new();
     let mut outgoing_webrtc_upgrades = JoinSet::new();
+    let mut failed_listeners = Vec::new();
 
     loop {
         tokio::select! {
             command = commands.recv() => match command {
+                #[cfg(test)]
+                Some(EngineCommand::HasDirectConnection { peer_id, result }) => {
+                    let _ = result.send(stream_control.has_connection(peer_id, &direct.retiring_connections, &HashSet::new()));
+                }
+                #[cfg(test)]
+                Some(EngineCommand::CloseDirectConnections { peer_id, result }) => {
+                    for (connection, _) in stream_control.eligible_connections(peer_id, &HashSet::new(), &HashSet::new()) {
+                        direct.retiring_connections.insert(connection);
+                        let _ = swarm.close_connection(connection);
+                    }
+                    let _ = result.send(());
+                }
                 Some(EngineCommand::Connect { options, stream_kind, result }) => {
                     if direct.pending.contains_key(&options.request_id)
-                        || direct.pending.values().any(|connect| connect.peer_id == options.peer_id)
+                        || direct.pending.values().any(|connect| connect.peer_id == options.peer_id
+                            && connect.stream_kind == stream_kind && connect.result.is_some())
                     {
                         let _ = result.send(Err(PeerError::new(
                             "peer_connect_in_progress",
@@ -850,7 +905,7 @@ async fn run_endpoint_async(
                     direct.pending.insert(request_id, PendingConnect {
                         attempt_id,
                         peer_id: options.peer_id,
-                        result,
+                        result: Some(result),
                         stream_kind,
                         deadline: Instant::now() + options.deadline,
                         opening: None,
@@ -886,6 +941,7 @@ async fn run_endpoint_async(
                         request_id,
                         &mut direct.pending,
                         &direct.retiring_connections,
+                        &direct.health,
                         stream_control.clone(),
                         mesh_control.clone(),
                         opened_tx.clone(),
@@ -937,6 +993,7 @@ async fn run_endpoint_async(
                             request_id,
                             &mut direct.pending,
                             &direct.retiring_connections,
+                            &direct.health,
                             stream_control.clone(),
                             mesh_control.clone(),
                             opened_tx.clone(),
@@ -983,6 +1040,7 @@ async fn run_endpoint_async(
                             request_id,
                             &mut direct.pending,
                             &direct.retiring_connections,
+                            &direct.health,
                             stream_control.clone(),
                             mesh_control.clone(),
                             opened_tx.clone(),
@@ -1067,7 +1125,7 @@ async fn run_endpoint_async(
                         UpgradeRole::Answerer,
                         UpgradeOptions {
                             stun_urls,
-                            udp_bind_addresses: vec!["0.0.0.0:0".to_owned()],
+                            udp_bind_addresses: default_webrtc_bind_addresses(),
                             deadline: WEBRTC_UPGRADE_DEADLINE,
                             cancellation,
                         },
@@ -1139,7 +1197,7 @@ async fn run_endpoint_async(
                     &mut coordination_relays,
                     &reachability,
                     &mut relay_anchors,
-                    &bound_addresses,
+                    &transit.listen_addresses,
                 );
                 maintain_coordination_relays(
                     &mut swarm,
@@ -1243,29 +1301,42 @@ async fn run_endpoint_async(
                                 request_id,
                                 &mut direct.pending,
                                 &direct.retiring_connections,
+                                &direct.health,
                                 stream_control.clone(),
                                 mesh_control.clone(),
                                 opened_tx.clone(),
                             );
                             continue;
                         }
-                        waiter.cancellation.cancel();
+                        // A usable transit path must not cancel an in-flight
+                        // direct upgrade. Keep one maintenance attempt per peer
+                        // while its streams are in use; it never opens or replays
+                        // application requests.
+                        let maintain_direct = waiter.stream_kind == StreamKind::Application
+                            && opened.path.relay_peer_id().is_some()
+                            && !direct.pending.values().any(|other| other.peer_id == waiter.peer_id && other.result.is_none());
+                        let result_sender = waiter.result.take();
+                        if !maintain_direct {
+                            waiter.cancellation.cancel();
+                        }
                         abort_pending_openings(&mut waiter);
                         let result = match waiter.stream_kind {
                             StreamKind::Application => {
-                                retire_direct_dials(
-                                    &mut swarm,
-                                    &mut direct.retiring_connections,
-                                    waiter.dials,
-                                    Some(connection_id),
-                                );
+                                if !maintain_direct {
+                                    retire_direct_dials(
+                                        &mut swarm, &mut direct,
+                                        std::mem::take(&mut waiter.dials), Some(connection_id),
+                                    );
+                                }
                                 *direct.active.entry(connection_id).or_default() += 1;
-                                release_coordination_relays(
-                                    &mut swarm,
-                                    &mut coordination_relays,
-                                    &waiter.coordination_relay_peers,
-                                    &direct.active,
-                                );
+                                if !maintain_direct {
+                                    release_coordination_relays(
+                                        &mut swarm,
+                                        &mut coordination_relays,
+                                        &waiter.coordination_relay_peers,
+                                        &direct.active,
+                                    );
+                                }
                                 Ok(spawn_stream(
                                     waiter.peer_id,
                                     opened.path,
@@ -1279,8 +1350,8 @@ async fn run_endpoint_async(
                             StreamKind::MeshControl => {
                                 retire_direct_dials(
                                     &mut swarm,
-                                    &mut direct.retiring_connections,
-                                    waiter.dials,
+                                    &mut direct,
+                                    std::mem::take(&mut waiter.dials),
                                     Some(connection_id),
                                 );
                                 *direct.active.entry(connection_id).or_default() += 1;
@@ -1291,15 +1362,21 @@ async fn run_endpoint_async(
                                     Some((
                                         StreamCompletion::MeshControl {
                                             connection_id,
-                                            coordination_relay_peers: waiter
-                                                .coordination_relay_peers,
+                                            coordination_relay_peers: std::mem::take(&mut waiter.coordination_relay_peers),
                                         },
                                         stream_completed_tx.clone(),
                                     )),
                                 ))
                             }
                         };
-                        let _ = waiter.result.send(result);
+                        if let Some(sender) = result_sender {
+                            let _ = sender.send(result);
+                        }
+                        if maintain_direct {
+                            waiter.dials.remove(&connection_id);
+                            waiter.deadline = Instant::now() + TRANSIT_HOLE_PUNCH_RETRY_INTERVAL;
+                            direct.pending.insert(request_id, waiter);
+                        }
                     }
                     Err(application_stream::OpenStreamError::UnsupportedProtocol) => {
                         fail_pending_connect(
@@ -1337,6 +1414,7 @@ async fn run_endpoint_async(
                             request_id,
                             &mut direct.pending,
                             &direct.retiring_connections,
+                            &direct.health,
                             stream_control.clone(),
                             mesh_control.clone(),
                             opened_tx.clone(),
@@ -1345,6 +1423,10 @@ async fn run_endpoint_async(
                 }
             }
             event = swarm.select_next_some() => {
+                if let SwarmEvent::ListenerClosed { listener_id, .. } = &event
+                    && let Some(address) = configured_listeners.remove(listener_id) {
+                    failed_listeners.push((address, Instant::now() + COORDINATION_RETRY_INTERVAL));
+                }
                 handle_swarm_event(
                     &mut swarm,
                     event,
@@ -1367,7 +1449,7 @@ async fn run_endpoint_async(
                     &mut coordination_relays,
                     &reachability,
                     &mut relay_anchors,
-                    &bound_addresses,
+                    &transit.listen_addresses,
                 );
                 maintain_coordination_relays(
                     &mut swarm,
@@ -1388,6 +1470,7 @@ async fn run_endpoint_async(
                         request_id,
                         &mut direct.pending,
                         &direct.retiring_connections,
+                        &direct.health,
                         stream_control.clone(),
                         mesh_control.clone(),
                         opened_tx.clone(),
@@ -1396,6 +1479,8 @@ async fn run_endpoint_async(
             }
             _ = deadline_tick.tick() => {
                 let now = Instant::now();
+                restore_listeners(&mut swarm, &mut configured_listeners, &mut failed_listeners, now);
+                maintain_direct_routes(&mut swarm, &mut direct, &mut coordination_relays, &stream_control, now);
                 rebalance_automatic_relays(
                     &mut swarm,
                     &mut coordination_relays,
@@ -1406,7 +1491,7 @@ async fn run_endpoint_async(
                     &mut coordination_relays,
                     &reachability,
                     &mut relay_anchors,
-                    &bound_addresses,
+                    &transit.listen_addresses,
                 );
                 maintain_coordination_relays(
                     &mut swarm,
@@ -1429,7 +1514,7 @@ async fn run_endpoint_async(
                     &mut outgoing_webrtc_upgrades,
                 );
                 let expired = direct.pending.iter()
-                    .filter_map(|(request_id, item)| (item.deadline <= now).then_some(*request_id))
+                    .filter_map(|(request_id, item)| (item.result.is_some() && item.deadline <= now).then_some(*request_id))
                     .collect::<Vec<_>>();
                 for request_id in expired {
                     if let Some(waiter) = direct.pending.remove(&request_id) {
@@ -1531,11 +1616,15 @@ fn build_swarm(
                 transit_relay_config(allowed_transit_peers),
             ),
             dcutr: dcutr::Behaviour::new(key.public().to_peer_id()),
-            identify: identify::Behaviour::new(identify::Config::new(
-                IDENTIFY_PROTOCOL.to_owned(),
-                key.public(),
-            )),
-            ping: ping::Behaviour::new(ping::Config::new()),
+            identify: identify::Behaviour::new(
+                identify::Config::new(IDENTIFY_PROTOCOL.to_owned(), key.public())
+                    .with_push_listen_addr_updates(true),
+            ),
+            ping: ping::Behaviour::new(
+                ping::Config::new()
+                    .with_interval(PING_INTERVAL)
+                    .with_timeout(PING_TIMEOUT),
+            ),
             application_stream,
             mesh_control: mesh_stream,
             webrtc_signaling: Toggle::from(webrtc_enabled.then_some(webrtc_signaling)),
@@ -1735,6 +1824,7 @@ fn update_connect_candidates(
         let _ = swarm.close_connection(connection_id);
     }
     let changed = direct_changed || coordination_changed || transit_changed;
+    let mut retired_dials = HashMap::new();
     if changed {
         waiter.next_route_attempt = Instant::now();
         waiter.transit_after = Instant::now();
@@ -1742,30 +1832,19 @@ fn update_connect_candidates(
             waiter.retry_coordination = true;
         }
         if direct_changed {
-            retire_pending_dials_by_origin(
-                swarm,
-                &mut direct.retiring_connections,
-                waiter,
-                DialOrigin::Direct,
-            );
+            retired_dials.extend(take_pending_dials_by_origin(waiter, DialOrigin::Direct));
         }
         if coordination_changed {
-            retire_pending_dials_by_origin(
-                swarm,
-                &mut direct.retiring_connections,
+            retired_dials.extend(take_pending_dials_by_origin(
                 waiter,
                 DialOrigin::Coordination,
-            );
+            ));
         }
         if transit_changed {
-            retire_pending_dials_by_origin(
-                swarm,
-                &mut direct.retiring_connections,
-                waiter,
-                DialOrigin::Transit,
-            );
+            retired_dials.extend(take_pending_dials_by_origin(waiter, DialOrigin::Transit));
         }
     }
+    retire_direct_dials(swarm, direct, retired_dials, None);
     release_coordination_relays(
         swarm,
         coordination_relays,
@@ -1838,7 +1917,14 @@ fn start_pending_webrtc_upgrades(
         let Some(waiter) = pending.get_mut(&request_id) else {
             continue;
         };
-        if waiter.stream_kind != StreamKind::Application || waiter.webrtc_active_attempt.is_some() {
+        if waiter.stream_kind != StreamKind::Application
+            || waiter.webrtc_active_attempt.is_some()
+            || signaling_control.has_connection(
+                waiter.peer_id,
+                retiring_connections,
+                &HashSet::new(),
+            )
+        {
             continue;
         }
         let Some(relay_peer_id) = next_webrtc_relay_peer(
@@ -1888,7 +1974,7 @@ fn start_pending_webrtc_upgrades(
                     UpgradeRole::Offerer,
                     UpgradeOptions {
                         stun_urls,
-                        udp_bind_addresses: vec!["0.0.0.0:0".to_owned()],
+                        udp_bind_addresses: default_webrtc_bind_addresses(),
                         deadline: WEBRTC_UPGRADE_DEADLINE,
                         cancellation,
                     },
@@ -2104,6 +2190,7 @@ fn maybe_open_peer_stream(
     request_id: u32,
     pending: &mut HashMap<u32, PendingConnect>,
     retiring_connections: &HashSet<ConnectionId>,
+    health: &HashMap<ConnectionId, ConnectionHealth>,
     application_control: application_stream::Control,
     mesh_control: application_stream::Control,
     opened_tx: mpsc::Sender<OpenedStream>,
@@ -2125,7 +2212,7 @@ fn maybe_open_peer_stream(
         .union(&waiter.rejected_connections)
         .copied()
         .collect::<HashSet<_>>();
-    if waiter.opening.is_some() {
+    if waiter.result.is_none() || waiter.opening.is_some() {
         return;
     }
     let stream_kind = waiter.stream_kind;
@@ -2137,10 +2224,9 @@ fn maybe_open_peer_stream(
             mesh_control.eligible_connections(peer_id, &excluded, &eligible_relay_peers)
         }
     };
-    let Some((connection_id, _)) = candidates
-        .into_iter()
-        .min_by_key(|(_, path)| stream_candidate_priority(path))
-    else {
+    let Some((connection_id, _)) = candidates.into_iter().min_by_key(|(connection_id, path)| {
+        stream_candidate_score(path, health.get(connection_id))
+    }) else {
         return;
     };
     let attempt_id = waiter.attempt_id;
@@ -2187,6 +2273,20 @@ fn stream_candidate_priority(path: &PeerConnectionPath) -> u8 {
     }
 }
 
+fn stream_candidate_score(
+    path: &PeerConnectionPath,
+    health: Option<&ConnectionHealth>,
+) -> (u8, bool, Duration, u8) {
+    (
+        health.map_or(0, |health| health.failures),
+        path.relay_peer_id().is_some(),
+        health
+            .and_then(|health| health.rtt)
+            .unwrap_or(Duration::from_millis(100)),
+        stream_candidate_priority(path),
+    )
+}
+
 async fn gracefully_disconnect(swarm: &mut Swarm<Behaviour>) {
     let peers = swarm.connected_peers().copied().collect::<Vec<_>>();
     for peer_id in peers {
@@ -2207,6 +2307,14 @@ fn handle_swarm_event(
     direct: &mut DirectConnectState,
     mut route_runtime: RouteRuntime<'_>,
 ) {
+    if matches!(
+        &event,
+        SwarmEvent::NewListenAddr { .. }
+            | SwarmEvent::ExpiredListenAddr { .. }
+            | SwarmEvent::ListenerClosed { .. }
+    ) {
+        refresh_listen_addresses(swarm, &mut route_runtime);
+    }
     let connectivity_changed = matches!(
         &event,
         SwarmEvent::ConnectionEstablished { .. } | SwarmEvent::ConnectionClosed { .. }
@@ -2248,6 +2356,7 @@ fn handle_swarm_event(
                 let _ = swarm.close_connection(connection_id);
                 return;
             }
+            direct.health.entry(connection_id).or_default();
             if let Some(relay) = coordination_relays.get_mut(&peer_id) {
                 let lifecycle_owned = relay.pending_connection == Some(connection_id);
                 if lifecycle_owned {
@@ -2275,6 +2384,7 @@ fn handle_swarm_event(
             connection_id,
             ..
         } => {
+            direct.health.remove(&connection_id);
             direct.retiring_connections.remove(&connection_id);
             for connect in direct.pending.values_mut() {
                 remove_pending_dial(connect, connection_id);
@@ -2321,6 +2431,18 @@ fn handle_swarm_event(
             }
             if reservation_changed {
                 publish_route_runtime(coordination_relays, &mut route_runtime);
+            }
+        }
+        SwarmEvent::Behaviour(BehaviourEvent::Ping(ping::Event {
+            connection, result, ..
+        })) => {
+            if direct
+                .health
+                .get_mut(&connection)
+                .is_some_and(|health| health.observe(result))
+            {
+                direct.retiring_connections.insert(connection);
+                let _ = swarm.close_connection(connection);
             }
         }
         SwarmEvent::OutgoingConnectionError {
@@ -2438,8 +2560,33 @@ fn handle_swarm_event(
         }
         SwarmEvent::Behaviour(BehaviourEvent::Identify(identify::Event::Received {
             peer_id,
+            info,
             ..
         })) => {
+            // Identify is authenticated by this peer's transport identity. Keep
+            // background dialing current when the remote changes interfaces;
+            // do not wait for the next application connection or Mesh sweep.
+            let routes = bounded_unique(
+                info.listen_addrs
+                    .into_iter()
+                    .filter(|address| {
+                        !is_relayed_address(address)
+                            && !address.iter().any(|p| matches!(p, Protocol::WebRTC))
+                    })
+                    .filter_map(|address| address_with_expected_peer(&address, peer_id).ok())
+                    .collect(),
+                MAX_CONNECT_ROUTES_PER_CLASS,
+            );
+            for pending in direct
+                .pending
+                .values_mut()
+                .filter(|pending| pending.peer_id == peer_id && pending.result.is_none())
+            {
+                if pending.direct_routes != routes {
+                    pending.direct_routes.clone_from(&routes);
+                    pending.next_route_attempt = Instant::now();
+                }
+            }
             if let Some(relay) = coordination_relays.get_mut(&peer_id) {
                 relay.identify_received = true;
             }
@@ -2626,6 +2773,7 @@ fn reconcile_pending_transit_connects(
     }
     let now = Instant::now();
     let mut unavailable = Vec::new();
+    let mut retired_dials = HashMap::new();
     for (request_id, waiter) in &mut direct.pending {
         if waiter.stream_kind != StreamKind::Application
             || waiter.transit_relay_peers.is_disjoint(revoked_relays)
@@ -2643,12 +2791,7 @@ fn reconcile_pending_transit_connects(
         if let Some(opening) = waiter.opening.take() {
             opening.task.abort();
         }
-        retire_pending_dials_by_origin(
-            swarm,
-            &mut direct.retiring_connections,
-            waiter,
-            DialOrigin::Transit,
-        );
+        retired_dials.extend(take_pending_dials_by_origin(waiter, DialOrigin::Transit));
         waiter.next_route_attempt = now;
         waiter.transit_after = now;
         if waiter.direct_routes.is_empty()
@@ -2658,6 +2801,7 @@ fn reconcile_pending_transit_connects(
             unavailable.push(*request_id);
         }
     }
+    retire_direct_dials(swarm, direct, retired_dials, None);
     for request_id in unavailable {
         let Some(waiter) = direct.pending.remove(&request_id) else {
             continue;
@@ -2675,22 +2819,21 @@ fn reconcile_pending_transit_connects(
     }
 }
 
-fn retire_pending_dials_by_origin(
-    swarm: &mut Swarm<Behaviour>,
-    retiring: &mut HashSet<ConnectionId>,
+fn take_pending_dials_by_origin(
     waiter: &mut PendingConnect,
     origin: DialOrigin,
-) {
+) -> HashMap<ConnectionId, DialOrigin> {
     let connections = waiter
         .dials
         .iter()
         .filter_map(|(connection_id, current)| (*current == origin).then_some(*connection_id))
         .collect::<Vec<_>>();
-    for connection_id in connections {
-        remove_pending_dial(waiter, connection_id);
-        retiring.insert(connection_id);
-        let _ = swarm.close_connection(connection_id);
-    }
+    connections
+        .into_iter()
+        .filter_map(|connection_id| {
+            remove_pending_dial(waiter, connection_id).map(|origin| (connection_id, origin))
+        })
+        .collect()
 }
 
 fn remove_pending_dial(
@@ -2713,14 +2856,16 @@ fn fail_pending_connect(
 ) {
     waiter.cancellation.cancel();
     abort_pending_openings(&mut waiter);
-    retire_direct_dials(swarm, &mut direct.retiring_connections, waiter.dials, None);
+    retire_direct_dials(swarm, direct, waiter.dials, None);
     release_coordination_relays(
         swarm,
         coordination_relays,
         &waiter.coordination_relay_peers,
         &direct.active,
     );
-    let _ = waiter.result.send(Err(error));
+    if let Some(result) = waiter.result {
+        let _ = result.send(Err(error));
+    }
 }
 
 fn abort_pending_openings(waiter: &mut PendingConnect) {
@@ -3121,8 +3266,102 @@ fn publish_route_runtime(
     else {
         return;
     };
-    let listen_addresses = reachability.borrow().listen_addresses.clone();
-    publish_active_coordination_relays(relays, reachability, relay_anchors, &listen_addresses);
+    publish_active_coordination_relays(
+        relays,
+        reachability,
+        relay_anchors,
+        &runtime.transit.listen_addresses,
+    );
+}
+
+fn restore_listeners(
+    swarm: &mut Swarm<Behaviour>,
+    configured: &mut HashMap<ListenerId, Multiaddr>,
+    failed: &mut Vec<(Multiaddr, Instant)>,
+    now: Instant,
+) {
+    failed.retain_mut(|(address, next_attempt)| {
+        if *next_attempt > now {
+            return true;
+        }
+        match swarm.listen_on(address.clone()) {
+            Ok(listener) => {
+                configured.insert(listener, address.clone());
+                false
+            }
+            Err(_) => {
+                *next_attempt = now + COORDINATION_RETRY_INTERVAL;
+                true
+            }
+        }
+    });
+}
+
+fn default_listen_addresses() -> Vec<Multiaddr> {
+    let mut addresses = vec![
+        "/ip4/0.0.0.0/udp/0/quic-v1"
+            .parse()
+            .expect("constant address"),
+        "/ip4/0.0.0.0/tcp/0".parse().expect("constant address"),
+    ];
+    // Some kernels disable IPv6. An optional family must not prevent the
+    // endpoint from starting on the available family.
+    if std::net::UdpSocket::bind("[::]:0").is_ok() {
+        addresses.push("/ip6/::/udp/0/quic-v1".parse().expect("constant address"));
+        addresses.push("/ip6/::/tcp/0".parse().expect("constant address"));
+    }
+    addresses
+}
+
+pub(crate) fn default_webrtc_bind_addresses() -> Vec<String> {
+    let mut addresses = vec!["0.0.0.0:0".to_owned()];
+    if std::net::UdpSocket::bind("[::]:0").is_ok() {
+        addresses.push("[::]:0".to_owned());
+    }
+    addresses
+}
+
+fn refresh_listen_addresses(swarm: &mut Swarm<Behaviour>, runtime: &mut RouteRuntime<'_>) {
+    let local_peer = *swarm.local_peer_id();
+    let mut addresses = swarm
+        .listeners()
+        .filter(|address| {
+            !is_relayed_address(address)
+                && !address
+                    .iter()
+                    .any(|protocol| matches!(protocol, Protocol::WebRTC))
+        })
+        .cloned()
+        .map(|address| address_with_peer(address, local_peer))
+        .collect::<Vec<_>>();
+    addresses.sort_unstable_by_key(ToString::to_string);
+    addresses.dedup();
+    let transit = &mut runtime.transit;
+    if transit.listen_addresses == addresses {
+        return;
+    }
+    for address in transit.published_addresses.clone() {
+        if !addresses.contains(&address) {
+            swarm.remove_external_address(&address);
+            transit
+                .published_addresses
+                .retain(|current| current != &address);
+        }
+    }
+    if transit
+        .allowed_peers
+        .read()
+        .is_ok_and(|peers| !peers.is_empty())
+    {
+        let existing = swarm.external_addresses().cloned().collect::<HashSet<_>>();
+        for address in &addresses {
+            if !existing.contains(address) {
+                swarm.add_external_address(address.clone());
+                transit.published_addresses.push(address.clone());
+            }
+        }
+    }
+    transit.listen_addresses = addresses;
 }
 
 fn bounded_relay_addresses(mut addresses: Vec<Multiaddr>) -> Vec<Multiaddr> {
@@ -3485,6 +3724,62 @@ fn webrtc_debug(message: std::fmt::Arguments<'_>) {
     }
 }
 
+fn maintain_direct_routes(
+    swarm: &mut Swarm<Behaviour>,
+    direct: &mut DirectConnectState,
+    relays: &mut HashMap<PeerId, CoordinationRelay>,
+    control: &application_stream::Control,
+    now: Instant,
+) {
+    let background = direct
+        .pending
+        .iter()
+        .filter_map(|(id, pending)| pending.result.is_none().then_some(*id))
+        .collect::<Vec<_>>();
+    for id in background {
+        let pending = direct
+            .pending
+            .get(&id)
+            .expect("collected maintenance attempt");
+        let in_use = control
+            .eligible_connections(
+                pending.peer_id,
+                &HashSet::new(),
+                &pending.transit_relay_peers,
+            )
+            .iter()
+            .any(|(connection, _)| direct.active.contains_key(connection));
+        if !in_use {
+            let pending = direct
+                .pending
+                .remove(&id)
+                .expect("maintenance attempt exists");
+            fail_pending_connect(
+                swarm,
+                direct,
+                relays,
+                pending,
+                PeerError::new("peer_connect_cancelled", "peer streams were released"),
+            );
+        } else if pending.deadline <= now {
+            let mut pending = direct
+                .pending
+                .remove(&id)
+                .expect("maintenance attempt exists");
+            pending.cancellation.cancel();
+            retire_direct_dials(swarm, direct, std::mem::take(&mut pending.dials), None);
+            pending.cancellation = CancellationToken::new();
+            pending.webrtc_active_attempt = None;
+            pending.webrtc_attempted_relays.clear();
+            pending.rejected_connections.clear();
+            pending.deadline = now + TRANSIT_HOLE_PUNCH_RETRY_INTERVAL;
+            pending.next_route_attempt = now;
+            pending.retry_coordination = true;
+            direct.pending.insert(id, pending);
+        }
+    }
+}
+
 fn retry_connect_routes(
     swarm: &mut Swarm<Behaviour>,
     direct: &mut DirectConnectState,
@@ -3502,7 +3797,12 @@ fn retry_connect_routes(
             .union(&connect.rejected_connections)
             .copied()
             .collect::<HashSet<_>>();
-        if stream_control.has_connection(peer_id, &excluded, &connect.transit_relay_peers) {
+        let allowed_relays = if connect.result.is_some() {
+            connect.transit_relay_peers.clone()
+        } else {
+            HashSet::new()
+        };
+        if stream_control.has_connection(peer_id, &excluded, &allowed_relays) {
             continue;
         }
         connect.next_route_attempt = now + COORDINATION_RETRY_INTERVAL;
@@ -3534,7 +3834,8 @@ fn retry_connect_routes(
             }
         }
 
-        if now >= connect.transit_after
+        if connect.result.is_some()
+            && now >= connect.transit_after
             && !connect
                 .dials
                 .values()
@@ -3607,15 +3908,27 @@ fn dial_direct_targets(
 
 fn retire_direct_dials(
     swarm: &mut Swarm<Behaviour>,
-    retiring: &mut HashSet<ConnectionId>,
+    direct: &mut DirectConnectState,
     dials: HashMap<ConnectionId, DialOrigin>,
     retained: Option<ConnectionId>,
 ) {
     for connection_id in dials.into_keys() {
-        if retained == Some(connection_id) {
+        if retained == Some(connection_id)
+            || direct.active.contains_key(&connection_id)
+            || direct
+                .health
+                .get(&connection_id)
+                .is_some_and(|health| health.rtt.is_some() && health.failures == 0)
+            || direct.pending.values().any(|pending| {
+                pending
+                    .opening
+                    .as_ref()
+                    .is_some_and(|opening| opening.connection_id == connection_id)
+            })
+        {
             continue;
         }
-        retiring.insert(connection_id);
+        direct.retiring_connections.insert(connection_id);
         let _ = swarm.close_connection(connection_id);
     }
 }
@@ -3627,6 +3940,223 @@ fn native_error(error: impl std::fmt::Display) -> PeerError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn path_health_recovers_from_jitter_and_prefers_a_responsive_alternative() {
+        let mut health = ConnectionHealth::default();
+        assert!(!health.observe(Ok(Duration::from_millis(20))));
+        assert!(!health.observe(Err(ping::Failure::Timeout)));
+        let healthy = ConnectionHealth {
+            failures: 0,
+            rtt: Some(Duration::from_millis(50)),
+        };
+        assert!(
+            stream_candidate_score(
+                &PeerConnectionPath::Direct(DirectTransport::Tcp),
+                Some(&healthy)
+            ) < stream_candidate_score(
+                &PeerConnectionPath::Direct(DirectTransport::Quic),
+                Some(&health)
+            )
+        );
+        assert!(!health.observe(Ok(Duration::from_millis(24))));
+        assert_eq!(health.failures, 0);
+        assert!(!health.observe(Err(ping::Failure::Timeout)));
+        assert!(!health.observe(Err(ping::Failure::Timeout)));
+        assert!(health.observe(Err(ping::Failure::Timeout)));
+    }
+
+    #[tokio::test]
+    async fn listener_changes_refresh_advertised_and_transit_addresses() {
+        let allowed = Arc::new(RwLock::new(HashSet::from([PeerId::random()])));
+        let trusted = Arc::new(RwLock::new(HashSet::new()));
+        let BuiltSwarm { mut swarm, .. } = build_swarm(
+            identity::Keypair::generate_ed25519(),
+            allowed.clone(),
+            trusted.clone(),
+            false,
+        )
+        .unwrap();
+        let mut transit = TransitRuntime {
+            allowed_peers: allowed,
+            approved_relays: HashSet::new(),
+            trusted_relays: trusted,
+            reservations: HashSet::new(),
+            circuits: HashMap::new(),
+            listen_addresses: Vec::new(),
+            published_addresses: Vec::new(),
+            snapshot: Arc::new(RwLock::new(TransitSnapshot::default())),
+        };
+        let mut relays = HashMap::new();
+        let mut direct = DirectConnectState::default();
+        let (reachability, _) = watch::channel(ReachabilitySnapshot::default());
+        let mut anchors = RelayAnchorHistory::open(None, *swarm.local_peer_id()).await;
+        let first = swarm
+            .listen_on("/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap())
+            .unwrap();
+        for (step, count) in [1, 2, 1, 2].into_iter().enumerate() {
+            if step == 3 {
+                let mut configured = HashMap::new();
+                let mut failed = vec![(
+                    "/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap(),
+                    Instant::now(),
+                )];
+                restore_listeners(&mut swarm, &mut configured, &mut failed, Instant::now());
+                assert!(failed.is_empty());
+                assert_eq!(configured.len(), 1);
+            } else if count == 2 {
+                swarm
+                    .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+                    .unwrap();
+            } else if !transit.listen_addresses.is_empty() {
+                assert!(swarm.remove_listener(first));
+            }
+            tokio::time::timeout(Duration::from_secs(3), async {
+                loop {
+                    let event = swarm.select_next_some().await;
+                    handle_swarm_event(
+                        &mut swarm,
+                        event,
+                        &mut relays,
+                        &mut direct,
+                        RouteRuntime {
+                            reachability: Some(&reachability),
+                            connectivity: None,
+                            relay_anchors: Some(&mut anchors),
+                            transit: &mut transit,
+                        },
+                    );
+                    publish_active_coordination_relays(
+                        &mut relays,
+                        &reachability,
+                        &mut anchors,
+                        &transit.listen_addresses,
+                    );
+                    if transit.listen_addresses.len() == count {
+                        break;
+                    }
+                }
+            })
+            .await
+            .expect("listener event must update routes");
+            assert_eq!(
+                reachability.borrow().listen_addresses,
+                transit.listen_addresses
+            );
+            assert_eq!(swarm.external_addresses().count(), count);
+        }
+        assert!(
+            reachability.borrow().listen_addresses[0]
+                .iter()
+                .any(|protocol| matches!(protocol, Protocol::Tcp(_)))
+        );
+        anchors.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn foreground_connect_does_not_wait_for_a_stalled_mesh_dial() {
+        let root = std::env::temp_dir().join(format!("maka-peer-dial-lanes-{}", PeerId::random()));
+        std::fs::create_dir_all(&root).unwrap();
+        let source = start(test_endpoint_options(root.join("source.key"))).unwrap();
+        let mut target = start(test_endpoint_options(root.join("target.key"))).unwrap();
+        let (result, mesh_response) = oneshot::channel();
+        source
+            .commands
+            .send(EngineCommand::Connect {
+                options: ConnectOptions {
+                    request_id: 1,
+                    peer_id: target.peer_id,
+                    route_hints: vec!["/ip4/127.0.0.1/udp/9/quic-v1".parse().unwrap()],
+                    coordination_relays: Vec::new(),
+                    transit_relay_peers: Vec::new(),
+                    deadline: Duration::from_secs(30),
+                },
+                stream_kind: StreamKind::MeshControl,
+                result,
+            })
+            .await
+            .unwrap();
+        let application = connect_test_stream(
+            &source,
+            target.peer_id,
+            test_listen_address(&target),
+            2,
+            StreamKind::Application,
+        )
+        .await;
+        let mut incoming = tokio::time::timeout(Duration::from_secs(3), target.incoming.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let mesh = tokio::time::timeout(Duration::from_secs(3), mesh_response)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        close_test_stream(mesh).await;
+        write_test_stream(&application, b"foreground-survives-mesh-release").await;
+        assert_eq!(
+            incoming.incoming.recv().await.unwrap().unwrap(),
+            b"foreground-survives-mesh-release"
+        );
+        close_test_stream(application).await;
+        close_test_stream(incoming).await;
+        stop_test_endpoint(source).await;
+        stop_test_endpoint(target).await;
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn default_endpoint_accepts_each_available_ip_family_and_transport() {
+        let root = std::env::temp_dir().join(format!("maka-peer-dual-stack-{}", PeerId::random()));
+        std::fs::create_dir_all(&root).unwrap();
+        let mut options = test_endpoint_options(root.join("target.key"));
+        options.listen_addresses.clear();
+        let mut target = start(options).unwrap();
+        let routes = target.reachability.borrow().listen_addresses.clone();
+        for (index, (ipv6, tcp)) in [(false, false), (false, true), (true, false), (true, true)]
+            .into_iter()
+            .enumerate()
+        {
+            if ipv6 && std::net::UdpSocket::bind("[::]:0").is_err() {
+                continue;
+            }
+            let route = routes
+                .iter()
+                .find(|route| {
+                    route.iter().any(|p| matches!(p, Protocol::Ip6(_))) == ipv6
+                        && route.iter().any(|p| matches!(p, Protocol::Tcp(_))) == tcp
+                })
+                .expect("available family and transport must be advertised")
+                .clone();
+            let mut options = test_endpoint_options(root.join(format!("source-{index}.key")));
+            options.listen_addresses.clear();
+            let source = start(options).unwrap();
+            let stream =
+                connect_test_stream(&source, target.peer_id, route, 1, StreamKind::Application)
+                    .await;
+            assert!(
+                matches!(
+                    stream.path,
+                    PeerConnectionPath::Direct(DirectTransport::Tcp)
+                ) == tcp
+            );
+            let mut inbound = tokio::time::timeout(Duration::from_secs(3), target.incoming.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            write_test_stream(&stream, b"dual-stack").await;
+            assert_eq!(
+                inbound.incoming.recv().await.unwrap().unwrap(),
+                b"dual-stack"
+            );
+            close_test_stream(stream).await;
+            close_test_stream(inbound).await;
+            stop_test_endpoint(source).await;
+        }
+        stop_test_endpoint(target).await;
+        std::fs::remove_dir_all(root).unwrap();
+    }
 
     #[test]
     fn application_streams_commit_on_the_best_established_path() {
@@ -3682,7 +4212,7 @@ mod tests {
             PendingConnect {
                 attempt_id,
                 peer_id: PeerId::random(),
-                result,
+                result: Some(result),
                 stream_kind: StreamKind::Application,
                 deadline: now,
                 opening: None,
@@ -3719,7 +4249,7 @@ mod tests {
         let mut waiter = PendingConnect {
             attempt_id,
             peer_id: PeerId::random(),
-            result,
+            result: Some(result),
             stream_kind: StreamKind::Application,
             deadline: now + Duration::from_secs(30),
             opening: None,
@@ -3773,7 +4303,7 @@ mod tests {
         let mut waiter = PendingConnect {
             attempt_id: ConnectAttemptId(11),
             peer_id: PeerId::random(),
-            result,
+            result: Some(result),
             stream_kind: StreamKind::Application,
             deadline: now + Duration::from_secs(30),
             opening: None,
@@ -4343,6 +4873,132 @@ mod tests {
             panic!("cancelled connect unexpectedly succeeded");
         };
         assert_eq!(error.code, "peer_connect_cancelled");
+
+        // Transit delivery must leave direct discovery running without opening
+        // or interrupting another application stream.
+        configure_test_transit_with_reservations(
+            &source,
+            HashSet::new(),
+            vec![test_listen_address(&relay)],
+        )
+        .await;
+        let (result, closed) = oneshot::channel();
+        source
+            .commands
+            .send(EngineCommand::CloseDirectConnections {
+                peer_id: target.peer_id,
+                result,
+            })
+            .await
+            .unwrap();
+        closed.await.unwrap();
+        let transit_stream = connect_test_stream_through_transit(
+            &source,
+            target.peer_id,
+            relay.peer_id,
+            50,
+            StreamKind::Application,
+        )
+        .await;
+        let mut transit_incoming =
+            tokio::time::timeout(Duration::from_secs(3), target.incoming.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        assert!(matches!(
+            transit_stream.path,
+            PeerConnectionPath::Transit { .. }
+        ));
+        let (result, updated) = oneshot::channel();
+        source
+            .commands
+            .send(EngineCommand::UpdateConnect {
+                request_id: 50,
+                candidates: ConnectCandidates {
+                    route_hints: vec![test_listen_address(&target)],
+                    coordination_relays: Vec::new(),
+                    transit_relay_peers: vec![relay.peer_id],
+                },
+                result,
+            })
+            .await
+            .unwrap();
+        assert!(
+            updated.await.unwrap().unwrap(),
+            "transit must retain background route maintenance"
+        );
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let (result, ready) = oneshot::channel();
+                source
+                    .commands
+                    .send(EngineCommand::HasDirectConnection {
+                        peer_id: target.peer_id,
+                        result,
+                    })
+                    .await
+                    .unwrap();
+                if ready.await.unwrap() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("direct path must appear without another application connect");
+        assert!(
+            target.incoming.try_recv().is_err(),
+            "maintenance must not open application streams"
+        );
+        write_test_stream(&transit_stream, b"transit-survives-upgrade").await;
+        assert_eq!(
+            transit_incoming.incoming.recv().await.unwrap().unwrap(),
+            b"transit-survives-upgrade"
+        );
+        let direct_stream = connect_test_stream(
+            &source,
+            target.peer_id,
+            test_listen_address(&target),
+            51,
+            StreamKind::Application,
+        )
+        .await;
+        assert!(matches!(direct_stream.path, PeerConnectionPath::Direct(_)));
+        let mut direct_incoming =
+            tokio::time::timeout(Duration::from_secs(3), target.incoming.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        // A route refresh may retire the maintenance dial, but not a stream
+        // another connect has already opened on that shared connection.
+        let (result, updated) = oneshot::channel();
+        source
+            .commands
+            .send(EngineCommand::UpdateConnect {
+                request_id: 50,
+                candidates: ConnectCandidates {
+                    route_hints: Vec::new(),
+                    coordination_relays: Vec::new(),
+                    transit_relay_peers: vec![relay.peer_id],
+                },
+                result,
+            })
+            .await
+            .unwrap();
+        assert!(updated.await.unwrap().unwrap());
+        write_test_stream(&direct_stream, b"shared-direct-survives-route-refresh").await;
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(3), direct_incoming.incoming.recv())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap(),
+            b"shared-direct-survives-route-refresh"
+        );
+        close_test_stream(transit_stream).await;
+        close_test_stream(transit_incoming).await;
+        close_test_stream(direct_stream).await;
+        close_test_stream(direct_incoming).await;
 
         let source_stream = connect_test_stream(
             &source,

--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -187,8 +187,9 @@ pub enum EngineCommand {
         result: oneshot::Sender<bool>,
     },
     #[cfg(test)]
-    CloseDirectConnections {
+    SetDirectConnectionsEnabled {
         peer_id: PeerId,
+        enabled: bool,
         result: oneshot::Sender<()>,
     },
 }
@@ -835,6 +836,8 @@ async fn run_endpoint_async(
     let mut incoming_webrtc_upgrades = JoinSet::new();
     let mut outgoing_webrtc_upgrades = JoinSet::new();
     let mut failed_listeners = Vec::new();
+    #[cfg(test)]
+    let mut blocked_direct_peers = HashSet::new();
 
     loop {
         tokio::select! {
@@ -844,10 +847,15 @@ async fn run_endpoint_async(
                     let _ = result.send(stream_control.has_connection(peer_id, &direct.retiring_connections, &HashSet::new()));
                 }
                 #[cfg(test)]
-                Some(EngineCommand::CloseDirectConnections { peer_id, result }) => {
-                    for (connection, _) in stream_control.eligible_connections(peer_id, &HashSet::new(), &HashSet::new()) {
-                        direct.retiring_connections.insert(connection);
-                        let _ = swarm.close_connection(connection);
+                Some(EngineCommand::SetDirectConnectionsEnabled { peer_id, enabled, result }) => {
+                    if enabled {
+                        blocked_direct_peers.remove(&peer_id);
+                    } else {
+                        blocked_direct_peers.insert(peer_id);
+                        for (connection, _) in stream_control.eligible_connections(peer_id, &HashSet::new(), &HashSet::new()) {
+                            direct.retiring_connections.insert(connection);
+                            let _ = swarm.close_connection(connection);
+                        }
                     }
                     let _ = result.send(());
                 }
@@ -1423,6 +1431,11 @@ async fn run_endpoint_async(
                 }
             }
             event = swarm.select_next_some() => {
+                #[cfg(test)]
+                if let SwarmEvent::ConnectionEstablished { peer_id, connection_id, endpoint, .. } = &event
+                    && !endpoint.is_relayed() && blocked_direct_peers.contains(peer_id) {
+                    direct.retiring_connections.insert(*connection_id);
+                }
                 if let SwarmEvent::ListenerClosed { listener_id, .. } = &event
                     && let Some(address) = configured_listeners.remove(listener_id) {
                     failed_listeners.push((address, Instant::now() + COORDINATION_RETRY_INTERVAL));
@@ -4885,8 +4898,9 @@ mod tests {
         let (result, closed) = oneshot::channel();
         source
             .commands
-            .send(EngineCommand::CloseDirectConnections {
+            .send(EngineCommand::SetDirectConnectionsEnabled {
                 peer_id: target.peer_id,
+                enabled: false,
                 result,
             })
             .await
@@ -4909,6 +4923,17 @@ mod tests {
             transit_stream.path,
             PeerConnectionPath::Transit { .. }
         ));
+        let (result, enabled) = oneshot::channel();
+        source
+            .commands
+            .send(EngineCommand::SetDirectConnectionsEnabled {
+                peer_id: target.peer_id,
+                enabled: true,
+                result,
+            })
+            .await
+            .unwrap();
+        enabled.await.unwrap();
         let (result, updated) = oneshot::channel();
         source
             .commands

--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -1405,9 +1405,15 @@ async fn run_endpoint_async(
                             request_id,
                         ));
                         waiter.rejected_connections.insert(connection_id);
-                        if remove_pending_dial(&mut waiter, connection_id).is_some() {
-                            direct.retiring_connections.insert(connection_id);
-                            let _ = swarm.close_connection(connection_id);
+                        if let Some(origin) = remove_pending_dial(&mut waiter, connection_id) {
+                            // A failed substream does not invalidate other streams
+                            // admitted concurrently on this connection.
+                            retire_direct_dials(
+                                &mut swarm,
+                                &mut direct,
+                                HashMap::from([(connection_id, origin)]),
+                                None,
+                            );
                         }
                         waiter.next_route_attempt = Instant::now();
                         direct.pending.insert(request_id, waiter);

--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -272,6 +272,7 @@ struct PendingConnect {
     rejected_connections: HashSet<ConnectionId>,
     dials: HashMap<ConnectionId, DialOrigin>,
     direct_routes: Vec<Multiaddr>,
+    identified_routes: Vec<Multiaddr>,
     coordination_relays: Vec<Multiaddr>,
     coordination_relay_peers: Vec<PeerId>,
     transit_relay_peers: HashSet<PeerId>,
@@ -920,6 +921,7 @@ async fn run_endpoint_async(
                         rejected_connections: HashSet::new(),
                         dials: HashMap::new(),
                         direct_routes: started.direct_routes,
+                        identified_routes: Vec::new(),
                         coordination_relays: options.coordination_relays,
                         coordination_relay_peers: started.coordination_relay_peers,
                         transit_relay_peers: started.transit_relay_peers,
@@ -2601,8 +2603,8 @@ fn handle_swarm_event(
                 .values_mut()
                 .filter(|pending| pending.peer_id == peer_id && pending.result.is_none())
             {
-                if pending.direct_routes != routes {
-                    pending.direct_routes.clone_from(&routes);
+                if pending.identified_routes != routes {
+                    pending.identified_routes.clone_from(&routes);
                     pending.next_route_attempt = Instant::now();
                 }
             }
@@ -3743,6 +3745,16 @@ fn webrtc_debug(message: std::fmt::Arguments<'_>) {
     }
 }
 
+// Identify can advertise only private listeners behind NAT. It supplements,
+// never replaces, caller-provided mapped addresses. Keep its own latest set so
+// withdrawing an advertised interface does not accumulate stale candidates.
+fn direct_dial_routes(configured: &[Multiaddr], identified: &[Multiaddr]) -> Vec<Multiaddr> {
+    bounded_unique(
+        configured.iter().chain(identified).cloned().collect(),
+        MAX_CONNECT_ROUTES_PER_CLASS,
+    )
+}
+
 fn maintain_direct_routes(
     swarm: &mut Swarm<Behaviour>,
     direct: &mut DirectConnectState,
@@ -3829,8 +3841,11 @@ fn retry_connect_routes(
             .dials
             .values()
             .any(|origin| *origin == DialOrigin::Direct)
-            && let Some(connection_id) =
-                dial_direct_targets(swarm, peer_id, connect.direct_routes.clone())
+            && let Some(connection_id) = dial_direct_targets(
+                swarm,
+                peer_id,
+                direct_dial_routes(&connect.direct_routes, &connect.identified_routes),
+            )
         {
             connect.dials.insert(connection_id, DialOrigin::Direct);
         }
@@ -3959,6 +3974,28 @@ fn native_error(error: impl std::fmt::Display) -> PeerError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn private_identify_refresh_preserves_mapped_routes_without_retaining_old_interfaces() {
+        let mapped: Multiaddr = "/ip4/203.0.113.10/udp/41000/quic-v1".parse().unwrap();
+        let old: Multiaddr = "/ip4/172.30.72.10/udp/41000/quic-v1".parse().unwrap();
+        let current: Multiaddr = "/ip4/172.30.72.11/udp/41000/quic-v1".parse().unwrap();
+        assert_eq!(
+            direct_dial_routes(std::slice::from_ref(&mapped), std::slice::from_ref(&old)),
+            vec![mapped.clone(), old]
+        );
+        assert_eq!(
+            direct_dial_routes(
+                std::slice::from_ref(&mapped),
+                std::slice::from_ref(&current)
+            ),
+            vec![mapped, current.clone()]
+        );
+        assert_eq!(
+            direct_dial_routes(&[], std::slice::from_ref(&current)),
+            vec![current]
+        );
+    }
 
     #[test]
     fn path_health_recovers_from_jitter_and_prefers_a_responsive_alternative() {
@@ -4238,6 +4275,7 @@ mod tests {
                 rejected_connections: HashSet::new(),
                 dials: HashMap::new(),
                 direct_routes: Vec::new(),
+                identified_routes: Vec::new(),
                 coordination_relays: Vec::new(),
                 coordination_relay_peers: Vec::new(),
                 transit_relay_peers: HashSet::new(),
@@ -4275,6 +4313,7 @@ mod tests {
             rejected_connections: HashSet::new(),
             dials: HashMap::new(),
             direct_routes: Vec::new(),
+            identified_routes: Vec::new(),
             coordination_relays: Vec::new(),
             coordination_relay_peers: vec![first_relay],
             transit_relay_peers: HashSet::new(),
@@ -4329,6 +4368,7 @@ mod tests {
             rejected_connections: HashSet::new(),
             dials: HashMap::new(),
             direct_routes: Vec::new(),
+            identified_routes: Vec::new(),
             coordination_relays: Vec::new(),
             coordination_relay_peers: vec![removed_relay],
             transit_relay_peers: HashSet::new(),

--- a/native/runtime-host-peer/src/engine/application_stream.rs
+++ b/native/runtime-host-peer/src/engine/application_stream.rs
@@ -221,6 +221,10 @@ impl Control {
             .is_empty()
     }
 
+    pub(super) fn connection_ids(&self) -> Vec<ConnectionId> {
+        lock(&self.shared).connections.keys().copied().collect()
+    }
+
     pub(super) fn eligible_connections(
         &self,
         peer_id: PeerId,

--- a/native/runtime-host-peer/src/engine/peer_stream.rs
+++ b/native/runtime-host-peer/src/engine/peer_stream.rs
@@ -70,7 +70,7 @@ pub enum StreamCommand {
 pub(super) fn spawn_stream(
     peer_id: PeerId,
     path: PeerConnectionPath,
-    stream: libp2p::swarm::Stream,
+    stream: impl futures::AsyncRead + futures::AsyncWrite + Unpin + Send + 'static,
     completion: Option<(StreamCompletion, mpsc::Sender<CompletedStream>)>,
 ) -> PeerStream {
     let (incoming_tx, incoming_rx) = mpsc::channel(QUEUE_CAPACITY);
@@ -80,73 +80,63 @@ pub(super) fn spawn_stream(
     tokio::spawn(async move {
         let _abort_guard = abort_guard;
         let (mut reader, mut writer) = stream.split();
-        let mut buffer = vec![0_u8; CHUNK_BYTES];
-        let mut pending_read: Option<Result<Vec<u8>, PeerError>> = None;
-        let mut finish_after_delivery = false;
-        let mut close_result = None;
-        loop {
+        // Drive both halves independently. Awaiting a backpressured write in
+        // the read loop deadlocks when both peers send more than the window.
+        let close_result = {
+            let reading = async {
+                let mut buffer = vec![0_u8; CHUNK_BYTES];
+                loop {
+                    match reader.read(&mut buffer).await {
+                        Ok(0) => break,
+                        Ok(size) => {
+                            if incoming_tx.send(Ok(buffer[..size].to_vec())).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            let _ = incoming_tx
+                                .send(Err(PeerError::new("peer_native_failed", error.to_string())))
+                                .await;
+                            break;
+                        }
+                    }
+                }
+            };
+            let writing = async {
+                while let Some(command) = command_rx.recv().await {
+                    match command {
+                        StreamCommand::Write { bytes, result } => {
+                            let outcome = async {
+                                writer.write_all(&bytes).await?;
+                                writer.flush().await
+                            }
+                            .await
+                            .map_err(|error: std::io::Error| {
+                                PeerError::new("peer_native_failed", error.to_string())
+                            });
+                            let failed = outcome.is_err();
+                            let _ = result.send(outcome);
+                            if failed {
+                                break;
+                            }
+                        }
+                        StreamCommand::Close { result } => {
+                            let outcome = writer.close().await.map_err(|error| {
+                                PeerError::new("peer_native_failed", error.to_string())
+                            });
+                            return Some((result, outcome));
+                        }
+                    }
+                }
+                None
+            };
             tokio::select! {
                 biased;
-                changed = abort_rx.changed() => {
-                    let _ = changed;
-                    break;
-                }
-                command = command_rx.recv() => match command {
-                    Some(StreamCommand::Write { bytes, result }) => {
-                        let outcome = tokio::select! {
-                            biased;
-                            _ = abort_rx.changed() => Err(PeerError::new(
-                                "peer_stream_aborted",
-                                "peer stream was aborted",
-                            )),
-                            outcome = async {
-                                writer.write_all(&bytes).await?;
-                                // Framed transports may buffer a complete write until flush.
-                                writer.flush().await
-                            } => outcome.map_err(|error| {
-                                PeerError::new("peer_native_failed", error.to_string())
-                            }),
-                        };
-                        let failed = outcome.is_err();
-                        let _ = result.send(outcome);
-                        if failed { break; }
-                    }
-                    Some(StreamCommand::Close { result }) => {
-                        let outcome = tokio::select! {
-                            biased;
-                            _ = abort_rx.changed() => Err(PeerError::new(
-                                "peer_stream_aborted",
-                                "peer stream was aborted",
-                            )),
-                            outcome = writer.close() => outcome.map_err(|error| {
-                                PeerError::new("peer_native_failed", error.to_string())
-                            }),
-                        };
-                        close_result = Some((result, outcome));
-                        break;
-                    }
-                    None => break,
-                },
-                permit = incoming_tx.reserve(), if pending_read.is_some() => match permit {
-                    Ok(permit) => {
-                        permit.send(pending_read.take().expect("read is pending"));
-                        if finish_after_delivery { break; }
-                    }
-                    Err(_) => break,
-                },
-                read = reader.read(&mut buffer), if pending_read.is_none() => match read {
-                    Ok(0) => break,
-                    Ok(size) => pending_read = Some(Ok(buffer[..size].to_vec())),
-                    Err(error) => {
-                        pending_read = Some(Err(PeerError::new(
-                            "peer_native_failed",
-                            error.to_string(),
-                        )));
-                        finish_after_delivery = true;
-                    }
-                },
+                _ = abort_rx.changed() => None,
+                result = writing => result,
+                _ = reading => None,
             }
-        }
+        };
         if let Some((completion, completed)) = completion {
             let (acknowledged, acknowledgment) = oneshot::channel();
             if completed
@@ -170,5 +160,69 @@ pub(super) fn spawn_stream(
         incoming: incoming_rx,
         commands: command_tx,
         abort: abort_tx,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_util::compat::TokioAsyncReadCompatExt;
+
+    #[tokio::test]
+    async fn simultaneous_large_writes_keep_reading_under_backpressure() {
+        let (left, right) = tokio::io::duplex(1024);
+        let mut left = spawn_stream(
+            PeerId::random(),
+            PeerConnectionPath::Direct(DirectTransport::Tcp),
+            left.compat(),
+            None,
+        );
+        let mut right = spawn_stream(
+            PeerId::random(),
+            PeerConnectionPath::Direct(DirectTransport::Tcp),
+            right.compat(),
+            None,
+        );
+        let (left_result, left_done) = oneshot::channel();
+        let (right_result, right_done) = oneshot::channel();
+        const BYTES: usize = 512 * 1024;
+        left.commands
+            .send(StreamCommand::Write {
+                bytes: vec![1; BYTES],
+                result: left_result,
+            })
+            .await
+            .unwrap();
+        right
+            .commands
+            .send(StreamCommand::Write {
+                bytes: vec![2; BYTES],
+                result: right_result,
+            })
+            .await
+            .unwrap();
+        async fn receive(stream: &mut PeerStream, expected: u8) {
+            let mut count = 0;
+            while count < BYTES {
+                let bytes = stream.incoming.recv().await.unwrap().unwrap();
+                assert!(bytes.iter().all(|byte| *byte == expected));
+                count += bytes.len();
+            }
+            assert_eq!(count, BYTES);
+        }
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            let (left_ack, right_ack, _, _) = tokio::join!(
+                left_done,
+                right_done,
+                receive(&mut left, 2),
+                receive(&mut right, 1)
+            );
+            left_ack.unwrap().unwrap();
+            right_ack.unwrap().unwrap();
+        })
+        .await;
+        left.abort.send_replace(true);
+        right.abort.send_replace(true);
+        outcome.expect("simultaneous writes must not stop either reader");
     }
 }

--- a/native/runtime-host-peer/src/webrtc_direct/tests.rs
+++ b/native/runtime-host-peer/src/webrtc_direct/tests.rs
@@ -42,6 +42,7 @@ async fn authenticated_signaling_yields_a_libp2p_stream() {
     let (signaling_a, signaling_b) = tokio::io::duplex(256 * 1024);
     let options = UpgradeOptions {
         deadline: Duration::from_secs(10),
+        udp_bind_addresses: crate::engine::default_webrtc_bind_addresses(),
         ..UpgradeOptions::default()
     };
 

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -2240,7 +2240,7 @@ describe('non-serving Runtime Host kernel', () => {
               error.cause.code === 'read_timeout' &&
               error.cause.message.includes('host.status'),
           ),
-          5_000,
+          12_000,
           'automatic Runtime Host liveness check did not reject pending work',
         );
         await withTimeout(

--- a/packages/runtime-host/src/__tests__/peer-listener.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-listener.test.ts
@@ -63,6 +63,69 @@ test('expires a peer that does not send its credential', async (context) => {
   await listener.cleanup();
 });
 
+test('expires stalled authentication responses and releases logical admission slots', {
+  timeout: 2_000,
+}, async (context) => {
+  context.mock.timers.enable({ apis: ['setTimeout'] });
+  let releaseWrites!: () => void;
+  const stalledWrite = new Promise<void>((resolve) => {
+    releaseWrites = resolve;
+  });
+  const streams = Array.from({ length: 4 }, (_, index) => {
+    const stream = recordingStream(
+      Buffer.from(
+        `${JSON.stringify({
+          v: 2,
+          credential: 'valid',
+          resume: { sessionId: String(index).padStart(64, '0'), generation: 1, received: 0 },
+        })}\n`,
+      ),
+    );
+    return { ...stream, write: async () => stalledWrite };
+  });
+  let admit!: (stream: RuntimeHostPeerNativeStream) => void;
+  const client = peerWith([]);
+  let accepted = 0;
+  const listener = createRuntimeHostPeerListener(
+    {
+      ...client,
+      serveApplication: async (onStream, signal) => {
+        admit = onStream;
+        return client.serveApplication(onStream, signal);
+      },
+    },
+    UNUSED_REACHABILITY,
+    {
+      authenticate: () => ({ operationGrants: 'all' }),
+      subscribeRevocations: () => () => {},
+    } as never,
+    () => {
+      accepted++;
+    },
+  );
+  context.after(async () => {
+    releaseWrites();
+    await listener.cleanup();
+  });
+  for (const stream of streams) admit(stream);
+  await waitForImmediate();
+  context.mock.timers.tick(5_000);
+  await waitForImmediate();
+  // Same PeerId, including a previously allocated session ID, must be reusable.
+  const healthy = recordingStream(
+    Buffer.from(
+      `${JSON.stringify({
+        v: 2,
+        credential: 'valid',
+        resume: { sessionId: '0'.repeat(64), generation: 1, received: 0 },
+      })}\n`,
+    ),
+  );
+  admit(healthy);
+  await waitForImmediate();
+  assert.equal(accepted, 1);
+});
+
 test('reports an explicit authentication rejection before closing the stream', async () => {
   const stream = recordingStream(Buffer.from('{"v":1,"credential":"rejected"}\n'));
   const listener = createRuntimeHostPeerListener(

--- a/packages/runtime-host/src/__tests__/peer-listener.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-listener.test.ts
@@ -32,7 +32,7 @@ test('bounds and aborts pending peer authentication', async () => {
   const listener = createRuntimeHostPeerListener(
     peerWith([...streams]),
     UNUSED_REACHABILITY,
-    {} as never,
+    { subscribeRevocations: () => () => {} } as never,
     () => {},
   );
   await waitForImmediate();
@@ -52,7 +52,7 @@ test('expires a peer that does not send its credential', async (context) => {
   const listener = createRuntimeHostPeerListener(
     peerWith([stream]),
     UNUSED_REACHABILITY,
-    {} as never,
+    { subscribeRevocations: () => () => {} } as never,
     () => {},
   );
   await waitForImmediate();
@@ -68,7 +68,7 @@ test('reports an explicit authentication rejection before closing the stream', a
   const listener = createRuntimeHostPeerListener(
     peerWith([stream]),
     UNUSED_REACHABILITY,
-    { authenticate: () => null } as never,
+    { authenticate: () => null, subscribeRevocations: () => () => {} } as never,
     () => {},
   );
   await waitForImmediate();
@@ -102,6 +102,7 @@ test('rechecks peer authority at admission after the authentication response is 
     UNUSED_REACHABILITY,
     {
       authenticate: () => (authentications++ === 0 ? { operationGrants: 'all' } : null),
+      subscribeRevocations: () => () => {},
     } as never,
     () => {
       accepted = true;
@@ -125,7 +126,10 @@ test('bounds active application streams from one authenticated peer', async () =
   const listener = createRuntimeHostPeerListener(
     peerWith([...streams]),
     UNUSED_REACHABILITY,
-    { authenticate: () => ({ operationGrants: 'all' }) } as never,
+    {
+      authenticate: () => ({ operationGrants: 'all' }),
+      subscribeRevocations: () => () => {},
+    } as never,
     () => {
       accepted += 1;
     },
@@ -163,7 +167,12 @@ test('projects newly accepted coordination relays from the running peer endpoint
       signature: 'AA',
     }),
   } as never;
-  const listener = createRuntimeHostPeerListener(peer, reachability, {} as never, () => {});
+  const listener = createRuntimeHostPeerListener(
+    peer,
+    reachability,
+    { subscribeRevocations: () => () => {} } as never,
+    () => {},
+  );
   const listeners = createRuntimeHostListenerSet(
     {
       kind: 'local_ipc',

--- a/packages/runtime-host/src/__tests__/peer-native.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-native.test.ts
@@ -44,7 +44,7 @@ test('preserves transit route failures from the native boundary', () => {
   assert.equal(error.message, 'no approved route');
 });
 
-test('shares one peer endpoint, serializes same-peer connects, and cancels independently', async () => {
+test('shares one endpoint with independent application and Mesh dial lanes', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'maka-peer-abort-'));
   const nativePath = join(directory, 'peer.cjs');
   try {
@@ -184,18 +184,16 @@ module.exports = {
     const application = client.connect(peerConnectInput('shared'));
     await waitForRequestCount(native.default.stats, 2);
     const queuedAbort = new AbortController();
-    const cancelled = client.connectMeshControl(peerConnectInput('shared'), queuedAbort.signal);
+    const cancelled = client.connect(peerConnectInput('shared'), queuedAbort.signal);
     queuedAbort.abort();
     await assert.rejects(cancelled, /aborted/u);
     const control = client.connectMeshControl(peerConnectInput('shared'));
-    await waitForImmediate();
-    assert.equal(native.default.stats.requests.length, 2);
-    native.default.resolveConnect(2);
-    await application;
     await waitForRequestCount(native.default.stats, 3);
     assert.equal(native.default.stats.requests.length, 3);
     native.default.resolveConnect(3);
     await control;
+    native.default.resolveConnect(2);
+    await application;
 
     const preparedBeforeReopen = preparedPeerIds.length;
     const reopenPhases: string[] = [];

--- a/packages/runtime-host/src/__tests__/peer-native.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-native.test.ts
@@ -429,6 +429,36 @@ test('bounds and separates the peer credential preface from Runtime Host frames'
   );
   assert.equal(result.accepted, true);
   assert.deepEqual(result.remainder, frame);
+  const resume = { sessionId: 'a'.repeat(64), generation: 2, received: 65_536 };
+  const resumed = await readRuntimeHostPeerAuthentication(
+    streamWith(
+      Buffer.concat([
+        Buffer.from(`${JSON.stringify({ v: 2, credential: 'token', resume })}\n`),
+        frame,
+      ]),
+    ),
+  );
+  assert.deepEqual(resumed.resume, resume);
+  assert.deepEqual(resumed.remainder, frame);
+  const resumedResult = await readRuntimeHostPeerAuthenticationResult(
+    streamWith(Buffer.from('{"v":2,"accepted":true,"resume":{"received":65536}}\n')),
+  );
+  assert.equal(resumedResult.resume?.received, 65_536);
+  for (const invalid of [
+    { ...resume, generation: 0 },
+    { ...resume, received: -1 },
+    { ...resume, sessionId: 'short' },
+    { ...resume, extra: true },
+  ]) {
+    await assert.rejects(
+      readRuntimeHostPeerAuthentication(
+        streamWith(
+          Buffer.from(`${JSON.stringify({ v: 2, credential: 'token', resume: invalid })}\n`),
+        ),
+      ),
+      /preface is invalid/u,
+    );
+  }
 });
 
 async function waitForRequestCount(

--- a/packages/runtime-host/src/__tests__/resumable-peer-stream.test.ts
+++ b/packages/runtime-host/src/__tests__/resumable-peer-stream.test.ts
@@ -1,0 +1,531 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { duplexPair, type Duplex } from 'node:stream';
+import { setImmediate as tick, setTimeout as delay } from 'node:timers/promises';
+import { test } from 'node:test';
+import { connect, createServer, type Socket } from 'node:net';
+import { once } from 'node:events';
+import { createRuntimeHostPeerListener } from '../server/peer-listener.js';
+import { RuntimeHostConnectionSession } from '../server/connection-session.js';
+import { LOCAL_OWNER_CONNECTION_AUTHORITY } from '../server/connection-authority.js';
+import {
+  createUnavailableDomainOperationHandlers,
+  createUnavailableHostCoreOperationHandlers,
+} from '../server/operation-dispatcher.js';
+import type { RuntimeHostPeerClient } from '../client/peer-client.js';
+import { connectPeerRuntimeHost } from '../client/host-profile.js';
+import type { RuntimeHostConnection } from '../client/connection.js';
+import {
+  decodeClientFrame,
+  encodeProtocolMessage,
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
+} from '../protocol/index.js';
+import {
+  ResumablePeerStream,
+  PeerResumeRejectedError,
+} from '../transport/resumable-peer-stream.js';
+import type { RuntimeHostPeerNativeStream } from '../transport/peer-native.js';
+
+function wire(socket: Duplex, peerId: string, dropAck = false): RuntimeHostPeerNativeStream {
+  const iterator = socket[Symbol.asyncIterator]();
+  socket.on('error', () => {});
+  return {
+    peerId,
+    path: { kind: 'direct', transport: 'tcp' },
+    read: async () => {
+      const next = await iterator.next();
+      return next.done ? null : Buffer.from(next.value as Buffer);
+    },
+    write: async (bytes) => {
+      if (dropAck && bytes[0] === 2) return;
+      await new Promise<void>((resolve, reject) =>
+        socket.write(bytes, (error) => (error ? reject(error) : resolve())),
+      );
+    },
+    close: async () => {
+      socket.destroy();
+    },
+    abort: () => {
+      socket.destroy();
+    },
+  };
+}
+
+function attach(left: ResumablePeerStream, right: ResumablePeerStream, dropAck = false) {
+  const [a, b] = duplexPair({ highWaterMark: 1024 });
+  const state = left.nextAttachment();
+  right.reserve(state);
+  const received = right.received;
+  right.attach(state.generation, {
+    stream: wire(b, left.peerId, dropAck),
+    remainder: Buffer.alloc(0),
+    received: state.received,
+  });
+  left.attach(state.generation, {
+    stream: wire(a, right.peerId),
+    remainder: Buffer.alloc(0),
+    received,
+  });
+  return () => {
+    a.destroy();
+    b.destroy();
+  };
+}
+
+function sessions() {
+  // Each test endpoint sees the same authenticated identity in its synthetic wire.
+  const left = new ResumablePeerStream({ peerId: 'peer' });
+  const right = new ResumablePeerStream({ peerId: 'peer', sessionId: left.sessionId });
+  return { left, right };
+}
+
+function payload(size: number, seed: number): Buffer {
+  const bytes = Buffer.allocUnsafe(size);
+  for (let i = 0; i < size; i++)
+    bytes[i] = (Math.imul(i, 31) ^ (i >>> 8) ^ Math.imul(i >>> 16, 17) ^ seed) & 255;
+  return bytes;
+}
+
+async function receive(stream: ResumablePeerStream, expected: Buffer) {
+  let count = 0;
+  while (count < expected.length) {
+    const bytes = await stream.read();
+    assert.ok(bytes);
+    assert.deepEqual(bytes, expected.subarray(count, count + bytes.length));
+    count += bytes.length;
+  }
+  assert.equal(count, expected.length);
+}
+
+test('full duplex exceeds the replay window and survives repeated path replacement', {
+  timeout: 10_000,
+}, async (t) => {
+  const { left, right } = sessions();
+  t.after(() => {
+    left.abort();
+    right.abort();
+  });
+  let cut = attach(left, right);
+  const size = 8 * 1024 * 1024;
+  const a = payload(size, 1);
+  const b = payload(size, 2);
+  const traffic = Promise.all([left.write(a), right.write(b), receive(left, b), receive(right, a)]);
+  for (let i = 0; i < 5; i++) {
+    await tick();
+    cut();
+    await tick();
+    cut = attach(left, right);
+  }
+  await traffic;
+  await left.close();
+  await right.closed;
+});
+
+test('lost ACK and retained unread bytes are not delivered twice on a new path', {
+  timeout: 5_000,
+}, async (t) => {
+  const { left, right } = sessions();
+  t.after(() => {
+    left.abort();
+    right.abort();
+  });
+  const cut = attach(left, right, true);
+  const bytes = payload(128 * 1024, 3);
+  const writing = left.write(bytes);
+  const first = await right.read();
+  assert.deepEqual(first, bytes.subarray(0, 64 * 1024));
+  await tick();
+  cut();
+  await tick();
+  attach(left, right);
+  await receive(right, bytes.subarray(64 * 1024));
+  await writing;
+  const marker = left.write(Buffer.from([4]));
+  assert.deepEqual(await right.read(), Buffer.from([4]));
+  await marker;
+});
+
+test('rejects stale generation, another peer, and impossible acknowledgment without replacing the live path', async (t) => {
+  const { left, right } = sessions();
+  t.after(() => {
+    left.abort();
+    right.abort();
+  });
+  attach(left, right);
+  assert.throws(
+    () => right.reserve({ sessionId: left.sessionId, generation: 1, received: 0 }),
+    PeerResumeRejectedError,
+  );
+  assert.throws(
+    () => right.reserve({ sessionId: left.sessionId, generation: 2, received: 100 }),
+    PeerResumeRejectedError,
+  );
+  const state = left.nextAttachment();
+  right.reserve(state);
+  const [a, b] = duplexPair();
+  assert.throws(
+    () =>
+      right.attach(state.generation, {
+        stream: wire(a, 'impostor'),
+        remainder: Buffer.alloc(0),
+        received: 0,
+      }),
+    PeerResumeRejectedError,
+  );
+  b.destroy();
+  const writing = left.write(Buffer.from([9]));
+  assert.deepEqual(await right.read(), Buffer.from([9]));
+  await writing;
+});
+
+test('one-way blackhole triggers automatic recovery and preserves the pending read', {
+  timeout: 5_000,
+}, async (t) => {
+  let right!: ResumablePeerStream;
+  let reattachments = 0;
+  const left = new ResumablePeerStream({
+    peerId: 'peer',
+    heartbeatMs: 20,
+    heartbeatTimeoutMs: 60,
+    recoveryMs: 500,
+    reconnect: async (state) => {
+      reattachments++;
+      const [a, b] = duplexPair();
+      right.reserve(state);
+      const received = right.received;
+      right.attach(state.generation, {
+        stream: wire(b, 'peer'),
+        received: state.received,
+        remainder: Buffer.alloc(0),
+      });
+      return { stream: wire(a, 'peer'), received, remainder: Buffer.alloc(0) };
+    },
+  });
+  right = new ResumablePeerStream({ peerId: 'peer', sessionId: left.sessionId });
+  t.after(() => {
+    left.abort();
+    right.abort();
+  });
+  const [a, b] = duplexPair();
+  const state = left.nextAttachment();
+  right.reserve(state);
+  const blackhole = wire(a, 'peer');
+  left.attach(state.generation, {
+    stream: { ...blackhole, write: async () => {} },
+    received: 0,
+    remainder: Buffer.alloc(0),
+  });
+  right.attach(state.generation, {
+    stream: wire(b, 'peer'),
+    received: 0,
+    remainder: Buffer.alloc(0),
+  });
+  const writing = left.write(Buffer.from('survives'));
+  assert.deepEqual(await right.read(), Buffer.from('survives'));
+  await writing;
+  assert.equal(reattachments, 1);
+});
+
+test('unrecoverable path has a bounded lifetime and abort wakes blocked reads and writes', {
+  timeout: 2_000,
+}, async (t) => {
+  const left = new ResumablePeerStream({ peerId: 'peer', recoveryMs: 60, heartbeatMs: 20 });
+  const right = new ResumablePeerStream({ peerId: 'peer', sessionId: left.sessionId });
+  t.after(() => {
+    left.abort();
+    right.abort();
+  });
+  const cut = attach(left, right);
+  const read = assert.rejects(left.read(), /recovery deadline/u);
+  const write = assert.rejects(left.write(Buffer.alloc(3 * 1024 * 1024)), /recovery deadline/u);
+  cut();
+  await Promise.all([read, write, delay(100)]);
+  assert.throws(() => left.nextAttachment(), /recovery deadline/u);
+});
+
+test('close has a hard deadline even when a healthy peer never drains its receive window', {
+  timeout: 3_000,
+}, async (t) => {
+  const { left, right } = sessions();
+  t.after(() => {
+    left.abort();
+    right.abort();
+  });
+  attach(left, right);
+  const blocked = assert.rejects(left.write(Buffer.alloc(3 * 1024 * 1024)), /aborted/u);
+  await tick();
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const closing = left.close();
+  t.mock.timers.tick(5_000);
+  await Promise.all([closing, blocked]);
+});
+
+test('failed proactive upgrade preserves transit; a later direct attachment keeps the logical stream', {
+  timeout: 13_000,
+}, async (t) => {
+  let right!: ResumablePeerStream;
+  let upgrades = 0;
+  const left = new ResumablePeerStream({
+    peerId: 'peer',
+    reconnect: async (state, _signal, upgrade) => {
+      assert.equal(upgrade, true);
+      upgrades++;
+      if (upgrades === 1) {
+        await right.write(Buffer.from('rejected-upgrade-retains-old'));
+        throw new PeerResumeRejectedError('candidate rejected');
+      }
+      const [a, b] = duplexPair();
+      right.reserve(state);
+      const received = right.received;
+      right.attach(state.generation, {
+        stream: wire(b, 'peer'),
+        received: state.received,
+        remainder: Buffer.alloc(0),
+      });
+      await right.write(Buffer.from('during-path-change'));
+      return { stream: wire(a, 'peer'), received, remainder: Buffer.alloc(0) };
+    },
+  });
+  right = new ResumablePeerStream({ peerId: 'peer', sessionId: left.sessionId });
+  t.after(() => {
+    left.abort();
+    right.abort();
+  });
+  const [a, b] = duplexPair();
+  const state = left.nextAttachment();
+  right.reserve(state);
+  const transit = (stream: RuntimeHostPeerNativeStream): RuntimeHostPeerNativeStream => ({
+    ...stream,
+    path: { kind: 'transit', relayPeerId: 'approved' },
+  });
+  right.attach(state.generation, {
+    stream: transit(wire(b, 'peer')),
+    received: 0,
+    remainder: Buffer.alloc(0),
+  });
+  left.attach(state.generation, {
+    stream: transit(wire(a, 'peer')),
+    received: 0,
+    remainder: Buffer.alloc(0),
+  });
+  await left.write(Buffer.from('before-upgrade'));
+  assert.deepEqual(await right.read(), Buffer.from('before-upgrade'));
+  assert.deepEqual(await left.read(), Buffer.from('rejected-upgrade-retains-old'));
+  assert.equal(left.path?.kind, 'transit');
+  await left.write(Buffer.from('old-path-still-live'));
+  assert.deepEqual(await right.read(), Buffer.from('old-path-still-live'));
+  assert.deepEqual(await left.read(), Buffer.from('during-path-change'));
+  assert.equal(left.path?.kind, 'direct');
+  assert.equal(upgrades, 2);
+  await left.write(Buffer.from('after-upgrade'));
+  assert.deepEqual(await right.read(), Buffer.from('after-upgrade'));
+});
+
+test('real TCP replacement preserves one Host dispatcher and does not re-execute a control operation; revocation ends recovery', {
+  timeout: 10_000,
+}, async (t) => {
+  let acceptStream!: (stream: RuntimeHostPeerNativeStream) => void;
+  let revoke!: (credentialId: string) => void;
+  let revoked = false;
+  let admissions = 0;
+  let executions = 0;
+  let teardowns = 0;
+  let entered!: () => void;
+  let release!: () => void;
+  const handlerEntered = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
+  const handlerReleased = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const runs: Promise<void>[] = [];
+  const sockets = new Set<Socket>();
+  const authority = { ...LOCAL_OWNER_CONNECTION_AUTHORITY, credentialId: 'credential' };
+  const rootId = 'a'.repeat(64);
+  const listener = createRuntimeHostPeerListener(
+    {
+      identity: () => ({ peerId: 'server' }),
+      serveApplication: async (accept, signal) => {
+        acceptStream = accept;
+        await new Promise<void>((resolve) =>
+          signal.addEventListener('abort', () => resolve(), { once: true }),
+        );
+      },
+    } as RuntimeHostPeerClient,
+    {} as never,
+    {
+      authenticate: (credential: string) =>
+        !revoked && credential === 'secret' ? authority : undefined,
+      subscribeRevocations: (callback: typeof revoke) => {
+        revoke = callback;
+        return () => {};
+      },
+    } as never,
+    ({ transport, authority: admittedAuthority }) => {
+      admissions++;
+      const session = new RuntimeHostConnectionSession({
+        transport,
+        connection: {
+          hostEpoch: 'host',
+          connectionId: 'same-connection',
+          clientInstanceId: 'client',
+          authority: admittedAuthority,
+        },
+        resolveContinuity: () => undefined,
+        resolveHandlers: () => ({
+          ...createUnavailableDomainOperationHandlers(),
+          ...createUnavailableHostCoreOperationHandlers(),
+          'host.status': async () => ({
+            ok: true,
+            result: {
+              hostEpoch: 'host',
+              compositionId: 'maka.interactive',
+              compositionRevision: '1',
+              state: 'ready',
+              connections: 1,
+              activeOperations: 0,
+              activeResidencies: 0,
+            },
+          }),
+          'host.diagnostics.query': async () => ({
+            ok: false,
+            error: { code: 'internal_failure', message: 'not used' },
+          }),
+          'host.resources.query': async () => ({
+            ok: false,
+            error: { code: 'internal_failure', message: 'not used' },
+          }),
+          'host.upgrade.prepare': async () => ({
+            ok: false,
+            error: { code: 'internal_failure', message: 'not used' },
+          }),
+          'turn.stop': async () => {
+            executions++;
+            entered();
+            await handlerReleased;
+            return {
+              ok: false,
+              error: { code: 'not_found', message: 'single execution result' },
+            };
+          },
+        }),
+        beginOperation: async () => ({
+          acquireResidency: () => ({ release() {} }),
+          seal() {},
+          finish() {},
+        }),
+        onTeardown: () => {
+          teardowns++;
+        },
+      });
+      runs.push(
+        (async () => {
+          const hello = decodeClientFrame(await transport.read(1_000));
+          assert.ok('kind' in hello && hello.kind === 'hello');
+          await transport.write(
+            encodeProtocolMessage({
+              kind: 'accepted',
+              rootId,
+              hostEpoch: 'host',
+              connectionId: 'same-connection',
+              selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+              compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+              compositionId: 'maka.interactive',
+              compositionRevision: '1',
+              state: 'ready',
+            }),
+          );
+          await session.run();
+        })(),
+      );
+    },
+  );
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    acceptStream(wire(socket, 'client'));
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const dial = async () => {
+    const socket = connect(address.port, '127.0.0.1');
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    await once(socket, 'connect');
+    return wire(socket, 'server');
+  };
+  let connection: RuntimeHostConnection | undefined;
+  t.after(async () => {
+    release();
+    await connection?.close();
+    await listener.cleanup();
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await Promise.all(runs);
+  });
+  const reachability = {
+    lease: {
+      version: 1 as const,
+      peerId: 'server',
+      revision: 1,
+      issuedAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+      directRoutes: [],
+      coordinationRoutes: [],
+    },
+    publicKey: 'AA',
+    signature: 'AA',
+  };
+  connection = await connectPeerRuntimeHost({
+    profileId: 'test',
+    transport: { kind: 'libp2p-direct', reachability },
+    credential: 'secret',
+    expectedRootId: rootId,
+    clientInstanceId: 'client',
+    peerClient: {
+      observeAuthenticatedReachability: () => reachability,
+      connect: dial,
+    } as unknown as RuntimeHostPeerClient,
+  });
+  const response = assert.rejects(
+    connection.request('turn.stop', { sessionId: 'session', turnId: 'turn', runId: 'run' }, 5_000),
+    /single execution result/u,
+  );
+  await handlerEntered;
+  for (const socket of sockets) socket.destroy();
+  release();
+  await response;
+  assert.equal(connection.connectionId, 'same-connection');
+  assert.equal(admissions, 1);
+  assert.equal(executions, 1);
+  assert.equal(teardowns, 0);
+  revoked = true;
+  revoke('credential');
+  await connection.closed;
+  await assert.rejects(
+    connection.request('turn.stop', { sessionId: 'session', turnId: 'turn', runId: 'run' }),
+  );
+  assert.equal(admissions, 1);
+  assert.equal(executions, 1);
+});

--- a/packages/runtime-host/src/__tests__/resumable-peer-stream.test.ts
+++ b/packages/runtime-host/src/__tests__/resumable-peer-stream.test.ts
@@ -116,6 +116,144 @@ async function receive(stream: ResumablePeerStream, expected: Buffer) {
   assert.equal(count, expected.length);
 }
 
+test('seeded fragmented full-duplex faults retain byte order and release every raw path', {
+  timeout: 180_000,
+}, async (t) => {
+  const seeds = Number(process.env.MAKA_PEER_STRESS_SEEDS ?? 8);
+  assert.ok(Number.isSafeInteger(seeds) && seeds >= 1 && seeds <= 256);
+  const latencies: number[] = [];
+  let failures = 0;
+  let livePaths = 0;
+  let peakPaths = 0;
+  const started = performance.now();
+  const run = async (seed: number) => {
+    let rng = seed;
+    const random = (limit: number) => {
+      rng = (Math.imul(rng, 1664525) + 1013904223) >>> 0;
+      return rng % limit;
+    };
+    let right!: ResumablePeerStream;
+    let cuts = 0;
+    let attempts = 0;
+    let failedAt = 0;
+    const paths = new Set<Duplex>();
+    const candidate = (state: ReturnType<ResumablePeerStream['nextAttachment']>) => {
+      const [a, b] = duplexPair({ highWaterMark: 1024 });
+      for (const socket of [a, b]) {
+        paths.add(socket);
+        livePaths++;
+        peakPaths = Math.max(peakPaths, livePaths);
+        socket.once('close', () => {
+          paths.delete(socket);
+          livePaths--;
+        });
+      }
+      const cutAfter = cuts < 4 ? 128 * 1024 + random(384 * 1024) : Infinity;
+      let written = 0;
+      let cut = false;
+      const fragmented = (socket: Duplex) => {
+        const raw = wire(socket, 'peer');
+        return {
+          ...raw,
+          write: async (bytes: Buffer) => {
+            const prefix = Math.min(bytes.length, 1 + random(31));
+            for (const part of [bytes.subarray(0, prefix), bytes.subarray(prefix)]) {
+              if (part.length === 0) continue;
+              const remaining = cutAfter - written;
+              if (!cut && part.length > remaining) {
+                cut = true;
+                if (remaining > 0) await raw.write(part.subarray(0, remaining));
+                cuts++;
+                failures++;
+                failedAt = performance.now();
+                a.destroy();
+                b.destroy();
+                throw new Error(`seed ${seed}: cut inside a frame`);
+              }
+              written += part.length;
+              await raw.write(part);
+            }
+          },
+        };
+      };
+      right.reserve(state);
+      const received = right.received;
+      right.attach(state.generation, {
+        stream: fragmented(b),
+        remainder: Buffer.alloc(0),
+        received: state.received,
+      });
+      return { stream: fragmented(a), remainder: Buffer.alloc(0), received };
+    };
+    const left = new ResumablePeerStream({
+      peerId: 'peer',
+      reconnect: async (state) => {
+        // Failed candidates and a retained unread window coexist with replay.
+        if (++attempts % 3 === 1) throw new Error(`seed ${seed}: dial unavailable`);
+        await delay(random(4));
+        const result = candidate(state);
+        latencies.push(performance.now() - failedAt);
+        return result;
+      },
+    });
+    right = new ResumablePeerStream({ peerId: 'peer', sessionId: left.sessionId });
+    const send = async (stream: ResumablePeerStream, bytes: Buffer) => {
+      for (let offset = 0; offset < bytes.length; ) {
+        const size = Math.min(bytes.length - offset, 1 + random(128 * 1024));
+        await stream.write(bytes.subarray(offset, offset + size));
+        offset += size;
+      }
+    };
+    const drain = async (stream: ResumablePeerStream, bytes: Buffer) => {
+      for (let offset = 0; offset < bytes.length; ) {
+        if (random(8) === 0) await delay(1);
+        const chunk = await stream.read();
+        assert.ok(chunk, `seed ${seed}: premature EOF at ${offset}`);
+        assert.deepEqual(
+          chunk,
+          bytes.subarray(offset, offset + chunk.length),
+          `seed ${seed}, offset ${offset}`,
+        );
+        offset += chunk.length;
+      }
+    };
+    try {
+      const state = left.nextAttachment();
+      left.attach(state.generation, candidate(state));
+      const a = payload(4 * 1024 * 1024, seed);
+      const b = payload(4 * 1024 * 1024, seed ^ 0xff);
+      await Promise.all([send(left, a), send(right, b), drain(right, a), drain(left, b)]);
+      assert.equal(cuts, 4, `seed ${seed}: all faults must occur during traffic`);
+      await left.close();
+      await right.closed;
+    } finally {
+      left.abort();
+      right.abort();
+      await tick();
+      assert.equal(paths.size, 0, `seed ${seed}: leaked raw paths`);
+    }
+  };
+  for (let seed = 1; seed <= seeds; seed += 4) {
+    await Promise.all(
+      Array.from({ length: Math.min(4, seeds - seed + 1) }, (_, index) => run(seed + index)),
+    );
+  }
+  latencies.sort((a, b) => a - b);
+  assert.equal(livePaths, 0);
+  t.diagnostic(
+    JSON.stringify({
+      seeds,
+      bytesVerified: seeds * 8 * 1024 * 1024,
+      failures,
+      peakRawHalves: peakPaths,
+      elapsedMs: Math.round(performance.now() - started),
+      attachmentP50Ms: Math.round(latencies[Math.floor(latencies.length * 0.5)]!),
+      attachmentP95Ms: Math.round(latencies[Math.floor(latencies.length * 0.95)]!),
+      attachmentMaxMs: Math.round(latencies.at(-1)!),
+    }),
+  );
+});
+
 test('full duplex exceeds the replay window and survives repeated path replacement', {
   timeout: 10_000,
 }, async (t) => {
@@ -243,6 +381,54 @@ test('one-way blackhole triggers automatic recovery and preserves the pending re
   assert.deepEqual(await right.read(), Buffer.from('survives'));
   await writing;
   assert.equal(reattachments, 1);
+});
+
+test('continuous incoming traffic cannot starve outbound data or heartbeat behind ACKs', {
+  timeout: 3_000,
+}, async (t) => {
+  const left = new ResumablePeerStream({
+    peerId: 'peer',
+    heartbeatMs: 20,
+    heartbeatTimeoutMs: 80,
+    recoveryMs: 100,
+  });
+  const right = new ResumablePeerStream({ peerId: 'peer', sessionId: left.sessionId });
+  t.after(() => {
+    left.abort();
+    right.abort();
+  });
+  const [a, b] = duplexPair();
+  const slow = wire(a, 'peer');
+  const state = left.nextAttachment();
+  right.reserve(state);
+  right.attach(state.generation, {
+    stream: wire(b, 'peer'),
+    received: 0,
+    remainder: Buffer.alloc(0),
+  });
+  left.attach(state.generation, {
+    stream: {
+      ...slow,
+      write: async (bytes) => {
+        await delay(5);
+        await slow.write(bytes);
+      },
+    },
+    received: 0,
+    remainder: Buffer.alloc(0),
+  });
+  const bytes = payload(150 * 512, 41);
+  await Promise.all([
+    receive(left, bytes),
+    receive(right, Buffer.from('outbound must progress')),
+    left.write(Buffer.from('outbound must progress')),
+    (async () => {
+      for (let offset = 0; offset < bytes.length; offset += 512) {
+        await right.write(bytes.subarray(offset, offset + 512));
+        await delay(2);
+      }
+    })(),
+  ]);
 });
 
 test('unrecoverable path has a bounded lifetime and abort wakes blocked reads and writes', {

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -1310,7 +1310,7 @@ test('probes an otherwise idle accepted Runtime Host connection', { timeout: 2_0
   );
 });
 
-test('accepts Session traffic as liveness while a route status observation is delayed', {
+test('tolerates a short Host stall without abandoning the connection', {
   timeout: 5_000,
 }, async () => {
   const observed = deferred<HostStatusResult>();
@@ -1333,9 +1333,8 @@ test('accepts Session traffic as liveness while a route status observation is de
       assert.ok(!('kind' in probe));
       assert.equal(probe.operation, 'host.status');
 
-      // Keep the status request pending past its original two-second deadline.
-      // A valid Session frame in between proves the same authenticated
-      // transport is alive and must extend that deadline.
+      // A transient pause beyond the old two-second deadline is recoverable.
+      // Only the eventual matching response completes the probe.
       await delay(1_100);
       await writeProtocolFrame(transport, {
         kind: 'session.catalog.changed',
@@ -1358,6 +1357,59 @@ test('accepts Session traffic as liveness while a route status observation is de
     {
       livenessIntervalMs: 20,
       onHostStatus: observed.resolve,
+    },
+  );
+});
+
+test('closes an unresponsive request path even while Host notifications continue', {
+  timeout: 12_000,
+}, async () => {
+  let received = 0;
+  let probes = 0;
+  await withProtocolPeer(
+    async (transport, hostEpoch, rootId) => {
+      await transport.read(1_000);
+      await writeProtocolFrame(transport, {
+        kind: 'accepted',
+        rootId,
+        hostEpoch,
+        connectionId: 'one-way-host',
+        selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+        compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+        compositionId: 'maka.interactive',
+        compositionRevision: '1',
+        state: 'ready',
+      });
+      let revision = 0;
+      const notifications = setInterval(() => {
+        void writeProtocolFrame(transport, {
+          kind: 'session.catalog.changed',
+          revision: ++revision,
+          sessionId: 'shared-session',
+        }).catch(() => undefined);
+      }, 10);
+      try {
+        const probe = decodeClientFrame(await transport.read(1_000));
+        assert.ok(!('kind' in probe));
+        assert.equal(probe.operation, 'host.status');
+        await transport.closed;
+      } finally {
+        clearInterval(notifications);
+      }
+    },
+    async (connection) => {
+      connection.subscribeSessionCatalogChanges(() => {
+        received += 1;
+      });
+      await connection.closed;
+      assert.ok(received > 10, 'inbound events must remain active during the failed probe');
+      assert.equal(probes, 0, 'one-way events cannot acknowledge a probe');
+    },
+    {
+      livenessIntervalMs: 20,
+      onLivenessProbe: () => {
+        probes += 1;
+      },
     },
   );
 });

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -92,6 +92,9 @@ const DEFAULT_LIVENESS_INTERVAL_MS = 2_000;
 // A bounded round trip tolerates short transport/Host stalls. Unrelated inbound
 // traffic must never extend it: receiving events does not prove requests work.
 const DEFAULT_LIVENESS_TIMEOUT_MS = 8_000;
+// Peer byte-stream recovery owns a bounded 30-second reattachment budget.
+// Its independent path probes detect failures; Host probes still bound a hung Host.
+const PEER_LIVENESS_TIMEOUT_MS = 45_000;
 const MAX_WEBSOCKET_FRAGMENTS = 256;
 const MAX_WEBSOCKET_BUFFERED_CHUNKS = 256;
 
@@ -192,6 +195,7 @@ export interface ConnectRuntimeHostMessageTransportInput {
   readonly onHostStatus?: (status: HostStatusResult) => void;
   readonly connectionResource?: RuntimeHostConnectionResource;
   readonly peerPath?: RuntimeHostPeerConnectionPath;
+  readonly getPeerPath?: () => RuntimeHostPeerConnectionPath | undefined;
 }
 
 export interface RuntimeHostConnectionResource {
@@ -350,7 +354,10 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   readonly selectedProtocol: number;
   readonly compositionId: string;
   readonly compositionRevision: string;
-  readonly peerPath: RuntimeHostPeerConnectionPath | undefined;
+  readonly #getPeerPath: () => RuntimeHostPeerConnectionPath | undefined;
+  get peerPath(): RuntimeHostPeerConnectionPath | undefined {
+    return this.#getPeerPath();
+  }
   readonly closed: Promise<void>;
   readonly #transport: RuntimeHostMessageTransport;
   readonly #pendingRequests = new Map<string, PendingRequest>();
@@ -391,6 +398,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       onHostStatus?: (status: HostStatusResult) => void;
       connectionResource?: RuntimeHostConnectionResource;
       peerPath?: RuntimeHostPeerConnectionPath;
+      getPeerPath?: () => RuntimeHostPeerConnectionPath | undefined;
     },
   ) {
     this.#livenessIntervalMs = options?.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS;
@@ -403,7 +411,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.selectedProtocol = accepted.selectedProtocol;
     this.compositionId = accepted.compositionId;
     this.compositionRevision = accepted.compositionRevision;
-    this.peerPath = options?.peerPath;
+    this.#getPeerPath = options?.getPeerPath ?? (() => options?.peerPath);
     const connectionResource = options?.connectionResource;
     if (connectionResource) {
       const abortForResourceClosure = (cause: Error) =>
@@ -553,7 +561,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     return this.#requestOperation(
       'host.status',
       {},
-      timeoutMs ?? DEFAULT_LIVENESS_TIMEOUT_MS,
+      timeoutMs ?? (this.peerPath ? PEER_LIVENESS_TIMEOUT_MS : DEFAULT_LIVENESS_TIMEOUT_MS),
       (status) => this.#validateHostStatusIdentity(status),
       'connection',
     );
@@ -848,10 +856,13 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   #startLivenessProbe(): void {
     if (this.#terminalError || this.#livenessProbePending) return;
     this.#livenessProbePending = true;
-    this.#livenessProbeDeadline = setTimeout(() => {
-      this.#livenessProbeDeadline = undefined;
-      this.#fail(requestTimeoutError('host.status'));
-    }, DEFAULT_LIVENESS_TIMEOUT_MS);
+    this.#livenessProbeDeadline = setTimeout(
+      () => {
+        this.#livenessProbeDeadline = undefined;
+        this.#fail(requestTimeoutError('host.status'));
+      },
+      this.peerPath ? PEER_LIVENESS_TIMEOUT_MS : DEFAULT_LIVENESS_TIMEOUT_MS,
+    );
     void this.#requestOperation(
       'host.status',
       {},
@@ -1082,6 +1093,7 @@ export async function connectRuntimeHostMessageTransport(
       onHostStatus: input.onHostStatus,
       connectionResource: input.connectionResource,
       ...(input.peerPath ? { peerPath: input.peerPath } : {}),
+      ...(input.getPeerPath ? { getPeerPath: input.getPeerPath } : {}),
     });
     if (result.kind === 'connected') {
       resourceTransferred = true;
@@ -1421,6 +1433,7 @@ interface ExchangeRuntimeHostHandshakeInput {
   readonly onHostStatus?: (status: HostStatusResult) => void;
   readonly connectionResource?: RuntimeHostConnectionResource;
   readonly peerPath?: RuntimeHostPeerConnectionPath;
+  readonly getPeerPath?: () => RuntimeHostPeerConnectionPath | undefined;
 }
 
 interface LegacySurfaceClientHello extends ClientHello {
@@ -1502,6 +1515,7 @@ async function exchangeRuntimeHostHandshake(
       onHostStatus: input.onHostStatus,
       connectionResource: input.connectionResource,
       ...(input.peerPath ? { peerPath: input.peerPath } : {}),
+      ...(input.getPeerPath ? { getPeerPath: input.getPeerPath } : {}),
     }),
   };
 }

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -89,7 +89,9 @@ import {
 const DEFAULT_CONNECT_TIMEOUT_MS = 500;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 2_000;
 const DEFAULT_LIVENESS_INTERVAL_MS = 2_000;
-const DEFAULT_LIVENESS_TIMEOUT_MS = 2_000;
+// A bounded round trip tolerates short transport/Host stalls. Unrelated inbound
+// traffic must never extend it: receiving events does not prove requests work.
+const DEFAULT_LIVENESS_TIMEOUT_MS = 8_000;
 const MAX_WEBSOCKET_FRAGMENTS = 256;
 const MAX_WEBSOCKET_BUFFERED_CHUNKS = 256;
 
@@ -103,12 +105,9 @@ export interface ConnectRuntimeHostInput {
   connectTimeoutMs?: number;
   handshakeTimeoutMs?: number;
   /**
-   * Maximum quiet interval before an end-to-end Host liveness probe.
-   * Any valid inbound frame restarts the quiet interval. A Host status
-   * observer additionally uses this as its periodic observation cadence;
-   * inbound traffic then extends an outstanding probe's progress deadline
-   * without suppressing future status observations. Injectable so tests can
-   * exercise the cadence without waiting the real default (2s).
+   * Interval between end-to-end Host liveness probes. Probes continue while
+   * inbound traffic is active; only a matching response proves a round trip.
+   * Injectable so tests can exercise the cadence without waiting 2 seconds.
    */
   livenessIntervalMs?: number;
   /**
@@ -680,7 +679,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     try {
       while (true) {
         const frame = decodeHostFrame(await this.#transport.read(0));
-        this.#resetLivenessCheck();
+        this.#scheduleLivenessCheck();
         if ('kind' in frame) {
           if (isClientCapabilityHostFrameKind(frame.kind)) {
             this.#clientCapabilities.accept(frame as ClientCapabilityHostFrame);
@@ -835,19 +834,8 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.#drainDomainRequests();
   }
 
-  #resetLivenessCheck(): void {
-    // Any authenticated Host frame proves the transport is still making
-    // progress, even when a periodic status observation is slow.
-    this.#resetLivenessProbeDeadline();
-    // A status observer needs periodic route observations even while other
-    // Session traffic keeps the connection active.
-    if (this.#onHostStatus) return;
-    if (this.#livenessTimer) clearTimeout(this.#livenessTimer);
-    this.#livenessTimer = undefined;
-    this.#scheduleLivenessCheck();
-  }
-
   #scheduleLivenessCheck(): void {
+    // Inbound events do not postpone the next bidirectional probe.
     if (this.#terminalError || this.#livenessTimer || this.#livenessProbePending) {
       return;
     }
@@ -860,7 +848,10 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   #startLivenessProbe(): void {
     if (this.#terminalError || this.#livenessProbePending) return;
     this.#livenessProbePending = true;
-    this.#resetLivenessProbeDeadline();
+    this.#livenessProbeDeadline = setTimeout(() => {
+      this.#livenessProbeDeadline = undefined;
+      this.#fail(requestTimeoutError('host.status'));
+    }, DEFAULT_LIVENESS_TIMEOUT_MS);
     void this.#requestOperation(
       'host.status',
       {},
@@ -883,15 +874,6 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
         this.#livenessProbePending = false;
         this.#scheduleLivenessCheck();
       });
-  }
-
-  #resetLivenessProbeDeadline(): void {
-    if (!this.#livenessProbePending || this.#terminalError) return;
-    if (this.#livenessProbeDeadline) clearTimeout(this.#livenessProbeDeadline);
-    this.#livenessProbeDeadline = setTimeout(() => {
-      this.#livenessProbeDeadline = undefined;
-      this.#fail(requestTimeoutError('host.status'));
-    }, DEFAULT_LIVENESS_TIMEOUT_MS);
   }
 
   #acceptSubscriptionFrame(frame: SubscriptionFrame): void {

--- a/packages/runtime-host/src/client/host-profile.ts
+++ b/packages/runtime-host/src/client/host-profile.ts
@@ -18,6 +18,10 @@
  */
 
 import { createHash, randomUUID } from 'node:crypto';
+import {
+  ResumablePeerStream,
+  PeerResumeRejectedError,
+} from '../transport/resumable-peer-stream.js';
 import { watch } from 'node:fs';
 import { chmod, mkdir, open, readFile, rename, rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
@@ -672,14 +676,54 @@ export async function connectPeerRuntimeHost(input: {
     }
     throw cause;
   }
-  const abort = () => stream.abort();
+  let logical: ResumablePeerStream | undefined;
+  const abort = () => {
+    logical?.abort();
+    stream.abort();
+  };
   input.signal?.addEventListener('abort', abort, { once: true });
   if (input.signal?.aborted) abort();
   let transferred = false;
   try {
     input.signal?.throwIfAborted();
     notifyConnectionPhase(input.onConnectionPhase, 'authenticating');
-    await writeRuntimeHostPeerAuthentication(stream, input.credential);
+    logical = new ResumablePeerStream({
+      peerId,
+      reconnect: async (state, signal, upgrade) => {
+        const candidate = await input.peerClient.connect(
+          {
+            peerId,
+            routeHints: bootstrap?.directRoutes ?? [],
+            coordinationRelays: bootstrap?.coordinationRoutes ?? [],
+            directDeadlineMs: upgrade ? 5_000 : 20_000,
+          },
+          signal,
+        );
+        let attached = false;
+        const abortCandidate = () => candidate.abort();
+        signal.addEventListener('abort', abortCandidate, { once: true });
+        try {
+          signal.throwIfAborted();
+          if (upgrade && candidate.path?.kind !== 'direct') return undefined;
+          await writeRuntimeHostPeerAuthentication(candidate, input.credential, state);
+          const response = await readRuntimeHostPeerAuthenticationResult(candidate, 5_000);
+          signal.throwIfAborted();
+          if (!response.accepted || !response.resume)
+            throw new PeerResumeRejectedError('Host rejected peer session recovery');
+          attached = true;
+          return {
+            stream: candidate,
+            remainder: response.remainder,
+            received: response.resume.received,
+          };
+        } finally {
+          signal.removeEventListener('abort', abortCandidate);
+          if (!attached) candidate.abort();
+        }
+      },
+    });
+    const state = logical.nextAttachment();
+    await writeRuntimeHostPeerAuthentication(stream, input.credential, state);
     const authentication = await readRuntimeHostPeerAuthenticationResult(
       stream,
       handshakeTimeoutMs,
@@ -690,11 +734,16 @@ export async function connectPeerRuntimeHost(input: {
         `Runtime Host profile ${input.profileId} rejected its access credential`,
       );
     }
+    if (!authentication.resume)
+      throw new PeerResumeRejectedError('Host does not support peer session continuity');
+    logical.attach(state.generation, {
+      stream,
+      remainder: authentication.remainder,
+      received: authentication.resume.received,
+    });
     notifyConnectionPhase(input.onConnectionPhase, 'handshaking');
     const result = await connectRuntimeHostMessageTransport({
-      transport: new FramedByteStreamTransport(
-        new RuntimeHostPeerByteStream(stream, authentication.remainder),
-      ),
+      transport: new FramedByteStreamTransport(new RuntimeHostPeerByteStream(logical)),
       expectedRootId: input.expectedRootId,
       compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
       protocol: {
@@ -714,6 +763,7 @@ export async function connectPeerRuntimeHost(input: {
         input.onHostStatus?.(status);
       },
       ...(stream.path ? { peerPath: stream.path } : {}),
+      getPeerPath: () => logical?.path,
     });
     input.signal?.throwIfAborted();
     if (result.kind === 'incompatible') {
@@ -735,7 +785,10 @@ export async function connectPeerRuntimeHost(input: {
     return result.connection;
   } finally {
     input.signal?.removeEventListener('abort', abort);
-    if (!transferred) stream.abort();
+    if (!transferred) {
+      logical?.abort();
+      stream.abort();
+    }
   }
 }
 

--- a/packages/runtime-host/src/client/peer-client.ts
+++ b/packages/runtime-host/src/client/peer-client.ts
@@ -475,20 +475,23 @@ class RuntimeHostPeerClientImpl implements RuntimeHostPeerClient {
     signal: AbortSignal | undefined,
     kind: 'application' | 'mesh-control',
   ): Promise<RuntimeHostPeerNativeStream> {
-    const previous = this.#connectTails.get(input.peerId) ?? Promise.resolve();
+    // Mesh reconciliation must not consume the foreground application's dial
+    // budget. The native endpoint multiplexes both lanes over peer connections.
+    const lane = `${kind}:${input.peerId}`;
+    const previous = this.#connectTails.get(lane) ?? Promise.resolve();
     let release!: () => void;
     const turn = new Promise<void>((resolve) => {
       release = resolve;
     });
     const tail = previous.then(() => turn);
-    this.#connectTails.set(input.peerId, tail);
+    this.#connectTails.set(lane, tail);
     try {
       await waitForPeerConnectTurn(previous, signal);
       return await this.#startConnect(input, signal, kind);
     } finally {
       release();
       void tail.then(() => {
-        if (this.#connectTails.get(input.peerId) === tail) this.#connectTails.delete(input.peerId);
+        if (this.#connectTails.get(lane) === tail) this.#connectTails.delete(lane);
       });
     }
   }

--- a/packages/runtime-host/src/server/peer-listener.ts
+++ b/packages/runtime-host/src/server/peer-listener.ts
@@ -28,6 +28,11 @@ import {
 import type { RuntimeHostPeerClient } from '../client/peer-client.js';
 import type { PeerReachabilityPublisher } from '../peer-reachability/index.js';
 import type { RuntimeHostAccessAuthority } from './access-authority.js';
+import {
+  ResumablePeerStream,
+  PeerResumeRejectedError,
+} from '../transport/resumable-peer-stream.js';
+import type { RuntimeHostConnectionAuthority } from './connection-authority.js';
 import type {
   RuntimeHostListenerConnection,
   RuntimeHostPeerListener as RuntimeHostPeerListenerContract,
@@ -85,6 +90,11 @@ class RuntimeHostPeerListener implements RuntimeHostPeerListenerContract {
   readonly #accept: (connection: RuntimeHostListenerConnection) => void;
   readonly #transports = new Set<FramedByteStreamTransport>();
   readonly #streams = new Set<RuntimeHostPeerNativeStream>();
+  readonly #sessions = new Map<
+    string,
+    { stream: ResumablePeerStream; authority: RuntimeHostConnectionAuthority }
+  >();
+  readonly #unsubscribeRevocations: () => void;
   readonly #authentications = new Map<RuntimeHostPeerNativeStream, Promise<void>>();
   readonly #serving: Promise<void>;
   readonly #serveLifetime = new AbortController();
@@ -104,6 +114,11 @@ class RuntimeHostPeerListener implements RuntimeHostPeerListenerContract {
     this.#reachability = reachability;
     this.#accessAuthority = accessAuthority;
     this.#accept = accept;
+    this.#unsubscribeRevocations = accessAuthority.subscribeRevocations((credentialId) => {
+      for (const session of this.#sessions.values()) {
+        if (session.authority.credentialId === credentialId) session.stream.abort();
+      }
+    });
     const captureFailure = (error: unknown) => {
       this.#acceptFailure ??= error;
     };
@@ -129,6 +144,8 @@ class RuntimeHostPeerListener implements RuntimeHostPeerListenerContract {
     this.#cleanupTask ??= (async () => {
       await this.closeAdmission();
       for (const transport of this.#transports) transport.abort();
+      for (const session of this.#sessions.values()) session.stream.abort();
+      this.#unsubscribeRevocations();
       this.#serveLifetime.abort();
       await this.#serving;
       if (this.#acceptFailure) throw this.#acceptFailure;
@@ -141,15 +158,6 @@ class RuntimeHostPeerListener implements RuntimeHostPeerListenerContract {
       stream.abort();
       return;
     }
-    let peerStreams = 0;
-    for (const admitted of this.#streams) {
-      if (admitted.peerId === stream.peerId) peerStreams += 1;
-    }
-    if (this.#streams.size >= MAX_ACTIVE_STREAMS || peerStreams >= MAX_ACTIVE_STREAMS_PER_PEER) {
-      stream.abort();
-      return;
-    }
-    this.#streams.add(stream);
     const task = this.#authenticateAndAccept(stream).finally(() => {
       this.#authentications.delete(stream);
     });
@@ -175,31 +183,110 @@ class RuntimeHostPeerListener implements RuntimeHostPeerListenerContract {
         stream.abort();
         return;
       }
-      await writeRuntimeHostPeerAuthenticationResult(stream, true);
-      if (!this.#admitting) {
+      const resume = authenticated.resume;
+      const existing = resume ? this.#sessions.get(resume.sessionId) : undefined;
+      if (existing) {
+        if (
+          existing.stream.peerId !== stream.peerId ||
+          existing.authority.credentialId !== authority.credentialId ||
+          existing.authority.principalKind !== authority.principalKind ||
+          existing.authority.principalId !== authority.principalId
+        ) {
+          await writeRuntimeHostPeerAuthenticationResult(stream, false);
+          stream.abort();
+          return;
+        }
+        existing.stream.reserve(resume!);
+        await writeRuntimeHostPeerAuthenticationResult(stream, true, {
+          received: existing.stream.received,
+        });
+        if (!this.#admitting || !this.#accessAuthority.authenticate(authenticated.credential)) {
+          stream.abort();
+          return;
+        }
+        existing.stream.attach(resume!.generation, {
+          stream,
+          remainder: authenticated.remainder,
+          received: resume!.received,
+        });
+        return;
+      }
+      // Recovery must never create a second Host connection after state loss.
+      if (resume && (resume.generation !== 1 || resume.received !== 0)) {
+        await writeRuntimeHostPeerAuthenticationResult(stream, false);
         stream.abort();
         return;
       }
-      const admittedAuthority = this.#accessAuthority.authenticate(authenticated.credential);
-      if (!admittedAuthority) {
+      const peerStreams = [...this.#streams].filter(
+        (admitted) => admitted.peerId === stream.peerId,
+      ).length;
+      if (this.#streams.size >= MAX_ACTIVE_STREAMS || peerStreams >= MAX_ACTIVE_STREAMS_PER_PEER) {
         stream.abort();
         return;
       }
-      const transport = new FramedByteStreamTransport(
-        new RuntimeHostPeerByteStream(stream, authenticated.remainder),
-      );
-      this.#transports.add(transport);
-      transportOwnsStream = true;
-      void transport.closed.then(() => {
-        this.#transports.delete(transport);
-        this.#streams.delete(stream);
-      });
+      const logical = resume
+        ? new ResumablePeerStream({ peerId: stream.peerId, sessionId: resume.sessionId })
+        : undefined;
+      if (logical && resume) {
+        logical.reserve(resume);
+        this.#sessions.set(resume.sessionId, { stream: logical, authority });
+        void logical.closed.then(() => {
+          if (this.#sessions.get(resume.sessionId)?.stream === logical)
+            this.#sessions.delete(resume.sessionId);
+        });
+      }
+      const admittedStream = logical ?? stream;
+      this.#streams.add(admittedStream);
+      let accepted = false;
       try {
-        this.#accept({ transport, authority: admittedAuthority });
-      } catch (error) {
-        transport.abort(asError(error));
+        await writeRuntimeHostPeerAuthenticationResult(
+          stream,
+          true,
+          logical ? { received: 0 } : undefined,
+        );
+        if (!this.#admitting) {
+          stream.abort();
+          return;
+        }
+        const admittedAuthority = this.#accessAuthority.authenticate(authenticated.credential);
+        if (!admittedAuthority) {
+          stream.abort();
+          return;
+        }
+        const transport = new FramedByteStreamTransport(
+          new RuntimeHostPeerByteStream(
+            admittedStream,
+            logical ? Buffer.alloc(0) : authenticated.remainder,
+          ),
+        );
+        if (logical && resume)
+          logical.attach(resume.generation, {
+            stream,
+            remainder: authenticated.remainder,
+            received: 0,
+          });
+        this.#transports.add(transport);
+        transportOwnsStream = true;
+        accepted = true;
+        void transport.closed.then(() => {
+          this.#transports.delete(transport);
+          this.#streams.delete(admittedStream);
+        });
+        try {
+          this.#accept({ transport, authority: admittedAuthority });
+        } catch (error) {
+          transport.abort(asError(error));
+        }
+      } finally {
+        if (!accepted) {
+          admittedStream.abort();
+          this.#streams.delete(admittedStream);
+        }
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof PeerResumeRejectedError) {
+        await writeRuntimeHostPeerAuthenticationResult(stream, false).catch(() => undefined);
+      }
       stream.abort();
     } finally {
       if (!transportOwnsStream) this.#streams.delete(stream);

--- a/packages/runtime-host/src/transport/peer-native.ts
+++ b/packages/runtime-host/src/transport/peer-native.ts
@@ -20,6 +20,7 @@
 import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import type { RuntimeHostByteStream } from './framed-byte-stream-transport.js';
+import type { PeerResumeState } from './resumable-peer-stream.js';
 
 const AUTHENTICATION_MAX_BYTES = 12 * 1024;
 const AUTHENTICATION_RESULT_MAX_BYTES = 256;
@@ -296,6 +297,7 @@ function loadNativeModule(path: string): RuntimeHostPeerNativeModule {
 export async function writeRuntimeHostPeerAuthentication(
   stream: RuntimeHostPeerNativeStream,
   credential: string,
+  resume?: PeerResumeState,
 ): Promise<void> {
   if (!credential || /\s/u.test(credential)) {
     throw new RuntimeHostPeerError(
@@ -303,19 +305,34 @@ export async function writeRuntimeHostPeerAuthentication(
       'Runtime Host access credential is invalid',
     );
   }
-  await stream.write(Buffer.from(`${JSON.stringify({ v: 1, credential })}\n`, 'utf8'));
+  await stream.write(
+    Buffer.from(
+      `${JSON.stringify(resume ? { v: 2, credential, resume } : { v: 1, credential })}\n`,
+      'utf8',
+    ),
+  );
 }
 
 export async function writeRuntimeHostPeerAuthenticationResult(
   stream: RuntimeHostPeerNativeStream,
   accepted: boolean,
+  resume?: { readonly received: number },
 ): Promise<void> {
-  await stream.write(Buffer.from(`${JSON.stringify({ v: 1, accepted })}\n`, 'utf8'));
+  await stream.write(
+    Buffer.from(
+      `${JSON.stringify(resume ? { v: 2, accepted, resume } : { v: 1, accepted })}\n`,
+      'utf8',
+    ),
+  );
 }
 
 export async function readRuntimeHostPeerAuthentication(
   stream: RuntimeHostPeerNativeStream,
-): Promise<{ readonly credential: string; readonly remainder: Buffer }> {
+): Promise<{
+  readonly credential: string;
+  readonly remainder: Buffer;
+  readonly resume?: PeerResumeState;
+}> {
   const decoded = await readBoundedJsonLine(
     stream,
     AUTHENTICATION_MAX_BYTES,
@@ -324,13 +341,21 @@ export async function readRuntimeHostPeerAuthentication(
   if (!isAuthenticationPreface(decoded.value)) {
     throw new RuntimeHostPeerError('peer_native_failed', 'Peer authentication preface is invalid');
   }
-  return { credential: decoded.value.credential, remainder: decoded.remainder };
+  return {
+    credential: decoded.value.credential,
+    remainder: decoded.remainder,
+    ...('resume' in decoded.value ? { resume: decoded.value.resume } : {}),
+  };
 }
 
 export async function readRuntimeHostPeerAuthenticationResult(
   stream: RuntimeHostPeerNativeStream,
   timeoutMs = RUNTIME_HOST_PEER_AUTHENTICATION_TIMEOUT_MS,
-): Promise<{ readonly accepted: boolean; readonly remainder: Buffer }> {
+): Promise<{
+  readonly accepted: boolean;
+  readonly remainder: Buffer;
+  readonly resume?: { readonly received: number };
+}> {
   const decoded = await withStreamDeadline(
     readBoundedJsonLine(stream, AUTHENTICATION_RESULT_MAX_BYTES, 'Peer authentication result'),
     stream,
@@ -340,7 +365,11 @@ export async function readRuntimeHostPeerAuthenticationResult(
   if (!isAuthenticationResult(decoded.value)) {
     throw new RuntimeHostPeerError('peer_native_failed', 'Peer authentication result is invalid');
   }
-  return { accepted: decoded.value.accepted, remainder: decoded.remainder };
+  return {
+    accepted: decoded.value.accepted,
+    remainder: decoded.remainder,
+    ...('resume' in decoded.value ? { resume: decoded.value.resume } : {}),
+  };
 }
 
 async function readBoundedJsonLine(
@@ -608,14 +637,19 @@ function isCount(value: unknown): value is number {
   return Number.isSafeInteger(value) && (value as number) >= 0;
 }
 
-function isAuthenticationPreface(value: unknown): value is { v: 1; credential: string } {
+function isAuthenticationPreface(
+  value: unknown,
+): value is { v: 1; credential: string } | { v: 2; credential: string; resume: PeerResumeState } {
   return (
     typeof value === 'object' &&
     value !== null &&
     !Array.isArray(value) &&
-    Object.keys(value).length === 2 &&
     'v' in value &&
-    value.v === 1 &&
+    ((value.v === 1 && Object.keys(value).length === 2) ||
+      (value.v === 2 &&
+        Object.keys(value).length === 3 &&
+        'resume' in value &&
+        isResumeState(value.resume))) &&
     'credential' in value &&
     typeof value.credential === 'string' &&
     value.credential.length > 0 &&
@@ -623,14 +657,41 @@ function isAuthenticationPreface(value: unknown): value is { v: 1; credential: s
   );
 }
 
-function isAuthenticationResult(value: unknown): value is { v: 1; accepted: boolean } {
+function isResumeState(value: unknown): value is PeerResumeState {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.keys(value).length === 3 &&
+    'sessionId' in value &&
+    typeof value.sessionId === 'string' &&
+    /^[a-f0-9]{64}$/u.test(value.sessionId) &&
+    'generation' in value &&
+    isCount(value.generation) &&
+    (value.generation as number) > 0 &&
+    'received' in value &&
+    isCount(value.received)
+  );
+}
+
+function isAuthenticationResult(
+  value: unknown,
+): value is
+  | { v: 1; accepted: boolean }
+  | { v: 2; accepted: boolean; resume: { readonly received: number } } {
   return (
     typeof value === 'object' &&
     value !== null &&
     !Array.isArray(value) &&
-    Object.keys(value).length === 2 &&
     'v' in value &&
-    value.v === 1 &&
+    ((value.v === 1 && Object.keys(value).length === 2) ||
+      (value.v === 2 &&
+        Object.keys(value).length === 3 &&
+        'resume' in value &&
+        typeof value.resume === 'object' &&
+        value.resume !== null &&
+        Object.keys(value.resume).length === 1 &&
+        'received' in value.resume &&
+        isCount(value.resume.received))) &&
     'accepted' in value &&
     typeof value.accepted === 'boolean'
   );

--- a/packages/runtime-host/src/transport/peer-native.ts
+++ b/packages/runtime-host/src/transport/peer-native.ts
@@ -305,11 +305,16 @@ export async function writeRuntimeHostPeerAuthentication(
       'Runtime Host access credential is invalid',
     );
   }
-  await stream.write(
-    Buffer.from(
-      `${JSON.stringify(resume ? { v: 2, credential, resume } : { v: 1, credential })}\n`,
-      'utf8',
+  await withStreamDeadline(
+    stream.write(
+      Buffer.from(
+        `${JSON.stringify(resume ? { v: 2, credential, resume } : { v: 1, credential })}\n`,
+        'utf8',
+      ),
     ),
+    stream,
+    RUNTIME_HOST_PEER_AUTHENTICATION_TIMEOUT_MS,
+    'Peer authentication write timed out',
   );
 }
 
@@ -318,11 +323,16 @@ export async function writeRuntimeHostPeerAuthenticationResult(
   accepted: boolean,
   resume?: { readonly received: number },
 ): Promise<void> {
-  await stream.write(
-    Buffer.from(
-      `${JSON.stringify(resume ? { v: 2, accepted, resume } : { v: 1, accepted })}\n`,
-      'utf8',
+  await withStreamDeadline(
+    stream.write(
+      Buffer.from(
+        `${JSON.stringify(resume ? { v: 2, accepted, resume } : { v: 1, accepted })}\n`,
+        'utf8',
+      ),
     ),
+    stream,
+    RUNTIME_HOST_PEER_AUTHENTICATION_TIMEOUT_MS,
+    'Peer authentication response write timed out',
   );
 }
 

--- a/packages/runtime-host/src/transport/resumable-peer-stream.ts
+++ b/packages/runtime-host/src/transport/resumable-peer-stream.ts
@@ -344,22 +344,26 @@ export class ResumablePeerStream implements RuntimeHostPeerNativeStream {
         }
         return;
       }
+      // One fair pass per class: continuous inbound consumption must not
+      // monopolize the writer with ACKs and starve PING/PONG or application data.
+      let wroteControl = false;
       if (path.acknowledged !== this.#consumed) {
         path.acknowledged = this.#consumed;
         await path.stream.write(frame(ACK, path.acknowledged));
-        continue;
+        wroteControl = true;
       }
       if (path.pong !== undefined) {
         const pong = path.pong;
         path.pong = undefined;
         await path.stream.write(frame(PONG, pong));
-        continue;
+        wroteControl = true;
       }
       if (path.ping && !path.ping.sent) {
         path.ping.sent = true;
         await path.stream.write(frame(PING, path.ping.id));
-        continue;
+        wroteControl = true;
       }
+      if (this.#path !== path || this.#ended) return;
       const next = this.#outgoing.find((chunk) => chunk.offset >= path.sent);
       if (next) {
         await path.stream.write(frame(DATA, next.offset, next.bytes));
@@ -376,7 +380,7 @@ export class ResumablePeerStream implements RuntimeHostPeerNativeStream {
         await path.stream.write(frame(FIN, this.#sent));
         continue;
       }
-      await this.#wait();
+      if (!wroteControl) await this.#wait();
     }
   }
 

--- a/packages/runtime-host/src/transport/resumable-peer-stream.ts
+++ b/packages/runtime-host/src/transport/resumable-peer-stream.ts
@@ -1,0 +1,495 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { setTimeout as delay } from 'node:timers/promises';
+import type { RuntimeHostPeerNativeStream } from './peer-native.js';
+
+const HEADER_BYTES = 13;
+const CHUNK_BYTES = 64 * 1024;
+const WINDOW_BYTES = 2 * 1024 * 1024;
+const DATA = 1;
+const ACK = 2;
+const FIN = 3;
+const PING = 4;
+const PONG = 5;
+const FIN_ACK = 6;
+export const PEER_RECOVERY_TIMEOUT_MS = 30_000;
+
+export interface PeerResumeState {
+  readonly sessionId: string;
+  readonly generation: number;
+  readonly received: number;
+}
+
+export interface PeerStreamAttachment {
+  readonly stream: RuntimeHostPeerNativeStream;
+  readonly remainder: Buffer;
+  readonly received: number;
+}
+
+export type ReconnectPeerStream = (
+  state: PeerResumeState,
+  signal: AbortSignal,
+  upgrade: boolean,
+) => Promise<PeerStreamAttachment | undefined>;
+
+interface Path extends PeerStreamAttachment {
+  sent: number;
+  acknowledged: number;
+  pong: number | undefined;
+  ping: { id: number; started: number; sent: boolean } | undefined;
+  finSent: boolean;
+}
+
+export class PeerResumeRejectedError extends Error {}
+
+/** Process-local reliable byte stream. No Host request is interpreted or retried here. */
+export class ResumablePeerStream implements RuntimeHostPeerNativeStream {
+  readonly sessionId: string;
+  readonly peerId: string;
+  readonly closed: Promise<void>;
+  readonly #lifetime = new AbortController();
+  readonly #changed = new Set<() => void>();
+  readonly #outgoing: { offset: number; bytes: Buffer }[] = [];
+  readonly #incoming: Buffer[] = [];
+  readonly #reconnect: ReconnectPeerStream | undefined;
+  readonly #recoveryMs: number;
+  readonly #heartbeatMs: number;
+  readonly #heartbeatTimeoutMs: number;
+  readonly #timer: NodeJS.Timeout;
+  #resolveClosed!: () => void;
+  #generation = 0;
+  #sent = 0;
+  #acknowledged = 0;
+  #received = 0;
+  #consumed = 0;
+  #path: Path | undefined;
+  #lastPath: RuntimeHostPeerNativeStream['path'];
+  #error: Error | undefined;
+  #ended = false;
+  #closing = false;
+  #remoteFin = false;
+  #reading = false;
+  #writeTail: Promise<void> = Promise.resolve();
+  #queuedBytes = 0;
+  #recovering = false;
+  #recoveryStarted: number | undefined;
+  #lastUpgrade = performance.now();
+  #lastPing = performance.now();
+  #pingId = 0;
+
+  constructor(options: {
+    peerId: string;
+    sessionId?: string;
+    reconnect?: ReconnectPeerStream;
+    recoveryMs?: number;
+    heartbeatMs?: number;
+    heartbeatTimeoutMs?: number;
+  }) {
+    this.peerId = options.peerId;
+    this.sessionId = options.sessionId ?? randomBytes(32).toString('hex');
+    this.#reconnect = options.reconnect;
+    this.#recoveryMs = options.recoveryMs ?? PEER_RECOVERY_TIMEOUT_MS;
+    this.#heartbeatMs = options.heartbeatMs ?? 2_000;
+    this.#heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? 6_000;
+    this.closed = new Promise((resolve) => {
+      this.#resolveClosed = resolve;
+    });
+    this.#timer = setInterval(() => this.#tick(), Math.min(this.#heartbeatMs, 250));
+    this.#timer.unref();
+  }
+
+  get path(): RuntimeHostPeerNativeStream['path'] {
+    return this.#path?.stream.path ?? this.#lastPath;
+  }
+  get received(): number {
+    return this.#consumed;
+  }
+
+  nextAttachment(): PeerResumeState {
+    this.#assertOpen();
+    return { sessionId: this.sessionId, generation: ++this.#generation, received: this.#consumed };
+  }
+
+  /** Reserve before awaiting authentication response: a delayed older attach cannot win. */
+  reserve(state: PeerResumeState): void {
+    this.#assertOpen();
+    if (state.sessionId !== this.sessionId || state.generation <= this.#generation) {
+      throw new PeerResumeRejectedError('Stale peer stream attachment');
+    }
+    this.#validateAcknowledgment(state.received);
+    this.#generation = state.generation;
+  }
+
+  attach(generation: number, attachment: PeerStreamAttachment): void {
+    try {
+      this.#assertOpen();
+      if (generation !== this.#generation || attachment.stream.peerId !== this.peerId) {
+        throw new PeerResumeRejectedError('Peer stream attachment identity changed');
+      }
+      this.#acknowledge(attachment.received);
+    } catch (error) {
+      attachment.stream.abort();
+      throw error;
+    }
+    const old = this.#path;
+    const path: Path = {
+      ...attachment,
+      sent: this.#acknowledged,
+      acknowledged: -1,
+      pong: undefined,
+      ping: undefined,
+      finSent: false,
+    };
+    this.#path = path;
+    this.#lastPath = path.stream.path;
+    this.#recoveryStarted = undefined;
+    old?.stream.abort();
+    this.#notify();
+    void this.#pumpRead(path).catch((error) => this.#pathFailed(path, error));
+    void this.#pumpWrite(path).catch((error) => this.#pathFailed(path, error));
+  }
+
+  async read(): Promise<Buffer | null> {
+    if (this.#reading) throw new Error('Concurrent peer stream read');
+    this.#reading = true;
+    try {
+      while (true) {
+        if (this.#error) throw this.#error;
+        const bytes = this.#incoming.shift();
+        if (bytes) {
+          this.#consumed += bytes.length;
+          this.#notify();
+          return bytes;
+        }
+        if (this.#ended || this.#remoteFin) return null;
+        await this.#wait();
+      }
+    } finally {
+      this.#reading = false;
+    }
+  }
+
+  write(bytes: Buffer): Promise<void> {
+    if (this.#ended || this.#closing)
+      return Promise.reject(this.#error ?? new Error('Peer stream closed'));
+    // The caller already owns its frame; cap queued ownership as well as replay bytes.
+    if (this.#queuedBytes + bytes.length > 4 * WINDOW_BYTES)
+      return Promise.reject(new Error('Peer stream write queue full'));
+    const owned = Buffer.from(bytes);
+    this.#queuedBytes += owned.length;
+    const task = this.#writeTail
+      .then(async () => {
+        for (let offset = 0; offset < owned.length; ) {
+          this.#assertOpen();
+          const size = Math.min(CHUNK_BYTES, owned.length - offset);
+          if (this.#sent - this.#acknowledged + size > WINDOW_BYTES) {
+            await this.#wait();
+            continue;
+          }
+          const chunk = Buffer.from(owned.subarray(offset, offset + size));
+          this.#outgoing.push({ offset: this.#sent, bytes: chunk });
+          this.#sent += size;
+          offset += size;
+          this.#notify();
+        }
+        // Match socket write semantics: accepted into a bounded send window,
+        // not one application frame per round trip. The replay owner retains
+        // bytes until ACK; close waits for the entire window before FIN.
+      })
+      .finally(() => {
+        this.#queuedBytes -= owned.length;
+        this.#notify();
+      });
+    this.#writeTail = task.catch(() => undefined);
+    return task;
+  }
+
+  async close(): Promise<void> {
+    if (this.#ended) return;
+    this.#closing = true;
+    const timer = setTimeout(() => this.abort(), 5_000);
+    try {
+      await this.#writeTail;
+      this.#notify();
+      await this.closed;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  abort(): void {
+    this.#finish(new Error('Peer stream aborted'));
+  }
+
+  #assertOpen(): void {
+    if (this.#ended)
+      throw this.#error ?? new PeerResumeRejectedError('Peer stream no longer exists');
+  }
+
+  #validateAcknowledgment(offset: number): void {
+    if (
+      !Number.isSafeInteger(offset) ||
+      offset < 0 ||
+      offset > this.#sent ||
+      (offset > this.#acknowledged &&
+        offset !== this.#sent &&
+        !this.#outgoing.some((chunk) => chunk.offset === offset))
+    ) {
+      throw new PeerResumeRejectedError('Invalid peer stream acknowledgment');
+    }
+  }
+
+  #acknowledge(offset: number): void {
+    this.#validateAcknowledgment(offset);
+    if (offset <= this.#acknowledged) return;
+    this.#acknowledged = offset;
+    while (this.#outgoing[0] && this.#outgoing[0].offset + this.#outgoing[0].bytes.length <= offset)
+      this.#outgoing.shift();
+    this.#notify();
+  }
+
+  async #pumpRead(path: Path): Promise<void> {
+    let buffered = path.remainder;
+    while (this.#path === path && !this.#ended) {
+      if (buffered.length < HEADER_BYTES) {
+        const chunk = await path.stream.read();
+        if (!chunk) throw new Error('Peer path ended');
+        if (this.#path !== path) return;
+        buffered = Buffer.concat([buffered, chunk]);
+        continue;
+      }
+      const type = buffered[0];
+      const wideOffset = buffered.readBigUInt64BE(1);
+      const size = buffered.readUInt32BE(9);
+      if (
+        wideOffset > BigInt(Number.MAX_SAFE_INTEGER) ||
+        size > CHUNK_BYTES ||
+        (type !== DATA && size !== 0)
+      ) {
+        throw new PeerResumeRejectedError('Invalid peer stream frame');
+      }
+      if (buffered.length < HEADER_BYTES + size) {
+        const chunk = await path.stream.read();
+        if (!chunk) throw new Error('Peer path ended inside frame');
+        if (this.#path !== path) return;
+        buffered = Buffer.concat([buffered, chunk]);
+        continue;
+      }
+      const offset = Number(wideOffset);
+      const bytes = buffered.subarray(HEADER_BYTES, HEADER_BYTES + size);
+      buffered = buffered.subarray(HEADER_BYTES + size);
+      switch (type) {
+        case DATA:
+          if (size === 0 || this.#remoteFin)
+            throw new PeerResumeRejectedError('Invalid peer stream data');
+          if (offset + size <= this.#received) break; // Lost ACK: already retained/delivered.
+          if (offset !== this.#received || this.#received - this.#consumed + size > WINDOW_BYTES)
+            throw new PeerResumeRejectedError('Peer stream receive window violated');
+          this.#incoming.push(Buffer.from(bytes));
+          this.#received += size;
+          break;
+        case ACK:
+          this.#acknowledge(offset);
+          break;
+        case PING:
+          path.pong = offset;
+          break;
+        case PONG:
+          if (path.ping?.id === offset) path.ping = undefined;
+          break;
+        case FIN:
+          if (offset !== this.#received)
+            throw new PeerResumeRejectedError('Peer stream close offset mismatch');
+          this.#remoteFin = true;
+          break;
+        case FIN_ACK:
+          if (!this.#closing || offset !== this.#sent)
+            throw new PeerResumeRejectedError('Unexpected peer stream close acknowledgment');
+          this.#finish();
+          return;
+        default:
+          throw new PeerResumeRejectedError('Unknown peer stream frame');
+      }
+      this.#notify();
+    }
+  }
+
+  async #pumpWrite(path: Path): Promise<void> {
+    while (this.#path === path && !this.#ended) {
+      if (this.#remoteFin) {
+        try {
+          await path.stream.write(frame(FIN_ACK, this.#received));
+        } finally {
+          // An explicit logical close is terminal even if its final ACK is lost.
+          if (this.#path === path) this.#finish();
+        }
+        return;
+      }
+      if (path.acknowledged !== this.#consumed) {
+        path.acknowledged = this.#consumed;
+        await path.stream.write(frame(ACK, path.acknowledged));
+        continue;
+      }
+      if (path.pong !== undefined) {
+        const pong = path.pong;
+        path.pong = undefined;
+        await path.stream.write(frame(PONG, pong));
+        continue;
+      }
+      if (path.ping && !path.ping.sent) {
+        path.ping.sent = true;
+        await path.stream.write(frame(PING, path.ping.id));
+        continue;
+      }
+      const next = this.#outgoing.find((chunk) => chunk.offset >= path.sent);
+      if (next) {
+        await path.stream.write(frame(DATA, next.offset, next.bytes));
+        path.sent = next.offset + next.bytes.length;
+        continue;
+      }
+      if (
+        this.#closing &&
+        this.#queuedBytes === 0 &&
+        this.#acknowledged === this.#sent &&
+        !path.finSent
+      ) {
+        path.finSent = true;
+        await path.stream.write(frame(FIN, this.#sent));
+        continue;
+      }
+      await this.#wait();
+    }
+  }
+
+  #pathFailed(path: Path, error: unknown): void {
+    if (this.#path !== path || this.#ended) return;
+    if (error instanceof PeerResumeRejectedError) {
+      this.#finish(error);
+      return;
+    }
+    this.#path = undefined;
+    path.stream.abort();
+    this.#recoveryStarted ??= performance.now();
+    this.#notify();
+    void this.#recover(false);
+  }
+
+  #tick(): void {
+    if (this.#ended) return;
+    const now = performance.now();
+    if (this.#recoveryStarted !== undefined && now - this.#recoveryStarted >= this.#recoveryMs) {
+      this.#finish(new Error('Peer stream recovery deadline exceeded'));
+      return;
+    }
+    const path = this.#path;
+    if (!path) return;
+    if (path.ping && now - path.ping.started >= this.#heartbeatTimeoutMs) {
+      this.#pathFailed(path, new Error('Peer path round trip timed out'));
+      return;
+    }
+    if (!path.ping && now - this.#lastPing >= this.#heartbeatMs) {
+      this.#lastPing = now;
+      path.ping = { id: ++this.#pingId, started: now, sent: false };
+      this.#notify();
+    }
+    if (
+      !this.#closing &&
+      path.stream.path?.kind === 'transit' &&
+      now - this.#lastUpgrade >= 5_000
+    ) {
+      this.#lastUpgrade = now;
+      void this.#recover(true);
+    }
+  }
+
+  async #recover(upgrade: boolean): Promise<void> {
+    if (!this.#reconnect || this.#recovering || this.#ended) return;
+    this.#recovering = true;
+    const deadline = AbortSignal.timeout(upgrade ? 5_000 : this.#recoveryMs);
+    const signal = AbortSignal.any([this.#lifetime.signal, deadline]);
+    try {
+      let attempt = 0;
+      do {
+        try {
+          const state = this.nextAttachment();
+          const attachment = await this.#reconnect(state, signal, upgrade);
+          if (attachment) {
+            if (signal.aborted || this.#ended) attachment.stream.abort();
+            else this.attach(state.generation, attachment);
+            return;
+          }
+        } catch (error) {
+          if (error instanceof PeerResumeRejectedError) {
+            // A failed optimization must not tear down an intact authorized
+            // attachment. Once the old path is lost, rejection is terminal.
+            if (!upgrade || !this.#path) this.#finish(error);
+            return;
+          }
+          if (signal.aborted) return;
+        }
+        if (upgrade) return;
+        await delay(
+          Math.min(250 * 2 ** attempt++, 2_000) + Math.floor(Math.random() * 100),
+          undefined,
+          { signal },
+        );
+      } while (!this.#ended && !signal.aborted);
+    } catch {
+      /* cancellation belongs to the logical lifetime */
+    } finally {
+      this.#recovering = false;
+      // A proactive dial may have overlapped failure of the old path.
+      if (!this.#ended && !this.#path) void this.#recover(false);
+    }
+  }
+
+  #finish(error?: Error): void {
+    if (this.#ended) return;
+    this.#ended = true;
+    this.#error = error;
+    clearInterval(this.#timer);
+    this.#lifetime.abort();
+    this.#path?.stream.abort();
+    this.#path = undefined;
+    this.#outgoing.length = 0;
+    if (error) this.#incoming.length = 0;
+    this.#notify();
+    this.#resolveClosed();
+  }
+
+  #wait(): Promise<void> {
+    return new Promise((resolve) => this.#changed.add(resolve));
+  }
+  #notify(): void {
+    for (const resolve of this.#changed) resolve();
+    this.#changed.clear();
+  }
+}
+
+function frame(type: number, offset: number, bytes: Buffer = Buffer.alloc(0)): Buffer {
+  const packet = Buffer.allocUnsafe(HEADER_BYTES + bytes.length);
+  packet[0] = type;
+  packet.writeBigUInt64BE(BigInt(offset), 1);
+  packet.writeUInt32BE(bytes.length, 9);
+  bytes.copy(packet, HEADER_BYTES);
+  return packet;
+}


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Improve Peer Mesh recovery and preserve an authenticated Host connection across peer-path replacement. Business traffic remains restricted to direct connections and explicitly approved transit peers.

## Changes

- Fix native full-duplex backpressure deadlocks and protect active streams when another substream fails to open.
- Refresh and withdraw listener addresses, recreate failed listeners, and enable QUIC/TCP over supported IPv4/IPv6 address families. Preserve caller-provided NAT-mapped routes when Identify advertises private listener addresses, so direct discovery can recover after transit fallback.
- Select established paths using ping health and smoothed RTT. Separate application and Mesh dial lanes, start approved-transit fallback after 250 ms, and continue background direct discovery.
- Add bounded, process-local stream continuity using byte offsets, acknowledgments and duplicate suppression. Recover failed paths and upgrade transit to direct without creating another Host connection or redispatching business operations.
- Reauthenticate every attachment and bind it to the original peer, credential/principal, session ID and generation. Reject unknown or expired sessions; terminate retained sessions on credential revocation.
- Prevent ACK traffic from starving data and heartbeat writes. Bound authentication writes and stream shutdown. Allow 30 seconds for path recovery and 45 seconds for peer Host probes; explicit operation deadlines remain unchanged.

## Validation

- Runtime Host: **1694 passed, 12 skipped**. Native: **38 passed**. Clippy, Biome and formatting checks passed.
- Seeded fault tests: **128 seeds, 512 mid-frame disconnects, 1 GiB verified byte-for-byte**, covering bidirectional traffic, fragmentation, slow consumers and failed reconnect candidates. All simulated underlying streams were released.
- Real TCP integration verifies one Host admission and one control-operation dispatch across reconnection, followed by credential revocation.
- Native-addon transport testing verifies **16 MiB** across approved transit, IPv4 QUIC/TCP and IPv6 QUIC/TCP attachments.
- Four-host ARM64 Linux/Docker integration covers loss/jitter, TCP-to-QUIC recovery, direct-to-transit fallback, transit-provider failure, direct restoration, and packet-verified NAT port/egress-address changes. Successful recovery preserves one Host connection without duplicate control dispatch. Ten repeated weak-link/3-second link-outage cycles verified **9,768 replies**, with file-descriptor counts returning to baseline.
- With no published client/Host ports, NAT cold start succeeds through approved transit; direct hole punching was not established in that configuration. Revocation terminates the active session. Blocking all authorized paths terminates it after **37.5 seconds**, with no automatic replay or resurrection after connectivity returns.

## Compatibility and limitations

- Adds peer authentication/framing v2 without changing the Host operation schema. The listener still accepts v1 clients, but the new client requires a v2 Host: **upgrade Host before Client**.
- Continuity is process-local and does not depend on native QUIC migration. Restart, revocation, explicit close and recovery expiry terminate the session; short operation deadlines can still expire during recovery.
- Recovery can visibly pause traffic: the worst observed response gap in cross-path failure tests was **17.9 seconds**. The repeated 3-second link-outage test reached **3.32 seconds**, including the injected outage. These measurements are not a production latency SLO.
- Mesh control retains its existing reconnect mechanism. These tests do not establish physical roaming, long-duration resource stability, or WebRTC cross-path continuity.

</details>

<details>
<summary>中文</summary>

## 概述

增强 Peer Mesh 恢复能力，在底层路径替换后保留同一条已认证 Host 连接。业务流量仍仅允许直连或明确批准的 transit 节点。

## 改动

- 修复原生层双向背压死锁；新子流打开失败时保护同一连接上的在用流。
- 动态更新／撤回监听地址、重建失效监听，支持可用 IPv4/IPv6 地址族上的 QUIC/TCP。Identify 广告私网监听地址时保留调用方提供的 NAT 映射路由，使 transit 回退后仍能恢复直连发现。
- 按 ping 健康状态与平滑 RTT 选择现有路径；分离业务与 Mesh 拨号队列，250 ms 后允许已批准 transit 回退，并继续后台直连发现。
- 基于字节偏移、ACK 和去重新增有界的进程内流接续。路径故障恢复及 transit 升级直连不新增 Host 连接、不重新派发业务操作。
- 每次替换重新认证，绑定原 peer、凭据／主体、会话 ID 和代次。拒绝未知或过期会话；撤销凭据时终止保留会话。
- 防止 ACK 流量饿死业务数据和心跳发送；限制认证写入与关闭耗时。路径恢复预算为 30 秒，peer Host 探测预算为 45 秒；显式业务操作超时不变。

## 验证

- Runtime Host：**1694 通过、12 跳过**；原生层：**38 通过**。Clippy、Biome 和格式检查通过。
- 随机故障测试：**128 个种子、512 次帧中途断流、逐字节校验 1 GiB**，覆盖双向流量、分片、慢消费者和失败的重连候选；结束后所有模拟底层流均释放。
- 真实 TCP 集成测试验证重连前后仅一次 Host 接入、一次控制操作派发，并验证后续凭据撤销。
- 原生 addon 传输测试跨已批准 transit、IPv4 QUIC/TCP、IPv6 QUIC/TCP，校验 **16 MiB** 数据。
- 四机 ARM64 Linux/Docker 集成测试覆盖丢包／抖动、TCP 转 QUIC、直连回退 transit、transit 节点故障、直连恢复，以及抓包确认的 NAT 端口／出口地址变化。成功恢复过程中保留同一 Host 连接，未重复派发控制操作。十轮弱网及 3 秒断网测试校验 **9,768 个响应**，文件描述符数量回到基线。
- 不开放客户端／Host 入站端口时，NAT 冷启动通过获授权 transit 成功；该配置未验证出直连打洞成功。撤权终止活动会话；阻断全部允许路径后，会话在 **37.5 秒**后终止，网络恢复后未自动重放操作或复活会话。

## 兼容性与限制

- 新增 peer 认证／分帧 v2，不改变 Host 操作 schema。listener 仍接受 v1 客户端，但新客户端要求 v2 Host：**先升级 Host，再升级 Client**。
- 接续状态仅保留在进程内，不依赖原生 QUIC migration。重启、撤权、显式关闭及恢复到期均终止会话；短业务超时仍可能在恢复期间到期。
- 恢复仍可能产生明显暂停：跨路径故障测试中最长响应间隔为 **17.9 秒**；反复注入 3 秒断网时为 **3.32 秒**，包含断网本身。这些测量不是生产延迟 SLO。
- Mesh 控制面沿用原有重连机制。这些测试不代表已验证物理网络漫游、长时间资源稳定性或 WebRTC 跨路径接续。

</details>
