### PR TITLE
fix(storage): reclaim the bytes the v1 upgrade orphaned

### DIFF
--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1755,6 +1755,15 @@ export async function createExecutionRuntimeHostComposition(
         recovery: {
           state: async () => {
             await skills.recover();
+            try {
+              await openedArtifactStore.reclaimUpgradeResidue();
+            } catch (error) {
+              // Leftover bytes are not worth refusing to start over; the next
+              // start tries again.
+              console.error(
+                `[runtime-host] upgrade residue could not be reclaimed: ${generalizedErrorMessage(error)}`,
+              );
+            }
           },
         },
         drain: [

--- a/packages/storage/src/__tests__/artifact-stores.test.ts
+++ b/packages/storage/src/__tests__/artifact-stores.test.ts
@@ -135,6 +135,114 @@ describe('interactive artifact store authority', () => {
     });
   });
 
+  test('reclaims the bytes the v1 upgrade orphaned, including a user-deleted upload', async () => {
+    await withInteractiveOwner(async (owner, root, track) => {
+      const initial = await openInteractiveArtifactStoreForWrite(owner.lease);
+      initial.close();
+      const db = new DatabaseSync(join(root, 'runtime.sqlite'));
+      db.exec(`
+        DROP TABLE artifact_records;
+        CREATE TABLE artifact_records (
+          storage_key TEXT PRIMARY KEY, artifact_id TEXT NOT NULL,
+          session_id TEXT NOT NULL, created_at INTEGER NOT NULL CHECK(created_at >= 0),
+          status TEXT NOT NULL CHECK(status IN ('live', 'deleted')),
+          relative_path TEXT NOT NULL, record_json TEXT NOT NULL
+        );
+        CREATE UNIQUE INDEX artifact_records_relative_path ON artifact_records(relative_path);
+        UPDATE operational_schema_migrations SET version = 1 WHERE scope = 'artifact';
+      `);
+      // One row per reason the upgrade drops one, each with bytes on disk.
+      const rows = [
+        { id: 'live', name: 'quarterly numbers.csv', status: 'live', source: 'user_upload' },
+        { id: 'erased', name: 'passport scan.pdf', status: 'deleted', source: 'user_upload' },
+        {
+          id: 'retired',
+          name: 'provider-request-step-4-cap.json',
+          status: 'live',
+          source: 'provider_request_capture',
+        },
+        { id: 'sourceless', name: 'recap-request.json', status: 'live', source: undefined },
+        { id: 'broken', name: 'unreadable.txt', status: 'live', source: 'tool_result' },
+        { id: 'mismatched', name: 'inconsistent.txt', status: 'live', source: 'tool_result' },
+        // Sorts first, and a directory cannot be unlinked, so it stands in for
+        // any leftover the store cannot remove.
+        { id: 'aborted', name: 'stuck', status: 'live', source: 'provider_request_capture' },
+      ];
+      await mkdir(join(root, 'artifacts', 'session-1'), { recursive: true });
+      for (const row of rows) {
+        const relativePath = `session-1/${row.id}-${row.name}`;
+        if (row.id === 'aborted') await mkdir(join(root, 'artifacts', relativePath));
+        else await writeFile(join(root, 'artifacts', relativePath), `bytes of ${row.id}`);
+        db.prepare('INSERT INTO artifact_records VALUES (?, ?, ?, ?, ?, ?, ?)').run(
+          row.id,
+          row.id,
+          'session-1',
+          1,
+          row.status,
+          relativePath,
+          row.id === 'broken'
+            ? '{'
+            : JSON.stringify({
+                id: row.id === 'mismatched' ? 'other-id' : row.id,
+                sessionId: 'session-1',
+                turnId: 'turn-1',
+                createdAt: 1,
+                name: row.name,
+                kind: 'file',
+                sizeBytes: `bytes of ${row.id}`.length,
+                relativePath,
+                ...(row.source ? { source: row.source } : {}),
+                status: row.status,
+              }),
+        );
+      }
+      db.close();
+
+      const store = track(await openInteractiveArtifactStoreForWrite(owner.lease));
+      // Re-creating a dropped record's exact path before the reclamation runs
+      // must keep the new bytes, not honour the note.
+      await store.create({
+        id: 'erased',
+        sessionId: 'session-1',
+        turnId: 'turn-2',
+        name: 'passport scan.pdf',
+        kind: 'file',
+        content: 'uploaded again',
+        source: 'user_upload',
+      });
+      await store.reclaimUpgradeResidue();
+      await store.reclaimUpgradeResidue();
+
+      const path = (id: string) =>
+        join(root, 'artifacts', `session-1/${id}-${rows.find((row) => row.id === id)!.name}`);
+      for (const id of ['retired', 'sourceless', 'broken', 'mismatched']) {
+        await assert.rejects(() => stat(path(id)), { code: 'ENOENT' });
+      }
+      assert.deepEqual(await store.readTextInSession('session-1', 'live'), {
+        ok: true,
+        text: 'bytes of live',
+      });
+      assert.deepEqual(await store.readTextInSession('session-1', 'erased'), {
+        ok: true,
+        text: 'uploaded again',
+      });
+      assert.equal((await stat(path('aborted'))).isDirectory(), true);
+      store.close();
+
+      // Everything behind the one that would not go was still reclaimed, and
+      // only its own note survives for a later attempt.
+      const remaining = new DatabaseSync(join(root, 'runtime.sqlite'), { readOnly: true });
+      assert.deepEqual(
+        remaining
+          .prepare('SELECT relative_path FROM artifact_upgrade_orphan_paths')
+          .all()
+          .map((row) => (row as { relative_path: string }).relative_path),
+        ['session-1/aborted-stuck'],
+      );
+      remaining.close();
+    });
+  });
+
   test('requires authentic leases and writer facades', async () => {
     await assert.rejects(
       () =>

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -182,6 +182,7 @@ export interface ArtifactAuthorityStore extends DurableArtifactAttachmentReader 
     input: ConversationArtifactCopyInput,
   ): Promise<ConversationArtifactCopyResult>;
   purgeSessionArtifacts(sessionId: string): Promise<void>;
+  reclaimUpgradeResidue(): Promise<void>;
   deleteOwnedArtifactInSession(
     sessionId: string,
     artifactId: string,
@@ -470,6 +471,43 @@ class SqliteArtifactStore implements ArtifactAuthorityStore {
       await this.purgeRecordsUnlocked(
         this.records.filter((record) => record.sessionId === sessionId),
       );
+    });
+  }
+
+  /**
+   * Deletes the files the v1 upgrade recorded as no longer named by any record.
+   *
+   * A path some record has since claimed keeps its bytes. A note is discharged
+   * once its file is gone, and a file that will not go keeps only its own note
+   * rather than holding up the ones behind it.
+   */
+  async reclaimUpgradeResidue(): Promise<void> {
+    await this.enqueueMutation(async () => {
+      await this.prepareMutationUnlocked();
+      const recorded = this.metadataRepository.readUpgradeOrphanPaths();
+      if (recorded.length === 0) return;
+      const claimed = new Set(this.records.map((record) => record.relativePath));
+      const directories = new Set<string>();
+      const discharged: string[] = [];
+      try {
+        for (const relativePath of recorded) {
+          if (claimed.has(relativePath) || !isSafeRelativeArtifactPath(relativePath)) {
+            discharged.push(relativePath);
+            continue;
+          }
+          const target = join(this.artifactRoot, relativePath);
+          try {
+            await unlink(target);
+            directories.add(dirname(target));
+          } catch (error) {
+            if (!isNotFound(error)) continue;
+          }
+          discharged.push(relativePath);
+        }
+      } finally {
+        for (const directory of directories) await syncDirectory(directory);
+      }
+      if (discharged.length > 0) this.metadataRepository.forgetUpgradeOrphanPaths(discharged);
     });
   }
 
@@ -1087,10 +1125,6 @@ function assertArtifactTurnKey(value: unknown): asserts value is string {
 
 const ARTIFACT_KIND_SET = new Set<ArtifactKind>(ARTIFACT_KINDS);
 const ARTIFACT_SOURCE_SET = new Set<ArtifactSource>(ARTIFACT_SOURCES);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 async function assertArtifactDirectory(artifactRoot: string, directory: string): Promise<void> {
   const root = await ensureRealDirectory(artifactRoot);

--- a/packages/storage/src/artifact-stores.ts
+++ b/packages/storage/src/artifact-stores.ts
@@ -72,6 +72,7 @@ export interface InteractiveArtifactStoreWriter extends DurableArtifactAttachmen
     input: ConversationArtifactCopyInput,
   ): Promise<ConversationArtifactCopyResult>;
   purgeSessionArtifacts(sessionId: string): Promise<void>;
+  reclaimUpgradeResidue(): Promise<void>;
   listPage: ArtifactAuthorityStore['listPage'];
   listTurnArtifacts: ArtifactAuthorityStore['listTurnArtifacts'];
   getInSession: ArtifactAuthorityStore['getInSession'];
@@ -177,6 +178,7 @@ function createWriterFacade(
       return run(() => store.copyConversationArtifacts(acceptedInput));
     },
     purgeSessionArtifacts: (sessionId) => run(() => store.purgeSessionArtifacts(sessionId)),
+    reclaimUpgradeResidue: () => run(() => store.reclaimUpgradeResidue()),
     deleteUserArtifactInSession: (sessionId, artifactId) =>
       run(() => store.deleteUserArtifactInSession(sessionId, artifactId)),
     close: () => {

--- a/packages/storage/src/sqlite-artifact-metadata.ts
+++ b/packages/storage/src/sqlite-artifact-metadata.ts
@@ -92,6 +92,24 @@ class SqliteArtifactMetadataRepository {
     });
   }
 
+  readUpgradeOrphanPaths(): string[] {
+    this.assertOpen();
+    const rows = this.#lease.database
+      .prepare('SELECT relative_path FROM artifact_upgrade_orphan_paths ORDER BY relative_path')
+      .all() as Array<{ relative_path: string }>;
+    return rows.map((row) => row.relative_path);
+  }
+
+  forgetUpgradeOrphanPaths(relativePaths: readonly string[]): void {
+    this.assertOpen();
+    this.#lease.transaction('write', () => {
+      const forget = this.#lease.database.prepare(
+        'DELETE FROM artifact_upgrade_orphan_paths WHERE relative_path = ?',
+      );
+      for (const relativePath of relativePaths) forget.run(relativePath);
+    });
+  }
+
   close(): void {
     if (this.#closed) return;
     this.#closed = true;

--- a/packages/storage/src/sqlite-artifact-schema.ts
+++ b/packages/storage/src/sqlite-artifact-schema.ts
@@ -18,7 +18,10 @@
  */
 
 import type { DatabaseSync } from 'node:sqlite';
-import { decodeArtifactRecordJsons } from './artifact-metadata-codec.js';
+import {
+  decodeArtifactRecordJsons,
+  isSafeRelativeArtifactPath,
+} from './artifact-metadata-codec.js';
 
 export const SQLITE_ARTIFACT_SCHEMA_VERSION = 3;
 
@@ -27,15 +30,21 @@ export function migrateSqliteArtifactDatabase(db: DatabaseSync): void {
     name?: unknown;
   }>;
   const retained: string[] = [];
-  if (columns.some(({ name }) => name === 'status' || name === 'storage_key')) {
+  // Every path the old table named. Whatever is not carried over is a file no
+  // catalog will name again, and this is the last moment anything knows it is
+  // there. Unlinking here is not an option: a rollback after one would be
+  // unrecoverable, so the paths are recorded for the store to reclaim later.
+  const scanned: string[] = [];
+  const hasStatusColumn = columns.some(({ name }) => name === 'status');
+  if (hasStatusColumn || columns.some(({ name }) => name === 'storage_key')) {
     const rows = db.prepare('SELECT * FROM artifact_records').all();
     for (const row of rows) {
-      if (columns.some(({ name }) => name === 'status') && row.status !== 'live') continue;
+      if (typeof row.relative_path === 'string' && isSafeRelativeArtifactPath(row.relative_path)) {
+        scanned.push(row.relative_path);
+      }
       try {
         const parsed = JSON.parse(String(row.record_json));
         if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
-        if (parsed.status !== undefined && parsed.status !== 'live') continue;
-        delete parsed.status;
         if (
           parsed.id !== row.artifact_id ||
           parsed.sessionId !== row.session_id ||
@@ -43,6 +52,13 @@ export function migrateSqliteArtifactDatabase(db: DatabaseSync): void {
           parsed.relativePath !== row.relative_path
         )
           continue;
+        if (
+          [hasStatusColumn ? row.status : undefined, parsed.status].some(
+            (value) => value !== undefined && value !== null && value !== 'live',
+          )
+        )
+          continue;
+        delete parsed.status;
         retained.push(JSON.stringify(parsed));
       } catch {}
     }
@@ -62,11 +78,22 @@ export function migrateSqliteArtifactDatabase(db: DatabaseSync): void {
 
     CREATE UNIQUE INDEX IF NOT EXISTS artifact_records_relative_path
       ON artifact_records(relative_path);
+
+    CREATE TABLE IF NOT EXISTS artifact_upgrade_orphan_paths (
+      relative_path TEXT PRIMARY KEY
+    );
   `);
+  const carried = decodeArtifactRecordJsons(retained);
+  const kept = new Set(carried.map((record) => record.relativePath));
+  const orphan = db.prepare(`
+    INSERT INTO artifact_upgrade_orphan_paths VALUES (?)
+    ON CONFLICT(relative_path) DO NOTHING
+  `);
+  for (const relativePath of scanned) if (!kept.has(relativePath)) orphan.run(relativePath);
   const insert = db.prepare(`
     INSERT INTO artifact_records VALUES (?, ?, ?, ?, ?)
   `);
-  for (const record of decodeArtifactRecordJsons(retained)) {
+  for (const record of carried) {
     insert.run(
       record.id,
       record.sessionId,


### PR DESCRIPTION
## Summary

#4808 left artifact bytes on disk with nothing pointing at them, and this reclaims them. It is the part of #4808 that PR could not finish, not a new mechanism.

Its v1 upgrade (`migrateSqliteArtifactDatabase`) rebuilds `artifact_records` by dropping the table and re-inserting whatever survives its own checks and `decodeArtifactRecordJsons`. Five kinds of row fail that gate, and each leaves its file behind:

| dropped because | where those files came from |
|---|---|
| `source` is no longer an artifact source | `provider_request_capture`, `history_compact_source`, `history_compact_block`, `synthesis_cache_block` — writers removed by #4722 and #3545, records never cleaned up |
| the record carries no `source` at all | the CLI `/recap` snapshot never passed one |
| `status` is not `live` | a user-deleted upload, whose bytes v1 deliberately kept for a sweep that no longer exists |
| `record_json` does not parse | corruption |
| the record disagrees with its own columns | inconsistency |

#4808 also removed the sweep that had been reclaiming the first group, which was self-consistent within that PR (the sweep found its work through the very records the upgrade drops, so it would have found nothing) but turns those bytes from *being reclaimed* into *staying forever*.

Dropping a row is the last moment anything knows where its bytes are — after the rebuild, no catalog can enumerate them, and a user's file has a user's name that no pattern could pick out of a directory. So the upgrade now records every path it does not carry over, in the same transaction that drops it. It cannot unlink there: it runs inside the `BEGIN IMMEDIATE` transaction `migrateOperationalStateDatabaseInternal` opens, where a rollback after a delete would be unrecoverable. `ArtifactStore` — still the only thing that deletes artifact bytes — drains the list on recovery, and a path some record has since claimed keeps its bytes.

Recording what the upgrade drops is exact where matching file names could only be a guess. Nothing scans the artifact tree, nothing is `stat`'d or resolved, so this does not go near the cold-start `realpath`/`lstat` walk of #4027; and nothing has to be kept in step with the writers that produced these files. It reaches malformed and inconsistent rows too, which a name-based pass could not have identified at all.

There is no sweeper and no timer. Steady state produces no orphans — `completePurgeUnlocked` removes bytes before metadata, so an interrupted purge leaves a record without bytes, never bytes without a record — and this residue has exactly one source, which is one-time. When the list is empty the reclamation returns immediately, and that is the whole record of having finished.

### Review focus

- **Capability given up: a store converted by an earlier build keeps its residue.** Its rows are already gone, so nothing anywhere still knows which files they named. That is the argument for landing this in the same release as the conversion; the conversion is not on the `nightly` channel.
- **A backup taken after the upgrade but before recovery carries the orphan bytes**, and restoring it brings them back with the list already drained. `operational-state-backup.ts` copies `artifacts/` wholesale. Those bytes are then unreclaimable, for the same reason as above.

## Verification

- `npm --workspace @maka/storage run build`, then `node --test --test-concurrency=4 "dist/**/*.test.js"` in `packages/storage` — 1109 pass, 8 skipped, 0 fail.
- `npm run format`, `npm run lint` — clean. `@maka/runtime-host` typecheck is clean for this change (it reports only the pre-existing `systeminformation` and `host-resource-collector.ts` errors present on `main`).
- On a copy of a real workspace that had never been upgraded, opening the store runs the upgrade and then the reclamation:

```
before: 3 rows | provider_request_capture=3
before: 3 files, 95K
after : 0 rows | -
after : 0 files, 0K
```

One test, verified to fail without the change, builds a real v1 table with one row per reason the upgrade drops one — retired source, absent source, tombstoned upload, unparseable JSON, record/column mismatch — and pins that each one's bytes go while a live upload's stay. It also re-creates a dropped record's exact path before the reclamation runs, to pin that the new bytes win over the note, and asserts the list is drained and a second call is a no-op.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — traced the residue to the upgrade's decode gate, enumerated the dropped kinds against each retired writer, wrote the reclamation, its test and this description, and ran the verification above. Reviewed and accepted by me.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
