### PR TITLE
fix(runtime): stop counting insignificant tool-argument whitespace as stream activity

### DIFF
--- a/packages/runtime/src/__tests__/model-adapter-tool-input-activity.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter-tool-input-activity.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { LanguageModelV4StreamPart } from '@ai-sdk/provider';
+import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
+import { ModelAdapter } from '../model-adapter.js';
+
+async function activityCount(parts: LanguageModelV4StreamPart[]): Promise<number> {
+  const model = new MockLanguageModelV4({
+    doStream: {
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        ...parts,
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage: {
+            inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+            outputTokens: { total: 0, text: 0, reasoning: 0 },
+          },
+        },
+      ]),
+    },
+  });
+  const adapter = new ModelAdapter({
+    connection: { providerType: 'openai' } as never,
+    apiKey: 'test',
+    modelId: 'mock',
+    modelFactory: () => model,
+    newId: () => 'id',
+    now: () => 0,
+  });
+  let count = 0;
+  const result = await adapter.startStream({
+    model,
+    messages: [{ role: 'user', content: 'run pwd' }],
+    tools: {},
+    activeTools: [],
+    abortSignal: new AbortController().signal,
+    repairToolCall: async () => null,
+    onStreamActivity: () => {
+      count += 1;
+    },
+  });
+  for await (const _event of result.events) {
+    /* drain */
+  }
+  assert.equal((await result.outcome).kind, 'completed');
+  // SDK start/start-step and finish-step/finish remain activity.
+  return count - 4;
+}
+
+for (const providerExecuted of [false, true]) {
+  test(`ignores insignificant whitespace after a value (providerExecuted=${providerExecuted})`, async () => {
+    const parts: LanguageModelV4StreamPart[] = [
+      { type: 'tool-input-start', id: 'a', toolName: 'Bash', providerExecuted },
+      { type: 'tool-input-delta', id: 'a', delta: '{"boundary_intent":"current"' },
+      ...Array.from({ length: 30 }, () => ({
+        type: 'tool-input-delta' as const,
+        id: 'a',
+        delta: ' \n\r\t',
+      })),
+      { type: 'tool-input-end', id: 'a' },
+    ];
+    assert.equal(await activityCount(parts), 3);
+  });
+}
+
+test('preserves whitespace inside strings across escaped quotes and backslashes', async () => {
+  const deltas = ['{"content":"line1', '\n\n   ', '\\', '"', ' ', '\\', '\\', '"', ' \t', '}'];
+  const parts: LanguageModelV4StreamPart[] = [
+    { type: 'tool-input-start', id: 'a', toolName: 'Write' },
+    ...deltas.map((delta) => ({ type: 'tool-input-delta' as const, id: 'a', delta })),
+    { type: 'tool-input-end', id: 'a' },
+  ];
+  // The escaped quote stays inside; the quote after an escaped backslash closes.
+  assert.equal(await activityCount(parts), parts.length - 1);
+});
+
+test('keeps interleaved call state independent and resets ended IDs', async () => {
+  const parts: LanguageModelV4StreamPart[] = [
+    { type: 'tool-input-start', id: 'a', toolName: 'Write' },
+    { type: 'tool-input-delta', id: 'a', delta: '{"content":"' },
+    { type: 'tool-input-start', id: 'b', toolName: 'Bash' },
+    { type: 'tool-input-delta', id: 'b', delta: '{"command":"pwd"' },
+    { type: 'tool-input-delta', id: 'b', delta: ' ' },
+    { type: 'tool-input-delta', id: 'a', delta: ' ' },
+    { type: 'tool-input-end', id: 'a' },
+    { type: 'tool-input-start', id: 'a', toolName: 'Write' },
+    { type: 'tool-input-delta', id: 'a', delta: ' ' },
+    { type: 'tool-input-delta', id: 'b', delta: ' }' },
+    { type: 'tool-input-end', id: 'a' },
+    { type: 'tool-input-end', id: 'b' },
+  ];
+  assert.equal(await activityCount(parts), parts.length - 2);
+});
+
+test('only JSON whitespace is insignificant outside strings', async () => {
+  const parts: LanguageModelV4StreamPart[] = [
+    { type: 'tool-input-start', id: 'a', toolName: 'Bash' },
+    { type: 'tool-input-delta', id: 'a', delta: '\u00a0' },
+    { type: 'tool-input-delta', id: 'a', delta: '\v' },
+    { type: 'tool-input-delta', id: 'a', delta: ' \t{}' },
+    { type: 'tool-input-end', id: 'a' },
+  ];
+  assert.equal(await activityCount(parts), parts.length);
+});
+
+test('counts every whitespace delta while a string remains open', async () => {
+  const parts: LanguageModelV4StreamPart[] = [
+    { type: 'tool-input-start', id: 'a', toolName: 'Write' },
+    { type: 'tool-input-delta', id: 'a', delta: '{"content":"line1' },
+    { type: 'tool-input-delta', id: 'a', delta: '   ' },
+    { type: 'tool-input-delta', id: 'a', delta: '\\' },
+    { type: 'tool-input-delta', id: 'a', delta: '"' },
+    { type: 'tool-input-delta', id: 'a', delta: '\n\t ' },
+    { type: 'tool-input-end', id: 'a' },
+  ];
+  assert.equal(await activityCount(parts), parts.length);
+});
+
+test('preserves whitespace activity for text and reasoning streams', async () => {
+  const parts: LanguageModelV4StreamPart[] = [
+    { type: 'text-start', id: 'text' },
+    { type: 'text-delta', id: 'text', delta: ' \n' },
+    { type: 'text-end', id: 'text' },
+    { type: 'reasoning-start', id: 'thought' },
+    { type: 'reasoning-delta', id: 'thought', delta: ' \n' },
+    { type: 'reasoning-end', id: 'thought' },
+  ];
+  assert.equal(await activityCount(parts), parts.length);
+});

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -124,7 +124,7 @@ export interface ModelAdapterStreamInput {
   messages: ModelMessage[];
   tools: ModelToolSet;
   activeTools: string[];
-  /** Observe each successfully pulled SDK stream part before semantic translation. */
+  /** Observe SDK activity, excluding insignificant JSON tool-argument whitespace. */
   onStreamActivity: () => void;
   system?: string;
   abortSignal: AbortSignal;
@@ -385,9 +385,34 @@ export class ModelAdapter {
         let streamedFinishReason: string | undefined;
         let streamedRawFinishReason: string | undefined;
         let sawUnfinalizedPlaintextSummary = false;
+        const toolInputStates = new Map<unknown, { inString: boolean; escapeNext: boolean }>();
         try {
           for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
-            onStreamActivity();
+            let hasActivity = true;
+            if (chunk.type === 'tool-input-start') {
+              toolInputStates.set(chunk.id, { inString: false, escapeNext: false });
+            } else if (chunk.type === 'tool-input-end') {
+              toolInputStates.delete(chunk.id);
+            } else if (chunk.type === 'tool-input-delta') {
+              const state = toolInputStates.get(chunk.id);
+              if (state) {
+                hasActivity = false;
+                // JSON permits only these four whitespace characters outside
+                // strings. Preserve string/escape state across delta boundaries.
+                for (const char of chunk.delta ?? '') {
+                  if (state.inString) {
+                    hasActivity = true;
+                    if (state.escapeNext) state.escapeNext = false;
+                    else if (char === '\\') state.escapeNext = true;
+                    else if (char === '"') state.inString = false;
+                  } else if (char !== ' ' && char !== '\n' && char !== '\r' && char !== '\t') {
+                    hasActivity = true;
+                    if (char === '"') state.inString = true;
+                  }
+                }
+              }
+            }
+            if (hasActivity) onStreamActivity();
             if (
               chunk.type === 'finish' ||
               chunk.type === 'finish-step' ||


### PR DESCRIPTION
## Summary

Insignificant JSON whitespace in tool-argument deltas no longer counts as stream activity; the existing idle watchdog and its recovery handle the stall.

Track string and escape state independently for each tool-call ID. Spaces, tabs, carriage returns, and line feeds outside JSON strings leave the activity clock unchanged. Whitespace inside strings remains activity, including across escaped quotes and split deltas. Other stream parts retain their existing behavior.

The criterion follows JSON syntax. The existing 120-second idle timeout, recovery policy, strict settings, and tool schemas remain unchanged. This patch adds no threshold or content heuristic.

Refs #4861

## Verification

- Red against the original implementation: 6 tests, 2 passed and 4 failed. Thirty insignificant whitespace deltas incorrectly produced 33 activity callbacks where 3 were expected.
- Final targeted green: 8 tests passed, 0 failed, including the existing stream-activity test. Coverage includes provider-executed tools, string whitespace, escaped quotes and backslashes split across deltas, interleaved IDs, ID reuse, non-JSON whitespace, and unchanged text/reasoning activity.
- Complete `@maka/runtime` `test:dist`: 3,268 tests, 3,255 passed, 13 skipped, 0 failed.
- Full repository build, format, lint, and typecheck passed.
- Live patched TUI, Auto mode, `gpt-6-astra`, captured relay traffic: a Bash argument loop emitted 4,129 argument bytes. Its last meaningful delta arrived at 5.015 seconds; Maka closed the HTTP stream at 125.025 seconds, **120.010 seconds later**. On unpatched main a comparable loop lasted about 902 seconds.
- The TUI showed `Retrying in 2s (2/2)`, then `Retrying (2/2)`. The retry completed `pwd`. Canonical accounting records attempt 0 as `aborted` with missing usage and attempt 1 as `completed` with reported usage under the same logical call ID. Provider code and retryable fields remain absent on the aborted attempt, following the existing watchdog accounting path.

## Security

The change lets the existing watchdog cancel a provider stream that only appends insignificant JSON whitespace. Permission checks, sandbox boundaries, and execution authority remain unchanged. The existing single idle-recovery allowance and observable-output safety gates still govern replay.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex-family model via pi implemented the patch, tests, and this description; human-reviewed.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes, described under Summary above
- [ ] No

## Open questions for maintainers

Should whitespace-only text or reasoning deltas eventually share this activity definition? This draft preserves their current behavior because whitespace in those streams can carry presentation meaning; tool-argument JSON supplies an explicit syntax-level distinction.
