### PR TITLE
fix(runtime): isolate Electron Node mode from user commands

### DIFF
--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -23,7 +23,12 @@ import { existsSync, promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { killWindowsTree } from '../process-tree-terminator.js';
-import { runProcessWithBoundedTail, runShellWithBoundedTail } from '../shell-exec.js';
+import {
+  buildUserCommandEnv,
+  runProcessWithBoundedTail,
+  runShellWithBoundedTail,
+} from '../shell-exec.js';
+import { defaultShellPlan } from '../shell-detect.js';
 
 const base = (over: Record<string, unknown> = {}) => ({
   cwd: process.cwd(),
@@ -71,6 +76,82 @@ function findPwsh(): string | undefined {
 }
 
 describe('runShellWithBoundedTail', () => {
+  test('removes Windows case variants without mutating the supplied environment', () => {
+    const input = {
+      ELECTRON_RUN_AS_NODE: 'upper',
+      electron_run_as_node: 'lower',
+      MAKA_SHELL_ENV_KEEP: 'kept',
+    };
+    const output = buildUserCommandEnv(input);
+    if (process.platform === 'win32') {
+      assert.deepEqual(output, { MAKA_SHELL_ENV_KEEP: 'kept' });
+    } else {
+      assert.deepEqual(output, {
+        electron_run_as_node: 'lower',
+        MAKA_SHELL_ENV_KEEP: 'kept',
+      });
+    }
+    assert.deepEqual(input, {
+      ELECTRON_RUN_AS_NODE: 'upper',
+      electron_run_as_node: 'lower',
+      MAKA_SHELL_ENV_KEEP: 'kept',
+    });
+  });
+
+  test('clears inherited Electron Node mode at the user-command boundary', async () => {
+    const previousElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+    const previousKeep = process.env.MAKA_SHELL_ENV_KEEP;
+    process.env.ELECTRON_RUN_AS_NODE = '1';
+    process.env.MAKA_SHELL_ENV_KEEP = 'kept-by-parent';
+    try {
+      const childEnv = buildUserCommandEnv(process.env);
+      assert.equal(childEnv.ELECTRON_RUN_AS_NODE, undefined);
+      assert.equal(childEnv.MAKA_SHELL_ENV_KEEP, 'kept-by-parent');
+
+      const result = await runShellWithBoundedTail(
+        shellEnvironmentProbeCommand(),
+        base({ env: process.env, shell: defaultShellPlan() }),
+      );
+      assert.equal(result.exitCode, 0);
+      assert.match(result.stdout, /electron=\r?\n/u);
+      assert.match(result.stdout, /keep=kept-by-parent/u);
+      assert.match(result.stdout, /explicit=explicit/u);
+      assert.equal(process.env.ELECTRON_RUN_AS_NODE, '1');
+      assert.equal(process.env.MAKA_SHELL_ENV_KEEP, 'kept-by-parent');
+    } finally {
+      if (previousElectronRunAsNode === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+      else process.env.ELECTRON_RUN_AS_NODE = previousElectronRunAsNode;
+      if (previousKeep === undefined) delete process.env.MAKA_SHELL_ENV_KEEP;
+      else process.env.MAKA_SHELL_ENV_KEEP = previousKeep;
+    }
+  });
+
+  test('clears inherited Electron Node mode for direct argv commands', async () => {
+    const previousElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+    const previousKeep = process.env.MAKA_SHELL_ENV_KEEP;
+    process.env.ELECTRON_RUN_AS_NODE = '1';
+    process.env.MAKA_SHELL_ENV_KEEP = 'kept-by-parent';
+    try {
+      const result = await runProcessWithBoundedTail(
+        process.execPath,
+        [
+          '-e',
+          "process.stdout.write(`electron=${process.env.ELECTRON_RUN_AS_NODE ?? ''}\\nkeep=${process.env.MAKA_SHELL_ENV_KEEP ?? ''}`)",
+        ],
+        base({ env: process.env }),
+      );
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stdout, 'electron=\nkeep=kept-by-parent');
+      assert.equal(process.env.ELECTRON_RUN_AS_NODE, '1');
+      assert.equal(process.env.MAKA_SHELL_ENV_KEEP, 'kept-by-parent');
+    } finally {
+      if (previousElectronRunAsNode === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+      else process.env.ELECTRON_RUN_AS_NODE = previousElectronRunAsNode;
+      if (previousKeep === undefined) delete process.env.MAKA_SHELL_ENV_KEEP;
+      else process.env.MAKA_SHELL_ENV_KEEP = previousKeep;
+    }
+  });
+
   test('writes a legacy WSL Bash command through stdin', {
     skip: process.platform === 'win32' ? 'uses /bin/sh as a portable stdin probe' : false,
   }, async () => {
@@ -349,3 +430,14 @@ describe('runShellWithBoundedTail', () => {
     assert.equal(await killWindowsTree(999_999), false);
   });
 });
+
+function shellEnvironmentProbeCommand(): string {
+  const shell = defaultShellPlan();
+  if (shell.kind === 'cmd') {
+    return 'echo electron=%ELECTRON_RUN_AS_NODE% & echo keep=%MAKA_SHELL_ENV_KEEP% & set ELECTRON_RUN_AS_NODE=explicit & call echo explicit=%%ELECTRON_RUN_AS_NODE%%';
+  }
+  if (shell.kind === 'pwsh' || shell.kind === 'powershell') {
+    return 'Write-Output "electron=$env:ELECTRON_RUN_AS_NODE"; Write-Output "keep=$env:MAKA_SHELL_ENV_KEEP"; $env:ELECTRON_RUN_AS_NODE=\'explicit\'; Write-Output "explicit=$env:ELECTRON_RUN_AS_NODE"';
+  }
+  return 'printf \'electron=%s\\nkeep=%s\\n\' "${ELECTRON_RUN_AS_NODE-}" "$MAKA_SHELL_ENV_KEEP"; ELECTRON_RUN_AS_NODE=explicit; printf \'explicit=%s\\n\' "$ELECTRON_RUN_AS_NODE"';
+}

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -173,6 +173,70 @@ describe('ShellRunProcessManager', () => {
     assert.equal(manager.liveCount(), 0);
   });
 
+  test('clears inherited Electron Node mode for background pipes, PTY, and argv', async () => {
+    const previousElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+    const previousKeep = process.env.MAKA_SHELL_ENV_KEEP;
+    process.env.ELECTRON_RUN_AS_NODE = '1';
+    process.env.MAKA_SHELL_ENV_KEEP = 'kept-by-parent';
+    let manager: ShellRunProcessManager | undefined;
+    try {
+      manager = await createTestManager();
+      const cwd = await workspace();
+      const probeScript =
+        "process.stdout.write(`electron=${process.env.ELECTRON_RUN_AS_NODE ?? '<missing>'}\\nkeep=${process.env.MAKA_SHELL_ENV_KEEP ?? '<missing>'}\\n`)";
+      const command = nodeCommand(probeScript);
+
+      const pipe = await manager.runBackgroundBash(shellInput({ cwd, command, timeoutMs: 10_000 }));
+      assert.equal(pipe.kind, 'shell_run');
+      const pipeResult = await waitForTerminalShellRun(manager, pipe.ref);
+      assert.equal(pipeResult.status, 'completed');
+      assert.equal(pipeResult.output?.mode, 'pipes');
+      if (pipeResult.output?.mode !== 'pipes') throw new Error('expected pipe output');
+      assert.match(pipeResult.output.stdout, /electron=<missing>/u);
+      assert.match(pipeResult.output.stdout, /keep=kept-by-parent/u);
+
+      const argv = await manager.runBackgroundBash(
+        shellInput({
+          cwd,
+          command: 'direct argv probe',
+          argv: [process.execPath, '-e', probeScript],
+          timeoutMs: 10_000,
+        }),
+      );
+      assert.equal(argv.kind, 'shell_run');
+      const argvResult = await waitForTerminalShellRun(manager, argv.ref);
+      assert.equal(argvResult.status, 'completed');
+      assert.equal(argvResult.output?.mode, 'pipes');
+      if (argvResult.output?.mode !== 'pipes') throw new Error('expected pipe output');
+      assert.match(argvResult.output.stdout, /electron=<missing>/u);
+      assert.match(argvResult.output.stdout, /keep=kept-by-parent/u);
+
+      const pty = await manager.runBackgroundBash(
+        shellInput({ cwd, command, pty: true, timeoutMs: 10_000 }),
+      );
+      assert.equal(pty.kind, 'shell_run');
+      const ptyResult = await waitForTerminalShellRun(manager, pty.ref);
+      assert.equal(ptyResult.status, 'completed');
+      assert.equal(ptyResult.output?.mode, 'pty');
+      if (ptyResult.output?.mode !== 'pty') throw new Error('expected PTY output');
+      const ptyText = terminalText(ptyResult.output);
+      assert.match(ptyText, /electron=<missing>/u);
+      assert.match(ptyText, /keep=kept-by-parent/u);
+
+      assert.equal(process.env.ELECTRON_RUN_AS_NODE, '1');
+      assert.equal(process.env.MAKA_SHELL_ENV_KEEP, 'kept-by-parent');
+    } finally {
+      try {
+        await manager?.terminateAll();
+      } finally {
+        if (previousElectronRunAsNode === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+        else process.env.ELECTRON_RUN_AS_NODE = previousElectronRunAsNode;
+        if (previousKeep === undefined) delete process.env.MAKA_SHELL_ENV_KEEP;
+        else process.env.MAKA_SHELL_ENV_KEEP = previousKeep;
+      }
+    }
+  });
+
   test('preserves CJK PowerShell output through pipes', {
     skip: process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression',
   }, async () => {

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -57,6 +57,8 @@ export const BASH_MAX_RETAINED_CHARS = 1024 * 1024;
 // chunks keep flowing into the retained tail buffer.
 export const BASH_MAX_LIVE_EMIT_CHARS = 1024 * 1024;
 
+const ELECTRON_RUN_AS_NODE = 'ELECTRON_RUN_AS_NODE';
+
 // Emitted once per stream when live forwarding is suppressed. The full output is
 // not lost — it still feeds the retained tail and the returned result.
 export const LIVE_OUTPUT_SUPPRESSED_MARKER =
@@ -120,6 +122,23 @@ export interface BoundedShellResult {
 }
 
 /**
+ * Build the environment boundary for a user command without changing the
+ * Runtime Host's own environment. Electron uses this variable to put the
+ * current process in Node mode; inheriting it would make Electron-launched
+ * user programs lose Electron APIs such as BrowserWindow. Windows environment
+ * names are case-insensitive, while POSIX environment names are not.
+ */
+export function buildUserCommandEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) =>
+      process.platform === 'win32'
+        ? key.toUpperCase() !== ELECTRON_RUN_AS_NODE
+        : key !== ELECTRON_RUN_AS_NODE,
+    ),
+  );
+}
+
+/**
  * Run `command` in a shell, streaming output into a memory-bounded tail. Never
  * kills the command for producing too much output — it keeps only the last
  * `maxRetainedChars` per stream. On timeout/abort it SIGTERMs (then SIGKILLs
@@ -131,18 +150,15 @@ export function runShellWithBoundedTail(
   command: string,
   options: BoundedShellOptions,
 ): Promise<BoundedShellResult> {
-  const plan = buildShellSpawnPlan(
-    options.shell ?? defaultShellPlan(),
-    command,
-    options.env ?? process.env,
-  );
+  const env = buildUserCommandEnv(options.env ?? process.env);
+  const plan = buildShellSpawnPlan(options.shell ?? defaultShellPlan(), command, env);
   return runSpawnedProcessWithBoundedTail(
     plan.file,
     plan.args,
     plan.useShellOption,
     {
       ...options,
-      ...(plan.env ? { env: plan.env } : {}),
+      env: plan.env ?? env,
     },
     plan.stdin,
   );
@@ -154,7 +170,10 @@ export function runProcessWithBoundedTail(
   args: readonly string[],
   options: BoundedShellOptions,
 ): Promise<BoundedShellResult> {
-  return runSpawnedProcessWithBoundedTail(program, args, false, options);
+  return runSpawnedProcessWithBoundedTail(program, args, false, {
+    ...options,
+    env: buildUserCommandEnv(options.env ?? process.env),
+  });
 }
 
 function runSpawnedProcessWithBoundedTail(

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -39,6 +39,7 @@ import {
   BASH_MAX_LIVE_EMIT_CHARS,
   BASH_MAX_RETAINED_CHARS,
   LIVE_OUTPUT_SUPPRESSED_MARKER,
+  buildUserCommandEnv,
 } from './shell-exec.js';
 import {
   DEFAULT_PROCESS_TERMINATION_GRACE_MS,
@@ -735,6 +736,7 @@ export class ShellRunProcessManager
     sessionEpoch: number,
     onLiveAdmission: ((live: LiveShellRun) => void) | undefined,
   ): Promise<LivePipeShellRun> {
+    const env = buildUserCommandEnv(input.env ?? process.env);
     const collector = new PipeTailCollector(this.maxRetainedChars);
     const pending: Array<(live: LivePipeShellRun) => void> = [];
     let live: LivePipeShellRun | undefined;
@@ -751,11 +753,7 @@ export class ShellRunProcessManager
             args: [...input.argv.slice(1)],
             useShellOption: false,
           }
-        : buildShellSpawnPlan(
-            input.shell ?? defaultShellPlan(),
-            input.command,
-            input.env ?? process.env,
-          );
+        : buildShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command, env);
       startingRecord = await this.createStartingRecord(
         input,
         shellRunId,
@@ -767,7 +765,7 @@ export class ShellRunProcessManager
       const driver = new PipeProcessDriver({
         plan,
         cwd: input.cwd,
-        ...((plan.env ?? input.env) ? { env: plan.env ?? input.env } : {}),
+        env: plan.env ?? env,
         ...(input.fdInputs ? { fdInputs: input.fdInputs } : {}),
         outputDrainMs: this.pipeOutputDrainMs,
         onData: (stream, data) => dispatch((target) => this.onPipeData(target, stream, data)),
@@ -813,6 +811,7 @@ export class ShellRunProcessManager
     slotReservation: ShellRunSlotReservation,
     sessionEpoch: number,
   ): Promise<LivePtyShellRun> {
+    const env = buildUserCommandEnv(input.env ?? process.env);
     const pending: Array<(live: LivePtyShellRun) => void> = [];
     let live: LivePtyShellRun | undefined;
     let driver: PtyProcessDriver | undefined;
@@ -836,11 +835,7 @@ export class ShellRunProcessManager
         onDirty: () => dispatch((target) => this.scheduleAutomaticFlush(target)),
         onFailure: (error) => dispatch((target) => this.handleIntegrityFailure(target, error)),
       });
-      const plan = buildPtyShellSpawnPlan(
-        input.shell ?? defaultShellPlan(),
-        input.command,
-        input.env ?? process.env,
-      );
+      const plan = buildPtyShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command, env);
       startingRecord = await this.createStartingRecord(
         input,
         shellRunId,
@@ -853,7 +848,7 @@ export class ShellRunProcessManager
         file: plan.file,
         args: plan.args,
         cwd: input.cwd,
-        env: plan.env ?? input.env ?? process.env,
+        env: plan.env ?? env,
         cols: PTY_INITIAL_COLS,
         rows: PTY_INITIAL_ROWS,
         onData: (data) => dispatch((target) => this.onPtyData(target, data)),


### PR DESCRIPTION
## Summary

Prevent Maka's internal Electron Node-mode environment from leaking into user commands. This is a general runtime correctness fix, not a Computer Use test workaround.

When the Runtime Host has `ELECTRON_RUN_AS_NODE=1`, its user-command children can inherit it. An Electron project that launches normally with `bun run dev` from a regular terminal can then run in Node mode when launched through Maka, losing Electron APIs such as `BrowserWindow`.

Build a fresh child environment at the foreground shell, direct-argv, background pipe, and PTY boundaries, removing this one variable while preserving other entries and leaving the parent environment untouched. Fixing the shared boundary avoids requiring every Electron project or generated command to know about Maka's internal launch mode.

Refs #2142. Discovered while validating #4668, but deliberately independent of that Computer Use integration and its foreground/background interaction policy.

## Compatibility and scope

- Applies to commands launched through the modified runtime helpers, not every subprocess in the application. Internal Runtime Host/Worker launch code is unchanged.
- Removes the key case-insensitively on Windows and only the exact uppercase key on POSIX.
- Also removes this variable from an explicitly supplied `env` object. Callers intentionally relying on passing Node mode through that object will observe a behavior change. A command may still explicitly set the variable inside its shell/script before launching its own child; this is environment hygiene, not a sandbox or a prohibition on Electron Node mode.
- Does not rewrite commands or working directories, install dependencies, or repair PATH, ports, project configuration, application code, or unrelated Electron startup errors. Existing shell-planning behavior remains in place.
- Does not relax permissions, sandbox admission, Computer Use focus/input restrictions, or verification semantics. No local executables, artifact pins, test profiles, or logs are included.
- This does not establish full Windows support or packaged/clean-machine release readiness.

## Verification

Prior local validation of this patch on Windows (before cherry-picking it onto the separate current-main branch):

- Incremental compilation passed.
- Four new focused test cases reported passing, covering environment copying/case handling, foreground shell and direct argv, and background pipes/argv/PTY. Probes observed the variable absent in children, unrelated values retained, and the parent's value unchanged; the foreground probe also checked explicit reassignment inside the command.
- The focused test process did not exit cleanly. Passing assertions are not an overall successful test-run exit.
- The full shell suite reported 53 pass / 17 fail / 10 skip, including Windows shell/PTY and cleanup failures. These failures are not resolved here; this is not an all-green or baseline-equivalence claim.
- A real SunCode Electron development project launched successfully through Maka's shell-run manager after the fix. The previously reported manual-terminal versus Maka launch discrepancy was resolved in that local scenario; this is not a cross-platform or packaged-app certification.
- At PR preparation, the separate branch was clean, its remote head matched `05895cd7a1e446b9906bc77e972300498f15fc57`, and `git diff --check` passed. Compilation and runtime tests were not rerun on this cherry-picked branch. macOS/Linux, clean-machine, and packaged release validation remain unverified.

## Before marking ready

- [ ] Obtain exact-head CI/build and affected-suite results; investigate test-runner non-exit and failing shell tests rather than treating passing assertions as a green suite.
- [ ] Confirm cross-platform behavior and the intentional explicit-`env` compatibility boundary during review.
- [ ] Add/retain the repository-required `Generated-by` attribution in the affected commit history/final squash commit before merge (the currently published commit lacks that trailer).

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex, including Luna (`gpt-5.6-luna`, high reasoning), assisted with implementation and tests; Codex assisted with review, local validation, commit preparation, and this PR description.

## Checklist

- [ ] Tests cover the change and fail without it (regression tests added; a fresh exact-head before/after run is still outstanding)
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary and Compatibility and scope
- [ ] No

<details>
<summary>中文翻译</summary>

## 概要

防止 Maka 内部用于 Electron Node 模式的环境变量泄漏到用户命令。这是通用运行时正确性修复，不是 Computer Use 测试专用绕过。

Runtime Host 带有 `ELECTRON_RUN_AS_NODE=1` 时，用户命令的子进程可能继承该值。因此，在普通终端执行 `bun run dev` 正常的 Electron 项目，通过 Maka 启动时可能变成 Node 模式，失去 `BrowserWindow` 等 Electron API。

在前台 shell、直接 argv、后台管道及 PTY 边界创建新的子进程环境，仅移除这个变量，保留其他条目，不修改父进程环境。在共享边界修复，可避免要求每个 Electron 项目或生成的命令了解 Maka 内部的启动模式。

关联 #2142，但不关闭该 Windows 支持总议题。问题在验证 #4668 时发现，本 PR 刻意独立于 Computer Use 集成及其前后台交互策略。

## 兼容性与范围

- 只覆盖经过本次修改的运行时辅助函数启动的命令，不覆盖应用中的所有子进程；内部 Runtime Host/Worker 启动代码不变。
- Windows 按不区分大小写移除该键；POSIX 仅移除完全匹配的大写键。
- 显式传入的 `env` 对象中的同名变量也会被移除。依赖这种传参方式主动启用 Node 模式的调用方会受到行为变化影响。命令仍可在自己的 shell/脚本内部主动设置该变量，再启动自己的子进程；这是环境隔离，不是沙箱，也不是禁止使用 Electron Node 模式。
- 不改写命令或工作目录，不安装依赖，不修复 PATH、端口、项目配置、应用代码或其他 Electron 启动错误；既有 shell 启动规划行为保持不变。
- 不放宽权限、沙箱准入、Computer Use 焦点/输入限制或验证语义。不包含本地可执行文件、制品绑定、测试配置或日志。
- 不代表 Windows 已全面受支持，也不代表打包发行版或干净机器验证完成。

## 验证

以下为该补丁在 Windows 本地的先前验证，发生在将其摘取到独立的当前 main 分支之前：

- 增量编译通过。
- 四个新增专项测试用例报告通过，覆盖环境复制/大小写、前台 shell 和直接 argv，以及后台管道/argv/PTY。探针确认子进程缺少该变量、其他值保留、父进程值不变；前台探针还检查了命令内部显式重新赋值。
- 专项测试进程没有正常退出。断言通过不等于整个测试运行成功退出。
- 完整 shell 测试报告 53 通过 / 17 失败 / 10 跳过，包含 Windows shell/PTY 及清理失败。本 PR 未解决这些失败，不宣称全部通过，也未证明与基线等价。
- 修复后，真实 SunCode Electron 开发项目通过 Maka 的 shell-run manager 成功启动。此前“手动终端正常、Maka 启动失败”的差异在该本地场景中得到解决；这不是跨平台或打包应用认证。
- 准备 PR 时，独立分支工作区干净，远端提交与 `05895cd7a1e446b9906bc77e972300498f15fc57` 一致，`git diff --check` 通过。没有在摘取后的独立分支重新运行编译和运行时测试。macOS/Linux、干净机器及打包发行验证仍未完成。

## 转为待合并状态前

- [ ] 获取精确提交的 CI/构建及受影响测试结果；调查测试进程不退出及 shell 测试失败，不能将断言通过当作测试全绿。
- [ ] 审查跨平台行为和显式 `env` 的预期兼容性边界。
- [ ] 合并前在受影响提交历史及最终 squash 提交中补充/保留仓库要求的 `Generated-by` 署名（当前已发布提交缺少该 trailer）。

## AI 使用

- [ ] 生成式工具未作出实质贡献
- [x] 生成式工具作出了实质贡献

工具及范围：OpenAI Codex，包括 Luna（`gpt-5.6-luna`，high 思考强度），协助实现及测试；Codex 协助审查、本地验证、提交准备和本 PR 说明。

## 检查清单

- [ ] 测试覆盖改动，并在没有修复时失败（已新增回归测试，仍需重新执行精确提交的修复前后对照）
- [ ] 本地 lint、格式、类型检查及受影响测试全部通过

本 PR 是否改变行为？

- [x] 是，已在概要和兼容性与范围中说明
- [ ] 否

</details>
