### PR TITLE
test(desktop): drag the quote selection from a settled answer

### DIFF
--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -27,14 +27,31 @@ test('a transcript drag releases outside the window through its owning Turn', as
   await composer.fill('pointer capture source');
   await composer.press('Enter');
 
-  const reply = page.getByText(/Fake backend received: pointer capture source/);
-  await expect(reply).toBeVisible();
   // Select from a settled answer. Selecting from a streaming one is broken for
   // an unrelated reason — see the fixme below — and this test exists to pin the
   // pointer-capture contract, not Selection survival across a stream close.
+  //
+  // Settled is three things, each landing on its own schedule after the
+  // footer: the lazy Markdown body has replaced its plain-text fallback (a
+  // drag begun in the fallback selects nodes about to be discarded), the
+  // stored turn has rendered (its timestamp row moves the answer down), and
+  // the transcript has written itself back to the tail.
+  const reply = page
+    .locator('[data-maka-contract="markdown"]')
+    .getByText(/Fake backend received: pointer capture source/);
+  await expect(reply).toBeVisible({ timeout: 20_000 });
   await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, {
     timeout: 20_000,
   });
+  await expect(page.getByRole('article', { name: '你发送的消息' }).locator('time')).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const root = document.querySelector('[data-chat-scroll-container="true"]')!;
+        return root.scrollHeight - root.scrollTop - root.clientHeight;
+      }),
+    )
+    .toBeLessThanOrEqual(4);
   const turn = reply.locator('xpath=ancestor::*[@data-turn-id][1]');
   const quoteLayer = page.locator('.maka-quote-actions');
   await turn.evaluate((element) => {


### PR DESCRIPTION
## Summary

`e2e/quote-selection.spec.ts:22` fails on CI about 5% of the time with the drag never producing a Selection (7 of the last ~135 E2E runs, across 7 branches including `main`).

The test waits for the 重新生成 footer and then measures where to drag. On a cold Electron two more commits land after that footer, each on its own schedule: the lazy `MarkdownBody` chunk replaces the answer's plain-text Suspense fallback (`.maka-markdown-pending`, which is what the answer is while the chunk loads with progressive streaming off), and the stored turn renders with the user message's timestamp row, moving the answer down 44px. The seven CI traces split exactly along those two: four pressed the mouse at y=474 on a paragraph that ended at 517 (the timestamp row landed after measuring), three pressed on the right pixel and lost the Selection when the fallback was swapped out from under it.

The test now locates the answer inside `[data-maka-contract="markdown"]`, waits for the user message's `time` element and for the transcript to be at its tail, and only then measures. All three are DOM states, not delays.

Product behavior is unchanged; the fallback swap discarding a Selection is the same class of gap the file's `fixme` already records for a stream close.

## Verification

Reproduced locally by throttling the renderer CPU 20× through CDP (macOS, 6 runs each):

```
before:
    Error: expect(received).toBe(expected) // Object.is equality
    Error: expect(received).toBe(expected) // Object.is equality
    Error: quote selection source has no visible text bounds
  3 failed
  3 passed (1.0m)

after:
  6 passed (41.8s)
```

The first two failures are the CI symptom; the third is the same swap landing between locating the fallback and measuring it. Also ran the spec unthrottled ×3 (passes) and `biome check` on the file (clean).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — trace analysis of the seven CI failures, the in-page timeline probe that isolated the two late commits, the fix, and this description, under the contributor's direction; the commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

https://claude.ai/code/session_01RLZUUq5ri1bHzydQ7tw32b
