### PR TITLE
test(eval): end live-proxy TLS at the local origin

### DIFF
--- a/packages/eval/harbor/egress-proxy/entrypoint.sh
+++ b/packages/eval/harbor/egress-proxy/entrypoint.sh
@@ -59,4 +59,5 @@ exec mitmdump \
   --set block_global=false \
   --set rawtcp=false \
   --set confdir="$STATE_DIR" \
-  --scripts /opt/maka-eval/egress_filter.py
+  --scripts /opt/maka-eval/egress_filter.py \
+  "$@"

--- a/packages/eval/harbor/test_egress_filter_live.py
+++ b/packages/eval/harbor/test_egress_filter_live.py
@@ -21,7 +21,8 @@ Unit tests cannot see addon order: script `next_layer` runs before the built-in
 classifier assigns `TCPLayer`. This test starts the pinned proxy image and a
 local origin, then asserts what a live cell would observe.
 
-It needs Docker, the pinned proxy image, and `python:3.12-slim`, so it is opt-in:
+It needs Docker, the pinned proxy image, `python:3.12-slim`, and `openssl`, so it is
+opt-in:
 
     MAKA_EVAL_EGRESS_PROXY_TEST=1 python3 harbor/test_egress_filter_live.py
 """
@@ -48,7 +49,7 @@ COMMAND_TIMEOUT_S = 60
 CLOSE_TIMEOUT_S = 2.0
 
 ORIGIN_SCRIPT = r"""
-import base64, hashlib, json, socket, threading
+import base64, hashlib, json, socket, ssl, threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 stats = {"raw_recv": 0, "raw_closed": 0, "upgrade_recv": 0, "upgrade_closed": 0}
@@ -139,6 +140,9 @@ threading.Thread(target=serve_raw, daemon=True).start()
 threading.Thread(target=lambda: ThreadingHTTPServer(("0.0.0.0", 19080), HttpHandler).serve_forever(), daemon=True).start()
 threading.Thread(target=lambda: ThreadingHTTPServer(("0.0.0.0", 19082), WsHandler).serve_forever(), daemon=True).start()
 threading.Thread(target=lambda: ThreadingHTTPServer(("0.0.0.0", 19083), UpgradeHandler).serve_forever(), daemon=True).start()
+tls = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER); tls.load_cert_chain("/origin/cert.pem", "/origin/key.pem")
+https = ThreadingHTTPServer(("0.0.0.0", 19443), HttpHandler); https.socket = tls.wrap_socket(https.socket, server_side=True)
+threading.Thread(target=https.serve_forever, daemon=True).start()
 ThreadingHTTPServer(("0.0.0.0", 19084), StatsHandler).serve_forever()
 """
 
@@ -336,6 +340,14 @@ class LiveEgressFilterTest(unittest.TestCase):
         cls.origin = f"maka-eval-egress-live-{run_id}-origin"
         cls.workdir = Path(tempfile.mkdtemp(prefix="maka-eval-egress-proxy-live-"))
         (cls.workdir / "origin.py").write_text(ORIGIN_SCRIPT)
+        # mitmproxy handshakes with the upstream before answering the client, so a
+        # public upstream made every TLS case depend on the runner's egress.
+        subprocess.run(
+            ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes", "-subj", "/CN=origin",
+             "-addext", "subjectAltName=DNS:origin",
+             "-keyout", str(cls.workdir / "key.pem"), "-out", str(cls.workdir / "cert.pem")],
+            check=True, capture_output=True, timeout=COMMAND_TIMEOUT_S,
+        )
         cls.addClassCleanup(shutil.rmtree, cls.workdir, ignore_errors=True)
         cls.addClassCleanup(cls._down)
         subprocess.run(["docker", "network", "create", cls.network], check=True, timeout=COMMAND_TIMEOUT_S)
@@ -351,10 +363,10 @@ class LiveEgressFilterTest(unittest.TestCase):
                 "--network-alias",
                 "origin",
                 "-v",
-                f"{cls.workdir / 'origin.py'}:/origin.py:ro",
+                f"{cls.workdir}:/origin:ro",
                 ORIGIN_IMAGE,
                 "python",
-                "/origin.py",
+                "/origin/origin.py",
             ],
             check=True,
             timeout=COMMAND_TIMEOUT_S,
@@ -372,7 +384,11 @@ class LiveEgressFilterTest(unittest.TestCase):
                 "127.0.0.1::8080",
                 "-v",
                 f"{HARBOR_DIR / 'egress_filter.py'}:/opt/maka-eval/egress_filter.py:ro",
+                "-v",
+                f"{cls.workdir / 'cert.pem'}:/opt/maka-eval/origin-ca.pem:ro",
                 PROXY_IMAGE,
+                "--set",
+                "ssl_verify_upstream_trusted_ca=/opt/maka-eval/origin-ca.pem",
             ],
             check=True,
             timeout=COMMAND_TIMEOUT_S,
@@ -507,7 +523,7 @@ class LiveEgressFilterTest(unittest.TestCase):
             incoming,
             outgoing,
             server_side=False,
-            server_hostname="example.com",
+            server_hostname="origin",
         )
         try:
             tls.do_handshake()
@@ -519,7 +535,7 @@ class LiveEgressFilterTest(unittest.TestCase):
 
         with socket.create_connection(("127.0.0.1", cls.proxy_port), 5) as sock:
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            sock.sendall(b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+            sock.sendall(b"CONNECT origin:19443 HTTP/1.1\r\nHost: origin:19443\r\n\r\n")
             header = b""
             while b"\r\n\r\n" not in header:
                 chunk = sock.recv(4096)
@@ -604,7 +620,7 @@ class LiveEgressFilterTest(unittest.TestCase):
                 "/dev/null",
                 "--write-out",
                 "%{http_code}",
-                "https://example.com/",
+                "https://origin:19443/",
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

The live Eval egress proxy test (`test_egress_filter_live.py`) intermittently fails with `TimeoutError` in `finish_memory_bio_handshake`, most recently in CI run 33966266753 on a PR that touches neither Eval nor the proxy.

Root cause: the fragmented-handshake and curl cases `CONNECT example.com:443`. mitmproxy completes the upstream TLS handshake before it answers the client's ClientHello, so whenever the runner's egress to example.com stalls mid-handshake, the client receives nothing for the full 20s deadline. The same step logged `Connection reset by peer` from PyPI, and the failing subtest (`first_fragment_size=3`) goes through mitmproxy's built-in classifier, not the code under test. #4488 rebound the recv clock to the deadline; this recurrence is a single recv that consumed the whole deadline, which that fix could not address.

The origin container now terminates TLS itself on 19443 with a self-signed certificate (SAN `DNS:origin`) issued by `openssl` at setup, the two TLS cases target `origin:19443`, and the proxy is started with `--set ssl_verify_upstream_trusted_ca` pointing at that certificate. `entrypoint.sh` passes extra `mitmdump` options through with `"$@"`; the production compose passes none, so the proxy behaves as before there. Upstream certificate verification stays on: dropping the trusted-CA option makes the curl case fail with `'502' != '200'`.

Refs #4240

## Verification

Before/after on the unmodified test vs this branch, both with the same fault injected (origin gets `--network-alias example.com` plus a listener on 443 that accepts and never speaks TLS, which is the failure shape from CI):

```text
  File ".../test_egress_filter_live.py", line 536, in fragmented_tls_via_proxy
    return finish_memory_bio_handshake(tls, incoming, outgoing, sock, timeout_s=20)
  File ".../test_egress_filter_live.py", line 181, in recv_within_deadline
    return sock.recv(16 * 1024)
TimeoutError: timed out
Ran 1 test in 62.095s
FAILED (errors=3)

test_fragmented_tls_record_prefix_still_handshakes ... ok
test_https_and_plain_http_still_forward ... ok
Ran 2 tests in 1.694s
OK
```

Full live suite on this branch (`MAKA_EVAL_EGRESS_PROXY_TEST=1 python3 harbor/test_egress_filter_live.py`, Docker 28.5.1, rebuilt proxy image): `Ran 8 tests in 4.783s OK`. `git diff --check` clean. Not run: the production compose path (`docker-compose-egress-proxy.yaml`), which does not pass arguments to the entrypoint.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code diagnosed the public-upstream dependency from the CI trace, wrote the fix and the before/after fault injection, and ran the live suite. The commit carries `Generated-by: Claude Code`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — test-only: the live suite no longer reaches the public internet; the proxy entrypoint accepts extra `mitmdump` options, which production does not pass
- [ ] No
