### PR TITLE
fix(peer-mesh): rediscover existing members after reconnecting

### DIFF
--- a/apps/desktop/e2e-budget.json
+++ b/apps/desktop/e2e-budget.json
@@ -30,8 +30,8 @@
       "electron": "needs a second real Session (Host round trip) to switch to; the focus and draft-restore halves alone would not earn a window"
     },
     "session-workbar.spec.ts": {
-      "tests": 5,
-      "electron": "Git changes re-read on window focus, terminal PTY ownership across Sessions, Side Chat's fork lifecycle, and a first send that has to reach the Host; the composer-usage test is renderer-only and rides along on those windows until app-shell.tsx's composer-to-workbar wiring has a story host"
+      "tests": 6,
+      "electron": "Git changes re-read on window focus, terminal PTY ownership across Sessions, Side Chat's fork lifecycle, per-Session workbar persistence across renderer reload, and a first send that has to reach the Host; the composer-usage test is renderer-only and rides along on those windows until app-shell.tsx's composer-to-workbar wiring has a story host"
     },
     "settings.spec.ts": {
       "tests": 4,

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -43,6 +43,7 @@ import {
   createFakeWorkbarServices,
   createSessionWorkbarPanelsState,
   reduceWorkbarLayout,
+  isSessionWorkbarCollapsed,
   SESSION_BOTTOM_PANEL_DEFAULT_HEIGHT,
   SESSION_WORKBAR_DEFAULT_WIDTH,
   type WorkbarLayoutState,
@@ -2971,7 +2972,8 @@ export const RailStaysOnTheVisiblePrompt: Story = {
 const workbarLayoutWithOneFace: WorkbarLayoutState = reduceWorkbarLayout(
   {
     panels: createSessionWorkbarPanelsState(),
-    rightCollapsed: true,
+    activeSessionId: 'session-active',
+    collapsedBySession: {},
     bottomOpen: false,
     rightWidth: SESSION_WORKBAR_DEFAULT_WIDTH,
     bottomHeight: SESSION_BOTTOM_PANEL_DEFAULT_HEIGHT,
@@ -2981,14 +2983,15 @@ const workbarLayoutWithOneFace: WorkbarLayoutState = reduceWorkbarLayout(
 
 function WorkbarInShell() {
   const [layout, dispatch] = useReducer(reduceWorkbarLayout, workbarLayoutWithOneFace);
+  const rightCollapsed = isSessionWorkbarCollapsed(layout);
   const collapseRight = (collapsed: boolean) =>
     dispatch({ type: 'collapse', placement: 'right', collapsed });
   return (
     <ToastProvider>
       <WorkbarServicesProvider services={createFakeWorkbarServices()}>
         <ComposedShell
-          workbarCollapsed={layout.rightCollapsed}
-          onToggleWorkbar={() => collapseRight(!layout.rightCollapsed)}
+          workbarCollapsed={rightCollapsed}
+          onToggleWorkbar={() => collapseRight(!rightCollapsed)}
           detailChildren={
             <div
               className="maka-detail-with-artifacts"
@@ -3002,7 +3005,7 @@ function WorkbarInShell() {
                 hidden={false}
                 onDismissPanel={() => collapseRight(true)}
                 panelsState={layout.panels}
-                rightCollapsed={layout.rightCollapsed}
+                rightCollapsed={rightCollapsed}
                 bottomOpen={layout.bottomOpen}
                 onActivateTab={(placement, tabId) =>
                   dispatch({ type: 'activate', placement, tabId })

--- a/native/runtime-host-peer/src/engine.rs
+++ b/native/runtime-host-peer/src/engine.rs
@@ -863,7 +863,7 @@ async fn run_endpoint_async(
                     }
                     let _ = result.send(());
                 }
-                Some(EngineCommand::Connect { options, stream_kind, result }) => {
+                Some(EngineCommand::Connect { mut options, stream_kind, result }) => {
                     if direct.pending.contains_key(&options.request_id)
                         || direct.pending.values().any(|connect| connect.peer_id == options.peer_id
                             && connect.stream_kind == stream_kind && connect.result.is_some())
@@ -873,6 +873,20 @@ async fn run_endpoint_async(
                             "a connection request with this identity is already in progress",
                         )));
                         continue;
+                    }
+                    if stream_kind == StreamKind::MeshControl {
+                        // A connected member may have no retained Mesh lease.
+                        // Reuse only live paths through still-approved transit
+                        // peers; this must not promote public coordination relays.
+                        for relay_peer in mesh_control
+                            .eligible_connections(options.peer_id, &direct.retiring_connections, &transit.approved_relays)
+                            .into_iter()
+                            .filter_map(|(_, path)| path.relay_peer_id())
+                        {
+                            if !options.transit_relay_peers.contains(&relay_peer) {
+                                options.transit_relay_peers.push(relay_peer);
+                            }
+                        }
                     }
                     if stream_kind == StreamKind::MeshControl
                         && options.route_hints.is_empty()
@@ -2814,9 +2828,7 @@ fn reconcile_pending_transit_connects(
     let mut unavailable = Vec::new();
     let mut retired_dials = HashMap::new();
     for (request_id, waiter) in &mut direct.pending {
-        if waiter.stream_kind != StreamKind::Application
-            || waiter.transit_relay_peers.is_disjoint(revoked_relays)
-        {
+        if waiter.transit_relay_peers.is_disjoint(revoked_relays) {
             continue;
         }
         waiter
@@ -4939,6 +4951,54 @@ mod tests {
                 .expect("expired route read failed"),
             b"after-route-expiry",
         );
+
+        // The mesh has forgotten the expired routes, but the application is
+        // still connected through an approved transit. Recover its signed
+        // evidence over that exact path without supplying the relay again.
+        let (result, response) = oneshot::channel();
+        source
+            .commands
+            .send(EngineCommand::Connect {
+                options: ConnectOptions {
+                    request_id: 11,
+                    peer_id: target.peer_id,
+                    route_hints: Vec::new(),
+                    coordination_relays: Vec::new(),
+                    transit_relay_peers: Vec::new(),
+                    deadline: Duration::from_secs(5),
+                },
+                stream_kind: StreamKind::MeshControl,
+                result,
+            })
+            .await
+            .expect("send Mesh recovery over live transit");
+        let recovered_mesh = tokio::time::timeout(Duration::from_secs(5), response)
+            .await
+            .expect("Mesh recovery timeout")
+            .expect("Mesh recovery response")
+            .expect("Mesh recovery failed");
+        assert_eq!(
+            recovered_mesh.path,
+            PeerConnectionPath::Transit {
+                relay_peer_id: relay.peer_id
+            },
+        );
+        let mut recovered_target =
+            tokio::time::timeout(Duration::from_secs(5), target.mesh_incoming.recv())
+                .await
+                .expect("recovered Mesh inbound timeout")
+                .expect("recovered Mesh inbound stream");
+        write_test_stream(&recovered_mesh, b"recover-mesh-routes").await;
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), recovered_target.incoming.recv())
+                .await
+                .expect("recovered Mesh read timeout")
+                .expect("Mesh ended")
+                .expect("Mesh read failed"),
+            b"recover-mesh-routes",
+        );
+        close_test_stream(recovered_mesh).await;
+        close_test_stream(recovered_target).await;
         configure_test_transit_with_reservations(
             &source,
             HashSet::new(),
@@ -4985,15 +5045,34 @@ mod tests {
             },
         )
         .await;
-        configure_test_transit(&source, HashSet::new()).await;
-        let result = tokio::time::timeout(Duration::from_secs(2), response)
+        let (result, mesh_response) = oneshot::channel();
+        source
+            .commands
+            .send(EngineCommand::Connect {
+                options: ConnectOptions {
+                    request_id: 12,
+                    peer_id: PeerId::random(),
+                    route_hints: Vec::new(),
+                    coordination_relays: Vec::new(),
+                    transit_relay_peers: vec![relay.peer_id],
+                    deadline: Duration::from_secs(10),
+                },
+                stream_kind: StreamKind::MeshControl,
+                result,
+            })
             .await
-            .expect("revoked pending connect timeout")
-            .expect("revoked pending connect response");
-        let Err(error) = result else {
-            panic!("revoked pending transit connect succeeded");
-        };
-        assert_eq!(error.code, "transit_unavailable");
+            .expect("send pending Mesh transit connect");
+        configure_test_transit(&source, HashSet::new()).await;
+        for response in [response, mesh_response] {
+            let result = tokio::time::timeout(Duration::from_secs(2), response)
+                .await
+                .expect("revoked pending connect timeout")
+                .expect("revoked pending connect response");
+            let Err(error) = result else {
+                panic!("revoked pending transit connect succeeded");
+            };
+            assert_eq!(error.code, "transit_unavailable");
+        }
         configure_test_transit(&relay, HashSet::from([target.peer_id])).await;
 
         close_test_stream(source_stream).await;

--- a/packages/runtime-host/src/__tests__/peer-mesh.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-mesh.test.ts
@@ -203,6 +203,11 @@ test('does not synchronize reachability to a peer removed after reconciliation s
     connection.release();
     await reconciliation;
 
+    authorityPeer.establishConnection('peer-b');
+    authority.peerConnected('peer-b');
+    authority.peerConnected('unknown-peer');
+    await authority.reconcile();
+    assert.deepEqual(authority.status()[0]?.roster.roster.members, ['peer-a']);
     assert.equal(memberPeer.receivedControlCount('sync'), synchronizedBeforeRemoval);
   } finally {
     await Promise.allSettled([authority.close(), member.close()]);
@@ -517,52 +522,104 @@ test('does not let a member replace the signed Mesh authority locator', async ()
   }
 });
 
-test('keeps Mesh membership while pruning reachability beyond its recovery horizon', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'maka-peer-mesh-expired-reachability-'));
-  const network = new MemoryPeerNetwork();
-  const authorityPeer = network.create('peer-a');
-  const memberPeer = network.create('peer-b');
-  let now = Date.now();
-  const authority = await openPeerMeshNode({
-    dataRoot: join(root, 'authority'),
-    peer: authorityPeer,
-    now: () => now,
-  });
-  const memberRoot = join(root, 'member');
-  let member = await openPeerMeshNode({
-    dataRoot: memberRoot,
-    peer: memberPeer,
-    now: () => now,
-  });
-  const serving = authority.serve();
-  try {
-    const meshId = (await authority.create()).roster.roster.meshId;
-    await member.join(await authority.invite(meshId));
-    await member.close();
-
-    now += PEER_REACHABILITY_LEASE_TTL_MS + 24 * 60 * 60 * 1_000 + 1;
-    member = await openPeerMeshNode({
+for (const reconnectingSide of ['authority', 'member'] as const) {
+  test(`recovers expired two-node Mesh routes when the ${reconnectingSide} observes a fresh connection`, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-peer-mesh-expired-reachability-'));
+    const network = new MemoryPeerNetwork();
+    const authorityPeer = network.create('peer-a');
+    const memberPeer = network.create('peer-b');
+    let now = Date.now();
+    const authorityRoot = join(root, 'authority');
+    let authority = await openPeerMeshNode({
+      dataRoot: authorityRoot,
+      peer: authorityPeer,
+      now: () => now,
+    });
+    const memberRoot = join(root, 'member');
+    let member = await openPeerMeshNode({
       dataRoot: memberRoot,
       peer: memberPeer,
       now: () => now,
     });
+    const serving = [authority.serve()];
+    try {
+      const meshId = (await authority.create()).roster.roster.meshId;
+      await member.join(await authority.invite(meshId));
+      await Promise.all([authority.close(), member.close()]);
+      await Promise.all(serving);
+      authorityPeer.setReachable(false);
+      memberPeer.setReachable(false);
 
-    assert.equal(member.status()[0]?.roster.roster.meshId, meshId);
-    const persisted = JSON.parse(await readFile(join(memberRoot, 'peer-mesh.json'), 'utf8')) as {
-      readonly reachability: readonly {
-        readonly lease: { readonly peerId: string };
-      }[];
-    };
-    assert.deepEqual(
-      persisted.reachability.map(({ lease }) => lease.peerId),
-      ['peer-b'],
-    );
-  } finally {
-    await Promise.allSettled([authority.close(), member.close()]);
-    await Promise.allSettled([authorityPeer.close(), memberPeer.close(), serving]);
-    await rm(root, { recursive: true, force: true });
-  }
-});
+      now += PEER_REACHABILITY_LEASE_TTL_MS + 24 * 60 * 60 * 1_000 + 1;
+      const authorityRoutes = ['/memory/peer-a-moved/p2p/peer-a'];
+      const memberRoutes = ['/memory/peer-b-moved/p2p/peer-b'];
+      await authorityPeer.setRouteHints(authorityRoutes);
+      await memberPeer.setRouteHints(memberRoutes);
+      await authorityPeer.setCoordinationRelays([]);
+      await memberPeer.setCoordinationRelays([]);
+      authority = await openPeerMeshNode({
+        dataRoot: authorityRoot,
+        peer: authorityPeer,
+        now: () => now,
+      });
+      member = await openPeerMeshNode({
+        dataRoot: memberRoot,
+        peer: memberPeer,
+        now: () => now,
+      });
+
+      assert.equal(member.status()[0]?.roster.roster.meshId, meshId);
+      const persisted = JSON.parse(await readFile(join(memberRoot, 'peer-mesh.json'), 'utf8')) as {
+        readonly reachability: readonly {
+          readonly lease: { readonly peerId: string };
+        }[];
+      };
+      assert.deepEqual(
+        persisted.reachability.map(({ lease }) => lease.peerId),
+        ['peer-b'],
+      );
+      assert.deepEqual(authority.resolveRoutes('peer-b').routeHints, []);
+      assert.deepEqual(member.resolveRoutes('peer-a').routeHints, []);
+      serving.push(authority.serve(), member.serve());
+      await Promise.all([authority.reconcile(), member.reconcile()]);
+
+      // A fresh share reconnects the same authenticated identities without a
+      // Mesh invitation, stored routes, public relay, or third discovery node.
+      authorityPeer.setReachable(true);
+      memberPeer.setReachable(true);
+      authorityPeer.establishConnection('peer-b');
+      if (reconnectingSide === 'authority') authority.peerConnected('peer-b');
+      else member.peerConnected('peer-a');
+      await Promise.all([
+        waitForRoutes(authority, 'peer-b', memberRoutes, []),
+        waitForRoutes(member, 'peer-a', authorityRoutes, []),
+      ]);
+      assert.deepEqual(authority.status()[0]?.roster.roster.members, ['peer-a', 'peer-b']);
+      assert.deepEqual(member.status()[0]?.roster.roster.members, ['peer-a', 'peer-b']);
+      assert.equal(authority.transitMeshId(), null);
+      assert.equal(member.transitMeshId(), null);
+
+      // Recovery must persist signed evidence, not just keep the share's live
+      // connection or an application-only route cache alive.
+      await Promise.all([authority.close(), member.close()]);
+      await Promise.all(serving);
+      authorityPeer.setReachable(false);
+      memberPeer.setReachable(false);
+      authority = await openPeerMeshNode({
+        dataRoot: authorityRoot,
+        peer: authorityPeer,
+        now: () => now,
+      });
+      member = await openPeerMeshNode({ dataRoot: memberRoot, peer: memberPeer, now: () => now });
+      assert.deepEqual(authority.resolveRoutes('peer-b').routeHints, memberRoutes);
+      assert.deepEqual(member.resolveRoutes('peer-a').routeHints, authorityRoutes);
+    } finally {
+      await Promise.allSettled([authority.close(), member.close()]);
+      await Promise.allSettled([authorityPeer.close(), memberPeer.close(), ...serving]);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}
 
 test('recovers persisted Mesh reachability after the wall clock moves backward', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-peer-mesh-clock-rollback-'));
@@ -1591,6 +1648,13 @@ class MemoryPeerClient implements PeerMeshTransport, PeerReachabilityPublisher {
 
   isConnected(peerId: string): boolean {
     return this.#connectedPeerIds.has(peerId);
+  }
+
+  establishConnection(peerId: string): void {
+    const remote = this.peers.get(peerId);
+    assert.ok(remote);
+    this.#connectedPeerIds.add(peerId);
+    remote.#connectedPeerIds.add(this.peerId);
   }
 
   transitSnapshot() {

--- a/packages/runtime-host/src/__tests__/peer-native.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-native.test.ts
@@ -323,6 +323,37 @@ module.exports = {
     assert.equal(connectivityWakeups, 1);
     unsubscribeConnectivity();
 
+    const connectedPeers: string[] = [];
+    const detachRecovery = client.attachRouteResolver({
+      prepareRoutes: async () => {},
+      resolveRoutes: () => ({
+        state: 'exhausted',
+        routeHints: [],
+        coordinationRelays: [],
+        transitRelayPeerIds: [],
+      }),
+      subscribeRoutes: () => () => {},
+      peerConnected: (peerId) => {
+        connectedPeers.push(peerId);
+        if (peerId === 'restored') throw new Error('recovery observer failed');
+      },
+    });
+    assert.deepEqual(connectedPeers, ['restored'], 'attachment observes an already connected peer');
+    native.default.establishPeer('ready');
+    await waitForImmediate();
+    assert.deepEqual(connectedPeers, ['restored', 'ready']);
+    native.default.establishPeer('ready');
+    await waitForImmediate();
+    assert.deepEqual(
+      connectedPeers,
+      ['restored', 'ready'],
+      'snapshot refreshes are not new connections',
+    );
+    detachRecovery();
+    native.default.establishPeer('detached');
+    await waitForImmediate();
+    assert.deepEqual(connectedPeers, ['restored', 'ready']);
+
     native.default.failEndpoint();
     await waitForImmediate();
     await assert.rejects(

--- a/packages/runtime-host/src/client/peer-client.ts
+++ b/packages/runtime-host/src/client/peer-client.ts
@@ -68,6 +68,7 @@ export type RuntimeHostPeerRouteResolution =
   | (RuntimeHostPeerRouteCandidateSnapshot & { readonly state: 'exhausted' });
 
 export interface RuntimeHostPeerRouteResolver {
+  peerConnected?(peerId: string): void;
   resolveRoutes(peerId: string): RuntimeHostPeerRouteResolution;
   prepareRoutes(peerId: string, signal: AbortSignal): Promise<void>;
   subscribeRoutes(peerId: string, listener: () => void): () => void;
@@ -268,6 +269,9 @@ class RuntimeHostPeerClientImpl implements RuntimeHostPeerClient {
     }
     if (this.#routeResolver === resolver) return () => undefined;
     this.#routeResolver = resolver;
+    for (const peerId of this.#endpoint?.connectivitySnapshot.connectedPeerIds ?? []) {
+      this.#notifyPeerConnected(peerId);
+    }
     for (const peerId of this.#routeListeners.keys()) {
       this.#subscribeResolver(peerId);
       this.#notifyRouteChange(peerId);
@@ -707,6 +711,8 @@ class RuntimeHostPeerClientImpl implements RuntimeHostPeerClient {
         current = next;
         for (const peerId of new Set([...previousPeers, ...nextPeers])) {
           if (previousPeers.has(peerId) !== nextPeers.has(peerId)) this.#notifyRouteChange(peerId);
+          if (!previousPeers.has(peerId) && nextPeers.has(peerId))
+            this.#notifyPeerConnected(peerId);
         }
       }
     } catch (error) {
@@ -714,6 +720,14 @@ class RuntimeHostPeerClientImpl implements RuntimeHostPeerClient {
       this.#terminalError = error instanceof Error ? error : new Error(String(error));
       this.#finishConsumer('application', this.#terminalError);
       this.#finishConsumer('mesh', this.#terminalError);
+    }
+  }
+
+  #notifyPeerConnected(peerId: string): void {
+    try {
+      this.#routeResolver?.peerConnected?.(peerId);
+    } catch {
+      // Mesh recovery must not interrupt the transport's connectivity watcher.
     }
   }
 

--- a/packages/runtime-host/src/peer-mesh/node.ts
+++ b/packages/runtime-host/src/peer-mesh/node.ts
@@ -185,6 +185,7 @@ export interface PeerMeshNode {
   resolveRoutes(peerId: string): RuntimeHostPeerRouteResolution;
   prepareRoutes(peerId: string, signal: AbortSignal): Promise<void>;
   subscribeRoutes(peerId: string, listener: () => void): () => void;
+  peerConnected(peerId: string): void;
   reconcile(signal?: AbortSignal): Promise<void>;
   serve(): Promise<void>;
   close(): Promise<void>;
@@ -989,6 +990,21 @@ class PeerMeshNodeImpl implements PeerMeshNode {
     });
   }
 
+  peerConnected(peerId: string): void {
+    if (this.#lifetime.signal.aborted) return;
+    const localPeerId = this.#peer.identity().peerId;
+    if (
+      peerId !== localPeerId &&
+      this.#store
+        .read()
+        .meshes.some(
+          (state) =>
+            isActiveMembership(state, localPeerId) && state.roster.roster.members.includes(peerId),
+        )
+    )
+      this.#triggerReconciliation();
+  }
+
   async prepareRoutes(peerId: string, signal: AbortSignal): Promise<void> {
     this.#assertOpen();
     signal.throwIfAborted();
@@ -1188,7 +1204,7 @@ class PeerMeshNodeImpl implements PeerMeshNode {
       | {
           readonly kind: 'membership';
           readonly meshId: string;
-          readonly target: SignedPeerReachabilityLeaseV1;
+          readonly target: ReturnType<typeof dialTarget>;
           readonly desiredMembership: 'active' | 'left';
           readonly roster: SignedPeerMeshRosterV1;
         }
@@ -1198,14 +1214,22 @@ class PeerMeshNodeImpl implements PeerMeshNode {
     const gossipCursor = this.#gossipCursor;
     this.#gossipCursor = (this.#gossipCursor + 1) % PEER_MESH_MAX_MEMBERS;
     const now = this.#now();
+    const targetFor = (peerId: string): ReturnType<typeof dialTarget> | undefined => {
+      const signed = latestReachability(stored.reachability, peerId, now, true);
+      if (signed) return dialTarget(signed);
+      // A fresh Session Share can reconnect an existing member after all of
+      // its stored routes expired. Reuse that authenticated connection to
+      // exchange signed evidence; the connection itself grants no membership.
+      return this.#peer.isConnected(peerId)
+        ? { peerId, routeHints: [], coordinationRelays: [] }
+        : undefined;
+    };
     for (const [index, state] of memberships.entries()) {
       const meshId = state.roster.roster.meshId;
       const desiredMembership = state.role === 'replica' ? state.desiredMembership : 'active';
       const authority =
-        state.role === 'replica'
-          ? currentAuthorityTarget(state, stored.reachability, now)
-          : undefined;
-      if (authority && authority.lease.peerId !== excludedPeerId) {
+        state.role === 'replica' ? targetFor(state.roster.roster.authorityPeerId) : undefined;
+      if (authority && authority.peerId !== excludedPeerId) {
         pending.push({
           kind: 'membership',
           meshId,
@@ -1223,7 +1247,7 @@ class PeerMeshNodeImpl implements PeerMeshNode {
             (state.role === 'authority' || peerId !== state.roster.roster.authorityPeerId),
         )
         .flatMap((peerId) => {
-          const target = peerTarget(peerId, stored.reachability, now);
+          const target = targetFor(peerId);
           return target ? [target] : [];
         });
       if (rotatingTargets.length === 0) continue;
@@ -1285,13 +1309,13 @@ class PeerMeshNodeImpl implements PeerMeshNode {
 
   async #notifyLeave(
     meshId: string,
-    target: SignedPeerReachabilityLeaseV1,
+    target: ReturnType<typeof dialTarget>,
     roster: SignedPeerMeshRosterV1,
     signal: AbortSignal,
   ): Promise<void> {
     const stream = await this.#peer.connectMeshControl(
       {
-        ...dialTarget(target),
+        ...target,
         directDeadlineMs: CONNECT_DEADLINE_MS,
       },
       signal,
@@ -1314,22 +1338,21 @@ class PeerMeshNodeImpl implements PeerMeshNode {
 
   async #syncPeer(
     meshId: string,
-    target: SignedPeerReachabilityLeaseV1,
+    target: ReturnType<typeof dialTarget>,
     signal: AbortSignal,
   ): Promise<void> {
     const localPeerId = this.#peer.identity().peerId;
-    const targetPeerId = target.lease.peerId;
+    const targetPeerId = target.peerId;
     for (let page = 0; page <= PEER_MESH_MAX_MEMBERS; page += 1) {
       if (!isActiveMeshMember(this.#store.read().meshes, meshId, localPeerId, targetPeerId)) return;
       const discovered = this.resolveRoutes(targetPeerId);
-      const targetRoutes = dialTarget(target);
       const stream = await this.#peer.connectMeshControl(
         {
           peerId: targetPeerId,
-          routeHints: mergeAddresses(discovered?.routeHints ?? [], targetRoutes.routeHints),
+          routeHints: mergeAddresses(discovered?.routeHints ?? [], target.routeHints),
           coordinationRelays: mergeAddresses(
             discovered?.coordinationRelays ?? [],
-            targetRoutes.coordinationRelays,
+            target.coordinationRelays,
           ),
           transitRelayPeerIds: discovered?.transitRelayPeerIds,
           directDeadlineMs: CONNECT_DEADLINE_MS,
@@ -2378,14 +2401,6 @@ function peerMeshStatus(
   });
 }
 
-function currentAuthorityTarget(
-  state: PeerMeshReplicaStateV1,
-  reachability: readonly SignedPeerReachabilityLeaseV1[],
-  now: number,
-): SignedPeerReachabilityLeaseV1 | undefined {
-  return latestReachability(reachability, state.roster.roster.authorityPeerId, now, true);
-}
-
 function rosterAnnouncementTargets(
   memberPeerIds: readonly string[],
   reachability: readonly SignedPeerReachabilityLeaseV1[],
@@ -2776,14 +2791,6 @@ function hasReachabilityRoutes(signed: SignedPeerReachabilityLeaseV1): boolean {
 
 function usableHistoricalReachability(signed: SignedPeerReachabilityLeaseV1, now: number): boolean {
   return signed.lease.expiresAt > now - PEER_REACHABILITY_RECOVERY_HORIZON_MS;
-}
-
-function peerTarget(
-  peerId: string,
-  reachability: readonly SignedPeerReachabilityLeaseV1[],
-  now: number,
-): SignedPeerReachabilityLeaseV1 | undefined {
-  return latestReachability(reachability, peerId, now, true);
 }
 
 function dialTarget(reachability: SignedPeerReachabilityLeaseV1): {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Problem

A two-node mesh can retain its membership but lose every remote route after the 24-hour historical reachability window. A fresh Session Share may reconnect the same peers, yet mesh reconciliation skips members without a retained lease and never exchanges fresh signed addresses over that connection.

## Changes

- Wake mesh reconciliation when an existing member gains an authenticated transport connection, including connections already present when the route resolver attaches.
- Allow existing connections to bootstrap mesh control even without a retained address lease. Reuse the existing synchronization and durable signed-evidence path instead of copying application caches or extending expired leases.
- Preserve membership, revocation, signature validation, and explicit transit policy. Connecting an unknown or removed peer does not admit it to a mesh.
- Recover over direct connections or live paths through currently approved known transit nodes. Revoke pending mesh-control attempts when their transit approval is removed; public relays are not automatically authorized.
- Align the workbar story fixture and Electron test inventory with the current per-Session layout model.

## Validation

- Two-node regression: advance the clock beyond lease expiry plus 24 hours, rotate both addresses, restart both mesh nodes, then restore only the authenticated connection. Recovery works when either side observes the connection, and both sides retain the new routes after another restart. No third discovery node or relay is used.
- All 39 native tests and Clippy pass, including empty-route mesh control over existing direct and approved-transit connections, isolated endpoint rejection, and revocation of pending application and mesh-control transit attempts.
- All 32 focused mesh and peer-client tests pass, including removed-member fencing, resolver attachment, duplicate connectivity snapshots, observer failures, and detachment.
- The full Runtime Host suite reports 1,709 passed, 12 skipped, and zero failures.
- All 2,264 Desktop tests and the full Storybook smoke (309 stories, 336 theme renders) pass.
- Full workspace build and type checks, lint, format, and ASF header checks pass.

The expiry scenario uses a simulated mesh transport and clock; native connection reuse is tested separately on local endpoints. A live Windows-to-macOS Session Share has not been exercised.

</details>

<details>
<summary>中文</summary>

## 问题

双节点 mesh 在历史地址超过 24 小时恢复窗口后，会保留成员身份但失去全部对端地址。新的 Session Share 即使重新连接了同一对节点，mesh 同步仍会跳过没有保留地址租约的成员，无法利用现有连接交换新的签名地址。

## 修改

- 现有成员建立经过身份认证的底层连接时，唤醒 mesh 同步；路由解析器挂载前已经存在的连接也会被观察到。
- 即使没有保留的地址租约，也允许通过现有连接启动 mesh-control，复用现有同步协议和签名信息持久化路径，不复制应用缓存，也不延长过期租约。
- 保留成员资格、撤销、签名校验及显式 transit 策略；未知或已移除节点不会因为建立连接而自动入网。
- 可通过直连或当前仍获批准的已知 transit 节点上的现有连接恢复同步；transit 授权撤销时取消依赖它的待建立 mesh-control 请求，不自动授权公共 relay。
- 将工作栏 Storybook 示例和 Electron 测试清单与当前按 Session 保存的布局模型对齐。

## 验证

- 双节点回归：将时钟推进至租约过期超过 24 小时，修改双方地址并重启两个 mesh 节点，仅恢复已认证连接。任一侧观察到连接均可恢复同步，再次重启后双方仍保留新地址；不使用第三个发现节点或 relay。
- 39 项原生测试及 Clippy 全部通过，覆盖空地址时复用现有直连和已批准 transit 连接、拒绝无连接的孤立节点，以及撤销待建立的 application 和 mesh-control transit 请求。
- 32 项 mesh 与 peer-client 定向测试全部通过，覆盖已移除成员隔离、解析器挂载、重复连接快照、观察者异常及解除挂载。
- 全量 Runtime Host 测试：1,709 项通过、12 项跳过、0 失败。
- 2,264 项 Desktop 测试和完整 Storybook smoke（309 个 story、336 次主题渲染）通过。
- 全工作区构建、类型检查、lint、格式和 ASF 版权头检查通过。

地址过期场景使用模拟 mesh 传输和时钟，原生连接复用另外通过本地真实端点验证；尚未进行真实 Windows–macOS Session Share 联调。

</details>
