### PR TITLE
fix(desktop): avoid Owner-only IPC requests from shared Session guests

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
@@ -281,6 +281,34 @@ describe('app shell session UI state controller', () => {
     assert.equal(notifications, 2);
   });
 
+  it('clears Owner landmarks and ignores their late response when the active Session becomes a Guest', async () => {
+    let resolveOwner!: (value: { throughSequence: number; landmarks: string[] }) => void;
+    let index: { sessionId: string; throughSequence: number | null; turns: readonly string[] } | undefined = {
+      sessionId: 'owner-session', throughSequence: 0, turns: ['previous-owner-turn'],
+    };
+    const dispose = transcriptReadingPosition.refreshLandmarks({
+      sessionId: 'owner-session',
+      newestDurablePromptSequence: 1,
+      list: () => new Promise<{ throughSequence: number; landmarks: string[] }>((resolve) => {
+        resolveOwner = resolve;
+      }),
+      isCurrent: () => true,
+      setIndex: (value) => { index = value; },
+    });
+    // The shell cleans up the Owner effect and passes no ownerActiveId for Guests.
+    dispose?.();
+    transcriptReadingPosition.refreshLandmarks<string>({
+      sessionId: undefined,
+      newestDurablePromptSequence: 1,
+      list: async () => assert.fail('Guests cannot query Owner turn landmarks'),
+      isCurrent: () => true,
+      setIndex: (value) => { index = value; },
+    });
+    resolveOwner({ throughSequence: 1, landmarks: ['owner-turn'] });
+    await Promise.resolve();
+    assert.equal(index, undefined);
+  });
+
   it('enriches a Turn-only reading anchor when its range sequence arrives later', () => {
     let anchor: { turnId: string; sequence?: number } | undefined;
     transcriptReadingPosition.restoreRange({

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -52,6 +52,7 @@ import {
   type DesktopRuntimeHostCandidateStartInput,
 } from '../runtime-host-desktop-candidate.js';
 import { RuntimeHostSessionObservationRegistry } from '../runtime-host-session-observation-registry.js';
+import { RuntimeHostReconnectingIpcMain } from '../runtime-host-reconnecting-ipc-main.js';
 import { desktopSessionResourceKey } from '../../shared/runtime-host-identity.js';
 import { waitFor as pollFor } from '@maka/core/test-only/async-primitives';
 
@@ -353,6 +354,42 @@ test('tears down the whole candidate when the Host connection closes', async () 
   await candidate.closed;
 
   assert.equal(host.closeCalls, 1);
+});
+
+test('preserves supported IPC when the connection closes before candidate startup returns', { timeout: 5_000 }, async (t) => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc);
+  t.after(() => router.close());
+  const firstHost = connectionHarness('closed-during-start');
+  const replaceCapabilities = firstHost.connection.replaceClientCapabilities;
+  firstHost.connection.replaceClientCapabilities = async (...args) => {
+    const result = await replaceCapabilities(...args);
+    // The final initialization response succeeds, immediately followed by EOF.
+    firstHost.disconnect();
+    return result;
+  };
+  const firstTarget = router.createTarget(TEST_TARGET_EPOCH);
+  const first = await createDesktopRuntimeHostCandidate(firstHost.connection, {
+    ...deps(ipc), ipcMain: firstTarget,
+  });
+  t.after(() => first.close());
+  firstTarget.completeRegistration();
+  router.activate(TEST_TARGET_EPOCH);
+  const pending = ipc.invoke('sessions:list').then(
+    (value) => ({ value }),
+    (error: unknown) => ({ error }),
+  );
+
+  const secondHost = connectionHarness('replacement');
+  const secondTarget = router.createTarget(TEST_TARGET_EPOCH);
+  const second = await createDesktopRuntimeHostCandidate(secondHost.connection, {
+    ...deps(ipc), ipcMain: secondTarget,
+  });
+  t.after(() => second.close());
+  secondTarget.completeRegistration();
+  const result = await pending;
+  assert.ok('value' in result, `supported read was rejected: ${'error' in result ? result.error : ''}`);
+  assert.deepEqual((result.value as SessionCatalogProjection[]).map(({ id }) => id), ['session-replacement']);
 });
 
 test('disposes candidate-scoped product IPC state on reconnect teardown', async () => {

--- a/apps/desktop/src/main/__tests__/runtime-host-guest-ipc-preload.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-guest-ipc-preload.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { runInNewContext } from 'node:vm';
+import test from 'node:test';
+import { build } from 'esbuild';
+import type { MakaBridge } from '../../preload/bridge-contract.js';
+
+test('onboarding and workspace search never fan out Owner IPC to a ready Guest', async () => {
+  const owner = {
+    hostId: 'owner-host', targetEpoch: 'owner-epoch', profileId: 'local',
+    profileName: 'Local', profileKind: 'local', profileAccess: 'owner', readiness: 'ready',
+  };
+  const guest = {
+    hostId: 'guest-host', targetEpoch: 'guest-epoch', profileId: 'shared',
+    profileName: 'Shared', profileKind: 'remote', profileAccess: 'session_guest', readiness: 'ready',
+  };
+  const calls: { channel: string; hostId?: string }[] = [];
+  const ipcRenderer = {
+    on() {}, off() {}, send() {},
+    async invoke(channel: string, scope?: { hostId?: string }) {
+      calls.push({ channel, hostId: scope?.hostId });
+      // A missing Guest handler must not hold up either aggregate.
+      if (scope?.hostId === guest.hostId) throw new Error('Guest has no Owner handler');
+      switch (channel) {
+        case 'runtime-host:activeIdentity': return owner;
+        case 'runtime-host:identities': return [owner, guest];
+        case 'onboarding:getSnapshot': return {
+          state: { kind: 'ready_empty' }, milestones: [], sessions: [], connections: [],
+          defaultSlug: null, chatModelChoices: [], sessionSendOutcomes: {},
+        };
+        case 'session-collaboration:mount:list': return [{
+          mountId: 'shared', name: 'Shared', hostId: guest.hostId,
+          session: {
+            kind: 'shared_session', id: 'shared-session', revision: 1,
+            createdAt: 1, activityAt: 1, name: 'Shared Session', status: 'active',
+          },
+        }];
+        case 'sessions:list':
+        case 'search:thread': return [];
+        default: throw new Error('Unexpected channel: ' + channel);
+      }
+    },
+  };
+  let bridge: MakaBridge | undefined;
+  const bundle = await build({
+    entryPoints: [fileURLToPath(new URL('../../../src/preload/preload.ts', import.meta.url))],
+    bundle: true, write: false, platform: 'node', format: 'cjs', external: ['electron'],
+  });
+  const require = createRequire(import.meta.url);
+  runInNewContext(bundle.outputFiles[0]!.text, {
+    require: (id: string) => id === 'electron' ? {
+      ipcRenderer,
+      contextBridge: { exposeInMainWorld: (name: string, value: MakaBridge) => {
+        if (name === 'maka') bridge = value;
+      } },
+    } : require(id),
+    process: { env: {} }, Buffer, console, setTimeout, clearTimeout, TextEncoder, TextDecoder,
+    crypto: globalThis.crypto,
+  });
+  assert.ok(bridge);
+  const snapshot = await bridge.onboarding.getSnapshot();
+  assert.equal(snapshot.sessions.length, 1);
+  assert.equal(snapshot.sessions[0]!.shared, true);
+  assert.equal(snapshot.sessions[0]!.name, 'Shared Session');
+  await bridge.search.thread({ query: 'hello', limit: 10, source: 'thread' });
+  assert.equal(calls.some(call => call.hostId === guest.hostId), false);
+  for (const channel of ['onboarding:getSnapshot', 'search:thread']) {
+    assert.equal(calls.filter(call => call.channel === channel && call.hostId === owner.hostId).length, 1);
+  }
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
@@ -43,7 +43,11 @@ test("unsupported Guest IPC fails immediately while an Owner channel still survi
   t.after(() => router.close());
   const owner = router.createTarget("owner");
   owner.handleReconnectableRead!("onboarding:getSnapshot", async () => "owner");
-  router.completeRegistration("owner");
+  owner.completeRegistration();
+  assert.throws(
+    () => owner.handleReconnectableRead!("late-channel", async () => "late"),
+    /registration is complete/,
+  );
   router.activate("owner");
   router.activate("guest");
   // A request during first connection can wait until its actual surface is known.
@@ -51,7 +55,7 @@ test("unsupported Guest IPC fails immediately while an Owner channel still survi
     ipc.invoke("onboarding:getSnapshot", scope("guest")),
     RuntimeHostHandlerUnsupportedError,
   );
-  router.completeRegistration("guest");
+  router.createTarget("guest").completeRegistration();
   await early;
   await assert.rejects(
     ipc.invoke("onboarding:getSnapshot", scope("guest")),
@@ -61,7 +65,7 @@ test("unsupported Guest IPC fails immediately while an Owner channel still survi
   const recovering = ipc.invoke("onboarding:getSnapshot", scope("owner"));
   const replacement = router.createTarget("owner");
   replacement.handleReconnectableRead!("onboarding:getSnapshot", async () => "replacement");
-  router.completeRegistration("owner");
+  replacement.completeRegistration();
   assert.equal(await recovering, "replacement");
 });
 
@@ -69,9 +73,9 @@ test("reconciliation becomes unavailable when the replacement no longer supports
   const ipc = ipcHarness();
   const router = new RuntimeHostReconnectingIpcMain(ipc);
   t.after(() => router.close());
-  const target = router.createTarget("owner") as ReconciledControlTarget;
+  const target = router.createTarget("owner");
   let dispatches = 0;
-  target.handleReconciledControl("goal:arm", {
+  target.handleReconciledControl!("goal:arm", {
     dispatch: async () => {
       dispatches += 1;
       return { kind: "reconcile", context: { sessionId: "session-1" } };
@@ -79,12 +83,12 @@ test("reconciliation becomes unavailable when the replacement no longer supports
     reconcile: async () => assert.fail("The closed candidate must not reconcile"),
     reconciliationUnavailable: async (context) => ({ kind: "unavailable", context }),
   });
-  router.completeRegistration("owner");
+  target.completeRegistration();
   router.activate("owner");
   const result = ipc.invoke("goal:arm", scope("owner"));
   await new Promise<void>((resolve) => setImmediate(resolve));
   target.removeHandler("goal:arm");
-  router.completeRegistration("owner");
+  router.createTarget("owner").completeRegistration();
   assert.deepEqual(await result, {
     kind: "unavailable", context: { sessionId: "session-1" },
   });

--- a/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
@@ -32,9 +32,64 @@ import {
 import * as ipcReconnectPolicy from "../ipc-reconnect-policy.js";
 import {
   RuntimeHostHandlerUnavailableError,
+  RuntimeHostHandlerUnsupportedError,
   RuntimeHostReconnectingIpcMain,
   RuntimeHostTargetChangedError,
 } from "../runtime-host-reconnecting-ipc-main.js";
+
+test("unsupported Guest IPC fails immediately while an Owner channel still survives reconnect", { timeout: 1_000 }, async (t) => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc);
+  t.after(() => router.close());
+  const owner = router.createTarget("owner");
+  owner.handleReconnectableRead!("onboarding:getSnapshot", async () => "owner");
+  router.completeRegistration("owner");
+  router.activate("owner");
+  router.activate("guest");
+  // A request during first connection can wait until its actual surface is known.
+  const early = assert.rejects(
+    ipc.invoke("onboarding:getSnapshot", scope("guest")),
+    RuntimeHostHandlerUnsupportedError,
+  );
+  router.completeRegistration("guest");
+  await early;
+  await assert.rejects(
+    ipc.invoke("onboarding:getSnapshot", scope("guest")),
+    RuntimeHostHandlerUnsupportedError,
+  );
+  owner.removeHandler("onboarding:getSnapshot");
+  const recovering = ipc.invoke("onboarding:getSnapshot", scope("owner"));
+  const replacement = router.createTarget("owner");
+  replacement.handleReconnectableRead!("onboarding:getSnapshot", async () => "replacement");
+  router.completeRegistration("owner");
+  assert.equal(await recovering, "replacement");
+});
+
+test("reconciliation becomes unavailable when the replacement no longer supports its channel", { timeout: 1_000 }, async (t) => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc);
+  t.after(() => router.close());
+  const target = router.createTarget("owner") as ReconciledControlTarget;
+  let dispatches = 0;
+  target.handleReconciledControl("goal:arm", {
+    dispatch: async () => {
+      dispatches += 1;
+      return { kind: "reconcile", context: { sessionId: "session-1" } };
+    },
+    reconcile: async () => assert.fail("The closed candidate must not reconcile"),
+    reconciliationUnavailable: async (context) => ({ kind: "unavailable", context }),
+  });
+  router.completeRegistration("owner");
+  router.activate("owner");
+  const result = ipc.invoke("goal:arm", scope("owner"));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  target.removeHandler("goal:arm");
+  router.completeRegistration("owner");
+  assert.deepEqual(await result, {
+    kind: "unavailable", context: { sessionId: "session-1" },
+  });
+  assert.equal(dispatches, 1);
+});
 
 test("classifies only dispatched control connection loss for reconciliation", () => {
   const predicate = (

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -1067,6 +1067,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     };
     while (true) {
       let result: DesktopRuntimeHostCandidateStartResult;
+      const ipcMain = this.#ipcMain.createTarget(target.epoch);
       try {
         result = await this.startCandidate(
           {
@@ -1080,7 +1081,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
                   },
                 }
               : {}),
-            ipcMain: this.#ipcMain.createTarget(target.epoch),
+            ipcMain,
             isTargetActive: () => this.#ipcMain.isActive(target.epoch),
             isTargetValid: () => target.valid,
             // Import progress belongs to the initial connection only. Override
@@ -1100,7 +1101,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
         throw error;
       }
       if (result.kind === 'ready') {
-        this.#ipcMain.completeRegistration(target.epoch);
+        ipcMain.completeRegistration();
         target.hostId = result.candidate.client.hostId;
         const previous = target.lastCandidate;
         const retainedOwnedProcess =

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -1100,6 +1100,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
         throw error;
       }
       if (result.kind === 'ready') {
+        this.#ipcMain.completeRegistration(target.epoch);
         target.hostId = result.candidate.client.hostId;
         const previous = target.lastCandidate;
         const retainedOwnedProcess =

--- a/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
@@ -52,9 +52,14 @@ interface HandlerWaiter {
   readonly reject: (error: Error) => void;
 }
 
+interface HandlerOwner {
+  readonly channels: Set<string>;
+  complete: boolean;
+}
+
 interface BoundHandler {
   readonly epoch: string;
-  readonly owner: symbol;
+  readonly owner: HandlerOwner;
   readonly listener: IpcHandler;
   readonly reconcile?: ReconcileIpcHandler;
   readonly reconciliationUnavailable?: ReconciliationUnavailableIpcHandler;
@@ -122,10 +127,10 @@ export class RuntimeHostReconnectingIpcMain {
     this.#replacementWaitTimeoutMs = replacementWaitTimeoutMs;
   }
 
-  createTarget(epoch: string): RuntimeHostTargetIpcMain {
+  createTarget(epoch: string): RuntimeHostTargetIpcMain & { completeRegistration(): void } {
     if (this.#closed) throw new Error("Desktop Runtime Host IPC router is closed");
     if (!epoch) throw new Error("Desktop Runtime Host target epoch is required");
-    const owner = Symbol(epoch);
+    const owner: HandlerOwner = { channels: new Set(), complete: false };
     return {
       epoch,
       isActive: () => this.#activeEpochs.has(epoch),
@@ -136,6 +141,10 @@ export class RuntimeHostReconnectingIpcMain {
       handleReconciledControl: (channel, handlers) =>
         this.#handleReconciledControl(epoch, owner, channel, handlers),
       removeHandler: (channel) => this.#removeHandler(owner, channel),
+      completeRegistration: () => {
+        owner.complete = true;
+        this.#completeRegistration(epoch, owner.channels);
+      },
     };
   }
 
@@ -144,13 +153,10 @@ export class RuntimeHostReconnectingIpcMain {
     this.#activeEpochs.add(epoch);
   }
 
-  /** Called only after a candidate has registered its complete IPC surface. */
-  completeRegistration(epoch: string): void {
-    const channels = new Set<string>();
-    for (const [channel, slot] of this.#slots) {
-      if (slot.handlers.has(epoch)) channels.add(channel);
-    }
-    // Retain supported channels through disconnects: only those can be restored.
+  #completeRegistration(epoch: string, channels: ReadonlySet<string>): void {
+    if (this.#closed) throw new Error("Desktop Runtime Host IPC router is closed");
+    // Registration history belongs to the candidate, not its live handlers:
+    // connection teardown can remove them before startup returns to the manager.
     this.#supportedChannels.set(epoch, channels);
     for (const [channel, slot] of this.#slots) {
       if (channels.has(channel)) continue;
@@ -189,7 +195,7 @@ export class RuntimeHostReconnectingIpcMain {
 
   #handle(
     epoch: string,
-    owner: symbol,
+    owner: HandlerOwner,
     channel: string,
     listener: IpcHandler,
     reconnectableRead: boolean,
@@ -198,6 +204,7 @@ export class RuntimeHostReconnectingIpcMain {
     reconciliationUnavailable?: ReconciliationUnavailableIpcHandler,
   ): void {
     if (this.#closed) throw new Error("Desktop Runtime Host IPC router is closed");
+    if (owner.complete) throw new Error("Desktop Runtime Host candidate IPC registration is complete");
     let slot = this.#slots.get(channel);
     if (!slot) {
       const created: HandlerSlot = {
@@ -230,6 +237,7 @@ export class RuntimeHostReconnectingIpcMain {
       ...(reconciliationUnavailable ? { reconciliationUnavailable } : {}),
     };
     slot.handlers.set(epoch, handler);
+    owner.channels.add(channel);
     for (const waiter of [...slot.waiters]) {
       if (waiter.epoch !== epoch) continue;
       slot.waiters.delete(waiter);
@@ -239,7 +247,7 @@ export class RuntimeHostReconnectingIpcMain {
 
   #handleReconciledControl<Context, Result>(
     epoch: string,
-    owner: symbol,
+    owner: HandlerOwner,
     channel: string,
     handlers: ReconciledControlHandlers<Context, Result>,
   ): void {
@@ -255,7 +263,7 @@ export class RuntimeHostReconnectingIpcMain {
     );
   }
 
-  #removeHandler(owner: symbol, channel: string): void {
+  #removeHandler(owner: HandlerOwner, channel: string): void {
     const slot = this.#slots.get(channel);
     if (!slot) return;
     for (const [epoch, handler] of slot.handlers) {

--- a/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
@@ -61,6 +61,7 @@ interface BoundHandler {
 }
 
 interface HandlerSlot {
+  readonly channel: string;
   readonly waiters: Set<HandlerWaiter>;
   readonly reconnectableRead: boolean;
   readonly reconciledControl: boolean;
@@ -88,6 +89,13 @@ export class RuntimeHostHandlerUnavailableError extends Error {
   }
 }
 
+export class RuntimeHostHandlerUnsupportedError extends Error {
+  constructor(channel: string) {
+    super(`Runtime Host target does not support IPC channel: ${channel}`);
+    this.name = "RuntimeHostHandlerUnsupportedError";
+  }
+}
+
 /**
  * Keeps Electron IPC registration stable across reconnects while fencing each
  * target generation. Reconnectable reads may move to a replacement candidate,
@@ -97,6 +105,7 @@ export class RuntimeHostReconnectingIpcMain {
   readonly #ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
   readonly #slots = new Map<string, HandlerSlot>();
   readonly #activeEpochs = new Set<string>();
+  readonly #supportedChannels = new Map<string, ReadonlySet<string>>();
   readonly #replacementWaitTimeoutMs: number;
   #closed = false;
 
@@ -135,11 +144,30 @@ export class RuntimeHostReconnectingIpcMain {
     this.#activeEpochs.add(epoch);
   }
 
+  /** Called only after a candidate has registered its complete IPC surface. */
+  completeRegistration(epoch: string): void {
+    const channels = new Set<string>();
+    for (const [channel, slot] of this.#slots) {
+      if (slot.handlers.has(epoch)) channels.add(channel);
+    }
+    // Retain supported channels through disconnects: only those can be restored.
+    this.#supportedChannels.set(epoch, channels);
+    for (const [channel, slot] of this.#slots) {
+      if (channels.has(channel)) continue;
+      for (const waiter of [...slot.waiters]) {
+        if (waiter.epoch !== epoch) continue;
+        slot.waiters.delete(waiter);
+        waiter.reject(new RuntimeHostHandlerUnsupportedError(channel));
+      }
+    }
+  }
+
   isActive(epoch: string): boolean {
     return this.#activeEpochs.has(epoch);
   }
 
   deactivate(epoch: string): void {
+    this.#supportedChannels.delete(epoch);
     if (!this.#activeEpochs.delete(epoch)) return;
     this.#rejectEpoch(epoch);
   }
@@ -148,6 +176,7 @@ export class RuntimeHostReconnectingIpcMain {
     if (this.#closed) return;
     this.#closed = true;
     this.#activeEpochs.clear();
+    this.#supportedChannels.clear();
     const error = new Error("Desktop Runtime Host IPC router is closed");
     for (const [channel, slot] of this.#slots) {
       for (const waiter of slot.waiters) waiter.reject(error);
@@ -172,6 +201,7 @@ export class RuntimeHostReconnectingIpcMain {
     let slot = this.#slots.get(channel);
     if (!slot) {
       const created: HandlerSlot = {
+        channel,
         handlers: new Map(),
         waiters: new Set(),
         reconnectableRead,
@@ -252,6 +282,7 @@ export class RuntimeHostReconnectingIpcMain {
         if (remainingMs <= 0) throw new HandlerWaitExpiredError();
         return await this.#waitForHandler(slot, epoch, previous, remainingMs);
       } catch (error) {
+        if (reconciling && error instanceof RuntimeHostHandlerUnsupportedError) return undefined;
         if (!(error instanceof HandlerWaitExpiredError)) throw error;
         if (reconciling) return undefined;
         throw new RuntimeHostHandlerUnavailableError();
@@ -331,6 +362,10 @@ export class RuntimeHostReconnectingIpcMain {
     const current = slot.handlers.get(epoch);
     if (current !== undefined && current !== previous) {
       return Promise.resolve(current);
+    }
+    const supported = this.#supportedChannels.get(epoch);
+    if (!current && supported && !supported.has(slot.channel)) {
+      return Promise.reject(new RuntimeHostHandlerUnsupportedError(slot.channel));
     }
     if (timeoutMs !== undefined && timeoutMs <= 0) {
       return Promise.reject(new HandlerWaitExpiredError());

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -411,6 +411,12 @@ async function runtimeHostScopeList(): Promise<readonly DesktopTargetScope[]> {
   }
 }
 
+async function readyOwnerRuntimeHostScopes(): Promise<readonly DesktopTargetScope[]> {
+  return (await runtimeHostScopeList()).filter(
+    (scope) => runtimeHostMetadataFor(scope)?.profileAccess === 'owner',
+  );
+}
+
 async function runtimeHostSessionRef(sessionId: string): Promise<{
   readonly scope: DesktopTargetScope;
   readonly sessionId: string;
@@ -811,7 +817,7 @@ function projectOnboardingSendOutcomes(
 async function loadDesktopOnboardingSnapshot(): Promise<OnboardingSnapshot> {
   const catalogSeed = desktopSessionCatalogRefresher.beginSeed();
   const defaultScope = await activeRuntimeHostRef();
-  const readyScopes = await runtimeHostScopeList();
+  const readyScopes = await readyOwnerRuntimeHostScopes();
   const scopes = [
     defaultScope,
     ...readyScopes.filter(
@@ -1464,9 +1470,7 @@ const makaBridge = {
       );
     },
     async getPendingTurnRequests() {
-      const scopes = (await runtimeHostScopeList()).filter(
-        (scope) => runtimeHostMetadataFor(scope)?.profileAccess === 'owner',
-      );
+      const scopes = await readyOwnerRuntimeHostScopes();
       return collectAvailablePendingTurnRequests(
         scopes.map(async (scope) => {
           const result = await ipcRenderer.invoke(
@@ -2883,7 +2887,8 @@ const makaBridge = {
   // PR110b: onboarding snapshot + milestone IPCs. Renderer polls
   // `getSnapshot()` on app load and re-polls on existing invalidations.
   // Onboarding state and connection setup belong to the default Host; bounded
-  // Session summaries and send outcomes are merged from every ready Host.
+  // Owner send outcomes are merged from ready Owner Hosts; Guest summaries
+  // come from the separate, authorized mount catalog.
   onboarding: {
     getSnapshot(): Promise<OnboardingSnapshot> {
       return loadDesktopOnboardingSnapshot();
@@ -2994,10 +2999,10 @@ const makaBridge = {
     },
   },
   search: {
-    // Search each ready Host independently; a remote profile sends the query
-    // over that Host's authenticated connection, never through telemetry.
+    // Search each ready Owner Host independently; Guests cannot search a workspace.
+    // Remote queries use that Host's authenticated connection, never telemetry.
     async thread(request: SearchRequest): Promise<SearchResult[] | { ok: false; reason: SearchErrorReason; message: string }> {
-      const scopes = await runtimeHostScopeList();
+      const scopes = await readyOwnerRuntimeHostScopes();
       return collectThreadSearchResponses(
         scopes.map(async (scope) => {
           const result = await ipcRenderer.invoke('search:thread', scope, request) as

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2331,13 +2331,13 @@ function AppShellContent({
     activeId,
   );
   useEffect(() => transcriptReadingPosition.refreshLandmarks({
-    sessionId: activeId,
+    sessionId: ownerActiveId,
     newestDurablePromptSequence,
     current: transcriptTurnIndex,
     list: (sessionId) => window.maka.sessions.listTurnLandmarks(sessionId),
     isCurrent: (sessionId) => activeIdRef.current === sessionId,
     setIndex: setTranscriptTurnIndex,
-  }), [activeId, activeIdRef, newestDurablePromptSequence, transcriptTurnIndex]);
+  }), [ownerActiveId, activeIdRef, newestDurablePromptSequence, transcriptTurnIndex]);
   useEffect(() => transcriptReadingPosition.restoreRange({
     sessionId: activeId,
     searchTarget: searchScrollTarget,


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Fix

Shared Session guests were included in Owner-only onboarding and workspace-search requests. Because those handlers are never registered for Guests, each request waited through the 15-second reconnection window, producing repeated errors and delaying aggregate results. The transcript also requested Owner-only turn landmarks for shared Sessions.

- Query only ready Owner hosts for onboarding aggregation and workspace search. Keep shared Sessions in the separate mount catalog.
- Request full-history turn landmarks only for Owner Sessions; preserve Guest transcript paging and navigation over loaded content.
- Seal each candidate's registration history separately from live handlers, so a connection closing before startup returns cannot erase its supported IPC surface. Reject unsupported channels immediately while retaining bounded recovery for supported channels during disconnects. Preserve uncertain-control reconciliation without replaying mutations.
- Leave Guest grants and the wire protocol unchanged.

## Validation

- Desktop suite: 2,188 tests passed.
- Main/preload builds and preload/renderer TypeScript checks passed.
- Changed-file lint, app-shell hook checks, and ASF header checks passed.
- Regression coverage exercises the production preload bundle with concurrent Owner/Guest identities, Guest catalog retention, unsupported IPC, Owner reconnect (including EOF after the final initialization response), unavailable reconciliation, and late Owner landmark responses after switching to Guest.
- Windows-to-macOS live-device retest remains pending; automated validation ran under Linux/WSL.

AI assistance: OpenAI Codex.

</details>

<details>
<summary>中文</summary>

## 修复

共享会话 Guest 被错误纳入了仅限 Owner 的 onboarding 和工作区搜索请求。这些接口从未在 Guest 上注册，每次调用却会等待 15 秒重连窗口，造成反复报错及聚合结果延迟。历史导航也会对共享会话请求仅限 Owner 的完整导航标记。

- onboarding 聚合和工作区搜索仅请求已就绪的 Owner；共享会话仍通过独立挂载目录保留在列表中。
- 仅对 Owner 会话请求完整历史导航标记，保留 Guest 的历史分页和已加载内容导航。
- 将每个 candidate 的注册记录与活跃 handler 分离并封存，避免初始化返回前断线清理错误地抹掉接口支持信息；不支持的调用立即拒绝，支持的接口仍按原有有界窗口恢复，不重放结果未确认的写操作。
- 不扩大 Guest 权限，不修改通信协议。

## 验证

- Desktop 全量 2,188 项测试通过。
- main/preload 构建及 preload/renderer TypeScript 检查通过。
- 改动文件 lint、app-shell hook 和 ASF 许可证头检查通过。
- 回归测试覆盖真实 preload bundle 中 Owner/Guest 并存、共享目录保留、不支持的 IPC、Owner 重连（包括初始化最后一步响应后立即断线）、无法继续核对的写操作，以及切换 Guest 后迟到的 Owner 导航响应。
- 尚未完成 Windows→macOS 真机复测；自动验证在 Linux/WSL 下执行。

AI 辅助：OpenAI Codex。

</details>
