### PR TITLE
test(storybook): wait for context menu to settle

### DIFF
--- a/apps/desktop/stories/composer-slash-menu.stories.tsx
+++ b/apps/desktop/stories/composer-slash-menu.stories.tsx
@@ -435,7 +435,7 @@ export const ContextSwitchStartsWithALoadingCatalog: Story = {
     await waitFor(() => expect(skillsRow).toHaveAttribute('aria-busy', 'true'));
     await expect(skillsRow).not.toHaveAttribute('aria-disabled', 'true');
     await userEvent.click(skillsRow);
-    await expect(menu).toBeVisible();
+    await waitFor(() => expect(menu).toBeVisible(), { timeout: 5_000 });
     await expect(editor(canvasElement)).toHaveTextContent('');
     await expect(page.queryByRole('listbox', { name: /技能/ })).not.toBeInTheDocument();
 


### PR DESCRIPTION
## Problem

The Storybook smoke test for switching from an existing session to a new task intermittently asserted that the context menu was visible during its asynchronous loading-catalog update. Hosted smoke failed at `menu.toBeVisible()` while the menu was between renders.

## Fix

Wait for the menu to settle before asserting it remains visible after clicking the loading Skills row. The story behavior and production Composer code are unchanged.

## Validation

- Changed-file Biome check passed.
- This is independent of artifact export PR #4833 and targets only the existing Storybook smoke timing assertion.

## AI use

Generative tooling contributed substantively to this patch. The commit carries `Generated-by: OpenAI Codex`.
