### PR TITLE
fix(desktop): preserve destination on artifact export failure

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-artifacts-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-artifacts-ipc-main.test.ts
@@ -18,7 +18,8 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import fs, { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -30,6 +31,92 @@ type StreamArtifact = (
   artifactId: string,
   writeChunk: (chunk: Uint8Array) => Promise<void>,
 ) => Promise<number>;
+
+// Exercise the public Save As result and destination bytes together. Faults
+// use real temporary files; only the failing filesystem operation is mocked.
+for (const [fault, reason] of [
+  ["none", null],
+  ["stream", "source_failed"],
+  ["total", "size_mismatch"],
+  ["length", "size_mismatch"],
+  ["rename", "replace_failed"],
+  ["directory", "replace_failed"],
+  ["write", "target_write_failed"],
+  ["sync", "target_write_failed"],
+  ["close", "target_write_failed"],
+] as const) {
+  test(`Save As preserves the destination and reports ${fault} correctly`, async (t) => {
+    const root = await mkdtemp(join(tmpdir(), "maka-save-artifact-"));
+    const target = join(root, "report.txt");
+    const originalPath = fault === "directory" ? join(target, "original.txt") : target;
+    const content = Buffer.from("NEW CONTENT\n中文内容测试：你好，世界。\n");
+    const handlers = new Map<string, Handler>();
+    const injectedError = () => Object.assign(new Error("Injected destination failure"), { code: "EIO" });
+    let injectedCalls = 0;
+    try {
+      if (fault === "directory") await mkdir(target);
+      await writeFile(originalPath, "ORIGINAL");
+      if (fault === "rename") {
+        const rename = fs.rename;
+        t.mock.method(fs, "rename", async (...args: Parameters<typeof rename>) => {
+          if (args[1] === target) {
+            injectedCalls += 1;
+            throw injectedError();
+          }
+          return rename(...args);
+        });
+      }
+      if (fault === "write" || fault === "sync" || fault === "close") {
+        const open = fs.open;
+        t.mock.method(fs, "open", async (...args: Parameters<typeof open>) => {
+          const handle = await open(...args);
+          t.mock.method(handle, fault, async () => {
+            injectedCalls += 1;
+            throw injectedError();
+          }, { times: 1 });
+          return handle;
+        });
+      }
+      syncBuiltinESMExports();
+      registerRuntimeHostArtifactsIpc({
+        ipcMain: { handle: (channel, handler) => handlers.set(channel, handler as Handler) },
+        client: {
+          hostEpoch: "host-1",
+          async getArtifact() {
+            return previewArtifact({ name: "report.txt", kind: "file", mimeType: "text/plain", sizeBytes: content.length });
+          },
+          async streamArtifact(_sessionId: string, _artifactId: string, writeChunk: (chunk: Uint8Array) => Promise<void>) {
+            await writeChunk(content.subarray(0, 4));
+            if (fault === "stream") throw new Error("Interrupted source stream");
+            if (fault !== "length") await writeChunk(content.subarray(4));
+            return content.length + (fault === "total" ? 1 : 0);
+          },
+        } as never,
+        mainWindowController: {
+          showSaveDialog: async () => ({ canceled: false, filePath: target }),
+        } as never,
+        sendToRenderer() {},
+        showItemInFolder() {},
+      });
+      const save = handlers.get("app:saveArtifactAs");
+      assert.ok(save);
+      const result = await save({}, "session-1", "artifact-1");
+      if (fault === "directory") {
+        assert.deepEqual(await readdir(target), ["original.txt"]);
+        assert.equal(await readFile(originalPath, "utf8"), "ORIGINAL");
+      } else {
+        assert.equal(await readFile(originalPath, "utf8"), reason ? "ORIGINAL" : content.toString());
+      }
+      assert.deepEqual(result, reason ? { ok: false, reason } : { ok: true, saved: "report.txt" });
+      assert.deepEqual(await readdir(root), ["report.txt"], "no staging or backup remains");
+      if (["rename", "write", "sync", "close"].includes(fault)) assert.equal(injectedCalls, 1);
+    } finally {
+      t.mock.restoreAll();
+      syncBuiltinESMExports();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}
 
 function previewArtifact(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {

--- a/apps/desktop/src/main/__tests__/runtime-host-artifacts-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-artifacts-ipc-main.test.ts
@@ -95,7 +95,6 @@ for (const [fault, reason] of [
         mainWindowController: {
           showSaveDialog: async () => ({ canceled: false, filePath: target }),
         } as never,
-        sendToRenderer() {},
         showItemInFolder() {},
       });
       const save = handlers.get("app:saveArtifactAs");

--- a/apps/desktop/src/main/runtime-host-artifacts-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-artifacts-ipc-main.ts
@@ -126,8 +126,9 @@ export function registerRuntimeHostArtifactsIpc(
           artifact.sizeBytes,
         );
         return { ok: true, saved: artifact.name };
-      } catch {
-        return { ok: false, reason: "write_failed" };
+      } catch (error) {
+        if (error instanceof ArtifactMaterializationError) return { ok: false, reason: error.reason };
+        return { ok: false, reason: "target_write_failed" };
       }
     },
   );
@@ -196,11 +197,14 @@ async function materializeArtifact(
   );
   const handle = await open(stagingPath, "wx");
   let offset = 0;
+  let writingStaging = false;
+  let streamCompleted = false;
   try {
     const totalBytes = await client.streamArtifact(
       sessionId,
       artifactId,
       async (chunk) => {
+        writingStaging = true;
         let written = 0;
         while (written < chunk.byteLength) {
           const result = await handle.write(
@@ -213,18 +217,39 @@ async function materializeArtifact(
           written += result.bytesWritten;
         }
         offset += written;
+        writingStaging = false;
       },
     );
+    streamCompleted = true;
     if (totalBytes !== expectedBytes || offset !== expectedBytes) {
-      throw new Error("Artifact size changed during export");
+      throw new ArtifactMaterializationError("size_mismatch");
     }
     await handle.sync();
     await handle.close();
-    await rm(targetPath, { force: true });
-    await rename(stagingPath, targetPath);
+    try {
+      await rename(stagingPath, targetPath);
+    } catch (error) {
+      throw new ArtifactMaterializationError("replace_failed", error);
+    }
   } catch (error) {
     await handle.close().catch(() => undefined);
     await rm(stagingPath, { force: true }).catch(() => undefined);
+    if (!(error instanceof ArtifactMaterializationError)) {
+      throw new ArtifactMaterializationError(
+        writingStaging || streamCompleted ? "target_write_failed" : "source_failed",
+        error,
+      );
+    }
     throw error;
+  }
+}
+
+class ArtifactMaterializationError extends Error {
+  constructor(
+    readonly reason: "source_failed" | "size_mismatch" | "target_write_failed" | "replace_failed",
+    cause?: unknown,
+  ) {
+    super(`Artifact materialization failed: ${reason}`, { cause });
+    this.name = "ArtifactMaterializationError";
   }
 }

--- a/apps/desktop/src/renderer/features/workbar/tools/artifacts/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/features/workbar/tools/artifacts/artifact-pane.tsx
@@ -60,11 +60,12 @@ import {
   Copy,
   Trash2,
 } from '@maka/ui/icons';
-import { canUserDeleteArtifact, type ArtifactDescriptor, type ArtifactKind } from '@maka/core/artifacts';
+import type { ArtifactDescriptor, ArtifactKind } from '@maka/core/artifacts';
 import type { UiLocale } from '@maka/core/ui-locale';
 import { formatRelativeTimestamp } from '@maka/core/relative-time';
 import { generalizedErrorMessageForLocale, redactSecrets } from '@maka/core/redaction';
 import {
+  Badge,
   Banner,
   Button,
   MoreMenu,
@@ -83,7 +84,6 @@ import { useWorkbarServices } from '../../services-context.js';
 
 export function ArtifactPane(props: {
   sessionId: string;
-  refreshEnabled: boolean;
   onCountChange?: (count: number) => void;
   onDismiss?: () => void;
 }) {
@@ -133,7 +133,7 @@ export function ArtifactPane(props: {
     setSelectedId(null);
   }, [sessionId]);
 
-  const refresh = useCallback(async (showFailureToast = true) => {
+  const refresh = useCallback(async () => {
     const requestSeq = ++artifactListRequestSeqRef.current;
     if (!sessionId) {
       recordsSessionIdRef.current = undefined;
@@ -143,7 +143,9 @@ export function ArtifactPane(props: {
       return;
     }
     try {
-      const next = await artifacts.list(sessionId);
+      const next = await artifacts.list(sessionId, {
+        includeDeleted: true,
+      });
       if (artifactPaneMountedRef.current && requestSeq === artifactListRequestSeqRef.current) {
         recordsSessionIdRef.current = sessionId;
         setRecordsSessionId(sessionId);
@@ -158,7 +160,7 @@ export function ArtifactPane(props: {
           recordsSessionIdRef.current = undefined;
           setRecordsSessionId(undefined);
           setRecords([]);
-        } else if (showFailureToast) {
+        } else {
           toast.error(copy.pane.refreshFailed, message, undefined, { sessionId });
         }
       }
@@ -166,22 +168,22 @@ export function ArtifactPane(props: {
   }, [artifacts, copy, locale, sessionId, toast]);
 
   useEffect(() => {
-    if (!props.refreshEnabled) return;
-    let stopped = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    // Writeback can commit after the terminal Session event. Read the existing
-    // catalog while the workbar is visible, including its background file tab's count.
-    const poll = async () => {
-      await refresh(false);
-      if (!stopped) timer = setTimeout(() => void poll(), 2_000);
-    };
-    void poll();
+    void refresh();
+    if (!sessionId) return;
+    // Keep the list in sync without polling. The
+    // backend emits `{ reason: 'created' | 'deleted' | 'purged' }` on the
+    // `artifacts:changed` channel; we just re-list since the list is bounded
+    // (one session's worth) and the metadata is already in memory on main.
+    const unsubscribe = artifacts.subscribeChanges((event) => {
+      if (event.sessionId === sessionId) {
+        void refresh();
+      }
+    });
     return () => {
-      stopped = true;
-      clearTimeout(timer);
       artifactListRequestSeqRef.current += 1;
+      unsubscribe();
     };
-  }, [props.refreshEnabled, sessionId, refresh]);
+  }, [artifacts, sessionId, refresh]);
 
   const activeRecords = useMemo(
     () => (recordsSessionId === sessionId ? filterUserVisibleArtifacts(records) : []),
@@ -192,6 +194,7 @@ export function ArtifactPane(props: {
     props.onCountChange?.(activeRecords.length);
   }, [activeRecords.length, props.onCountChange]);
 
+  // 已删除墓碑记录保持可选，用于展示明确失败态；只有选中 id 彻底消失时才回退到最新 live artifact。
   useEffect(() => {
     if (activeRecords.length === 0) {
       if (selectedId !== null) setSelectedId(null);
@@ -353,7 +356,6 @@ export function ArtifactPane(props: {
   async function deleteArtifact(artifactId: string) {
     const actionSessionId = sessionId;
     const record = activeRecords.find((entry) => entry.id === artifactId);
-    if (!record || !canUserDeleteArtifact(record)) return;
     const name = record?.name ?? copy.pane.fallbackName;
     const ok = await toast.confirm({
       title: copy.pane.deleteTitle(name),
@@ -492,6 +494,7 @@ export function ArtifactPane(props: {
                   // ArrowUp/Down.
                   tabIndex={-1}
                   data-selected={record.id === selectedId ? 'true' : 'false'}
+                  data-deleted={record.status === 'deleted' ? 'true' : 'false'}
                   onClick={() => openPreview(record.id)}
                   label={record.name}
                   icon={(
@@ -505,6 +508,9 @@ export function ArtifactPane(props: {
                       <span className="maka-artifact-row-time">
                         {formatRelativeTimestamp(record.createdAt, Date.now(), locale)}
                       </span>
+                      {record.status === 'deleted' && (
+                        <Badge variant="error" className="maka-artifact-row-badge" label={copy.pane.deletedBadge} />
+                      )}
                     </span>
                   )}
                 />
@@ -560,14 +566,22 @@ export function ArtifactPane(props: {
                       onClick: () => void runArtifactAction(`${previewRecord.id}:copy`, () => copyText(previewRecord.id)),
                     }]
                   : []),
-                ...(canUserDeleteArtifact(previewRecord) ? [{ type: 'divider' as const }, {
-                  label: copy.pane.delete,
+                { type: 'divider' as const },
+                {
+                  label:
+                    previewRecord.source === 'deep_research' ||
+                    previewRecord.source === 'tool_result_archive'
+                      ? copy.pane.deleteReadOnly
+                      : copy.pane.delete,
                   icon: <Trash2 size={ICON_SIZE.control} aria-hidden="true" />,
+                  isDisabled:
+                    previewRecord.source === 'deep_research' ||
+                    previewRecord.source === 'tool_result_archive',
                   onClick: () => void runArtifactAction(
                     `${previewRecord.id}:delete`,
                     () => deleteArtifact(previewRecord.id),
                   ),
-                }] : []),
+                },
               ]}
             />
           </header>
@@ -605,8 +619,16 @@ function saveArtifactFailureCopy(reason: string, copy: ArtifactCopy): string {
       return copy.pane.saveFailures.not_found;
     case 'not_allowed':
       return copy.pane.saveFailures.not_allowed;
-    case 'write_failed':
-      return copy.pane.saveFailures.write_failed;
+    case 'deleted':
+      return copy.pane.saveFailures.deleted;
+    case 'source_failed':
+      return copy.pane.saveFailures.source_failed;
+    case 'size_mismatch':
+      return copy.pane.saveFailures.size_mismatch;
+    case 'target_write_failed':
+      return copy.pane.saveFailures.target_write_failed;
+    case 'replace_failed':
+      return copy.pane.saveFailures.replace_failed;
     default:
       return copy.pane.saveFailures.default;
   }
@@ -616,7 +638,8 @@ function artifactActionErrorMessage(error: unknown, locale: UiLocale, copy: Arti
   const raw = redactSecrets(error instanceof Error ? error.message : String(error ?? '')).trim();
   if (!raw) return copy.pane.actionFailed;
   const classified = generalizedErrorMessageForLocale(new Error(raw), '', locale);
-  return classified || copy.pane.actionFailed;
+  if (classified) return classified;
+  return locale === 'zh-CN' && /[\u4e00-\u9fff]/.test(raw) ? raw : copy.pane.actionFailed;
 }
 
 function KindIcon(props: { kind: ArtifactKind }) {
@@ -645,5 +668,5 @@ function KindIcon(props: { kind: ArtifactKind }) {
    formatter cache. Removed; we import the shared helper. */
 
 function preferredArtifactSelectionId(records: readonly ArtifactDescriptor[]): string | null {
-  return records[0]?.id ?? null;
+  return (records.find((record) => record.status !== 'deleted') ?? records[0])?.id ?? null;
 }

--- a/apps/desktop/src/renderer/features/workbar/tools/artifacts/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/features/workbar/tools/artifacts/artifact-pane.tsx
@@ -60,12 +60,11 @@ import {
   Copy,
   Trash2,
 } from '@maka/ui/icons';
-import type { ArtifactDescriptor, ArtifactKind } from '@maka/core/artifacts';
+import { canUserDeleteArtifact, type ArtifactDescriptor, type ArtifactKind } from '@maka/core/artifacts';
 import type { UiLocale } from '@maka/core/ui-locale';
 import { formatRelativeTimestamp } from '@maka/core/relative-time';
 import { generalizedErrorMessageForLocale, redactSecrets } from '@maka/core/redaction';
 import {
-  Badge,
   Banner,
   Button,
   MoreMenu,
@@ -84,6 +83,7 @@ import { useWorkbarServices } from '../../services-context.js';
 
 export function ArtifactPane(props: {
   sessionId: string;
+  refreshEnabled: boolean;
   onCountChange?: (count: number) => void;
   onDismiss?: () => void;
 }) {
@@ -133,7 +133,7 @@ export function ArtifactPane(props: {
     setSelectedId(null);
   }, [sessionId]);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (showFailureToast = true) => {
     const requestSeq = ++artifactListRequestSeqRef.current;
     if (!sessionId) {
       recordsSessionIdRef.current = undefined;
@@ -143,9 +143,7 @@ export function ArtifactPane(props: {
       return;
     }
     try {
-      const next = await artifacts.list(sessionId, {
-        includeDeleted: true,
-      });
+      const next = await artifacts.list(sessionId);
       if (artifactPaneMountedRef.current && requestSeq === artifactListRequestSeqRef.current) {
         recordsSessionIdRef.current = sessionId;
         setRecordsSessionId(sessionId);
@@ -160,7 +158,7 @@ export function ArtifactPane(props: {
           recordsSessionIdRef.current = undefined;
           setRecordsSessionId(undefined);
           setRecords([]);
-        } else {
+        } else if (showFailureToast) {
           toast.error(copy.pane.refreshFailed, message, undefined, { sessionId });
         }
       }
@@ -168,22 +166,22 @@ export function ArtifactPane(props: {
   }, [artifacts, copy, locale, sessionId, toast]);
 
   useEffect(() => {
-    void refresh();
-    if (!sessionId) return;
-    // Keep the list in sync without polling. The
-    // backend emits `{ reason: 'created' | 'deleted' | 'purged' }` on the
-    // `artifacts:changed` channel; we just re-list since the list is bounded
-    // (one session's worth) and the metadata is already in memory on main.
-    const unsubscribe = artifacts.subscribeChanges((event) => {
-      if (event.sessionId === sessionId) {
-        void refresh();
-      }
-    });
-    return () => {
-      artifactListRequestSeqRef.current += 1;
-      unsubscribe();
+    if (!props.refreshEnabled) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // Writeback can commit after the terminal Session event. Read the existing
+    // catalog while the workbar is visible, including its background file tab's count.
+    const poll = async () => {
+      await refresh(false);
+      if (!stopped) timer = setTimeout(() => void poll(), 2_000);
     };
-  }, [artifacts, sessionId, refresh]);
+    void poll();
+    return () => {
+      stopped = true;
+      clearTimeout(timer);
+      artifactListRequestSeqRef.current += 1;
+    };
+  }, [props.refreshEnabled, sessionId, refresh]);
 
   const activeRecords = useMemo(
     () => (recordsSessionId === sessionId ? filterUserVisibleArtifacts(records) : []),
@@ -194,7 +192,6 @@ export function ArtifactPane(props: {
     props.onCountChange?.(activeRecords.length);
   }, [activeRecords.length, props.onCountChange]);
 
-  // 已删除墓碑记录保持可选，用于展示明确失败态；只有选中 id 彻底消失时才回退到最新 live artifact。
   useEffect(() => {
     if (activeRecords.length === 0) {
       if (selectedId !== null) setSelectedId(null);
@@ -356,6 +353,7 @@ export function ArtifactPane(props: {
   async function deleteArtifact(artifactId: string) {
     const actionSessionId = sessionId;
     const record = activeRecords.find((entry) => entry.id === artifactId);
+    if (!record || !canUserDeleteArtifact(record)) return;
     const name = record?.name ?? copy.pane.fallbackName;
     const ok = await toast.confirm({
       title: copy.pane.deleteTitle(name),
@@ -494,7 +492,6 @@ export function ArtifactPane(props: {
                   // ArrowUp/Down.
                   tabIndex={-1}
                   data-selected={record.id === selectedId ? 'true' : 'false'}
-                  data-deleted={record.status === 'deleted' ? 'true' : 'false'}
                   onClick={() => openPreview(record.id)}
                   label={record.name}
                   icon={(
@@ -508,9 +505,6 @@ export function ArtifactPane(props: {
                       <span className="maka-artifact-row-time">
                         {formatRelativeTimestamp(record.createdAt, Date.now(), locale)}
                       </span>
-                      {record.status === 'deleted' && (
-                        <Badge variant="error" className="maka-artifact-row-badge" label={copy.pane.deletedBadge} />
-                      )}
                     </span>
                   )}
                 />
@@ -566,22 +560,14 @@ export function ArtifactPane(props: {
                       onClick: () => void runArtifactAction(`${previewRecord.id}:copy`, () => copyText(previewRecord.id)),
                     }]
                   : []),
-                { type: 'divider' as const },
-                {
-                  label:
-                    previewRecord.source === 'deep_research' ||
-                    previewRecord.source === 'tool_result_archive'
-                      ? copy.pane.deleteReadOnly
-                      : copy.pane.delete,
+                ...(canUserDeleteArtifact(previewRecord) ? [{ type: 'divider' as const }, {
+                  label: copy.pane.delete,
                   icon: <Trash2 size={ICON_SIZE.control} aria-hidden="true" />,
-                  isDisabled:
-                    previewRecord.source === 'deep_research' ||
-                    previewRecord.source === 'tool_result_archive',
                   onClick: () => void runArtifactAction(
                     `${previewRecord.id}:delete`,
                     () => deleteArtifact(previewRecord.id),
                   ),
-                },
+                }] : []),
               ]}
             />
           </header>
@@ -619,14 +605,15 @@ function saveArtifactFailureCopy(reason: string, copy: ArtifactCopy): string {
       return copy.pane.saveFailures.not_found;
     case 'not_allowed':
       return copy.pane.saveFailures.not_allowed;
+    case 'write_failed':
+    case 'target_write_failed':
+      return copy.pane.saveFailures.target_write_failed;
     case 'deleted':
       return copy.pane.saveFailures.deleted;
     case 'source_failed':
       return copy.pane.saveFailures.source_failed;
     case 'size_mismatch':
       return copy.pane.saveFailures.size_mismatch;
-    case 'target_write_failed':
-      return copy.pane.saveFailures.target_write_failed;
     case 'replace_failed':
       return copy.pane.saveFailures.replace_failed;
     default:
@@ -638,8 +625,7 @@ function artifactActionErrorMessage(error: unknown, locale: UiLocale, copy: Arti
   const raw = redactSecrets(error instanceof Error ? error.message : String(error ?? '')).trim();
   if (!raw) return copy.pane.actionFailed;
   const classified = generalizedErrorMessageForLocale(new Error(raw), '', locale);
-  if (classified) return classified;
-  return locale === 'zh-CN' && /[\u4e00-\u9fff]/.test(raw) ? raw : copy.pane.actionFailed;
+  return classified || copy.pane.actionFailed;
 }
 
 function KindIcon(props: { kind: ArtifactKind }) {
@@ -668,5 +654,5 @@ function KindIcon(props: { kind: ArtifactKind }) {
    formatter cache. Removed; we import the shared helper. */
 
 function preferredArtifactSelectionId(records: readonly ArtifactDescriptor[]): string | null {
-  return (records.find((record) => record.status !== 'deleted') ?? records[0])?.id ?? null;
+  return records[0]?.id ?? null;
 }

--- a/apps/desktop/src/renderer/locales/artifact-copy.ts
+++ b/apps/desktop/src/renderer/locales/artifact-copy.ts
@@ -34,7 +34,6 @@ export type ArtifactCopy = {
     deleteTitle(name: string): string;
     deleteDescription: string;
     delete: string;
-    deleteReadOnly: string;
     cancel: string;
     deleted(name: string): string;
     deleteFailed(name: string): string;
@@ -43,7 +42,6 @@ export type ArtifactCopy = {
     retrying: string;
     retry: string;
     listAria: string;
-    deletedBadge: string;
     previewNamed(name: string): string;
     empty: string;
     emptyHint: string;
@@ -52,7 +50,7 @@ export type ArtifactCopy = {
     openInFinder: string;
     saveAs: string;
     copy: string;
-    saveFailures: Record<'not_found' | 'not_allowed' | 'deleted' | 'source_failed' | 'size_mismatch' | 'target_write_failed' | 'replace_failed' | 'default', string>;
+    saveFailures: Record<'not_found' | 'not_allowed' | 'write_failed' | 'deleted' | 'source_failed' | 'size_mismatch' | 'target_write_failed' | 'replace_failed' | 'default', string>;
     actionFailed: string;
   };
   preview: {
@@ -72,7 +70,6 @@ export type ArtifactCopy = {
     readFailed: ReasonCopy;
     notAllowed: ReasonCopy;
     tooLarge(bytes: number): ReasonCopy;
-    deleted: ReasonCopy;
     unsupportedMime: ReasonCopy;
   };
   registry: {
@@ -96,13 +93,13 @@ const ARTIFACT_COPY = {
     pane: {
       refreshFailed: '刷新生成文件失败', openFailed: '无法在 Finder 中打开生成文件', copyFailed: '复制失败',
       readTextFailed: '无法读取生成文件文本内容。', copied: '已复制生成文件文本', saved: '已另存生成文件', saveFailed: '另存失败',
-      fallbackName: '生成文件', deleteTitle: (name) => `删除 "${name}"`, deleteDescription: '软删除：在记录中标记为已删除，文件保留 6 小时可恢复。',
-      delete: '删除', deleteReadOnly: '删除（只读文件）', cancel: '取消', deleted: (name) => `已删除 ${name}`, deleteFailed: (name) => `删除 ${name} 失败`, panelAria: '生成文件预览面板',
-      listLoadFailed: '生成文件列表载入失败', retrying: '重试中…', retry: '重试', listAria: '生成文件列表', deletedBadge: '已删除',
+      fallbackName: '生成文件', deleteTitle: (name) => `删除 "${name}"`, deleteDescription: '永久删除此生成文件及其记录，无法恢复。',
+      delete: '删除', cancel: '取消', deleted: (name) => `已删除 ${name}`, deleteFailed: (name) => `删除 ${name} 失败`, panelAria: '生成文件预览面板',
+      listLoadFailed: '生成文件列表载入失败', retrying: '重试中…', retry: '重试', listAria: '生成文件列表',
       previewNamed: (name) => `预览 ${name}`, empty: '暂无生成文件', emptyHint: '助手生成文件后会显示在这里。',
       back: '返回生成文件列表', moreActions: (name) => `${name} 的更多操作`,
       openInFinder: '在 Finder 中打开', saveAs: '另存为', copy: '复制',
-      saveFailures: { not_found: '生成文件不存在。', not_allowed: '生成文件路径检查未通过。', deleted: '生成文件已删除，不能另存。', source_failed: '生成文件传输中断，请重试。', size_mismatch: '生成文件大小在传输过程中发生变化，请重试。', target_write_failed: '目标位置无法写入。', replace_failed: '替换目标文件失败，原文件已保留。', default: '无法保存生成文件。' },
+      saveFailures: { not_found: '生成文件不存在。', not_allowed: '生成文件路径检查未通过。', write_failed: '目标位置无法写入。', deleted: '生成文件已删除，不能另存。', source_failed: '生成文件传输中断，请重试。', size_mismatch: '生成文件大小在传输过程中发生变化，请重试。', target_write_failed: '目标位置无法写入。', replace_failed: '替换目标文件失败，原文件已保留。', default: '无法保存生成文件。' },
       actionFailed: '生成文件操作失败，请稍后重试。',
     },
     preview: {
@@ -116,7 +113,6 @@ const ARTIFACT_COPY = {
       readFailed: { title: '无法读取生成文件', description: '路径可能已被外部删除。请通过更多菜单「在 Finder 中打开」检查文件位置。' },
       notAllowed: { title: '无法读取生成文件', description: '路径检查未通过，文件已不在允许预览的生成文件目录内。' },
       tooLarge: (bytes) => ({ title: '文件超出预览大小', description: `${bytes} 字节超过文本预览阈值，请通过更多菜单打开或另存完整内容。` }),
-      deleted: { title: '此生成文件已删除', description: '预览已停止。如需查看原文件请使用「在 Finder 中打开」。' },
       unsupportedMime: { title: '不支持的文件类型', description: '该生成文件的 MIME 类型不在内联预览允许列表中。请使用工具栏「在 Finder 中打开」或「另存为」。' },
     },
     registry: {
@@ -132,13 +128,13 @@ const ARTIFACT_COPY = {
     pane: {
       refreshFailed: '重新整理生成檔案失敗', openFailed: '無法在 Finder 中開啟生成檔案', copyFailed: '複製失敗',
       readTextFailed: '無法讀取生成檔案文本內容。', copied: '已複製生成檔案文本', saved: '已另存生成檔案', saveFailed: '另存失敗',
-      fallbackName: '生成檔案', deleteTitle: (name) => `刪除 "${name}"`, deleteDescription: '軟刪除：在記錄中標記為已刪除，檔案保留 6 小時可恢復。',
-      delete: '刪除', deleteReadOnly: '刪除（只讀檔案）', cancel: '取消', deleted: (name) => `已刪除 ${name}`, deleteFailed: (name) => `刪除 ${name} 失敗`, panelAria: '生成檔案預覽面板',
-      listLoadFailed: '生成檔案列表載入失敗', retrying: '重試中…', retry: '重試', listAria: '生成檔案列表', deletedBadge: '已刪除',
+      fallbackName: '生成檔案', deleteTitle: (name) => `刪除 "${name}"`, deleteDescription: '永久刪除此生成檔案及其記錄，無法復原。',
+      delete: '刪除', cancel: '取消', deleted: (name) => `已刪除 ${name}`, deleteFailed: (name) => `刪除 ${name} 失敗`, panelAria: '生成檔案預覽面板',
+      listLoadFailed: '生成檔案列表載入失敗', retrying: '重試中…', retry: '重試', listAria: '生成檔案列表',
       previewNamed: (name) => `預覽 ${name}`, empty: '暫無生成檔案', emptyHint: '助手生成檔案後會顯示在這裡。',
       back: '返回生成檔案列表', moreActions: (name) => `${name} 的更多操作`,
       openInFinder: '在 Finder 中開啟', saveAs: '另存為', copy: '複製',
-      saveFailures: { not_found: '生成檔案不存在。', not_allowed: '生成檔案路徑檢查未透過。', deleted: '生成檔案已刪除，不能另存。', source_failed: '生成檔案傳輸中斷，請重試。', size_mismatch: '生成檔案大小在傳輸過程中發生變化，請重試。', target_write_failed: '目標位置無法寫入。', replace_failed: '替換目標檔案失敗，原檔案已保留。', default: '無法儲存生成檔案。' },
+      saveFailures: { not_found: '生成檔案不存在。', not_allowed: '生成檔案路徑檢查未透過。', write_failed: '目標位置無法寫入。', deleted: '生成檔案已刪除，不能另存。', source_failed: '生成檔案傳輸中斷，請重試。', size_mismatch: '生成檔案大小在傳輸過程中發生變化，請重試。', target_write_failed: '目標位置無法寫入。', replace_failed: '替換目標檔案失敗，原檔案已保留。', default: '無法儲存生成檔案。' },
       actionFailed: '生成檔案操作失敗，請稍後重試。',
     },
     preview: {
@@ -152,7 +148,6 @@ const ARTIFACT_COPY = {
       readFailed: { title: '無法讀取生成檔案', description: '路徑可能已被外部刪除。請透過更多選單「在 Finder 中開啟」檢查檔案位置。' },
       notAllowed: { title: '無法讀取生成檔案', description: '路徑檢查未透過，檔案已不在允許預覽的生成檔案目錄內。' },
       tooLarge: (bytes) => ({ title: '檔案超出預覽大小', description: `${bytes} 位元組超過文本預覽閾值，請透過更多選單開啟或另存完整內容。` }),
-      deleted: { title: '此生成檔案已刪除', description: '預覽已停止。如需檢視原檔案請使用「在 Finder 中開啟」。' },
       unsupportedMime: { title: '不支援的檔案型別', description: '該生成檔案的 MIME 型別不在內聯預覽允許列表中。請使用工具欄「在 Finder 中開啟」或「另存為」。' },
     },
     registry: {
@@ -168,13 +163,13 @@ const ARTIFACT_COPY = {
     pane: {
       refreshFailed: 'Failed to refresh generated files', openFailed: 'Could not show generated file in Finder', copyFailed: 'Copy failed',
       readTextFailed: 'Could not read the generated file as text.', copied: 'Generated file text copied', saved: 'Generated file saved as', saveFailed: 'Save as failed',
-      fallbackName: 'generated file', deleteTitle: (name) => `Delete "${name}"`, deleteDescription: 'Soft delete: mark this record as deleted and keep the file recoverable for 6 hours.',
-      delete: 'Delete', deleteReadOnly: 'Delete (read-only file)', cancel: 'Cancel', deleted: (name) => `Deleted ${name}`, deleteFailed: (name) => `Failed to delete ${name}`, panelAria: 'Generated file preview panel',
-      listLoadFailed: 'Failed to load generated files', retrying: 'Retrying…', retry: 'Retry', listAria: 'Generated files', deletedBadge: 'Deleted',
+      fallbackName: 'generated file', deleteTitle: (name) => `Delete "${name}"`, deleteDescription: 'Permanently delete this generated file and its record. This cannot be undone.',
+      delete: 'Delete', cancel: 'Cancel', deleted: (name) => `Deleted ${name}`, deleteFailed: (name) => `Failed to delete ${name}`, panelAria: 'Generated file preview panel',
+      listLoadFailed: 'Failed to load generated files', retrying: 'Retrying…', retry: 'Retry', listAria: 'Generated files',
       previewNamed: (name) => `Preview ${name}`, empty: 'No generated files', emptyHint: 'Files generated by the assistant appear here.',
       back: 'Back to generated files', moreActions: (name) => `More actions for ${name}`,
       openInFinder: 'Show in Finder', saveAs: 'Save as', copy: 'Copy',
-      saveFailures: { not_found: 'The generated file does not exist.', not_allowed: 'The generated file failed the path safety check.', deleted: 'Deleted generated files cannot be saved.', source_failed: 'The generated file transfer was interrupted. Try again.', size_mismatch: 'The generated file size changed during transfer. Try again.', target_write_failed: 'The destination is not writable.', replace_failed: 'Could not replace the destination. The original file was kept.', default: 'Could not save the generated file.' },
+      saveFailures: { not_found: 'The generated file does not exist.', not_allowed: 'The generated file failed the path safety check.', write_failed: 'The destination is not writable.', deleted: 'Deleted generated files cannot be saved.', source_failed: 'The generated file transfer was interrupted. Try again.', size_mismatch: 'The generated file size changed during transfer. Try again.', target_write_failed: 'The destination is not writable.', replace_failed: 'Could not replace the destination. The original file was kept.', default: 'Could not save the generated file.' },
       actionFailed: 'The generated file action failed. Try again later.',
     },
     preview: {
@@ -188,7 +183,6 @@ const ARTIFACT_COPY = {
       readFailed: { title: 'Could not read generated file', description: 'The file may have been deleted externally. Use “Show in Finder” in the More menu to check its location.' },
       notAllowed: { title: 'Could not read generated file', description: 'The path safety check failed because the file is no longer inside the allowed generated-files directory.' },
       tooLarge: (bytes) => ({ title: 'File exceeds preview size', description: `${bytes} bytes exceeds the text preview limit. Use the More menu to open or save the complete file.` }),
-      deleted: { title: 'This generated file was deleted', description: 'The preview has stopped. Use “Show in Finder” to inspect the original file.' },
       unsupportedMime: { title: 'Unsupported file type', description: 'This generated file’s MIME type is not allowed for inline preview. Use “Show in Finder” or “Save as”.' },
     },
     registry: {

--- a/apps/desktop/src/renderer/locales/artifact-copy.ts
+++ b/apps/desktop/src/renderer/locales/artifact-copy.ts
@@ -34,6 +34,7 @@ export type ArtifactCopy = {
     deleteTitle(name: string): string;
     deleteDescription: string;
     delete: string;
+    deleteReadOnly: string;
     cancel: string;
     deleted(name: string): string;
     deleteFailed(name: string): string;
@@ -42,6 +43,7 @@ export type ArtifactCopy = {
     retrying: string;
     retry: string;
     listAria: string;
+    deletedBadge: string;
     previewNamed(name: string): string;
     empty: string;
     emptyHint: string;
@@ -50,7 +52,7 @@ export type ArtifactCopy = {
     openInFinder: string;
     saveAs: string;
     copy: string;
-    saveFailures: Record<'not_found' | 'not_allowed' | 'write_failed' | 'default', string>;
+    saveFailures: Record<'not_found' | 'not_allowed' | 'deleted' | 'source_failed' | 'size_mismatch' | 'target_write_failed' | 'replace_failed' | 'default', string>;
     actionFailed: string;
   };
   preview: {
@@ -70,6 +72,7 @@ export type ArtifactCopy = {
     readFailed: ReasonCopy;
     notAllowed: ReasonCopy;
     tooLarge(bytes: number): ReasonCopy;
+    deleted: ReasonCopy;
     unsupportedMime: ReasonCopy;
   };
   registry: {
@@ -93,13 +96,13 @@ const ARTIFACT_COPY = {
     pane: {
       refreshFailed: '刷新生成文件失败', openFailed: '无法在 Finder 中打开生成文件', copyFailed: '复制失败',
       readTextFailed: '无法读取生成文件文本内容。', copied: '已复制生成文件文本', saved: '已另存生成文件', saveFailed: '另存失败',
-      fallbackName: '生成文件', deleteTitle: (name) => `删除 "${name}"`, deleteDescription: '永久删除此生成文件及其记录，无法恢复。',
-      delete: '删除', cancel: '取消', deleted: (name) => `已删除 ${name}`, deleteFailed: (name) => `删除 ${name} 失败`, panelAria: '生成文件预览面板',
-      listLoadFailed: '生成文件列表载入失败', retrying: '重试中…', retry: '重试', listAria: '生成文件列表',
+      fallbackName: '生成文件', deleteTitle: (name) => `删除 "${name}"`, deleteDescription: '软删除：在记录中标记为已删除，文件保留 6 小时可恢复。',
+      delete: '删除', deleteReadOnly: '删除（只读文件）', cancel: '取消', deleted: (name) => `已删除 ${name}`, deleteFailed: (name) => `删除 ${name} 失败`, panelAria: '生成文件预览面板',
+      listLoadFailed: '生成文件列表载入失败', retrying: '重试中…', retry: '重试', listAria: '生成文件列表', deletedBadge: '已删除',
       previewNamed: (name) => `预览 ${name}`, empty: '暂无生成文件', emptyHint: '助手生成文件后会显示在这里。',
       back: '返回生成文件列表', moreActions: (name) => `${name} 的更多操作`,
       openInFinder: '在 Finder 中打开', saveAs: '另存为', copy: '复制',
-      saveFailures: { not_found: '生成文件不存在。', not_allowed: '生成文件路径检查未通过。', write_failed: '目标位置无法写入。', default: '无法保存生成文件。' },
+      saveFailures: { not_found: '生成文件不存在。', not_allowed: '生成文件路径检查未通过。', deleted: '生成文件已删除，不能另存。', source_failed: '生成文件传输中断，请重试。', size_mismatch: '生成文件大小在传输过程中发生变化，请重试。', target_write_failed: '目标位置无法写入。', replace_failed: '替换目标文件失败，原文件已保留。', default: '无法保存生成文件。' },
       actionFailed: '生成文件操作失败，请稍后重试。',
     },
     preview: {
@@ -113,6 +116,7 @@ const ARTIFACT_COPY = {
       readFailed: { title: '无法读取生成文件', description: '路径可能已被外部删除。请通过更多菜单「在 Finder 中打开」检查文件位置。' },
       notAllowed: { title: '无法读取生成文件', description: '路径检查未通过，文件已不在允许预览的生成文件目录内。' },
       tooLarge: (bytes) => ({ title: '文件超出预览大小', description: `${bytes} 字节超过文本预览阈值，请通过更多菜单打开或另存完整内容。` }),
+      deleted: { title: '此生成文件已删除', description: '预览已停止。如需查看原文件请使用「在 Finder 中打开」。' },
       unsupportedMime: { title: '不支持的文件类型', description: '该生成文件的 MIME 类型不在内联预览允许列表中。请使用工具栏「在 Finder 中打开」或「另存为」。' },
     },
     registry: {
@@ -128,13 +132,13 @@ const ARTIFACT_COPY = {
     pane: {
       refreshFailed: '重新整理生成檔案失敗', openFailed: '無法在 Finder 中開啟生成檔案', copyFailed: '複製失敗',
       readTextFailed: '無法讀取生成檔案文本內容。', copied: '已複製生成檔案文本', saved: '已另存生成檔案', saveFailed: '另存失敗',
-      fallbackName: '生成檔案', deleteTitle: (name) => `刪除 "${name}"`, deleteDescription: '永久刪除此生成檔案及其記錄，無法復原。',
-      delete: '刪除', cancel: '取消', deleted: (name) => `已刪除 ${name}`, deleteFailed: (name) => `刪除 ${name} 失敗`, panelAria: '生成檔案預覽面板',
-      listLoadFailed: '生成檔案列表載入失敗', retrying: '重試中…', retry: '重試', listAria: '生成檔案列表',
+      fallbackName: '生成檔案', deleteTitle: (name) => `刪除 "${name}"`, deleteDescription: '軟刪除：在記錄中標記為已刪除，檔案保留 6 小時可恢復。',
+      delete: '刪除', deleteReadOnly: '刪除（只讀檔案）', cancel: '取消', deleted: (name) => `已刪除 ${name}`, deleteFailed: (name) => `刪除 ${name} 失敗`, panelAria: '生成檔案預覽面板',
+      listLoadFailed: '生成檔案列表載入失敗', retrying: '重試中…', retry: '重試', listAria: '生成檔案列表', deletedBadge: '已刪除',
       previewNamed: (name) => `預覽 ${name}`, empty: '暫無生成檔案', emptyHint: '助手生成檔案後會顯示在這裡。',
       back: '返回生成檔案列表', moreActions: (name) => `${name} 的更多操作`,
       openInFinder: '在 Finder 中開啟', saveAs: '另存為', copy: '複製',
-      saveFailures: { not_found: '生成檔案不存在。', not_allowed: '生成檔案路徑檢查未透過。', write_failed: '目標位置無法寫入。', default: '無法儲存生成檔案。' },
+      saveFailures: { not_found: '生成檔案不存在。', not_allowed: '生成檔案路徑檢查未透過。', deleted: '生成檔案已刪除，不能另存。', source_failed: '生成檔案傳輸中斷，請重試。', size_mismatch: '生成檔案大小在傳輸過程中發生變化，請重試。', target_write_failed: '目標位置無法寫入。', replace_failed: '替換目標檔案失敗，原檔案已保留。', default: '無法儲存生成檔案。' },
       actionFailed: '生成檔案操作失敗，請稍後重試。',
     },
     preview: {
@@ -148,6 +152,7 @@ const ARTIFACT_COPY = {
       readFailed: { title: '無法讀取生成檔案', description: '路徑可能已被外部刪除。請透過更多選單「在 Finder 中開啟」檢查檔案位置。' },
       notAllowed: { title: '無法讀取生成檔案', description: '路徑檢查未透過，檔案已不在允許預覽的生成檔案目錄內。' },
       tooLarge: (bytes) => ({ title: '檔案超出預覽大小', description: `${bytes} 位元組超過文本預覽閾值，請透過更多選單開啟或另存完整內容。` }),
+      deleted: { title: '此生成檔案已刪除', description: '預覽已停止。如需檢視原檔案請使用「在 Finder 中開啟」。' },
       unsupportedMime: { title: '不支援的檔案型別', description: '該生成檔案的 MIME 型別不在內聯預覽允許列表中。請使用工具欄「在 Finder 中開啟」或「另存為」。' },
     },
     registry: {
@@ -163,13 +168,13 @@ const ARTIFACT_COPY = {
     pane: {
       refreshFailed: 'Failed to refresh generated files', openFailed: 'Could not show generated file in Finder', copyFailed: 'Copy failed',
       readTextFailed: 'Could not read the generated file as text.', copied: 'Generated file text copied', saved: 'Generated file saved as', saveFailed: 'Save as failed',
-      fallbackName: 'generated file', deleteTitle: (name) => `Delete "${name}"`, deleteDescription: 'Permanently delete this generated file and its record. This cannot be undone.',
-      delete: 'Delete', cancel: 'Cancel', deleted: (name) => `Deleted ${name}`, deleteFailed: (name) => `Failed to delete ${name}`, panelAria: 'Generated file preview panel',
-      listLoadFailed: 'Failed to load generated files', retrying: 'Retrying…', retry: 'Retry', listAria: 'Generated files',
+      fallbackName: 'generated file', deleteTitle: (name) => `Delete "${name}"`, deleteDescription: 'Soft delete: mark this record as deleted and keep the file recoverable for 6 hours.',
+      delete: 'Delete', deleteReadOnly: 'Delete (read-only file)', cancel: 'Cancel', deleted: (name) => `Deleted ${name}`, deleteFailed: (name) => `Failed to delete ${name}`, panelAria: 'Generated file preview panel',
+      listLoadFailed: 'Failed to load generated files', retrying: 'Retrying…', retry: 'Retry', listAria: 'Generated files', deletedBadge: 'Deleted',
       previewNamed: (name) => `Preview ${name}`, empty: 'No generated files', emptyHint: 'Files generated by the assistant appear here.',
       back: 'Back to generated files', moreActions: (name) => `More actions for ${name}`,
       openInFinder: 'Show in Finder', saveAs: 'Save as', copy: 'Copy',
-      saveFailures: { not_found: 'The generated file does not exist.', not_allowed: 'The generated file failed the path safety check.', write_failed: 'The destination is not writable.', default: 'Could not save the generated file.' },
+      saveFailures: { not_found: 'The generated file does not exist.', not_allowed: 'The generated file failed the path safety check.', deleted: 'Deleted generated files cannot be saved.', source_failed: 'The generated file transfer was interrupted. Try again.', size_mismatch: 'The generated file size changed during transfer. Try again.', target_write_failed: 'The destination is not writable.', replace_failed: 'Could not replace the destination. The original file was kept.', default: 'Could not save the generated file.' },
       actionFailed: 'The generated file action failed. Try again later.',
     },
     preview: {
@@ -183,6 +188,7 @@ const ARTIFACT_COPY = {
       readFailed: { title: 'Could not read generated file', description: 'The file may have been deleted externally. Use “Show in Finder” in the More menu to check its location.' },
       notAllowed: { title: 'Could not read generated file', description: 'The path safety check failed because the file is no longer inside the allowed generated-files directory.' },
       tooLarge: (bytes) => ({ title: 'File exceeds preview size', description: `${bytes} bytes exceeds the text preview limit. Use the More menu to open or save the complete file.` }),
+      deleted: { title: 'This generated file was deleted', description: 'The preview has stopped. Use “Show in Finder” to inspect the original file.' },
       unsupportedMime: { title: 'Unsupported file type', description: 'This generated file’s MIME type is not allowed for inline preview. Use “Show in Finder” or “Save as”.' },
     },
     registry: {

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -90,24 +90,13 @@ export const ARTIFACT_SOURCES = [
   'tool_result',
   'tool_result_projection',
   'tool_result_archive',
-  'synthesis_cache_block',
-  'history_compact_block',
-  'history_compact_source',
-  'provider_request_capture',
   'subagent_writeback',
   'deep_research',
   'user_upload',
-  'export',
-  'snapshot',
   'session_effect',
-  'fixture',
 ] as const;
 
 export type ArtifactSource = (typeof ARTIFACT_SOURCES)[number];
-
-export const ARTIFACT_STATUSES = ['live', 'deleted'] as const;
-
-export type ArtifactStatus = (typeof ARTIFACT_STATUSES)[number];
 
 export const ARTIFACT_ENTITY_ID_MAX_CHARS = 128;
 export const ARTIFACT_TURN_KEY_MAX_CHARS = 512;
@@ -138,9 +127,8 @@ export interface ArtifactDescriptor {
   kind: ArtifactKind;
   sizeBytes: number;
   mimeType?: string;
-  source?: ArtifactSource;
+  source: ArtifactSource;
   summary?: string;
-  status: ArtifactStatus;
 }
 
 export interface ArtifactRecord extends ArtifactDescriptor {
@@ -163,48 +151,37 @@ const ARTIFACT_SOURCE_POLICIES = {
   tool_result: { userDeletable: true, userVisible: false, sharedReadable: true },
   tool_result_projection: { userDeletable: false, userVisible: false, sharedReadable: true },
   tool_result_archive: { userDeletable: false, userVisible: false, sharedReadable: false },
-  synthesis_cache_block: { userDeletable: true, userVisible: false, sharedReadable: false },
-  history_compact_block: { userDeletable: true, userVisible: false, sharedReadable: false },
-  history_compact_source: { userDeletable: true, userVisible: false, sharedReadable: false },
-  // Historical only: nothing produces these any more. The policy stays so the
-  // records already on disk keep decoding and stay deletable.
-  provider_request_capture: { userDeletable: true, userVisible: false, sharedReadable: false },
   subagent_writeback: { userDeletable: false, userVisible: true, sharedReadable: false },
   deep_research: { userDeletable: false, userVisible: true, sharedReadable: false },
   user_upload: { userDeletable: true, userVisible: false, sharedReadable: true },
-  export: { userDeletable: true, userVisible: true, sharedReadable: false },
-  snapshot: { userDeletable: true, userVisible: true, sharedReadable: false },
   session_effect: { userDeletable: false, userVisible: false, sharedReadable: false },
-  fixture: { userDeletable: true, userVisible: true, sharedReadable: false },
 } as const satisfies Record<ArtifactSource, ArtifactSourcePolicy>;
 
-export function canUserDeleteArtifact(record: Pick<ArtifactRecord, 'source'>): boolean {
-  return record.source === undefined || ARTIFACT_SOURCE_POLICIES[record.source].userDeletable;
-}
+const CHILD_RESULT_OUTPUT_SOURCES = new Set<ArtifactSource>([
+  'tool_result',
+  'tool_result_projection',
+  'subagent_writeback',
+  'deep_research',
+]);
 
 export function isArtifactUserVisible(record: Pick<ArtifactRecord, 'source'>): boolean {
-  return record.source === undefined || ARTIFACT_SOURCE_POLICIES[record.source].userVisible;
+  return ARTIFACT_SOURCE_POLICIES[record.source].userVisible;
+}
+
+/** Visibility does not grant permission to destroy evidence owned by a runtime workflow. */
+export function canUserDeleteArtifact(record: Pick<ArtifactRecord, 'source'>): boolean {
+  return ARTIFACT_SOURCE_POLICIES[record.source].userDeletable;
 }
 
 export function isArtifactSharedSessionReadable(record: Pick<ArtifactRecord, 'source'>): boolean {
-  return record.source !== undefined && ARTIFACT_SOURCE_POLICIES[record.source].sharedReadable;
+  return ARTIFACT_SOURCE_POLICIES[record.source].sharedReadable;
 }
 
-export type ArtifactChangedReason = 'created' | 'deleted' | 'purged';
-
-export interface ArtifactChangedEvent {
-  reason: ArtifactChangedReason;
-  artifactId: string;
-  sessionId: string;
-  ts: number;
+export function isArtifactChildResultOutput(record: Pick<ArtifactRecord, 'source'>): boolean {
+  return CHILD_RESULT_OUTPUT_SOURCES.has(record.source);
 }
 
-export type ArtifactReadFailureReason =
-  | 'not_found'
-  | 'too_large'
-  | 'read_failed'
-  | 'not_allowed'
-  | 'deleted';
+export type ArtifactReadFailureReason = 'not_found' | 'too_large' | 'read_failed' | 'not_allowed';
 
 export type ArtifactBinaryReadFailureReason = ArtifactReadFailureReason | 'unsupported_mime';
 
@@ -220,6 +197,7 @@ export type ArtifactSaveFailureReason =
   | 'canceled'
   | 'not_found'
   | 'not_allowed'
+  | 'write_failed'
   | 'deleted'
   | 'source_failed'
   | 'size_mismatch'

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -90,13 +90,24 @@ export const ARTIFACT_SOURCES = [
   'tool_result',
   'tool_result_projection',
   'tool_result_archive',
+  'synthesis_cache_block',
+  'history_compact_block',
+  'history_compact_source',
+  'provider_request_capture',
   'subagent_writeback',
   'deep_research',
   'user_upload',
+  'export',
+  'snapshot',
   'session_effect',
+  'fixture',
 ] as const;
 
 export type ArtifactSource = (typeof ARTIFACT_SOURCES)[number];
+
+export const ARTIFACT_STATUSES = ['live', 'deleted'] as const;
+
+export type ArtifactStatus = (typeof ARTIFACT_STATUSES)[number];
 
 export const ARTIFACT_ENTITY_ID_MAX_CHARS = 128;
 export const ARTIFACT_TURN_KEY_MAX_CHARS = 512;
@@ -127,8 +138,9 @@ export interface ArtifactDescriptor {
   kind: ArtifactKind;
   sizeBytes: number;
   mimeType?: string;
-  source: ArtifactSource;
+  source?: ArtifactSource;
   summary?: string;
+  status: ArtifactStatus;
 }
 
 export interface ArtifactRecord extends ArtifactDescriptor {
@@ -151,37 +163,48 @@ const ARTIFACT_SOURCE_POLICIES = {
   tool_result: { userDeletable: true, userVisible: false, sharedReadable: true },
   tool_result_projection: { userDeletable: false, userVisible: false, sharedReadable: true },
   tool_result_archive: { userDeletable: false, userVisible: false, sharedReadable: false },
+  synthesis_cache_block: { userDeletable: true, userVisible: false, sharedReadable: false },
+  history_compact_block: { userDeletable: true, userVisible: false, sharedReadable: false },
+  history_compact_source: { userDeletable: true, userVisible: false, sharedReadable: false },
+  // Historical only: nothing produces these any more. The policy stays so the
+  // records already on disk keep decoding and stay deletable.
+  provider_request_capture: { userDeletable: true, userVisible: false, sharedReadable: false },
   subagent_writeback: { userDeletable: false, userVisible: true, sharedReadable: false },
   deep_research: { userDeletable: false, userVisible: true, sharedReadable: false },
   user_upload: { userDeletable: true, userVisible: false, sharedReadable: true },
+  export: { userDeletable: true, userVisible: true, sharedReadable: false },
+  snapshot: { userDeletable: true, userVisible: true, sharedReadable: false },
   session_effect: { userDeletable: false, userVisible: false, sharedReadable: false },
+  fixture: { userDeletable: true, userVisible: true, sharedReadable: false },
 } as const satisfies Record<ArtifactSource, ArtifactSourcePolicy>;
 
-const CHILD_RESULT_OUTPUT_SOURCES = new Set<ArtifactSource>([
-  'tool_result',
-  'tool_result_projection',
-  'subagent_writeback',
-  'deep_research',
-]);
-
-export function isArtifactUserVisible(record: Pick<ArtifactRecord, 'source'>): boolean {
-  return ARTIFACT_SOURCE_POLICIES[record.source].userVisible;
+export function canUserDeleteArtifact(record: Pick<ArtifactRecord, 'source'>): boolean {
+  return record.source === undefined || ARTIFACT_SOURCE_POLICIES[record.source].userDeletable;
 }
 
-/** Visibility does not grant permission to destroy evidence owned by a runtime workflow. */
-export function canUserDeleteArtifact(record: Pick<ArtifactRecord, 'source'>): boolean {
-  return ARTIFACT_SOURCE_POLICIES[record.source].userDeletable;
+export function isArtifactUserVisible(record: Pick<ArtifactRecord, 'source'>): boolean {
+  return record.source === undefined || ARTIFACT_SOURCE_POLICIES[record.source].userVisible;
 }
 
 export function isArtifactSharedSessionReadable(record: Pick<ArtifactRecord, 'source'>): boolean {
-  return ARTIFACT_SOURCE_POLICIES[record.source].sharedReadable;
+  return record.source !== undefined && ARTIFACT_SOURCE_POLICIES[record.source].sharedReadable;
 }
 
-export function isArtifactChildResultOutput(record: Pick<ArtifactRecord, 'source'>): boolean {
-  return CHILD_RESULT_OUTPUT_SOURCES.has(record.source);
+export type ArtifactChangedReason = 'created' | 'deleted' | 'purged';
+
+export interface ArtifactChangedEvent {
+  reason: ArtifactChangedReason;
+  artifactId: string;
+  sessionId: string;
+  ts: number;
 }
 
-export type ArtifactReadFailureReason = 'not_found' | 'too_large' | 'read_failed' | 'not_allowed';
+export type ArtifactReadFailureReason =
+  | 'not_found'
+  | 'too_large'
+  | 'read_failed'
+  | 'not_allowed'
+  | 'deleted';
 
 export type ArtifactBinaryReadFailureReason = ArtifactReadFailureReason | 'unsupported_mime';
 
@@ -193,7 +216,15 @@ export type ArtifactBinaryReadResult =
   | { ok: true; base64: string; mimeType: string }
   | { ok: false; reason: ArtifactBinaryReadFailureReason };
 
-export type ArtifactSaveFailureReason = 'canceled' | 'not_found' | 'not_allowed' | 'write_failed';
+export type ArtifactSaveFailureReason =
+  | 'canceled'
+  | 'not_found'
+  | 'not_allowed'
+  | 'deleted'
+  | 'source_failed'
+  | 'size_mismatch'
+  | 'target_write_failed'
+  | 'replace_failed';
 
 export type ArtifactSaveResult =
   | { ok: true; saved: string }


### PR DESCRIPTION
## Problem

Artifact export could remove an existing destination before replacement completed. If the final rename failed, the new file was not installed and the old destination was gone. Source-stream, size-validation, and final destination-write failures also lacked distinct user-facing reasons.

## Fix

- Write and flush the artifact to a unique same-directory staging file.
- Replace the destination with one rename only after the staging file is complete. If that rename fails, the existing destination was never moved or deleted.
- Distinguish source, size, destination-write, and replacement failures in the Save As IPC result and renderer copy.
- Keep this change limited to the failed artifact overwrite described in #4832; no recovery protocol or unrelated Finder behavior was added.

## Validation

- `npm run build:test` passed.
- Focused desktop artifact IPC suite: 12 passed, covering successful overwrite plus source interruption, size mismatch, replacement failure, directory target, write failure, sync failure, and close failure. Each failure asserts the existing destination remains intact and staging is cleaned up.
- Fault injection returned `replace_failed` for a failed replacement and `target_write_failed` for staging flush/close failures.
- Chinese and Traditional Chinese size-mismatch copy describes the byte-size change actually checked by the code.
- `git diff --check` and changed-file Biome checks passed.
- Native interactive macOS/Windows Save As flows were not run by the agent.

## AI use

Generative tooling contributed substantively to this patch. The single affected commit carries `Generated-by: OpenAI Codex`.

Fixes #4832
