### PR TITLE
fix(ui): keep write geometry through a late scroll echo

### DIFF
--- a/packages/ui/src/__tests__/transcript-scroll-authority.test.ts
+++ b/packages/ui/src/__tests__/transcript-scroll-authority.test.ts
@@ -231,6 +231,25 @@ test('a scroll event that arrives late is still this authority\'s own write', ()
   });
 });
 
+test('growth a late echo already sees still explains the offset move after it', () => {
+  withObservers((resize) => {
+    const root = fakeRoot({ scrollHeight: 3_523, clientHeight: 860 });
+    const authority = createTranscriptScrollAuthority();
+    authority.attach(root as unknown as HTMLElement);
+
+    // Content grew before the write's echo landed, then the offset moved by
+    // less than that growth: content, not the reader.
+    root.grow(600);
+    root.emitScroll();
+    root.scrollTop += 91;
+    root.emitScroll();
+    assert.equal(authority.getSnapshot().pinned, true);
+
+    resize();
+    assert.equal(root.scrollTop, 3_263);
+  });
+});
+
 test('growth that outruns the write does not read as the reader scrolling up', () => {
   withObservers((resize) => {
     const root = fakeRoot();

--- a/packages/ui/src/transcript-scroll-authority.tsx
+++ b/packages/ui/src/transcript-scroll-authority.tsx
@@ -170,10 +170,8 @@ export function createTranscriptScrollAuthority(): TranscriptScrollAuthority {
         // scrollers (a tool output box, a terminal) never reach here at all:
         // `scroll` does not bubble, and there is no `wheel` listener to catch
         // instead.
+        // Growth this echo already sees has not reached the observer yet.
         if (lastWrittenTop !== undefined && Math.abs(target.scrollTop - lastWrittenTop) < 1) {
-          lastScrollHeight = target.scrollHeight;
-          lastClientHeight = target.clientHeight;
-          lastScrollTop = target.scrollTop;
           return;
         }
         // Content moves the offset too, and only ever by how much the end of


### PR DESCRIPTION
## Summary

A pinned transcript could stop following its tail after content grew below the reader: the storybook smoke for `product-shell-official-appshell--tail-follows-growth-outside-turns` failed on CI with the view left 509px short of a 600px growth (run 33945967155).

`createTranscriptScrollAuthority` tells its own write's scroll echo from the reader by offset, and when the echo arrived it also refreshed the remembered scroll geometry. If that echo landed after content had grown but before the `ResizeObserver` wrote the tail, the growth was absorbed into the baseline, and the next offset move had no growth left to explain it. The band classifier then read a partial move as the reader scrolling away, released the pin, and the observer's write never came. The echo branch now leaves the geometry as the last write recorded it; the observer refreshes it on its own write, and a move the growth explains stays classified as content.

The unit test replays the CI numbers (3523/860 scroller, +600 growth, +91 offset move → 509 from the tail) and fails without the change. The browser-level trigger of that +91 move was not reproduced locally (0/40 story runs at normal speed and under 8× CPU throttling), so this fixes the defect the numbers point at rather than a repro.

## Verification

```
packages/ui unit tests, before:
✖ growth a late echo already sees still explains the offset move after it
ℹ pass 13
ℹ fail 1

packages/ui unit tests, after:
ℹ pass 374
ℹ fail 0
```

Also ran: `biome check` on the two files (clean); storybook smoke (290 stories / 316 renders passed). Not run: desktop E2E.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — diagnosis from the CI trace numbers, the fix, the test, and this description, under the contributor's direction; the commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

https://claude.ai/code/session_01RLZUUq5ri1bHzydQ7tw32b
