### PR TITLE
fix(desktop): hug the right edge and ease the workbar column open and shut

### DIFF
--- a/apps/desktop/src/renderer/features/workbar/ui/workbar-surface.tsx
+++ b/apps/desktop/src/renderer/features/workbar/ui/workbar-surface.tsx
@@ -102,6 +102,7 @@ function WorkbarPanelLoading(props: { label: string }) {
 function WorkbarPanel(props: {
   id?: string;
   active: boolean;
+  collapsed?: boolean;
   placement: SessionWorkbarPlacement;
   overlay?: boolean;
   className?: string;
@@ -115,6 +116,7 @@ function WorkbarPanel(props: {
       hidden={!props.active}
       data-placement={props.placement}
       data-overlay={props.overlay || undefined}
+      data-collapsed={props.collapsed || undefined}
       className={
         props.className
           ? `maka-session-workbar-panel ${props.className}`
@@ -422,9 +424,8 @@ export function WorkbarSurface(props: {
         const panel = props.panelsState[placement];
         const activeTab = panel.tabs.find((tab) => tab.id === panel.activeTabId);
         const showingLauncher = panel.launcherOpen || !activeTab;
-        const visible =
-          !props.hidden &&
-          (placement === 'right' ? !props.rightCollapsed : props.bottomOpen);
+        const collapsed =
+          placement === 'right' ? props.rightCollapsed : !props.bottomOpen;
         return (
           <Card
             key={placement}
@@ -433,7 +434,8 @@ export function WorkbarSurface(props: {
             height="100%"
             className="maka-session-workbar maka-session-workbar-frame"
             data-placement={placement}
-            data-collapsed={!visible || undefined}
+            data-collapsed={collapsed || undefined}
+            hidden={props.hidden}
             data-maka-contract={`session-workbar-${placement}`}
             role="complementary"
             aria-label={copy.ariaLabel}
@@ -465,7 +467,7 @@ export function WorkbarSurface(props: {
                 }
               />
             </div>
-            <WorkbarPanel active={visible && showingLauncher} placement={placement}>
+            <WorkbarPanel active={showingLauncher} placement={placement}>
               <WorkbarLauncher
                 onOpen={(kind) => props.onRequestOpenTab(placement, kind)}
                 sideChatAvailable={props.sourceSession !== undefined}
@@ -480,8 +482,8 @@ export function WorkbarSurface(props: {
         const showingLauncher = panel.launcherOpen || !activeTab;
         const panelVisible =
           placement === 'right' ? !props.rightCollapsed : props.bottomOpen;
-        const active =
-          panelVisible && !showingLauncher && activeTab?.id === tab.id;
+        const selected = !showingLauncher && activeTab?.id === tab.id;
+        const active = panelVisible && selected;
         let content: ReactNode = null;
         if (tab.kind === 'review') {
           content = (
@@ -567,7 +569,8 @@ export function WorkbarSurface(props: {
           <WorkbarPanel
             key={tab.id}
             id={`maka-workbar-panel-${tab.id}`}
-            active={active}
+            active={selected && !props.hidden}
+            collapsed={!panelVisible}
             placement={placement}
             overlay
             className={

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -881,6 +881,13 @@
      everything already standing between it and that edge. Two literals would be
      two chances to change one of them. */
   --maka-titlebar-gutter-left: max(var(--space-6), var(--maka-titlebar-area-x));
+  /* Shared by the titlebar strip and the workbar's bar, which hold one collapse
+     toggle to the same x. Deliberately not the left gutter's `--space-6`
+     floor: the left is a safe area under the traffic lights, the right is the
+     bar's own inset. */
+  --maka-titlebar-gutter-right: calc(
+    var(--space-2) + var(--maka-titlebar-overlay-right-width)
+  );
   --maka-titlebar-gap: var(--space-2);
   /* What the strip keeps for itself. This window has no OS title bar, so the
      strip IS the drag handle, and the session breadcrumb is a grid item that

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -267,13 +267,11 @@
      --background right). Windows titleBarOverlay still samples --background
      for the OS caption strip on the content side. */
   background: transparent;
-  /* One gutter rule per side: our own `--space-6` of breathing room, or the
-     platform's native-control safe area when that is wider. Nothing here knows
-     which platform it is on or how wide any control is — `max()` picks whichever
-     the OS reports (macOS: traffic lights on the left; Windows: caption buttons
-     on the right; Linux: neither, so the design floor stands). */
+  /* One gutter rule per side, both resolved in maka-tokens.css from what the
+     OS reports (macOS: traffic lights on the left; Windows: caption buttons on
+     the right; Linux: neither, so the design floors stand). */
   padding-left: var(--maka-titlebar-gutter-left);
-  padding-right: calc(var(--space-6) + var(--maka-titlebar-overlay-right-width));
+  padding-right: var(--maka-titlebar-gutter-right);
   -webkit-app-region: drag;
 
   /* Three columns, not a flex row, because the middle one has to line up with

--- a/apps/desktop/src/renderer/styles/workbar/artifacts.css
+++ b/apps/desktop/src/renderer/styles/workbar/artifacts.css
@@ -387,7 +387,6 @@
   .maka-session-workbar-panel[data-overlay][data-placement] {
     width: 100%;
     min-width: 0;
-    max-width: none;
     min-height: min(220px, 42dvh);
     max-height: min(42dvh, 360px);
     height: min(42dvh, 360px);

--- a/apps/desktop/src/renderer/styles/workbar/shell.css
+++ b/apps/desktop/src/renderer/styles/workbar/shell.css
@@ -63,12 +63,55 @@
   box-sizing: border-box;
 }
 
-.maka-session-workbar[data-placement="right"] {
+/* The frame and the overlay panel share the grid area, so they carry the same
+   width and margin. No `min-width` here: it would stop the collapse short,
+   and `workbar-layout.ts` already clamps the value. */
+.maka-session-workbar[data-placement="right"],
+.maka-session-workbar-panel[data-overlay][data-placement="right"] {
   grid-area: right;
   width: var(--maka-session-workbar-width, 480px);
-  min-width: 320px;
-  max-width: 600px;
   margin-left: var(--agents-content-area-gap);
+}
+
+/* On a wide window the right column eases open and shut the way the sidebar
+   does. The children keep the open width and hang off the box's right edge,
+   so the face and the toggle stay where they will rest and the box's left
+   edge sweeps over them; left-anchored they would ride in from the toggle.
+   The lone grid track grows to the children's width, so it is the track that
+   sits at the end: `end` alignment overflows at the start edge. An auto
+   margin would resolve to 0 instead. */
+@media (min-width: 991px) {
+  .maka-session-workbar[data-placement="right"],
+  .maka-session-workbar-panel[data-overlay][data-placement="right"] {
+    justify-content: end;
+    transition:
+      width var(--duration-large) var(--ease-out-strong),
+      margin-left var(--duration-large) var(--ease-out-strong);
+  }
+
+  .maka-session-workbar[data-placement="right"] > *,
+  .maka-session-workbar-panel[data-overlay][data-placement="right"] > * {
+    width: var(--maka-session-workbar-width, 480px);
+  }
+
+  .maka-session-workbar[data-placement="right"][data-collapsed],
+  .maka-session-workbar-panel[data-overlay][data-placement="right"][data-collapsed] {
+    display: grid;
+    width: 0;
+    margin-left: 0;
+    visibility: hidden;
+    transition:
+      width var(--duration-large) var(--ease-out-strong),
+      margin-left var(--duration-large) var(--ease-out-strong),
+      visibility 0s var(--duration-large);
+  }
+
+  /* A pointer drag feeds the width back on every move; an ease would trail it. */
+  .maka-detail-with-artifacts:has([data-resizing]) .maka-session-workbar[data-placement="right"],
+  .maka-detail-with-artifacts:has([data-resizing])
+    .maka-session-workbar-panel[data-overlay][data-placement="right"] {
+    transition: none;
+  }
 }
 
 .maka-session-workbar[data-placement="bottom"] {
@@ -79,10 +122,6 @@
   max-height: 520px;
   margin-top: var(--agents-content-area-gap);
   grid-template-rows: auto minmax(0, 1fr);
-}
-
-.maka-session-workbar[data-collapsed] {
-  display: none;
 }
 
 .maka-workbar-resize-handle-right {
@@ -103,11 +142,9 @@
 }
 
 .maka-session-workbar-panel[data-overlay][data-placement="right"] {
-  grid-area: right;
-  width: var(--maka-session-workbar-width, 480px);
-  min-width: 320px;
-  max-width: 600px;
-  margin-left: var(--agents-content-area-gap);
+  /* One stretched track, like the frame: the face fills the height and the
+     column can be aligned as a whole. */
+  display: grid;
   padding-top: var(--maka-plate-titlebar-clearance);
 }
 
@@ -119,6 +156,13 @@
   max-height: 520px;
   margin-top: var(--agents-content-area-gap);
   padding-top: var(--size-element-sm);
+}
+
+/* After the placement rules, which set `display` at the same specificity, and
+   one attribute lighter than the wide-window rule above, which restores it. */
+.maka-session-workbar[data-collapsed],
+.maka-session-workbar-panel[data-overlay][data-collapsed] {
+  display: none;
 }
 
 .maka-session-workbar-toolbar {
@@ -168,14 +212,10 @@
   --maka-workbar-rail-gap: calc(
     (var(--maka-plate-titlebar-clearance) - var(--size-element-sm)) / 2
   );
-  /* The right pad is the window titlebar strip's own gutter, not this bar's:
-     the collapse toggle is one control that moves between the two bands, and
-     `app-shell.stories.tsx` holds it to the same x in both. Narrowing this to
-     the bar's own gutter would slide it 16px on every collapse. On top of it,
-     the caption buttons where the platform draws them on the right (Windows);
-     macOS puts them on the left, over the sidebar, and reports 0 here. */
-  padding-inline: var(--space-2)
-    calc(var(--space-6) + var(--maka-titlebar-overlay-right-width));
+  /* The right pad is the window titlebar strip's gutter: the collapse toggle
+     is one control that moves between the two bands, and
+     `app-shell.stories.tsx` holds it to the same x in both. */
+  padding-inline: var(--space-2) var(--maka-titlebar-gutter-right);
   -webkit-app-region: drag;
 }
 
@@ -229,9 +269,6 @@
   min-height: 0;
   overflow: hidden;
 }
-
-/* Section sets its own `display`, so the attribute needs the override. */
-.maka-session-workbar-panel[hidden] { display: none; }
 
 .maka-workbar-panel-loading {
   display: grid;

--- a/apps/desktop/src/renderer/styles/workbar/side-chat.css
+++ b/apps/desktop/src/renderer/styles/workbar/side-chat.css
@@ -18,12 +18,11 @@
  */
 
 /* The quote lives as a transient tab inside the session workbar (not a second
-   right column, which was too crowded). The tab panel is a flex column so the
-   companion's ChatView transcript fills the height and the Composer pins to the
-   bottom — the same vertical rhythm as the main conversation. */
+   right column, which was too crowded). The panel's single grid track
+   (workbar/shell.css) stretches the companion to the full height, so its
+   ChatView transcript fills it and the Composer pins to the bottom — the same
+   vertical rhythm as the main conversation. */
 .maka-quote-workbar-panel {
-  display: flex;
-  flex-direction: column;
   min-height: 0;
   padding: 0;
   overflow: hidden;

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -2995,6 +2995,7 @@ function WorkbarInShell() {
     <ToastProvider>
       <WorkbarServicesProvider services={createFakeWorkbarServices()}>
         <ComposedShell
+          motionEnabled
           workbarCollapsed={rightCollapsed}
           onToggleWorkbar={() => collapseRight(!rightCollapsed)}
           detailChildren={
@@ -3047,9 +3048,12 @@ function WorkbarInShell() {
 // The collapse toggle is one control that moves between two bands — the
 // workbar's own bar and the titlebar's right cluster — and `workbar/shell.css`
 // pads the bar with the titlebar strip's gutter precisely so it lands on the
-// same x in both. Only a story that mounts both bands can hold it there, which
-// is why this lives beside the shell rather than with the workbar's own
-// stories.
+// same x in both, one `--space-2` in from the plate's edge on a platform that
+// draws nothing there. Only a story that mounts both bands can hold it there,
+// which is why this lives beside the shell rather than with the workbar's own
+// stories. The column eases shut and open the way the sidebar does, and the
+// face and the toggle keep their x through every frame of it: the box's left
+// edge sweeps over content that is already where it will rest.
 export const WorkbarCollapseKeepsOneToggleInPlace: Story = {
   render: () => <WorkbarInShell />,
   play: async ({ canvasElement }) => {
@@ -3071,6 +3075,49 @@ export const WorkbarCollapseKeepsOneToggleInPlace: Story = {
     const pickerIsShowing = () =>
       canvas.queryByRole('list', { name: '打开工具' }) !== null;
     const face = await bar.findByRole('tab', { selected: true });
+    expect(
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+      'a reduced-motion browser collapses in one frame and this story stops testing the ease',
+    ).toBe(false);
+    // Frames around a click. The runner may be too slow to land the 280ms ease
+    // inside the window, so the resting state is awaited separately.
+    const faceContent = facePanel.firstElementChild!;
+    const sample = () =>
+      new Promise<{
+        frame: number[];
+        panel: number[];
+        faceRight: number[];
+        toggleX: number[];
+        eased: boolean;
+      }>((resolve) => {
+        const out = {
+          frame: [] as number[],
+          panel: [] as number[],
+          faceRight: [] as number[],
+          toggleX: [] as number[],
+          eased: false,
+        };
+        const start = performance.now();
+        const tick = () => {
+          const frameBox = frame.getBoundingClientRect();
+          out.frame.push(Math.round(frameBox.width));
+          out.panel.push(Math.round(facePanel.getBoundingClientRect().width));
+          out.faceRight.push(Math.round(faceContent.getBoundingClientRect().right - frameBox.right));
+          out.toggleX.push(Math.round(collapse.getBoundingClientRect().x));
+          out.eased ||= frame
+            .getAnimations()
+            .some((animation) => (animation as CSSTransition).transitionProperty === 'width');
+          if (performance.now() - start < 500) requestAnimationFrame(tick);
+          else resolve(out);
+        };
+        requestAnimationFrame(tick);
+      });
+    const eased = (sampled: Awaited<ReturnType<typeof sample>>, toggleX: number) => {
+      expect(sampled.eased).toBe(true);
+      expect(sampled.panel).toEqual(sampled.frame);
+      expect(new Set(sampled.faceRight)).toEqual(new Set([0]));
+      expect(new Set(sampled.toggleX)).toEqual(new Set([Math.round(toggleX)]));
+    };
 
     expect(canvas.queryByRole('toolbar', { name: '工作区辅助操作' })).toBeNull();
     expect(pickerIsShowing()).toBe(false);
@@ -3082,46 +3129,57 @@ export const WorkbarCollapseKeepsOneToggleInPlace: Story = {
         faceBox.y + faceBox.height / 2 - (openToggleBox.y + openToggleBox.height / 2),
       ),
     ).toBeLessThanOrEqual(1);
+    expect(frame.getBoundingClientRect().right - openToggleBox.right).toBe(8);
 
     // Windows draws its caption buttons over the right of the strip and reports
     // their width here; macOS reports 0. The bar has to give that width back.
+    // The root is where `maka-tokens.css` reads it into the gutter, so the
+    // override goes there, the way `env()` would report it.
     const captionWidth = 80;
-    canvasElement.style.setProperty(
+    document.documentElement.style.setProperty(
       '--maka-titlebar-overlay-right-width',
       `${captionWidth}px`,
     );
-    await waitFor(() => {
-      expect(collapse.getBoundingClientRect().x).toBeCloseTo(
-        openToggleBox.x - captionWidth,
-        0,
-      );
-    });
-    const parked = collapse.getBoundingClientRect();
+    try {
+      await waitFor(() => {
+        expect(collapse.getBoundingClientRect().x).toBeCloseTo(
+          openToggleBox.x - captionWidth,
+          0,
+        );
+      });
+      const parked = collapse.getBoundingClientRect();
 
-    // [+] is a menu over the panel, not a swap to the launcher: the face you
-    // are reading stays on screen while you pick another one.
-    await userEvent.click(bar.getByRole('button', { name: '打开或关闭工作栏的面' }));
-    const menu = await within(document.body).findByRole('menu');
-    await userEvent.keyboard('{Escape}');
-    await waitFor(() => expect(menu).not.toBeVisible());
-    expect(pickerIsShowing()).toBe(false);
+      // [+] is a menu over the panel, not a swap to the launcher: the face you
+      // are reading stays on screen while you pick another one.
+      await userEvent.click(bar.getByRole('button', { name: '打开或关闭工作栏的面' }));
+      const menu = await within(document.body).findByRole('menu');
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => expect(menu).not.toBeVisible());
+      expect(pickerIsShowing()).toBe(false);
 
-    await userEvent.click(collapse);
-    const restore = await canvas.findByRole('button', { name: '展开任务工作栏' });
-    await waitFor(() => expect(frame).not.toBeVisible());
-    expect(facePanel).not.toBeVisible();
-    const restoreBox = restore.getBoundingClientRect();
-    expect(Math.abs(restoreBox.x - parked.x)).toBeLessThanOrEqual(1);
-    expect(Math.abs(restoreBox.y - parked.y)).toBeLessThanOrEqual(1);
+      let sampling = sample();
+      await userEvent.click(collapse);
+      const restore = await canvas.findByRole('button', { name: '展开任务工作栏' });
+      eased(await sampling, parked.x);
+      await waitFor(() => expect(frame).not.toBeVisible());
+      expect(facePanel).not.toBeVisible();
+      const restoreBox = restore.getBoundingClientRect();
+      expect(Math.abs(restoreBox.x - parked.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(restoreBox.y - parked.y)).toBeLessThanOrEqual(1);
 
-    await userEvent.click(restore);
-    await waitFor(() => expect(frame).toBeVisible());
-    expect(facePanel).toBeVisible();
-    expect(pickerIsShowing()).toBe(false);
-    const restoredToggleBox = bar
-      .getByRole('button', { name: '收起任务工作栏' })
-      .getBoundingClientRect();
-    expect(Math.abs(restoredToggleBox.x - parked.x)).toBeLessThanOrEqual(1);
-    expect(Math.abs(restoredToggleBox.y - parked.y)).toBeLessThanOrEqual(1);
+      sampling = sample();
+      await userEvent.click(restore);
+      eased(await sampling, parked.x);
+      await waitFor(() => expect(frame).toBeVisible());
+      expect(facePanel).toBeVisible();
+      expect(pickerIsShowing()).toBe(false);
+      const restoredToggleBox = bar
+        .getByRole('button', { name: '收起任务工作栏' })
+        .getBoundingClientRect();
+      expect(Math.abs(restoredToggleBox.x - parked.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(restoredToggleBox.y - parked.y)).toBeLessThanOrEqual(1);
+    } finally {
+      document.documentElement.style.removeProperty('--maka-titlebar-overlay-right-width');
+    }
   },
 };

--- a/apps/desktop/stories/session-workbar.stories.tsx
+++ b/apps/desktop/stories/session-workbar.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import type { CSSProperties } from 'react';
+import { useState, type CSSProperties } from 'react';
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import type { ArtifactRecord } from '@maka/core/artifacts';
@@ -27,7 +27,7 @@ import type { SessionSummary } from '@maka/core/session';
 import type { SessionTrace } from '@maka/core/session-trace';
 import type { ContextDiagnosticsResult } from '@maka/runtime-host/protocol';
 import { ToastProvider } from '@maka/ui';
-import { WorkbarServicesProvider } from '../src/renderer/features/workbar';
+import { WorkbarServicesProvider, WorkbarTitlebarActions } from '../src/renderer/features/workbar';
 import { WorkbarSurface } from '../src/renderer/features/workbar/stories';
 import {
   createFakeWorkbarServices,
@@ -927,7 +927,13 @@ function Workbar(props: {
   sourceSession?: SessionSummary;
   /** Overrides the restored column width, the way the resize handle does. */
   width?: number;
+  /**
+   * Lets the column's own collapse toggle and the titlebar's restore
+   * affordance drive `rightCollapsed`, the way the app's reducer does.
+   */
+  collapsible?: boolean;
 }) {
+  const [collapsed, setCollapsed] = useState(false);
   const emptyTabsState = createSessionWorkbarTabsState();
   let tab: SessionWorkbarTab | undefined;
   let quotes: QuoteCompanionPanelState[] | undefined;
@@ -985,13 +991,21 @@ function Workbar(props: {
           ...(props.width ? { '--maka-session-workbar-width': `${props.width}px` } : {}),
         } as CSSProperties}
       >
-        <div className="mainColumn" />
+        <div className="mainColumn">
+          {props.collapsible && (
+            <WorkbarTitlebarActions
+              available
+              collapsed={collapsed}
+              onToggle={() => setCollapsed(false)}
+            />
+          )}
+        </div>
         <WorkbarSurface
           sessionId={SESSION_ID}
           hidden={false}
-          onDismissPanel={noop}
+          onDismissPanel={props.collapsible ? () => setCollapsed(true) : noop}
           panelsState={createSessionWorkbarPanelsState(tabsState)}
-          rightCollapsed={false}
+          rightCollapsed={collapsed}
           bottomOpen={false}
           onActivateTab={noop}
           onCloseTab={noop}
@@ -1074,6 +1088,37 @@ export const SeveralFacesAtColumnFloor: Story = {
   render: () => (
     <Workbar tab="review" alsoOpen={['browser', 'files']} width={320} />
   ),
+};
+
+// Below 991px the column stacks under the conversation at full width. The
+// wide-window ease (app-shell.stories.tsx holds that contract) must not reach
+// it: the face spans the row, and collapsing removes the row instead of
+// leaving an empty band. The smoke lane sizes stories named `narrow` to 720px.
+export const CollapseNarrowStack: Story = {
+  parameters: { viewport: { options: STACKED_WINDOW_VIEWPORT } },
+  globals: { viewport: { value: 'makaStackedWindow', isRotated: false } },
+  decorators: [bridge()],
+  render: () => <Workbar tab="review" collapsible />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const frame = canvasElement.querySelector<HTMLElement>(
+      '.maka-session-workbar[data-placement="right"]',
+    )!;
+    const panel = canvasElement.querySelector<HTMLElement>(
+      '.maka-session-workbar-panel[data-overlay][data-placement="right"]',
+    )!;
+    const toolbar = frame.querySelector<HTMLElement>('.maka-session-workbar-toolbar')!;
+    await canvas.findByRole('region', { name: 'Git 变更' });
+    expect(window.innerWidth).toBeLessThanOrEqual(990);
+    expect(toolbar.getBoundingClientRect().width).toBe(frame.getBoundingClientRect().width);
+    expect(panel.firstElementChild!.getBoundingClientRect().width).toBe(
+      panel.getBoundingClientRect().width,
+    );
+
+    await userEvent.click(canvas.getByRole('button', { name: '收起任务工作栏' }));
+    await waitFor(() => expect(getComputedStyle(frame).display).toBe('none'));
+    expect(getComputedStyle(panel).display).toBe('none');
+  },
 };
 
 // Real path: 任务工作栏 → 变更 on a session whose branch matches its base. The


### PR DESCRIPTION
## Summary

Two things the right workbar got wrong next to the sidebar it mirrors.

**The collapse toggle sat 24px in from the plate's right edge on macOS**, where the OS draws nothing on that side. The titlebar strip and the workbar's own bar each spelled the right gutter out as `--space-6 + --maka-titlebar-overlay-right-width`. That is now one token, `--maka-titlebar-gutter-right`, built from the bar's own `--space-2` inset plus whatever the platform reports: 0 on macOS and Linux, the caption-button width on Windows. Both bands read it, so the toggle keeps the same x whether the column is open or collapsed, and only Windows caption buttons push it inward.

**The column snapped between `display: none` and its width.** The sidebar eases with `--duration-large` / `--ease-out-strong`; the workbar had nothing. The frame and the overlay panel that shares its grid area now animate `width` and `margin-left`, with `visibility` gated by the same duration so a hidden column takes no focus or hit-testing. Their children hold the open width and hang off the right edge (`justify-content: end` on the lone grid track; an auto margin resolves to 0 against negative free space), so the face and the toggle keep their resting x and the box's left edge sweeps over them, the way the sidebar reveals its own content. Left-anchored, the whole face rode in from the toggle. A pointer drag on the resize handle disables the ease the way the sidebar does. The ease is scoped to `@media (min-width: 991px)`: below that the column stacks under the conversation at full width, so collapsing still removes the row, and the bottom placement keeps `display: none` at every width. A modal obscuring the shell now sets `hidden` on the frame instead of collapsing it, so opening a dialog does not play the ease.

Also removed: the `min-width: 320px` / `max-width: 600px` on the column. `workbar-layout.ts` already clamps the value to 340–600, and a CSS floor would stop the collapse short of 0.

Refs #2188. That tracker's "8px / 8px toolbar padding" box is ticked, but #4789's description says it left that open; this PR is what lands it.

## Verification

- `product-shell-official-appshell--workbar-collapse-keeps-one-toggle-in-place` (from #4877) now carries the motion contract too, since it is the one story that mounts both bands: it asserts the 8px gutter before simulating a caption width, then samples `requestAnimationFrame` frames around collapse and restore. Each pass has to see a running `width` transition on the frame, the overlay panel's width equal to the frame's on every frame, and the face's right edge and the toggle's x unmoved throughout. The resting state is awaited separately so a slow runner cannot cut the ease short (the first CI run failed exactly there). `WorkbarInShell` passes `motionEnabled`, because `ShellFrame` otherwise pins the fixture attribute that turns every transition off. The caption-width override goes on the document root, where the gutter token reads it, and is cleared in a `finally`.
- New story `product-session-workbar--collapse-narrow-stack` runs at the smoke runner's 720px viewport (and the stacked viewport in the Storybook UI) and asserts the stacked column keeps its face at full width and that collapsing removes both the frame and the panel.
- `npm run smoke:storybook` passes both. The same run reports 4 unrelated failures (session-list project groups, plus-menu during skill refresh, two slash-menu stories) that fail identically against a Storybook built from `main`.
- Reviewed adversarially twice against Astryx's motion, layout and styling docs, the repo's cascade-layer contract, and for bloat. `Section`'s `display` and the children's `width` are overridden from the `components` layer, which `cascade-layers.css` reserves for product CSS; reduced motion is honoured by the global `transition: none` in `styles/base.css`, so the story asserts it is not running under `prefers-reduced-motion`. The reviews' findings (narrow-window stacking, bottom overlay panels, modal hide, dead rules, a redundant second motion story and its fake titlebar host, a monotonicity check that added no information) are folded in.
- `e2e/session-workbar.spec.ts` passes (6/6) in Electron.
- The titlebar strip's right padding shrinks by 16px on every platform, so the whole right cluster (today only the workbar action) moves with it; on Windows it now sits 8px from the caption buttons. That is the #2188 target and is deliberate.
- Cost of keeping the panels mounted and easing them: a CDP performance trace of one 280ms collapse in Electron measures ~95ms of main-thread work across 33 frames with 0 dropped frames at 120Hz, in line with the sidebar's ease.
- `npm run format`, `npm run lint`, `npm run build:renderer`, `npm run build-storybook` all clean.
- Found while measuring, not caused here: the transcript's first-column glyph stems ("F", "T") are clipped by a pixel at DPR 2 when the workbar is open. Reproduced on a renderer built from `main`; left alone in this PR.

Real Electron window from the `gitReviewWindow` E2E fixture, 1240×820 at DPR 2, cropped to the right 1000×420 CSS px so the toolbar reads. Renderer built from `main` at a03dd577bb on the left, from this branch on the right. The fixture pins transitions to `none`; the capture drops that attribute before clicking collapse.

![Light, open: toggle position](https://github.com/user-attachments/assets/19abb4d8-7b73-40de-927e-3cca49d4c3b7)

![Dark, open: toggle position](https://github.com/user-attachments/assets/5ea33a66-f121-4818-ab55-3080c40d2160)

![Light, 40ms after collapse](https://github.com/user-attachments/assets/c93afec0-27d7-4845-916a-2367877bdab1)

![Dark, 40ms after collapse](https://github.com/user-attachments/assets/98ea5abb-2872-41cb-a4e8-d170a8b8e94c)

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Fable 5.1) diagnosed the gap and the missing motion over CDP, wrote the CSS, the `WorkbarPanel` change, the story and the E2E adjustment, and ran the measurements; reviewed and directed by the author.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

