### PR TITLE
test(storybook): wait for dialog mount and post-close focus restore in ProjectGroups

### DIFF
--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -672,9 +672,14 @@ export const ProjectGroups: Story = {
     await expect(action).toHaveFocus();
     await userEvent.keyboard('{Enter}');
     await userEvent.click(page.getByRole('menuitem', { name: '重命名' }));
-    await expect(page.getByRole('dialog', { name: '重命名项目' })).toBeVisible();
+    // The menu close and the dialog mount are one frame apart (#4884); query
+    // by waiting for the dialog rather than racing the handover.
+    await expect(await page.findByRole('dialog', { name: '重命名项目' })).toBeVisible();
     await userEvent.click(page.getByRole('button', { name: '关闭' }));
-    await expect(action).toHaveFocus();
+    // Focus returns to the opener on the frame after the dialog unmounts
+    // (#4884): while the modal is up, everything outside it is inert and a
+    // focus() there is refused. This matcher checks once, not until it passes.
+    await waitFor(() => expect(action).toHaveFocus());
 
     await userEvent.hover(taskControl);
     const taskCard = await page.findByText('正在把侧栏交互契约迁移到浏览器 story。');

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -672,10 +672,8 @@ export const ProjectGroups: Story = {
     await expect(action).toHaveFocus();
     await userEvent.keyboard('{Enter}');
     await userEvent.click(page.getByRole('menuitem', { name: '重命名' }));
-    // Dialog mounts one frame after the menu closes (#4884).
     await expect(await page.findByRole('dialog', { name: '重命名项目' })).toBeVisible();
     await userEvent.click(page.getByRole('button', { name: '关闭' }));
-    // Focus restores on the frame after the dialog unmounts (#4884).
     await waitFor(() => expect(action).toHaveFocus());
 
     await userEvent.hover(taskControl);

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -672,13 +672,10 @@ export const ProjectGroups: Story = {
     await expect(action).toHaveFocus();
     await userEvent.keyboard('{Enter}');
     await userEvent.click(page.getByRole('menuitem', { name: '重命名' }));
-    // The menu close and the dialog mount are one frame apart (#4884); query
-    // by waiting for the dialog rather than racing the handover.
+    // Dialog mounts one frame after the menu closes (#4884).
     await expect(await page.findByRole('dialog', { name: '重命名项目' })).toBeVisible();
     await userEvent.click(page.getByRole('button', { name: '关闭' }));
-    // Focus returns to the opener on the frame after the dialog unmounts
-    // (#4884): while the modal is up, everything outside it is inert and a
-    // focus() there is refused. This matcher checks once, not until it passes.
+    // Focus restores on the frame after the dialog unmounts (#4884).
     await waitFor(() => expect(action).toHaveFocus());
 
     await userEvent.hover(taskControl);


### PR DESCRIPTION
Fixes #4884.

## Summary

The `product-sidebar-session-list--project-groups` play function races two one-frame boundaries under the smoke runner's four-page concurrency (`runJobs(..., 4)` in `scripts/storybook-visual-smoke.mjs`):

1. **Dialog query after picking 重命名.** The menu close and the dialog mount are one frame apart; `getByRole('dialog', { name: '重命名项目' })` ran before the dialog mounted, failing with `missing dialog role "重命名项目"`.
2. **Focus assertion after closing the rename dialog.** The product restores opener focus through `requestAnimationFrame` after the dialog unmounts (`packages/ui/src/session-history-list.tsx:408`): while the modal is up, everything outside it is inert and a `focus()` there is refused. The Storybook `toHaveFocus` matcher is a one-shot synchronous check, so when the assertion ran before the next frame it read `<body>` and failed — even though the restore always completed (~300 ms later, observed 53/53 in failure probes).

Both failure modes are documented in #4884, with the historical stack mapping to exactly these two assertions (run 33992802279 / job 101377914164, `session-list-panel.stories-BCpYL2Ip.js:1:10335`).

## Change

Test-only, in `packages/ui/stories/session-list-panel.stories.tsx` (ProjectGroups play):

- Query the rename dialog with `await page.findByRole('dialog', { name: '重命名项目' })` instead of racing the handover.
- Assert the post-close focus inside `waitFor(() => expect(action).toHaveFocus())` so the matcher polls until the rAF restore lands.

Both patterns are already used elsewhere in this file and across `packages/ui/stories` (`findByRole` with the sibling 重命名任务 story at line 721, `waitFor` focus assertions in `accessibility-dialogs.stories.tsx`). No product change: closing the dialog and refocusing the opener on the next frame is intended behavior.

## Verification

- Full Storybook smoke on the built catalog: **305 stories, 332 theme renders, all pass**, including `product-sidebar-session-list--project-groups`.
- Biome check clean on the touched file; ASF header and protocol-epoch guards pass on commit.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — analysis and implementation of the two wait points, plus reproduction probes (17/120 → 240/240 → revert 36/120) and this description, under the contributor's direction; AI use is declared in this description (the small test-only commits carry no trailers).
