### PR TITLE
fix(desktop): keep "return to latest" at the tail

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -899,7 +899,7 @@
           "react": 1
         },
         "importSpecifiers": 124,
-        "nonTriviaTokens": 15588
+        "nonTriviaTokens": 15582
       },
       "src/renderer/use-app-shell-composer-quotes.ts": {
         "importDeclarations": 2,

--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -899,7 +899,7 @@
           "react": 1
         },
         "importSpecifiers": 124,
-        "nonTriviaTokens": 15582
+        "nonTriviaTokens": 15581
       },
       "src/renderer/use-app-shell-composer-quotes.ts": {
         "importDeclarations": 2,

--- a/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
@@ -31,7 +31,10 @@ import {
   createInitialAppShellSessionUiState,
   type AppShellSessionUiState,
 } from '../../renderer/app-shell-session-ui-state.js';
-import { transcriptReadingPosition } from '../../renderer/features/conversation/index.js';
+import {
+  transcriptReadingPosition,
+  type TranscriptHistoryGates,
+} from '../../renderer/features/conversation/index.js';
 
 function boundaryRequest(requestId: string): SandboxBoundaryRequestEvent {
   return {
@@ -58,6 +61,75 @@ function healthSnapshot(sessionId: string): SessionEventStreamSnapshot {
  *  looks like once its turn has produced a single event. */
 function answeredArm(turnId: string) {
   return confirmLiveTurn(armLiveTurn(turnId), turnId)!;
+}
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function deferredHistoryController() {
+  const before = deferred();
+  const latest = deferred();
+  const calls: string[] = [];
+  return {
+    controller: {
+      loadBefore: () => {
+        calls.push('before');
+        return before.promise;
+      },
+      loadLatest: () => {
+        calls.push('latest');
+        return latest.promise;
+      },
+    },
+    calls,
+    settleBefore: before.resolve,
+    settleLatest: latest.resolve,
+    failBefore: before.reject,
+  };
+}
+
+function crossSessionGateScenario() {
+  const gates: TranscriptHistoryGates = new WeakMap();
+  const sides = {
+    a: deferredHistoryController(),
+    b: deferredHistoryController(),
+  };
+  let active: 'a' | 'b' = 'a';
+  let range: object = sides.a.controller;
+  const pending = { a: [] as boolean[], b: [] as boolean[] };
+  const errors = { a: [] as unknown[], b: [] as unknown[] };
+  return {
+    sides,
+    pending,
+    errors,
+    switchTo(id: 'a' | 'b') {
+      active = id;
+      range = sides[id].controller;
+    },
+    load(
+      id: 'a' | 'b',
+      request: { target: 'earlier' | 'latest'; anchorTurnId?: string },
+    ) {
+      const side = sides[id];
+      // Detached: a late rejection belongs to its Session, not this await.
+      void transcriptReadingPosition.loadHistory({
+        gates,
+        request,
+        controller: side.controller,
+        maxBytes: 4096,
+        isCurrent: () => active === id && range === side.controller,
+        setPending: (value) => pending[id].push(value),
+        onError: (error) => errors[id].push(error),
+      }).catch(() => undefined);
+    },
+  };
 }
 
 function seededState(): AppShellSessionUiState {
@@ -440,6 +512,111 @@ describe('app shell session UI state controller', () => {
     assert.deepEqual(messages, [{ id: 'latest' }]);
     assert.deepEqual(anchorWrites, [undefined]);
     assert.deepEqual(unavailable, { sessionId: 'session', turnId: 'removed' });
+  });
+
+  it('starts another Session history load without waiting behind an in-flight load elsewhere', async () => {
+    const scenario = crossSessionGateScenario();
+    const stale = scenario.load('a', { target: 'earlier' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.sides.a.calls, ['before']);
+    assert.deepEqual(scenario.pending.a, [true]);
+
+    scenario.switchTo('b');
+    scenario.load('b', { target: 'latest' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.sides.b.calls, ['latest']);
+    assert.deepEqual(scenario.pending.b, [true]);
+  });
+
+  it('leaves the switched-to Session untouched when a stale Session load settles late', async () => {
+    const scenario = crossSessionGateScenario();
+    const stale = scenario.load('a', { target: 'earlier' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    scenario.switchTo('b');
+    scenario.load('b', { target: 'latest' });
+    scenario.sides.b.settleLatest();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.pending.b, [true, false]);
+    assert.deepEqual(scenario.sides.b.calls, ['latest']);
+
+    scenario.sides.a.settleBefore();
+    await stale;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.pending.b, [true, false]);
+    assert.deepEqual(scenario.sides.b.calls, ['latest']);
+    assert.deepEqual(scenario.errors.b, []);
+  });
+
+  it('reports a late history load failure to its own Session alone', async () => {
+    const scenario = crossSessionGateScenario();
+    const stale = scenario.load('a', { target: 'earlier' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    scenario.switchTo('b');
+    scenario.sides.a.failBefore(new Error('earlier read failed'));
+    await stale;
+    assert.deepEqual(scenario.errors.a, []);
+    assert.deepEqual(scenario.pending.a, [true, false]);
+    assert.deepEqual(scenario.pending.b, []);
+  });
+
+  it('replays the queued latest load once after an in-flight load settles on the same Session', async () => {
+    const scenario = crossSessionGateScenario();
+    scenario.load('a', { target: 'earlier' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    scenario.load('a', { target: 'earlier', anchorTurnId: 'turn-anchor' });
+    scenario.load('a', { target: 'latest' });
+    assert.deepEqual(scenario.sides.a.calls, ['before']);
+
+    scenario.sides.a.settleBefore();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.sides.a.calls, ['before', 'latest']);
+    scenario.sides.a.settleLatest();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.pending.a, [true, false, true, false]);
+  });
+
+  it('keeps the queued latest load when an earlier request arrives after it', async () => {
+    const scenario = crossSessionGateScenario();
+    scenario.load('a', { target: 'earlier' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    scenario.load('a', { target: 'latest' });
+    scenario.load('a', { target: 'earlier', anchorTurnId: 'turn-anchor' });
+    assert.deepEqual(scenario.sides.a.calls, ['before']);
+
+    scenario.sides.a.settleBefore();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.sides.a.calls, ['before', 'latest']);
+    scenario.sides.a.settleLatest();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.pending.a, [true, false, true, false]);
+  });
+
+  it('does not replay a settled load after its Session range was replaced', async () => {
+    const scenario = crossSessionGateScenario();
+    scenario.load('a', { target: 'earlier' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    scenario.load('a', { target: 'latest' });
+    scenario.switchTo('b');
+    scenario.sides.a.settleBefore();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.sides.a.calls, ['before']);
+    assert.deepEqual(scenario.sides.b.calls, []);
+    assert.deepEqual(scenario.pending.a, [true, false]);
+  });
+
+  it('replays a queued load through its own Session callbacks', async () => {
+    const scenario = crossSessionGateScenario();
+    scenario.load('a', { target: 'earlier' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    scenario.load('a', { target: 'latest' });
+    scenario.sides.a.settleBefore();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    scenario.sides.a.settleLatest();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(scenario.sides.a.calls, ['before', 'latest']);
+    assert.deepEqual(scenario.pending.a, [true, false, true, false]);
+    assert.deepEqual(scenario.pending.b, []);
+    assert.deepEqual(scenario.sides.b.calls, []);
   });
 
   it('keeps the synchronous live-turn ref aligned with reducer updates', () => {

--- a/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
@@ -118,8 +118,7 @@ function crossSessionGateScenario() {
       request: { target: 'earlier' | 'latest'; anchorTurnId?: string },
     ) {
       const side = sides[id];
-      // Detached: a late rejection belongs to its Session, not this await.
-      void transcriptReadingPosition.loadHistory({
+      return transcriptReadingPosition.loadHistory({
         gates,
         request,
         controller: side.controller,
@@ -127,7 +126,7 @@ function crossSessionGateScenario() {
         isCurrent: () => active === id && range === side.controller,
         setPending: (value) => pending[id].push(value),
         onError: (error) => errors[id].push(error),
-      }).catch(() => undefined);
+      });
     },
   };
 }
@@ -522,10 +521,15 @@ describe('app shell session UI state controller', () => {
     assert.deepEqual(scenario.pending.a, [true]);
 
     scenario.switchTo('b');
-    scenario.load('b', { target: 'latest' });
+    const navigation = scenario.load('b', { target: 'latest' });
     await new Promise<void>((resolve) => setImmediate(resolve));
     assert.deepEqual(scenario.sides.b.calls, ['latest']);
     assert.deepEqual(scenario.pending.b, [true]);
+
+    scenario.sides.b.settleLatest();
+    scenario.sides.a.settleBefore();
+    await navigation;
+    await stale;
   });
 
   it('leaves the switched-to Session untouched when a stale Session load settles late', async () => {
@@ -533,9 +537,9 @@ describe('app shell session UI state controller', () => {
     const stale = scenario.load('a', { target: 'earlier' });
     await new Promise<void>((resolve) => setImmediate(resolve));
     scenario.switchTo('b');
-    scenario.load('b', { target: 'latest' });
+    const navigation = scenario.load('b', { target: 'latest' });
     scenario.sides.b.settleLatest();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await navigation;
     assert.deepEqual(scenario.pending.b, [true, false]);
     assert.deepEqual(scenario.sides.b.calls, ['latest']);
 
@@ -561,59 +565,62 @@ describe('app shell session UI state controller', () => {
 
   it('replays the queued latest load once after an in-flight load settles on the same Session', async () => {
     const scenario = crossSessionGateScenario();
-    scenario.load('a', { target: 'earlier' });
+    const inFlight = scenario.load('a', { target: 'earlier' });
     await new Promise<void>((resolve) => setImmediate(resolve));
-    scenario.load('a', { target: 'earlier', anchorTurnId: 'turn-anchor' });
-    scenario.load('a', { target: 'latest' });
+    const queuedEarlier = scenario.load('a', { target: 'earlier', anchorTurnId: 'turn-anchor' });
+    const queuedLatest = scenario.load('a', { target: 'latest' });
     assert.deepEqual(scenario.sides.a.calls, ['before']);
 
     scenario.sides.a.settleBefore();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await inFlight;
     assert.deepEqual(scenario.sides.a.calls, ['before', 'latest']);
     scenario.sides.a.settleLatest();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await Promise.allSettled([queuedEarlier, queuedLatest]);
     assert.deepEqual(scenario.pending.a, [true, false, true, false]);
   });
 
   it('keeps the queued latest load when an earlier request arrives after it', async () => {
     const scenario = crossSessionGateScenario();
-    scenario.load('a', { target: 'earlier' });
+    const inFlight = scenario.load('a', { target: 'earlier' });
     await new Promise<void>((resolve) => setImmediate(resolve));
-    scenario.load('a', { target: 'latest' });
-    scenario.load('a', { target: 'earlier', anchorTurnId: 'turn-anchor' });
+    const queuedLatest = scenario.load('a', { target: 'latest' });
+    const queuedEarlier = scenario.load('a', { target: 'earlier', anchorTurnId: 'turn-anchor' });
     assert.deepEqual(scenario.sides.a.calls, ['before']);
 
     scenario.sides.a.settleBefore();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await inFlight;
     assert.deepEqual(scenario.sides.a.calls, ['before', 'latest']);
     scenario.sides.a.settleLatest();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await Promise.allSettled([queuedLatest, queuedEarlier]);
     assert.deepEqual(scenario.pending.a, [true, false, true, false]);
   });
 
   it('does not replay a settled load after its Session range was replaced', async () => {
     const scenario = crossSessionGateScenario();
-    scenario.load('a', { target: 'earlier' });
+    const inFlight = scenario.load('a', { target: 'earlier' });
     await new Promise<void>((resolve) => setImmediate(resolve));
-    scenario.load('a', { target: 'latest' });
+    const queued = scenario.load('a', { target: 'latest' });
     scenario.switchTo('b');
     scenario.sides.a.settleBefore();
+    await inFlight;
     await new Promise<void>((resolve) => setImmediate(resolve));
     assert.deepEqual(scenario.sides.a.calls, ['before']);
     assert.deepEqual(scenario.sides.b.calls, []);
     assert.deepEqual(scenario.pending.a, [true, false]);
+    scenario.sides.a.settleLatest();
+    await queued;
   });
 
   it('replays a queued load through its own Session callbacks', async () => {
     const scenario = crossSessionGateScenario();
-    scenario.load('a', { target: 'earlier' });
+    const inFlight = scenario.load('a', { target: 'earlier' });
     await new Promise<void>((resolve) => setImmediate(resolve));
-    scenario.load('a', { target: 'latest' });
+    const queued = scenario.load('a', { target: 'latest' });
     scenario.sides.a.settleBefore();
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    scenario.sides.a.settleLatest();
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await inFlight;
     assert.deepEqual(scenario.sides.a.calls, ['before', 'latest']);
+    scenario.sides.a.settleLatest();
+    await queued;
     assert.deepEqual(scenario.pending.a, [true, false, true, false]);
     assert.deepEqual(scenario.pending.b, []);
     assert.deepEqual(scenario.sides.b.calls, []);

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -78,7 +78,7 @@ import {
   isTaskSubmissionHardBlocked,
   resolveTaskReadinessModelTarget,
   transcriptReadingPosition,
-  type TranscriptHistoryGate,
+  type TranscriptHistoryGates,
 } from './features/conversation';
 import { deriveWorkspaceReadinessRecovery } from './workspace-readiness-recovery';
 import { LiveTurnReconciler } from './live-turn-reconciler';
@@ -455,7 +455,7 @@ function AppShellContent({
   // reads. A scroller can ask twice in one task — two scroll events before
   // React has re-rendered anything — and a state read is still the old value
   // for both of them.
-  const historyLoadGateRef = useRef<TranscriptHistoryGate>({ pending: false });
+  const historyLoadGatesRef = useRef<TranscriptHistoryGates>(new WeakMap());
   const [transcriptTurnIndex, setTranscriptTurnIndex] = useState<{
     sessionId: string;
     throughSequence: number | null;
@@ -2543,7 +2543,7 @@ function AppShellContent({
     const sessionId = activeId;
     if (!controller || !sessionId) return;
     return transcriptReadingPosition.loadHistory({
-      gate: historyLoadGateRef.current,
+      gates: historyLoadGatesRef.current,
       request: { target, anchorTurnId },
       controller,
       maxBytes: DESKTOP_TRANSCRIPT_RANGE_MAX_BYTES,

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -78,6 +78,7 @@ import {
   isTaskSubmissionHardBlocked,
   resolveTaskReadinessModelTarget,
   transcriptReadingPosition,
+  type TranscriptHistoryGate,
 } from './features/conversation';
 import { deriveWorkspaceReadinessRecovery } from './workspace-readiness-recovery';
 import { LiveTurnReconciler } from './live-turn-reconciler';
@@ -454,7 +455,7 @@ function AppShellContent({
   // reads. A scroller can ask twice in one task — two scroll events before
   // React has re-rendered anything — and a state read is still the old value
   // for both of them.
-  const historyLoadPendingRef = useRef(false);
+  const historyLoadGateRef = useRef<TranscriptHistoryGate>({ pending: false });
   const [transcriptTurnIndex, setTranscriptTurnIndex] = useState<{
     sessionId: string;
     throughSequence: number | null;
@@ -2537,24 +2538,19 @@ function AppShellContent({
       setAnchor: sessionUiController.setTranscriptReadingAnchor,
     });
   }
-  async function loadTranscriptHistory(target: 'earlier' | 'latest', anchorTurnId?: string) {
+  function loadTranscriptHistory(target: 'earlier' | 'latest', anchorTurnId?: string) {
     const controller = transcriptRangeRef.current;
     const sessionId = activeId;
-    if (!controller || !sessionId || historyLoadPendingRef.current) return;
-    historyLoadPendingRef.current = true;
-    setHistoryLoadPendingSessionId(sessionId);
-    try {
-      if (target === 'earlier') {
-        await controller.loadBefore(DESKTOP_TRANSCRIPT_RANGE_MAX_BYTES, anchorTurnId);
-      } else await controller.loadLatest();
-    } catch (error) {
-      if (
-        activeIdRef.current !== sessionId ||
-        transcriptRangeRef.current !== controller
-      ) {
-        return;
-      }
-      showSessionError(
+    if (!controller || !sessionId) return;
+    return transcriptReadingPosition.loadHistory({
+      gate: historyLoadGateRef.current,
+      request: { target, anchorTurnId },
+      controller,
+      maxBytes: DESKTOP_TRANSCRIPT_RANGE_MAX_BYTES,
+      isCurrent: () => activeIdRef.current === sessionId && transcriptRangeRef.current === controller,
+      setPending: (pending) => setHistoryLoadPendingSessionId((current) =>
+        pending ? sessionId : current === sessionId ? undefined : current),
+      onError: (error) => showSessionError(
         sessionId,
         desktopConversationCopy.actions.messageReadFailedTitle,
         localizedShellErrorMessage(
@@ -2562,11 +2558,8 @@ function AppShellContent({
           desktopConversationCopy.actions.operationFailedFallback,
           uiLocale,
         ),
-      );
-    } finally {
-      historyLoadPendingRef.current = false;
-      setHistoryLoadPendingSessionId((current) => current === sessionId ? undefined : current);
-    }
+      ),
+    });
   }
   const homeSurfaceActive =
     navSelection.section === 'sessions' &&

--- a/apps/desktop/src/renderer/features/conversation/controller/transcript-reading-position.ts
+++ b/apps/desktop/src/renderer/features/conversation/controller/transcript-reading-position.ts
@@ -109,8 +109,12 @@ export interface TranscriptHistoryGate {
   queued?: TranscriptHistoryRequest;
 }
 
+/** One gate per controller: the shell rebuilds the controller per Session, so
+ *  keying by it keeps Sessions from queuing behind each other's loads. */
+export type TranscriptHistoryGates = WeakMap<object, TranscriptHistoryGate>;
+
 export async function loadTranscriptHistory(options: {
-  readonly gate: TranscriptHistoryGate;
+  readonly gates: TranscriptHistoryGates;
   readonly request: TranscriptHistoryRequest;
   readonly controller: {
     loadBefore(maxBytes: number, anchorTurnId?: string): Promise<void>;
@@ -121,7 +125,9 @@ export async function loadTranscriptHistory(options: {
   readonly setPending: (pending: boolean) => void;
   readonly onError: (error: unknown) => void;
 }): Promise<void> {
-  const { gate, request } = options;
+  const { gates, controller, request } = options;
+  let gate = gates.get(controller) ?? { pending: false };
+  gates.set(controller, gate);
   if (gate.pending) {
     // The scroller asks on every reader movement; dropping the request behind
     // an in-flight load strands the reader until they move again.

--- a/apps/desktop/src/renderer/features/conversation/controller/transcript-reading-position.ts
+++ b/apps/desktop/src/renderer/features/conversation/controller/transcript-reading-position.ts
@@ -99,6 +99,52 @@ export function refreshTranscriptTurnLandmarks<T>(options: {
   };
 }
 
+export interface TranscriptHistoryRequest {
+  readonly target: 'earlier' | 'latest';
+  readonly anchorTurnId?: string;
+}
+
+export interface TranscriptHistoryGate {
+  pending: boolean;
+  queued?: TranscriptHistoryRequest;
+}
+
+export async function loadTranscriptHistory(options: {
+  readonly gate: TranscriptHistoryGate;
+  readonly request: TranscriptHistoryRequest;
+  readonly controller: {
+    loadBefore(maxBytes: number, anchorTurnId?: string): Promise<void>;
+    loadLatest(): Promise<void>;
+  };
+  readonly maxBytes: number;
+  readonly isCurrent: () => boolean;
+  readonly setPending: (pending: boolean) => void;
+  readonly onError: (error: unknown) => void;
+}): Promise<void> {
+  const { gate, request } = options;
+  if (gate.pending) {
+    // The scroller asks on every reader movement; dropping the request behind
+    // an in-flight load strands the reader until they move again.
+    if (request.target === 'latest' || gate.queued?.target !== 'latest') gate.queued = request;
+    return;
+  }
+  gate.pending = true;
+  options.setPending(true);
+  try {
+    if (request.target === 'earlier') {
+      await options.controller.loadBefore(options.maxBytes, request.anchorTurnId);
+    } else await options.controller.loadLatest();
+  } catch (error) {
+    if (options.isCurrent()) options.onError(error);
+  } finally {
+    gate.pending = false;
+    options.setPending(false);
+    const queued = gate.queued;
+    gate.queued = undefined;
+    if (queued && options.isCurrent()) void loadTranscriptHistory({ ...options, request: queued });
+  }
+}
+
 export function restoreSessionTranscriptRange<Message>(options: {
   readonly sessionId?: string;
   readonly searchTarget?: SearchTarget | null;

--- a/apps/desktop/src/renderer/features/conversation/index.ts
+++ b/apps/desktop/src/renderer/features/conversation/index.ts
@@ -35,7 +35,7 @@ export const transcriptReadingPosition = {
   restoreRange: restoreSessionTranscriptRange,
 };
 
-export type { TranscriptHistoryGate } from './controller/transcript-reading-position.js';
+export type { TranscriptHistoryGates } from './controller/transcript-reading-position.js';
 export {
   deriveTaskReadinessNotice,
   isTaskSubmissionHardBlocked,

--- a/apps/desktop/src/renderer/features/conversation/index.ts
+++ b/apps/desktop/src/renderer/features/conversation/index.ts
@@ -20,6 +20,7 @@
 import {
   captureTranscriptReadingAnchor,
   currentTranscriptRange,
+  loadTranscriptHistory,
   newestDurablePromptSequence,
   refreshTranscriptTurnLandmarks,
   restoreSessionTranscriptRange,
@@ -28,11 +29,13 @@ import {
 export const transcriptReadingPosition = {
   captureAnchor: captureTranscriptReadingAnchor,
   currentRange: currentTranscriptRange,
+  loadHistory: loadTranscriptHistory,
   newestDurablePromptSequence,
   refreshLandmarks: refreshTranscriptTurnLandmarks,
   restoreRange: restoreSessionTranscriptRange,
 };
 
+export type { TranscriptHistoryGate } from './controller/transcript-reading-position.js';
 export {
   deriveTaskReadinessNotice,
   isTaskSubmissionHardBlocked,

--- a/packages/ui/src/__tests__/return-to-latest-pin.test.tsx
+++ b/packages/ui/src/__tests__/return-to-latest-pin.test.tsx
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The return-to-latest command must pin before it loads. An unpinned scroller
+ * reports the Turn it is leaving as the reading anchor, and the restore effect
+ * would pull the arriving range straight back — the bug the 60-run E2E guard
+ * covers, held here as a fast unit so reverting the two-line order goes red
+ * without a browser.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { Fragment, act, createElement, type ReactElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { parseHTML } from 'linkedom';
+import type { SessionSummary, StoredMessage } from '@maka/core/session';
+import { AstryxLocaleProvider } from '../astryx-i18n.js';
+import { ChatSurfaceLayout } from '../chat-surface-layout.js';
+import { ChatView } from '../chat-view.js';
+import { LocaleProvider } from '../locale-context.js';
+import {
+  TranscriptScrollAuthorityProvider,
+  useTranscriptScrollAuthority,
+  type TranscriptScrollAuthority,
+} from '../transcript-scroll-authority.js';
+
+const originalGlobals = {
+  CSS: globalThis.CSS,
+  document: globalThis.document,
+  Element: globalThis.Element,
+  HTMLElement: globalThis.HTMLElement,
+  IntersectionObserver: globalThis.IntersectionObserver,
+  MutationObserver: globalThis.MutationObserver,
+  Node: globalThis.Node,
+  ResizeObserver: globalThis.ResizeObserver,
+  matchMedia: globalThis.matchMedia,
+  requestAnimationFrame: globalThis.requestAnimationFrame,
+  cancelAnimationFrame: globalThis.cancelAnimationFrame,
+  window: globalThis.window,
+};
+const originalActEnvironment = (globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+}).IS_REACT_ACT_ENVIRONMENT;
+
+let mountedRoot: ReturnType<typeof createRoot> | undefined;
+
+afterEach(async () => {
+  if (mountedRoot) await act(() => mountedRoot?.unmount());
+  mountedRoot = undefined;
+  Object.assign(globalThis, {
+    ...originalGlobals,
+    IS_REACT_ACT_ENVIRONMENT: originalActEnvironment,
+  });
+});
+
+const activeSession: SessionSummary = {
+  id: 'session-return',
+  name: '回到最新',
+  isFlagged: false,
+  isArchived: false,
+  labels: [],
+  hasUnread: false,
+  status: 'active',
+  lastMessageAt: 0,
+  backend: 'ai-sdk',
+  llmConnectionId: 'connection-anthropic',
+  llmConnectionSlug: 'anthropic',
+  connectionLocked: false,
+  model: 'claude-sonnet-4-5',
+  permissionMode: 'ask',
+};
+
+const TURN_COUNT = 6;
+
+function turnMessages(): StoredMessage[] {
+  return Array.from({ length: TURN_COUNT }, (_, index): StoredMessage[] => [
+    {
+      type: 'user',
+      id: `user-${index}`,
+      turnId: `turn-${index}`,
+      ts: index * 2,
+      text: `第 ${index} 个问题`,
+    },
+    {
+      type: 'assistant',
+      id: `assistant-${index}`,
+      turnId: `turn-${index}`,
+      ts: index * 2 + 1,
+      text: '答案',
+      modelId: 'claude-sonnet-4-5',
+    },
+  ]).flat();
+}
+
+function deferredClick(): { onClick: () => Promise<void>; release: () => void } {
+  let release!: (value: void) => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    onClick: () => promise,
+    release: () => {
+      release();
+    },
+  };
+}
+
+
+interface ReturnToLatestHarness {
+  readonly anchors: Array<string | undefined>;
+  /** The authority `ChatSurfaceLayout` provided, read through a probe child. */
+  readonly authority: TranscriptScrollAuthority;
+  readonly scrollRoot: HTMLElement;
+  readonly scrollButton: HTMLElement;
+  readonly clickEvent: Event;
+  readerScroll(): void;
+}
+
+/**
+ * Renders `ChatView` with a deferred return-to-latest load inside the same
+ * linkedom + act harness `prompt-rail-observer-identity.test.tsx` established.
+ * A probe child publishes the authority so the test can read the pin.
+ */
+function harness(options: { readonly onClick: () => Promise<void> | void }): ReturnToLatestHarness {
+  const { document, window } = parseHTML('<main id="mount"></main>');
+  // linkedom lays nothing out, so every box is zero-sized. The geometry this
+  // test needs is a scroller away from its tail with a Turn visible, which a
+  // constant viewport rectangle plus scrollTop and scrollHeight fields give.
+  const rect = {
+    bottom: 600, height: 600, left: 0, right: 800, top: 0, width: 800, x: 0, y: 0,
+    toJSON: () => ({}),
+  } satisfies DOMRect;
+  window.Element.prototype.getBoundingClientRect = () => rect;
+  class InertResizeObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  class InertIntersectionObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+  Object.assign(globalThis, {
+    CSS: { supports: () => false },
+    document,
+    Element: window.Element,
+    HTMLElement: window.HTMLElement,
+    IntersectionObserver: InertIntersectionObserver,
+    MutationObserver: window.MutationObserver,
+    Node: window.Node,
+    ResizeObserver: InertResizeObserver,
+    matchMedia: () => ({
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+    }),
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    },
+    cancelAnimationFrame: () => {},
+    window,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  const anchors: Array<string | undefined> = [];
+  let authority: TranscriptScrollAuthority | undefined;
+  const AuthorityProbe = (): ReactElement => {
+    authority = useTranscriptScrollAuthority();
+    return createElement(Fragment, null);
+  };
+  const probe = createElement(TranscriptScrollAuthorityProvider, {
+    children: createElement(AuthorityProbe),
+  });
+  const view = (): ReactElement => {
+    const chat = createElement(ChatView, {
+      messages: turnMessages(),
+      activeSession,
+      onNew: () => {},
+      scrollBehavior: 'auto' as const,
+      hasOlderHistory: true,
+      onLoadEarlierHistory: () => undefined,
+      onReadingAnchorChange: (turnId?: string) => {
+        anchors.push(turnId);
+      },
+      returnToLatest: {
+        title: '查看较早的消息',
+        label: '回到最新',
+        isPending: false,
+        onClick: options.onClick,
+      },
+    } as never);
+    const layout = createElement(ChatSurfaceLayout, {
+      scrollOwner: 'host',
+      composer: null,
+      children: chat,
+    });
+    const astryx = createElement(AstryxLocaleProvider, { children: layout });
+    return createElement(LocaleProvider, {
+      locale: 'zh-CN',
+      children: createElement(Fragment, null, astryx, probe),
+    });
+  };
+  const mount = document.querySelector<HTMLElement>('#mount');
+  assert.ok(mount);
+  const root = createRoot(mount);
+  mountedRoot = root;
+  act(() => {
+    root.render(view());
+  });
+  const scrollRoot = mount.querySelector<HTMLElement>('[data-chat-scroll-container]');
+  assert.ok(scrollRoot, 'the layout mounts a scroll container');
+  const scrollButton = [...mount.querySelectorAll('button')]
+    .find((button) => button.textContent?.includes('回到最新'));
+  assert.ok(scrollButton, 'the return-to-latest affordance is rendered');
+  // The authority attached itself to the scroller on mount and wrote the tail
+  // into a zero-sized box, so its classification state says scrollTop=0 over a
+  // zero-height scroller. Give the box real geometry, then deliver one scroll
+  // event at that same offset so the echo branch refreshes the recorded
+  // geometry without being taken for the reader. Park the reader at 600 — the
+  // way paging back leaves them — and let `readerScroll()` announce it.
+  Object.assign(scrollRoot, { scrollHeight: 2_400, clientHeight: 600 });
+  scrollRoot.scrollTop = 0;
+  scrollRoot.dispatchEvent(new window.Event('scroll'));
+  scrollRoot.scrollTop = 600;
+  // linkedom ships Event but not MouseEvent; a bubbling Event still reaches
+  // React's root listener, which reads only the type for onClick.
+  const clickEvent = new window.Event('click', { bubbles: true });
+  return {
+    anchors,
+    get authority(): TranscriptScrollAuthority {
+      assert.ok(authority, 'the layout provided a scroll authority');
+      return authority;
+    },
+    scrollRoot,
+    scrollButton,
+    clickEvent,
+    readerScroll() {
+      scrollRoot.dispatchEvent(new window.Event('scroll'));
+    },
+  };
+}
+
+test('returning to latest pins before it loads, so the anchor reports nothing', async () => {
+  const click = deferredClick();
+  const view = harness({ onClick: click.onClick });
+
+  // Mount reports the pinned (cleared) anchor once; the reader scroll that
+  // parks away from the tail then reports the Turn being left.
+  view.readerScroll();
+  assert.deepEqual(view.anchors, [undefined, 'turn-0'], 'an unpinned scroller reports the left Turn');
+
+  view.scrollButton.dispatchEvent(view.clickEvent);
+  await act(async () => {});
+  assert.equal(
+    view.authority.getSnapshot().pinned,
+    true,
+    'the click pinned synchronously, before the load settled',
+  );
+  assert.deepEqual(
+    view.anchors,
+    [undefined, 'turn-0', undefined],
+    'the pin cleared the reading anchor while the load was in flight',
+  );
+
+  click.release();
+  await act(async () => {});
+});
+
+test('the anchor stays cleared while the range is still loading', async () => {
+  const click = deferredClick();
+  const view = harness({ onClick: click.onClick });
+  view.readerScroll();
+  view.scrollButton.dispatchEvent(view.clickEvent);
+  await act(async () => {});
+
+  // The arriving range is what used to re-report the anchor; whatever moves
+  // the scroller while the load is pending must not hand the shell a Turn.
+  view.readerScroll();
+  assert.deepEqual(view.anchors, [undefined, 'turn-0', undefined]);
+
+  click.release();
+  await act(async () => {});
+});

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -744,12 +744,11 @@ export function ChatView(props: {
           actionLabel={props.returnToLatest.label}
           isPending={props.returnToLatest.isPending}
           onReturnToLatest={async () => {
-            // Loading the latest range is the shell's job; putting the viewport
-            // on it is this view's, and setting the pin is the whole of it —
-            // the range that arrives afterwards is growth, and growth is
-            // already followed.
-            await props.returnToLatest?.onClick();
+            // Pin first: an unpinned scroller reports the Turn it is leaving
+            // as the reading anchor, and restoring that anchor would pull the
+            // arriving range straight back.
             scrollAuthority.pinToTail();
+            await props.returnToLatest?.onClick();
           }}
         />
       ) : null}


### PR DESCRIPTION
## Summary

Fixes #4882

Clicking **返回最新消息** after paging far back flashed the tail and jumped back to the Turn the reader had been on; fast wheel paging occasionally stalled one page short. Together they are the `transcript-scroll-cost.spec.ts:239` flake on `main`.

Root cause of the jump-back: `ChatView` pinned the scroller to the tail only after `await onClick()` resolved, but the tail batch reaches the store before that. In the gap the unpinned scroller reported the top Turn as the reading anchor, and the `restoreRange` effect (which re-runs on every `messages` change) found it missing from the new range and called `loadAround` on it. The fix pins first: a pinned scroller reports no anchor, so the range that arrives has nothing to be pulled back to.

Root cause of the stall: `loadTranscriptHistory` returned silently while a load was pending. The scroller asks on every reader movement, so the request behind an in-flight load was lost and nothing re-asked. The guard now lives in `transcript-reading-position.ts` as `loadTranscriptHistory`, keeps the last request that arrived mid-flight (`latest` outranks `earlier`) and replays it when the current load settles, still gated on the session and controller being current. Moving it out of `app-shell.tsx` is what the renderer architecture ratchet asks for and leaves the shell smaller.

The gate itself was one shell-wide object, shared by every Session. A navigation on the Session switched to next queued behind the first Session's in-flight load and was then dropped when that load settled under the old Session's currency check — the "Return to latest" click did nothing. The second commit keys the gate per controller (`WeakMap<object, TranscriptHistoryGate>`); each Session's in-flight load and queued request stay to themselves, with the same-Session queue semantics unchanged.

Overlaps with #4560, which rebuilds this area and removes the notice; that PR clears the anchor in `app-shell.tsx` before the load, which locally still loses the race (the scroller re-reports the anchor 17 ms after the load starts).

## Verification

`apps/desktop`: `npm run typecheck`, renderer ratchet `--write` then `--base $(git merge-base HEAD origin/main)`, `biome check` on the touched files, `@maka/ui` `test:dist` — all pass.

`transcript-scroll-cost.spec.ts -g "paging back" --repeat-each=60 --workers=4`, macOS, `main` 411512bd9 vs this branch:

```
  3 failed
  17 passed (1.4m)          # main, --repeat-each=20
666735 [history] batch hasNewer=false hasOlder=true through=239 frags=20 evicted=220 idsMin=220 idsMax=239
666749 [history] restoreRange loadAround turn=turn-prompt-rail-1 seq=0
666811 [history] batch hasNewer=true hasOlder=false through=239 frags=20 evicted=220 idsMin=0 idsMax=19

  60 passed (3.1m)          # this branch, --repeat-each=60; 0 restoreRange loads after the tail across 60 runs
```

The instrumented lines are from a throwaway build of `main` with `console.info` in the store, the restore path and the shell; the fix branch is un-instrumented.

Second commit adds cross-session gate coverage to `apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts` and re-runs the paging-back regression on that head:

```
  ✔ starts another Session history load without waiting behind an in-flight load elsewhere (0.224583ms)
  ✔ leaves the switched-to Session untouched when a stale Session load settles late (0.192958ms)
  ✔ reports a late history load failure to its own Session alone (0.114042ms)
  ✔ replays the queued latest load once after an in-flight load settles on the same Session (0.18725ms)
  ✔ keeps the queued latest load when an earlier request arrives after it (0.1795ms)
  ✔ does not replay a settled load after its Session range was replaced (0.16225ms)
  ✔ replays a queued load through its own Session callbacks (0.15575ms)
ℹ tests 27
ℹ pass 27
ℹ fail 0

  60 passed (3.4m)          # 76692daa8, --repeat-each=60
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — trace analysis, instrumentation, root-cause bisection, the code change, and the per-controller gate follow-up with its regression tests; verified by the author.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
