### PR TITLE
fix(runtime-host): drop Bash boundary declarations under Full access

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -72,6 +72,7 @@ import { agentGraphIdForRootSession } from '@maka/runtime/stream-graph-coordinat
 import { resolveTurnShellPlan, ShellPreferenceError } from '@maka/runtime/shell-detect';
 import { buildParentAgentTools } from '@maka/runtime/subagent-tools';
 import { SESSION_RECAP_INSTRUCTION } from '@maka/runtime/session-recap';
+import { MacosSeatbeltBackend, SandboxCommandError, SandboxManager } from '@maka/runtime/sandbox';
 import { createToolResultArchiveCapability } from '@maka/runtime/tool-result-archive-capability';
 import { loadHistoryCompactCheckpointsFromRunLedger } from '@maka/runtime/history-compact-ledger';
 import { stableHash, toolCatalogHash } from '@maka/runtime/request-shape';
@@ -4297,6 +4298,133 @@ test('backend composition survives a moved saved Git Bash executable while Bash 
   const capturedBash = childComposer.tools.find((tool) => tool.name === 'Bash');
   assert.match(capturedBash?.description ?? '', /captured child shell/);
   assert.doesNotMatch(capturedBash?.description ?? '', /unavailable this turn/);
+});
+
+test('child Bash boundary declarations follow the child permission mode', () => {
+  const expected = {
+    bypass: {
+      bashKeys: ['command', 'timeout_ms', 'run_in_background', 'pty'],
+      declaresBoundary: false,
+    },
+    ask: {
+      bashKeys: [
+        'command',
+        'timeout_ms',
+        'run_in_background',
+        'pty',
+        'boundary_intent',
+        'required_boundary',
+      ],
+      declaresBoundary: true,
+    },
+    explore: {
+      bashKeys: [
+        'command',
+        'timeout_ms',
+        'run_in_background',
+        'pty',
+        'boundary_intent',
+        'required_boundary',
+      ],
+      declaresBoundary: true,
+    },
+  } as const;
+
+  const shellRuns = {
+    runForegroundBash: () => Promise.reject(new Error('not used')),
+    runBackgroundBash: () => Promise.reject(new Error('not used')),
+  };
+
+  for (const permissionMode of ['bypass', 'ask', 'explore'] as const) {
+    const composition = createHostChildAgentToolComposition({
+      builtinTools: { shellRuns },
+      permissionMode,
+      worktreePatchWriteBackAvailable: true,
+    });
+    const bash = composition.childTools.find((tool) => tool.name === 'Bash');
+    assert.ok(bash, `expected child Bash under ${permissionMode}`);
+    assert.deepEqual(
+      Object.keys(z.toJSONSchema(bash.parameters as z.ZodTypeAny).properties ?? {}),
+      expected[permissionMode].bashKeys,
+      permissionMode,
+    );
+    assert.equal(
+      composition.childTools.some(({ name }) => name === 'request_sandbox_boundary'),
+      false,
+      permissionMode,
+    );
+    assert.equal(
+      bash.description.includes('Enforced by the current session sandbox boundary.'),
+      expected[permissionMode].declaresBoundary,
+      permissionMode,
+    );
+  }
+});
+
+test('projected child Bash reaches managed enforcement without requesting expansion', async () => {
+  const permissionProfile = createWorkspaceWritePermissionProfile();
+  let boundaryRequests = 0;
+  let shellInput: unknown;
+  const composition = createHostChildAgentToolComposition({
+    builtinTools: {
+      permissionProfile,
+      sandboxManager: new SandboxManager([new MacosSeatbeltBackend()]),
+      sandboxPlatform: 'darwin',
+      shellRuns: {
+        async runForegroundBash(input) {
+          shellInput = input;
+          throw new SandboxCommandError({
+            domain: 'command',
+            stage: 'operation',
+            reason: 'sandbox_denial',
+            backend: 'macos-seatbelt',
+            recoverable: true,
+          });
+        },
+        async runBackgroundBash() {
+          throw new Error('background execution was not requested');
+        },
+      },
+    },
+    permissionMode: 'bypass',
+    worktreePatchWriteBackAvailable: true,
+  });
+  const bash = composition.childTools.find((tool) => tool.name === 'Bash') as
+    | MakaTool<Record<string, unknown>, unknown>
+    | undefined;
+  assert.ok(bash);
+  const parameters = bash.parameters as z.ZodTypeAny;
+  assert.deepEqual(Object.keys(z.toJSONSchema(parameters).properties ?? {}), [
+    'command',
+    'timeout_ms',
+    'run_in_background',
+    'pty',
+  ]);
+  const args = parameters.parse({ command: 'cat /private/denied' }) as Record<string, unknown>;
+
+  await assert.rejects(
+    async () =>
+      await bash.impl(args, {
+        sessionId: 'child-session',
+        turnId: 'child-turn',
+        cwd: process.cwd(),
+        permissionMode: 'bypass',
+        executionBoundary: createManagedExecutionBoundary(permissionProfile, 0),
+        toolCallId: 'child-bash',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+        requestSandboxBoundary: async () => {
+          boundaryRequests += 1;
+          throw new Error('boundary expansion must not be requested');
+        },
+      }),
+    (error: unknown) => error instanceof SandboxCommandError && error.reason === 'sandbox_denial',
+  );
+  assert.equal(boundaryRequests, 0);
+  assert.equal(
+    (shellInput as { argv?: readonly string[] } | undefined)?.argv?.[0],
+    '/usr/bin/sandbox-exec',
+  );
 });
 
 test('child execution Bash carries the configured shell guidance and spawn plan', async () => {

--- a/packages/runtime-host/src/__tests__/interactive-run-composer.test.ts
+++ b/packages/runtime-host/src/__tests__/interactive-run-composer.test.ts
@@ -19,6 +19,9 @@
 
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import { z } from 'zod';
+import type { PermissionMode } from '@maka/core/permission';
+import type { PlanStore } from '@maka/core/plan';
 import { createDefaultRuntimePolicy } from '@maka/core/runtime-policy';
 import type { SessionTodoToolStore } from '@maka/runtime/session-todo-tools';
 import type { MakaTool } from '@maka/runtime/tool-runtime';
@@ -33,6 +36,79 @@ test('the interactive tool surface does not expose the retired ExploreAgent tool
     composer.tools.some(({ name }) => name === 'ExploreAgent'),
     false,
   );
+});
+
+test('the interactive tool surface follows the session permission mode', () => {
+  const expected = {
+    bypass: {
+      bashKeys: ['command', 'timeout_ms', 'run_in_background', 'pty'],
+      declaresBoundary: false,
+    },
+    ask: {
+      bashKeys: [
+        'command',
+        'timeout_ms',
+        'run_in_background',
+        'pty',
+        'boundary_intent',
+        'required_boundary',
+      ],
+      declaresBoundary: true,
+    },
+    explore: {
+      bashKeys: [
+        'command',
+        'timeout_ms',
+        'run_in_background',
+        'pty',
+        'boundary_intent',
+        'required_boundary',
+      ],
+      declaresBoundary: true,
+    },
+  } as const satisfies Record<PermissionMode, unknown>;
+
+  for (const permissionMode of ['bypass', 'ask', 'explore'] as const) {
+    const composer = createFixtureComposer({
+      builtinTools: {
+        shellRuns: {
+          runForegroundBash: () => Promise.reject(new Error('not used')),
+          runBackgroundBash: () => Promise.reject(new Error('not used')),
+        },
+      },
+      plan: {
+        store: {} as PlanStore,
+        state: {
+          schemaVersion: 1,
+          sessionId: 'session-1',
+          storeVersion: 0,
+          proposals: [],
+          executions: [],
+        },
+        mode: 'agent',
+        permissionMode,
+      },
+    });
+    const bash = composer.tools.find(({ name }) => name === 'Bash');
+    if (!bash) throw new Error(`Bash tool missing under ${permissionMode}`);
+    const schema = z.toJSONSchema(bash.parameters as z.ZodTypeAny);
+
+    assert.deepEqual(
+      Object.keys(schema.properties ?? {}),
+      expected[permissionMode].bashKeys,
+      permissionMode,
+    );
+    assert.equal(
+      composer.tools.some(({ name }) => name === 'request_sandbox_boundary'),
+      expected[permissionMode].declaresBoundary,
+      permissionMode,
+    );
+    assert.equal(
+      bash.description.includes('Enforced by the current session sandbox boundary.'),
+      expected[permissionMode].declaresBoundary,
+      permissionMode,
+    );
+  }
 });
 
 test('Deep Research keeps standard inspection tools and its durable workspace tools', () => {

--- a/packages/runtime-host/src/__tests__/interactive-run-composer.test.ts
+++ b/packages/runtime-host/src/__tests__/interactive-run-composer.test.ts
@@ -111,6 +111,45 @@ test('the interactive tool surface follows the session permission mode', () => {
   }
 });
 
+test('top-level bypass projects Bash without a plan store and overrides the plan mode', () => {
+  for (const plan of [
+    undefined,
+    {
+      store: {} as PlanStore,
+      state: {
+        schemaVersion: 1 as const,
+        sessionId: 'session-1',
+        storeVersion: 0,
+        proposals: [],
+        executions: [],
+      },
+      mode: 'agent' as const,
+      permissionMode: 'ask' as const,
+    },
+  ]) {
+    const composer = createFixtureComposer({
+      permissionMode: 'bypass',
+      ...(plan ? { plan } : {}),
+      builtinTools: {
+        shellRuns: {
+          runForegroundBash: () => Promise.reject(new Error('not used')),
+          runBackgroundBash: () => Promise.reject(new Error('not used')),
+        },
+      },
+    });
+    const bash = composer.tools.find(({ name }) => name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+    assert.deepEqual(
+      Object.keys(z.toJSONSchema(bash.parameters as z.ZodTypeAny).properties ?? {}),
+      ['command', 'timeout_ms', 'run_in_background', 'pty'],
+    );
+    assert.equal(
+      composer.tools.some(({ name }) => name === 'request_sandbox_boundary'),
+      false,
+    );
+  }
+});
+
 test('Deep Research keeps standard inspection tools and its durable workspace tools', () => {
   const tool = (name: string): MakaTool => ({
     name,

--- a/packages/runtime-host/src/__tests__/interactive-run-composer.test.ts
+++ b/packages/runtime-host/src/__tests__/interactive-run-composer.test.ts
@@ -111,7 +111,47 @@ test('the interactive tool surface follows the session permission mode', () => {
   }
 });
 
-test('top-level bypass projects Bash without a plan store and overrides the plan mode', () => {
+test('explicit Bash boundary declaration options override the permission-mode default', () => {
+  for (const { permissionMode, declareSandboxBoundary, expectedKeys } of [
+    {
+      permissionMode: 'ask' as const,
+      declareSandboxBoundary: false,
+      expectedKeys: ['command', 'timeout_ms', 'run_in_background', 'pty'],
+    },
+    {
+      permissionMode: 'bypass' as const,
+      declareSandboxBoundary: true,
+      expectedKeys: [
+        'command',
+        'timeout_ms',
+        'run_in_background',
+        'pty',
+        'boundary_intent',
+        'required_boundary',
+      ],
+    },
+  ]) {
+    const composer = createFixtureComposer({
+      permissionMode,
+      builtinTools: {
+        declareSandboxBoundary,
+        shellRuns: {
+          runForegroundBash: () => Promise.reject(new Error('not used')),
+          runBackgroundBash: () => Promise.reject(new Error('not used')),
+        },
+      },
+    });
+    const bash = composer.tools.find(({ name }) => name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+    assert.deepEqual(
+      Object.keys(z.toJSONSchema(bash.parameters as z.ZodTypeAny).properties ?? {}),
+      expectedKeys,
+      `${permissionMode}/${String(declareSandboxBoundary)}`,
+    );
+  }
+});
+
+test('top-level bypass projects Bash without a plan store and overrides the plan mode', async () => {
   for (const plan of [
     undefined,
     {
@@ -123,7 +163,7 @@ test('top-level bypass projects Bash without a plan store and overrides the plan
         proposals: [],
         executions: [],
       },
-      mode: 'agent' as const,
+      mode: 'plan' as const,
       permissionMode: 'ask' as const,
     },
   ]) {
@@ -147,6 +187,19 @@ test('top-level bypass projects Bash without a plan store and overrides the plan
       composer.tools.some(({ name }) => name === 'request_sandbox_boundary'),
       false,
     );
+    if (plan) {
+      assert.equal(
+        composer.tools.some(({ name }) => name === 'Write'),
+        true,
+      );
+      const prompt = await composer.resolveSystemPrompt({
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        cwd: '/workspace',
+      });
+      assert.match(prompt.text ?? '', /Full access is active/);
+      assert.doesNotMatch(prompt.text ?? '', /do not modify files/);
+    }
   }
 });
 

--- a/packages/runtime-host/src/server/builtin-tool-permission-projection.ts
+++ b/packages/runtime-host/src/server/builtin-tool-permission-projection.ts
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { PermissionMode } from '@maka/core/permission';
+import type { BuildBuiltinToolsOptions } from '@maka/runtime/builtin-tools';
+
+/** Defaults the Bash declaration surface from permission mode without overriding a caller choice. */
+export function projectBuiltinToolsForPermissionMode(
+  options: BuildBuiltinToolsOptions,
+  permissionMode?: PermissionMode,
+): BuildBuiltinToolsOptions {
+  if (permissionMode === undefined) return options;
+  return {
+    ...options,
+    declareSandboxBoundary: options.declareSandboxBoundary ?? permissionMode !== 'bypass',
+  };
+}

--- a/packages/runtime-host/src/server/child-agent-composition.ts
+++ b/packages/runtime-host/src/server/child-agent-composition.ts
@@ -29,6 +29,10 @@ import { type MakaTool } from '@maka/runtime/tool-runtime';
 
 import { type SessionManager } from '@maka/runtime/session-manager';
 
+import type { PermissionMode } from '@maka/core/permission';
+
+import { projectBuiltinToolsForPermissionMode } from './builtin-tool-permission-projection.js';
+
 type ChildAgentAuthority = Pick<
   SessionManager,
   'spawnChildSession' | 'listChildAgents' | 'readChildAgentOutput'
@@ -47,10 +51,13 @@ export interface HostChildAgentToolComposition {
 /** Composes the parent control tools and the exact catalog-child capability union. */
 export function createHostChildAgentToolComposition(input: {
   readonly builtinTools: BuildBuiltinToolsOptions;
+  readonly permissionMode?: PermissionMode;
   readonly hostTools?: readonly MakaTool[];
   readonly worktreePatchWriteBackAvailable?: boolean;
 }): HostChildAgentToolComposition {
-  const builtinTools = buildBuiltinTools(input.builtinTools);
+  const builtinTools = buildBuiltinTools(
+    projectBuiltinToolsForPermissionMode(input.builtinTools, input.permissionMode),
+  );
   const childTools = buildChildAgentTools([...builtinTools, ...(input.hostTools ?? [])]);
   const definitions = listRunnableBuiltinAgentDefinitions({
     tools: childTools,

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1134,6 +1134,7 @@ export async function createExecutionRuntimeHostComposition(
         const runProfile = hostedExecutionRunProfile(header.toolProfile);
         return createInteractiveRunComposer({
           runtimePolicy,
+          permissionMode: header.permissionMode,
           shell: resolveTurnShellPlan(runtimePolicy.policy.shell),
           skills,
           memory: requireMemory(memory),
@@ -1199,6 +1200,7 @@ export async function createExecutionRuntimeHostComposition(
           });
           return createInteractiveRunComposer({
             runtimePolicy,
+            permissionMode,
             shell: resolveTurnShellPlan(runtimePolicy.policy.shell),
             skills,
             memory: requireMemory(memory),

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1262,6 +1262,7 @@ export async function createExecutionRuntimeHostComposition(
       );
       const childTools = createHostChildAgentToolComposition({
         builtinTools: { ...builtinTools, shell },
+        permissionMode: header.permissionMode,
         hostTools,
         worktreePatchWriteBackAvailable: true,
       }).childTools;

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -95,6 +95,7 @@ const CHILD_INSTRUCTION_BOUNDARY = [
 
 export interface InteractiveRunComposerInput {
   readonly runtimePolicy: RuntimePolicySnapshot;
+  readonly permissionMode?: PermissionMode;
   readonly skills: HostSkillCatalogCoordinator;
   readonly pluginSkills?: PluginSkillService;
   readonly memory: HostMemoryCoordinator;
@@ -164,7 +165,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
         input.scheduledTaskTool,
         input.goalTools,
         input.parentAgentTools,
-        input.plan?.permissionMode,
+        input.permissionMode ?? input.plan?.permissionMode,
         input.plan,
         input.deepResearch?.tools,
       );
@@ -452,6 +453,7 @@ export function createInteractiveRunComposerFactory(
       const { hostTools, boundTools, parentAgentTools } = toolSurface;
       const composer = createInteractiveRunComposer({
         runtimePolicy,
+        permissionMode: backendContext.header.permissionMode,
         skills: input.skills,
         ...(input.pluginSkills ? { pluginSkills: input.pluginSkills } : {}),
         memory: input.memory,

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -65,6 +65,7 @@ import type { PluginSkillService } from '@maka/runtime/plugin-skill-service';
 import type { ScannedSkill } from '@maka/runtime/skills';
 import { type ToolGroup } from '@maka/runtime/tool-availability';
 import { resolveTurnShellPlan, type TurnShellPlan } from '@maka/runtime/shell-detect';
+import { projectBuiltinToolsForPermissionMode } from './builtin-tool-permission-projection.js';
 import type {
   ClientCapabilitySnapshot,
   HostClientCapabilityCoordinator,
@@ -145,6 +146,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
     input.builtinTools && input.shell
       ? { ...input.builtinTools, shell: input.shell }
       : input.builtinTools;
+  const effectivePermissionMode = input.permissionMode ?? input.plan?.permissionMode;
   const inventorySnapshotFor = createTurnSkillInventorySnapshotResolver(
     input.skills,
     input.pluginSkills,
@@ -165,7 +167,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
         input.scheduledTaskTool,
         input.goalTools,
         input.parentAgentTools,
-        input.permissionMode ?? input.plan?.permissionMode,
+        effectivePermissionMode,
         input.plan,
         input.deepResearch?.tools,
       );
@@ -189,7 +191,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
           mode: input.plan.mode,
           tools: candidateTools,
           hasActiveExecution: activeExecution !== undefined,
-          fullAccess: input.plan.permissionMode === 'bypass',
+          fullAccess: effectivePermissionMode === 'bypass',
         })
       : candidateTools;
     // A bound tool list is an exact child/local activation ceiling. Dynamic
@@ -262,7 +264,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
               workspaceInstructions,
               promptState.memory,
               input.plan?.mode === 'plan'
-                ? renderPlanModePrompt({ fullAccess: input.plan.permissionMode === 'bypass' })
+                ? renderPlanModePrompt({ fullAccess: effectivePermissionMode === 'bypass' })
                 : undefined,
               input.deepResearch ? buildDeepResearchSystemPromptFragment() : undefined,
               input.sideConversation ? buildSideConversationSystemPromptFragment() : undefined,
@@ -552,10 +554,9 @@ function buildDefaultHostTools(
   plan?: InteractiveRunComposerInput['plan'],
   deepResearchTools: readonly MakaTool[] = [],
 ): MakaTool[] {
-  const projectedBuiltinOptions =
-    builtinOptions && permissionMode !== undefined
-      ? { ...builtinOptions, declareSandboxBoundary: permissionMode !== 'bypass' }
-      : builtinOptions;
+  const projectedBuiltinOptions = builtinOptions
+    ? projectBuiltinToolsForPermissionMode(builtinOptions, permissionMode)
+    : undefined;
   const builtins = projectedBuiltinOptions ? buildBuiltinTools(projectedBuiltinOptions) : [];
   const question = buildAskUserQuestionTool();
   const sandboxBoundaryTools =

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -164,6 +164,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
         input.scheduledTaskTool,
         input.goalTools,
         input.parentAgentTools,
+        input.plan?.permissionMode,
         input.plan,
         input.deepResearch?.tools,
       );
@@ -545,12 +546,18 @@ function buildDefaultHostTools(
   scheduledTaskTool?: MakaTool,
   goalTools: readonly MakaTool[] = [],
   parentAgentTools: readonly MakaTool[] = [],
+  permissionMode?: PermissionMode,
   plan?: InteractiveRunComposerInput['plan'],
   deepResearchTools: readonly MakaTool[] = [],
 ): MakaTool[] {
-  const builtins = builtinOptions ? buildBuiltinTools(builtinOptions) : [];
+  const projectedBuiltinOptions =
+    builtinOptions && permissionMode !== undefined
+      ? { ...builtinOptions, declareSandboxBoundary: permissionMode !== 'bypass' }
+      : builtinOptions;
+  const builtins = projectedBuiltinOptions ? buildBuiltinTools(projectedBuiltinOptions) : [];
   const question = buildAskUserQuestionTool();
-  const sandboxBoundary = buildRequestSandboxBoundaryTool();
+  const sandboxBoundaryTools =
+    permissionMode === 'bypass' ? [] : [buildRequestSandboxBoundaryTool()];
   const todoTools = buildSessionTodoTools(sessionTodo);
   const activeExecution = plan ? activePlanExecution(plan.state) : undefined;
   const interruptedExecution = plan
@@ -570,7 +577,7 @@ function buildDefaultHostTools(
     ...builtins.map((tool) => tool.name),
     ...hostTools.map((tool) => tool.name),
     question.name,
-    sandboxBoundary.name,
+    ...sandboxBoundaryTools.map((tool) => tool.name),
     'Skill',
     'SkillSearch',
     ...todoTools.map((tool) => tool.name),
@@ -586,7 +593,7 @@ function buildDefaultHostTools(
     ...builtins,
     ...hostTools,
     question,
-    sandboxBoundary,
+    ...sandboxBoundaryTools,
     buildSkillAgentToolFromInventory(inventoryFor, skillHost, { shadowTracker }),
     buildSkillSearchAgentToolFromInventory(inventoryFor, skillHost, { shadowTracker }),
     ...todoTools,

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -272,6 +272,26 @@ describe('builtin Bash projection and shell execution', () => {
     );
   });
 
+  test('executor Bash omits boundary declarations only when the host disables them', () => {
+    const schemaKeys = (declareSandboxBoundary?: boolean): string[] => {
+      const options = {
+        ...(declareSandboxBoundary === undefined ? {} : { declareSandboxBoundary }),
+      };
+      const bash = buildBuiltinTools(options).find((tool) => tool.name === 'Bash');
+      if (!bash) throw new Error('Bash tool missing');
+      const schema = z.toJSONSchema(bash.parameters as z.ZodTypeAny);
+      return Object.keys(schema.properties ?? {});
+    };
+
+    assert.deepStrictEqual(schemaKeys(), [
+      'command',
+      'timeout_ms',
+      'boundary_intent',
+      'required_boundary',
+    ]);
+    assert.deepStrictEqual(schemaKeys(false), ['command', 'timeout_ms']);
+  });
+
   test('executor Bash executes with the same shell it declares', async () => {
     // /bin/echo stands in for pwsh.exe: if the shell reaches the local
     // executor's spawn, stdout echoes the PowerShell flags and wrapper instead
@@ -468,6 +488,38 @@ describe('builtin Bash streaming output', () => {
     );
     assert.match(modelVisibleSchema, /loopback connection, or listener/);
     assert.match(modelVisibleSchema, /Omit for offline commands and tests/);
+  });
+
+  test('managed Bash omits boundary declarations only when the host disables them', () => {
+    const shellRuns: ShellRunLauncher = {
+      runForegroundBash: () => Promise.reject(new Error('not used')),
+      runBackgroundBash: () => Promise.reject(new Error('not used')),
+    };
+    const schemaKeys = (declareSandboxBoundary?: boolean): string[] => {
+      const options = {
+        shellRuns,
+        ...(declareSandboxBoundary === undefined ? {} : { declareSandboxBoundary }),
+      };
+      const bash = buildBuiltinTools(options).find((tool) => tool.name === 'Bash');
+      if (!bash) throw new Error('Bash tool missing');
+      const schema = z.toJSONSchema(bash.parameters as z.ZodTypeAny);
+      return Object.keys(schema.properties ?? {});
+    };
+
+    assert.deepStrictEqual(schemaKeys(), [
+      'command',
+      'timeout_ms',
+      'run_in_background',
+      'pty',
+      'boundary_intent',
+      'required_boundary',
+    ]);
+    assert.deepStrictEqual(schemaKeys(false), [
+      'command',
+      'timeout_ms',
+      'run_in_background',
+      'pty',
+    ]);
   });
 
   test('background-capable Bash stays foreground unless explicitly requested', async () => {

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -292,6 +292,28 @@ describe('builtin Bash projection and shell execution', () => {
     assert.deepStrictEqual(schemaKeys(false), ['command', 'timeout_ms']);
   });
 
+  test('executor Bash strips historical boundary keys only when declarations are disabled', () => {
+    const input = { command: 'pwd', boundary_intent: 'out-of-scope', required_boundary: {} };
+    for (const declareSandboxBoundary of [false, true]) {
+      const bash = buildBuiltinTools({ declareSandboxBoundary }).find(
+        ({ name }) => name === 'Bash',
+      )!;
+      const schema = bash.parameters as z.ZodTypeAny;
+      if (declareSandboxBoundary) {
+        assert.equal(schema.safeParse(input).success, false);
+        assert.equal(schema.safeParse({ command: 'pwd' }).success, true);
+      } else {
+        assert.deepEqual(schema.parse(input), { command: 'pwd' });
+        assert.equal(schema.safeParse({ ...input, unexpected: true }).success, false);
+        assert.deepEqual(input, {
+          command: 'pwd',
+          boundary_intent: 'out-of-scope',
+          required_boundary: {},
+        });
+      }
+    }
+  });
+
   test('executor Bash executes with the same shell it declares', async () => {
     // /bin/echo stands in for pwsh.exe: if the shell reaches the local
     // executor's spawn, stdout echoes the PowerShell flags and wrapper instead
@@ -520,6 +542,32 @@ describe('builtin Bash streaming output', () => {
       'run_in_background',
       'pty',
     ]);
+  });
+
+  test('managed Bash strips historical boundary keys only when declarations are disabled', () => {
+    const shellRuns: ShellRunLauncher = {
+      runForegroundBash: () => Promise.reject(new Error('not used')),
+      runBackgroundBash: () => Promise.reject(new Error('not used')),
+    };
+    const input = { command: 'pwd', boundary_intent: 'out-of-scope', required_boundary: {} };
+    for (const declareSandboxBoundary of [false, true]) {
+      const bash = buildBuiltinTools({ shellRuns, declareSandboxBoundary }).find(
+        ({ name }) => name === 'Bash',
+      )!;
+      const schema = bash.parameters as z.ZodTypeAny;
+      if (declareSandboxBoundary) {
+        assert.equal(schema.safeParse(input).success, false);
+        assert.equal(schema.safeParse({ command: 'pwd' }).success, true);
+      } else {
+        assert.deepEqual(schema.parse(input), { command: 'pwd' });
+        assert.equal(schema.safeParse({ ...input, unexpected: true }).success, false);
+        assert.deepEqual(input, {
+          command: 'pwd',
+          boundary_intent: 'out-of-scope',
+          required_boundary: {},
+        });
+      }
+    }
   });
 
   test('background-capable Bash stays foreground unless explicitly requested', async () => {

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -92,6 +92,7 @@ import {
   refineBashBoundaryDeclaration,
   sandboxBoundaryExpansionSchema,
   selectedBashBoundaryExpansion,
+  stripHistoricalBashBoundaryFields,
 } from './sandbox-boundary-declaration.js';
 
 // Generous wall-clock cap for the ripgrep-backed Grep tool. A search should be
@@ -707,16 +708,7 @@ function buildExecutorBashTool(
             .strict()
             .superRefine(refineBashBoundaryDeclaration),
         )
-      : z.preprocess((input) => {
-          // Historical calls may retain boundary fields after a session mode switch.
-          if (typeof input !== 'object' || input === null || Array.isArray(input)) return input;
-          const {
-            boundary_intent: _intent,
-            required_boundary: _boundary,
-            ...fields
-          } = input as Record<string, unknown>;
-          return fields;
-        }, z.object(executorBashFields).strict()),
+      : z.preprocess(stripHistoricalBashBoundaryFields, z.object(executorBashFields).strict()),
     toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     executionFacts: executor.facts,
     impl: async (input, ctx) => {

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -707,7 +707,16 @@ function buildExecutorBashTool(
             .strict()
             .superRefine(refineBashBoundaryDeclaration),
         )
-      : z.object(executorBashFields).strict(),
+      : z.preprocess((input) => {
+          // Historical calls may retain boundary fields after a session mode switch.
+          if (typeof input !== 'object' || input === null || Array.isArray(input)) return input;
+          const {
+            boundary_intent: _intent,
+            required_boundary: _boundary,
+            ...fields
+          } = input as Record<string, unknown>;
+          return fields;
+        }, z.object(executorBashFields).strict()),
     toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     executionFacts: executor.facts,
     impl: async (input, ctx) => {

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -180,6 +180,8 @@ export interface BuildBuiltinToolsOptions {
   shellEnvironment?: Readonly<Record<string, string>>;
   permissionProfile?: PermissionProfile;
   sandboxManager?: SandboxManager;
+  /** Whether Bash should expose declarations for a host-enforced sandbox boundary. */
+  declareSandboxBoundary?: boolean;
   /** Sandboxed worker used for all local filesystem tools. */
   filesystemWorker?: Pick<FilesystemWorkerClient, 'execute'>;
   /** Test/embedding override. Production callers use the current process platform. */
@@ -299,6 +301,9 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         buildManagedBashTool(options.shellRuns, {
           executionFacts,
           shell,
+          ...(options.declareSandboxBoundary === undefined
+            ? {}
+            : { declareSandboxBoundary: options.declareSandboxBoundary }),
           ...(options.sandboxManager
             ? {
                 transformCommand: ({ command, pty, requiredBoundary, ctx }) => {
@@ -337,6 +342,9 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         buildExecutorBashTool(executor, shell, {
           ...(options.permissionProfile ? { permissionProfile: options.permissionProfile } : {}),
           ...(options.sandboxManager ? { sandboxManager: options.sandboxManager } : {}),
+          ...(options.declareSandboxBoundary === undefined
+            ? {}
+            : { declareSandboxBoundary: options.declareSandboxBoundary }),
           sandboxPlatform,
         }),
       ];
@@ -667,6 +675,7 @@ interface ExecutorBashSandboxOptions {
   permissionProfile?: PermissionProfile;
   sandboxManager?: SandboxManager;
   sandboxPlatform: SandboxPlatform;
+  declareSandboxBoundary?: boolean;
 }
 
 function buildExecutorBashTool(
@@ -674,25 +683,31 @@ function buildExecutorBashTool(
   shell: TurnShellPlan,
   sandboxOptions: ExecutorBashSandboxOptions,
 ): MakaTool {
+  const declareSandboxBoundary = sandboxOptions.declareSandboxBoundary !== false;
+  const executorBashFields = {
+    command: z.string().describe('The shell command to execute'),
+    timeout_ms: z.number().int().positive().max(600_000).optional(),
+  };
   return {
     name: 'Bash',
     activityKind: 'command',
     description:
       withTurnShellGuidance('Run a shell command in the session cwd.', shell) +
-      ' Enforced by the current session sandbox boundary.',
-    parameters: preprocessBashBoundaryDeclaration(
-      z
-        .object({
-          command: z.string().describe('The shell command to execute'),
-          timeout_ms: z.number().int().positive().max(600_000).optional(),
-          boundary_intent: bashBoundaryIntentSchema,
-          required_boundary: sandboxBoundaryExpansionSchema
-            .optional()
-            .describe(BASH_REQUIRED_BOUNDARY_DESCRIPTION),
-        })
-        .strict()
-        .superRefine(refineBashBoundaryDeclaration),
-    ),
+      (declareSandboxBoundary ? ' Enforced by the current session sandbox boundary.' : ''),
+    parameters: declareSandboxBoundary
+      ? preprocessBashBoundaryDeclaration(
+          z
+            .object({
+              ...executorBashFields,
+              boundary_intent: bashBoundaryIntentSchema,
+              required_boundary: sandboxBoundaryExpansionSchema
+                .optional()
+                .describe(BASH_REQUIRED_BOUNDARY_DESCRIPTION),
+            })
+            .strict()
+            .superRefine(refineBashBoundaryDeclaration),
+        )
+      : z.object(executorBashFields).strict(),
     toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     executionFacts: executor.facts,
     impl: async (input, ctx) => {

--- a/packages/runtime/src/sandbox-boundary-declaration.ts
+++ b/packages/runtime/src/sandbox-boundary-declaration.ts
@@ -107,6 +107,17 @@ export function preprocessBashBoundaryDeclaration<T extends z.ZodType>(schema: T
   return z.preprocess(dropInactiveBashBoundaryDeclaration, schema);
 }
 
+/** Removes declaration-only fields from a Bash call whose active schema omits them. */
+export function stripHistoricalBashBoundaryFields(value: unknown): unknown {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return value;
+  const {
+    boundary_intent: _intent,
+    required_boundary: _boundary,
+    ...fields
+  } = value as Record<string, unknown>;
+  return fields;
+}
+
 function dropInactiveBashBoundaryDeclaration(value: unknown): unknown {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return value;
   const input = value as Record<string, unknown>;

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -75,6 +75,7 @@ import {
   refineBashBoundaryDeclaration,
   sandboxBoundaryExpansionSchema,
   selectedBashBoundaryExpansion,
+  stripHistoricalBashBoundaryFields,
 } from './sandbox-boundary-declaration.js';
 
 export interface ForegroundBashExecuteInput {
@@ -282,16 +283,10 @@ export function buildManagedBashTool(
             .superRefine(refineManagedBash)
             .superRefine(refineBashBoundaryDeclaration),
         )
-      : z.preprocess((input) => {
-          // Historical calls may retain boundary fields after a session mode switch.
-          if (typeof input !== 'object' || input === null || Array.isArray(input)) return input;
-          const {
-            boundary_intent: _intent,
-            required_boundary: _boundary,
-            ...fields
-          } = input as Record<string, unknown>;
-          return fields;
-        }, z.object(managedBashFields).strict().superRefine(refineManagedBash)),
+      : z.preprocess(
+          stripHistoricalBashBoundaryFields,
+          z.object(managedBashFields).strict().superRefine(refineManagedBash),
+        ),
     toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
     impl: async (input, ctx) => {

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -282,7 +282,16 @@ export function buildManagedBashTool(
             .superRefine(refineManagedBash)
             .superRefine(refineBashBoundaryDeclaration),
         )
-      : z.object(managedBashFields).strict().superRefine(refineManagedBash),
+      : z.preprocess((input) => {
+          // Historical calls may retain boundary fields after a session mode switch.
+          if (typeof input !== 'object' || input === null || Array.isArray(input)) return input;
+          const {
+            boundary_intent: _intent,
+            required_boundary: _boundary,
+            ...fields
+          } = input as Record<string, unknown>;
+          return fields;
+        }, z.object(managedBashFields).strict().superRefine(refineManagedBash)),
     toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
     impl: async (input, ctx) => {


### PR DESCRIPTION
## Summary

- expose the existing Bash boundary-declaration switch through `BuildBuiltinToolsOptions` for both managed and executor-backed Bash
- project the default interactive tool surface from the session permission mode
- omit Bash boundary declarations and `request_sandbox_boundary` under Full access while preserving the existing Auto behavior

The change is limited to the provider-facing tool surface. It does not alter execution-boundary refresh or sandbox enforcement. Child sessions are projected from their own Session header (see Child-session projection below); the startup catalog composition has no Session header and stays fail-closed.

Fixes #4859

### Child-session projection

Concrete child activations now rebuild their bound builtin tool surface from the child Session header's effective permission mode. A bypass child receives the four-field Bash schema without boundary-negotiation wording, while ask and explore retain the declared-boundary schema. The startup catalog composition intentionally remains fail-closed: it has no Session header and is used only to construct the directory-level child capability union and parent definitions.

### Review follow-ups

The permission-mode projection preserves an explicit `declareSandboxBoundary` caller value instead of overwriting it. Historical `boundary_intent` and `required_boundary` stripping is shared by executor and managed Bash. The interactive composer derives one effective permission mode and uses it consistently for builtin projection, collaboration tool selection, and Plan-mode prompt rendering.

### Additional validation

A deterministic execution-level regression invokes the projected four-field child Bash under a managed boundary, verifies that no expansion request is issued, confirms that command sandbox transformation is reached, and observes a typed sandbox denial. This test uses a stubbed shell launcher rather than a provider-to-real-OS child-session path.

## Verification

Original patch:

- Red regression run: 67 tests, 64 passed and 3 failed on the unpatched behavior (managed Bash, executor Bash, and interactive Full access projection).
- Green targeted run: 67/67 passed.
- `@maka/runtime` full suite: 3,228 tests; 3,215 passed, 13 skipped, 0 failed.
- `@maka/runtime-host` full suite: 1,711 tests; 1,699 passed, 12 skipped, 0 failed.

Review follow-up (rebased onto `12d3fb93`, 2026-09-12):

- Red: each of the three new regressions fails on the previous head (child bypass exposed six fields; ask overwrote an explicit `false`; Plan-mode selection dropped Bash under a top-level bypass).
- Targeted set (3 files): 116/116.
- `@maka/runtime` full suite: 3,435 tests; 3,422 passed, 13 skipped, 0 failed.
- `@maka/runtime-host` full suite: 1,871 tests; 1,859 passed, 12 skipped, 0 failed.
- Build, format check, lint, typecheck and `git diff --check` passed.
- Full repository build passed.
- Format, lint, and typecheck passed.
- Production TUI capture with `gpt-6-astra`:
  - Auto: Bash had six fields and the sandbox-enforcement description.
  - Full access: Bash had four fields and no sandbox-enforcement description.
  - Auto again: the six fields and description returned.
  - All three `Run pwd` turns completed successfully. The ledger recorded bypass revision 1 and managed revision 2 after switching back.

The provider request shaper did not directly advertise `request_sandbox_boundary` in either Auto capture; the composer-level regression test therefore verifies its permission-mode projection directly (`ask`/`explore`: present, `bypass`: absent).

## Security

This only narrows the model-visible tool surface when the authoritative session mode is already Full access. It does not grant permission, bypass a sandbox, widen filesystem or network authority, or change execution behavior. Auto keeps its existing boundary declaration and negotiation surface.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex-family model via pi; human-reviewed. The model assisted with source tracing, implementation, regression tests, verification, and draft text.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No


