### PR TITLE
fix(desktop): stop inspector summary loading line flickering on usage refresh

### DIFF
--- a/apps/desktop/src/renderer/features/workbar/tools/inspector/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/features/workbar/tools/inspector/session-inspector-panel.tsx
@@ -134,8 +134,12 @@ export function SessionInspectorPanel(props: { sessionId: string; active: boolea
         )}
 
         {/* Usage and context answer to different owners, so a successful
-            snapshot beside an empty or failed trace remains visible (#2323). */}
-        {snapshot.summaryLoading && (
+            snapshot beside an empty or failed trace remains visible (#2323).
+
+            Render only while there is no summary yet, same as the trace line above:
+            a live session re-reads its summary on every usage update, so gating on
+            the loading flag alone would blink this line in and out. */}
+        {snapshot.summaryLoading && !snapshot.summary && (
           <Text type="supporting" color="secondary">
             {copy.loadingSummary}
           </Text>


### PR DESCRIPTION
## Summary

The inspector's summary loading line appeared whenever `summaryLoading`
was set. A live session re-reads its summary on every usage update
without clearing the last one, so that line was inserted and removed on
each refresh and the timeline jumped.

Show the line only while there is no summary yet, same as the trace
loader above. Background refreshes stay on `aria-busy`.

## Verification

- `npx biome check` on the touched file — clean
- Manual: live session usage updates no longer flash the loading line
  or jump the timeline; first load with no summary still shows it
- Not run: `npm test` (one boolean gate; no new test)
- Not attached: before/after recording (please say if you want one)

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka — drafted the gate and the comment; I reviewed
the loading/refresh path and the wording.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
