### PR TITLE
fix(ci): guard stale allowScripts entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
       - name: Test script entrypoint contracts
         run: node --test scripts/script-entrypoints.test.mjs
 
+      - name: Test the allowScripts gate
+        run: node --test --test-concurrency=1 scripts/check-allow-scripts.test.mjs
+
       # The packaged Windows lane drives the updater through this wiring. It
       # is a few lines, so it is asserted here on every change rather than by
       # naming its module in that lane's 25-minute path filter.
@@ -159,8 +162,11 @@ jobs:
           node-version: '24'
           cache: npm
 
-      - name: Select the release npm toolchain
-        if: steps.plan.outputs.cli_package == 'true'
+      # The allowScripts gate delegates package identity and install-script
+      # detection to npm itself, so install lanes select packageManager rather
+      # than inheriting whichever npm minor happens to ship with Node 24.
+      - name: Select the repository npm toolchain
+        if: steps.plan.outputs.code == 'true' || steps.plan.outputs.astryx_surface == 'true' || steps.plan.outputs.asf_source == 'true' || steps.plan.outputs.cli_package == 'true' || steps.plan.outputs.release_contract == 'true'
         run: npm install --global --no-audit --no-fund "$(node -p 'require("./package.json").packageManager')"
 
       - name: Restore Electron artifact cache
@@ -190,6 +196,10 @@ jobs:
       - name: Install dependencies
         if: steps.plan.outputs.code == 'true' || steps.plan.outputs.astryx_surface == 'true' || steps.plan.outputs.asf_source == 'true' || steps.plan.outputs.cli_package == 'true' || steps.plan.outputs.release_contract == 'true'
         run: npm ci
+
+      - name: Check the install-script allowlist
+        if: steps.plan.outputs.code == 'true' || steps.plan.outputs.astryx_surface == 'true' || steps.plan.outputs.asf_source == 'true' || steps.plan.outputs.cli_package == 'true' || steps.plan.outputs.release_contract == 'true'
+        run: npm run check:allow-scripts
 
       - name: Check localized TUI copy boundaries
         if: steps.plan.outputs.code == 'true'

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "build:test": "npm run clean && npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/mcp run build && npm --workspace @maka/runtime run build && npm --workspace @maka/runtime-host run build && npm --workspace @maka/computer-use run build && npm --workspace @maka/eval run build && npm --workspace maka-agent run build && npm --workspace @maka/ui run build && npm --workspace @maka/desktop run build:test",
     "clean": "node scripts/clean-build.mjs",
     "rebuild": "npm run clean && npm run build",
+    "check:allow-scripts": "node scripts/check-allow-scripts.mjs",
     "check:stale": "node scripts/check-stale-dist.mjs",
     "generate:third-party-notices": "node scripts/generate-third-party-notices.mjs",
     "check:third-party-notices": "node scripts/generate-third-party-notices.mjs --check",
@@ -123,8 +124,8 @@
     "yaml": "2.9.0"
   },
   "allowScripts": {
-    "esbuild@0.27.7": true,
-    "@jackwener/opencli@1.8.4": true,
+    "esbuild@0.28.2": true,
+    "@jackwener/opencli@1.8.7": true,
     "node-pty@1.2.0-beta.15": true
   },
   "overrides": {

--- a/scripts/check-allow-scripts.mjs
+++ b/scripts/check-allow-scripts.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { npmSpawnOptions } from './npm-spawn.mjs';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const pruneArgs = ['install-scripts', 'prune', '--dry-run', '--json'];
+
+/**
+ * Resolve the npm CLI that launched this script so the check uses the exact
+ * packageManager version selected by the caller. Direct `node` invocations
+ * fall back to the npm executable on PATH.
+ */
+export function npmInvocation({ npmExecPath, execPath = process.execPath } = {}) {
+  if (npmExecPath) {
+    return { command: execPath, args: [npmExecPath, ...pruneArgs] };
+  }
+  return { command: 'npm', args: pruneArgs };
+}
+
+/** Parse npm 11.19's stable JSON result and reject incomplete output. */
+export function parsePruneReport(stdout) {
+  let document;
+  try {
+    document = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error('npm install-scripts prune did not return valid JSON.', { cause: error });
+  }
+
+  const report = document?.allowScripts;
+  if (!report || !Array.isArray(report.removed) || report.dryRun !== true) {
+    throw new Error('npm install-scripts prune returned an unexpected JSON shape.');
+  }
+
+  for (const entry of report.removed) {
+    if (
+      !entry ||
+      typeof entry.key !== 'string' ||
+      typeof entry.value !== 'boolean' ||
+      !['not-installed', 'no-scripts'].includes(entry.reason)
+    ) {
+      throw new Error('npm install-scripts prune returned an invalid removed entry.');
+    }
+  }
+  return report;
+}
+
+/** Run npm's own policy matcher against the installed dependency tree. */
+export function inspectAllowScripts({
+  cwd = root,
+  env = process.env,
+  execPath = process.execPath,
+  platform = process.platform,
+  spawn = spawnSync,
+} = {}) {
+  const invocation = npmInvocation({
+    npmExecPath: env.npm_execpath,
+    execPath,
+  });
+  const options = {
+    cwd,
+    encoding: 'utf8',
+    env: { ...env, npm_config_update_notifier: 'false' },
+  };
+  const result = spawn(
+    invocation.command,
+    invocation.args,
+    env.npm_execpath ? options : npmSpawnOptions(options, platform),
+  );
+
+  if (result.error) {
+    throw new Error(`Could not start npm install-scripts prune: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
+  if (result.status !== 0) {
+    const details = [result.stderr, result.stdout]
+      .filter((value) => typeof value === 'string' && value.trim() !== '')
+      .map((value) => value.trim())
+      .join('\n');
+    throw new Error(
+      ['npm install-scripts prune failed. Use the npm version declared in package.json.', details]
+        .filter(Boolean)
+        .join('\n'),
+    );
+  }
+
+  return parsePruneReport(result.stdout);
+}
+
+/** Fail CI when npm says any approval or denial no longer applies. */
+export function assertNoUnusedEntries(report) {
+  if (report.removed.length === 0) return;
+
+  const descriptions = report.removed.map(({ key, reason }) => {
+    const detail =
+      reason === 'no-scripts' ? 'package has no install scripts' : 'package not installed';
+    return `  ${key} (${detail})`;
+  });
+  throw new Error(
+    [
+      `${report.removed.length} unused allowScripts entr${report.removed.length === 1 ? 'y' : 'ies'}:`,
+      ...descriptions,
+      'Review the dependency scripts, then update or remove these policy entries.',
+    ].join('\n'),
+  );
+}
+
+export function checkAllowScripts(options) {
+  const report = inspectAllowScripts(options);
+  assertNoUnusedEntries(report);
+  return report;
+}
+
+function main() {
+  try {
+    checkAllowScripts();
+    console.log('All allowScripts entries match installed packages with install scripts.');
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-allow-scripts.test.mjs
+++ b/scripts/check-allow-scripts.test.mjs
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  assertNoUnusedEntries,
+  inspectAllowScripts,
+  npmInvocation,
+  parsePruneReport,
+} from './check-allow-scripts.mjs';
+
+const cleanOutput = JSON.stringify({
+  allowScripts: { removed: [], dryRun: true },
+});
+
+test('uses the npm CLI that launched the package script', () => {
+  assert.deepEqual(
+    npmInvocation({ npmExecPath: '/tools/npm-cli.js', execPath: '/tools/node', platform: 'linux' }),
+    {
+      command: '/tools/node',
+      args: ['/tools/npm-cli.js', 'install-scripts', 'prune', '--dry-run', '--json'],
+    },
+  );
+});
+
+test('falls back to npm on PATH for direct node runs', () => {
+  assert.deepEqual(npmInvocation(), {
+    command: 'npm',
+    args: ['install-scripts', 'prune', '--dry-run', '--json'],
+  });
+});
+
+test('parses a dry-run prune report', () => {
+  assert.deepEqual(parsePruneReport(cleanOutput), { removed: [], dryRun: true });
+});
+
+test('rejects malformed or mutating prune output', () => {
+  assert.throws(() => parsePruneReport('not json'), /did not return valid JSON/);
+  assert.throws(
+    () => parsePruneReport(JSON.stringify({ allowScripts: { removed: [], dryRun: false } })),
+    /unexpected JSON shape/,
+  );
+  assert.throws(
+    () =>
+      parsePruneReport(
+        JSON.stringify({
+          allowScripts: {
+            removed: [{ key: 'pkg@1.0.0', value: true, reason: 'unexpected' }],
+            dryRun: true,
+          },
+        }),
+      ),
+    /invalid removed entry/,
+  );
+});
+
+test('runs npm in dry-run mode without mutating package.json', () => {
+  const calls = [];
+  const report = inspectAllowScripts({
+    cwd: '/workspace',
+    env: { npm_execpath: '/tools/npm-cli.js' },
+    execPath: '/tools/node',
+    platform: 'linux',
+    spawn(command, args, options) {
+      calls.push({ command, args, options });
+      return { status: 0, stdout: cleanOutput, stderr: '' };
+    },
+  });
+
+  assert.deepEqual(report, { removed: [], dryRun: true });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, '/tools/node');
+  assert.deepEqual(calls[0].args, [
+    '/tools/npm-cli.js',
+    'install-scripts',
+    'prune',
+    '--dry-run',
+    '--json',
+  ]);
+  assert.equal(calls[0].options.cwd, '/workspace');
+  assert.equal(calls[0].options.env.npm_config_update_notifier, 'false');
+  assert.equal(calls[0].options.shell, undefined);
+});
+
+test('uses the repository npm shell rule for direct Windows runs', () => {
+  const calls = [];
+  inspectAllowScripts({
+    env: {},
+    platform: 'win32',
+    spawn(command, args, options) {
+      calls.push({ command, args, options });
+      return { status: 0, stdout: cleanOutput, stderr: '' };
+    },
+  });
+
+  assert.equal(calls[0].command, 'npm');
+  assert.equal(calls[0].options.shell, true);
+});
+
+test('surfaces npm failures with the required-toolchain guidance', () => {
+  assert.throws(
+    () =>
+      inspectAllowScripts({
+        env: {},
+        platform: 'linux',
+        spawn() {
+          return { status: 1, stdout: '', stderr: 'Unknown command: install-scripts' };
+        },
+      }),
+    /Use the npm version declared in package\.json\.\nUnknown command: install-scripts/,
+  );
+});
+
+test('reports every unused approval and denial', () => {
+  assert.throws(
+    () =>
+      assertNoUnusedEntries({
+        removed: [
+          { key: 'esbuild@0.27.7', value: true, reason: 'not-installed' },
+          { key: 'old-denial', value: false, reason: 'no-scripts' },
+        ],
+        dryRun: true,
+      }),
+    (error) => {
+      assert.match(error.message, /2 unused allowScripts entries/);
+      assert.match(error.message, /esbuild@0\.27\.7 \(package not installed\)/);
+      assert.match(error.message, /old-denial \(package has no install scripts\)/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Refresh the stale `allowScripts` pins for `esbuild` and `@jackwener/opencli`.
- Add a CI guard that fails when npm reports unused `allowScripts` approvals or denials.
- Delegate package identity and install-script detection to npm 11.19's `install-scripts prune --dry-run --json` instead of duplicating npm's matching rules.
- Select the repository's declared npm version before dependency installation so the check uses consistent semantics.

This PR covers the confirmed stale-policy guard. It does not approve or deny the remaining packages with unreviewed install scripts.

Refs #4374

## Verification

Passed:

- `npx --yes npm@11.19.0 run check:allow-scripts`
- `node --test --test-concurrency=1 scripts/check-allow-scripts.test.mjs`
- Affected CI and release workflow policy tests
- `npx --yes npm@11.19.0 run lint`
- `npx --yes npm@11.19.0 run format:check`
- `npx --yes npm@11.19.0 run check:asf-npm`
- `npm run check:asf-headers`

Not run:

- Full build and typecheck, because this change does not modify application, TypeScript, or Rust code.

## Security

The updated install-script pins were reviewed before approval:

- `esbuild@0.28.2` retains the existing postinstall entry and adds integrity verification for fallback binary downloads.
- The relevant postinstall files in `@jackwener/opencli@1.8.7` are byte-identical to those in the previously approved `1.8.4` release.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex assisted with implementation, tests, CI integration, npm 11.19 behavior research, and install-script review.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No