### PR TITLE
test(desktop): cover composer mention catalog context guard

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-mentions.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-mentions.test.ts
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { strict as assert } from 'node:assert';
+import { test, type TestContext } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { act, createElement, useLayoutEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { InvocableSkillEntry } from '@maka/runtime/skill-invocation';
+import {
+  ComposerMentionsProvider,
+  useComposerMentionsContext,
+  type ComposerMentions,
+} from '../../renderer/composer-mentions.js';
+
+interface CatalogObservation {
+  sessionId: string;
+  skills: ComposerMentions['mentionSkills'];
+  loading: boolean;
+  unavailable: boolean;
+}
+
+const skillA: InvocableSkillEntry = {
+  ref: 'workspace:skill-a',
+  id: 'skill-a',
+  name: 'Skill A',
+  description: 'Available in session A.',
+};
+const skillB: InvocableSkillEntry = {
+  ref: 'workspace:skill-b',
+  id: 'skill-b',
+  name: 'Skill B',
+  description: 'Available in session B.',
+};
+
+function installCatalogRenderer(t: TestContext) {
+  const originalGlobals = {
+    document: globalThis.document,
+    window: globalThis.window,
+    HTMLElement: globalThis.HTMLElement,
+    HTMLIFrameElement: globalThis.HTMLIFrameElement,
+    IS_REACT_ACT_ENVIRONMENT: (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+      .IS_REACT_ACT_ENVIRONMENT,
+  };
+  const { document, window } = parseHTML('<div id="root"></div>');
+  Object.assign(globalThis, {
+    document,
+    window,
+    HTMLElement: window.HTMLElement,
+    HTMLIFrameElement: window.HTMLIFrameElement ?? class HTMLIFrameElement {},
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+
+  const pending: Array<{
+    sessionId: string;
+    resolve(skills: InvocableSkillEntry[]): void;
+  }> = [];
+  (window as unknown as { maka: unknown }).maka = {
+    skills: {
+      listInvocable: (sessionId: string) => new Promise<InvocableSkillEntry[]>((resolve) => {
+        pending.push({ sessionId, resolve });
+      }),
+    },
+    sessions: { subscribeChanges: () => () => {} },
+    mcp: { subscribeChanges: () => () => {} },
+  };
+
+  const observations: CatalogObservation[] = [];
+  function Consumer({ sessionId }: { sessionId: string }) {
+    const mentions = useComposerMentionsContext();
+    assert.ok(mentions);
+    useLayoutEffect(() => {
+      // Record what a consumer sees before the provider's passive effect can
+      // replace the previous context's catalog and hide a missing render guard.
+      observations.push({
+        sessionId,
+        skills: mentions.mentionSkills,
+        loading: mentions.mentionSkillsLoading,
+        unavailable: mentions.mentionSkillsUnavailable,
+      });
+    });
+    return null;
+  }
+
+  const container = document.querySelector('#root');
+  assert.ok(container);
+  const root = createRoot(container);
+  t.after(async () => {
+    try {
+      await act(() => root.unmount());
+    } finally {
+      Object.assign(globalThis, originalGlobals);
+    }
+  });
+
+  return {
+    observations,
+    latest() {
+      const observation = observations.at(-1);
+      assert.ok(observation);
+      return observation;
+    },
+    async render(sessionId: string, skillCatalogRevision = 0) {
+      await act(() => root.render(createElement(ComposerMentionsProvider, {
+        sessionId,
+        skillCatalogRevision,
+        children: createElement(Consumer, { sessionId }),
+      })));
+    },
+    async settleNext(sessionId: string, skills: InvocableSkillEntry[]) {
+      const request = pending.shift();
+      assert.ok(request, 'A catalog request must be waiting for its response.');
+      assert.equal(request.sessionId, sessionId);
+      await act(async () => request.resolve(skills));
+    },
+  };
+}
+
+for (const previous of [
+  { name: 'populated', skills: [skillA] },
+  { name: 'empty', skills: [] },
+]) {
+  test(`a session switch immediately replaces the ${previous.name} catalog with loading`, async (t) => {
+    const renderer = installCatalogRenderer(t);
+    await renderer.render('session-a');
+    await renderer.settleNext('session-a', previous.skills);
+    assert.deepEqual(renderer.latest(), {
+      sessionId: 'session-a',
+      skills: previous.skills,
+      loading: false,
+      unavailable: previous.skills.length === 0,
+    });
+
+    const beforeSwitch = renderer.observations.length;
+    await renderer.render('session-b');
+    const firstInSessionB = renderer.observations
+      .slice(beforeSwitch)
+      .find((observation) => observation.sessionId === 'session-b');
+    const loadingCatalog = {
+      sessionId: 'session-b',
+      skills: [],
+      loading: true,
+      unavailable: false,
+    };
+    assert.deepEqual(firstInSessionB, loadingCatalog);
+    assert.deepEqual(renderer.latest(), loadingCatalog);
+
+    await renderer.settleNext('session-b', [skillB]);
+    assert.deepEqual(renderer.latest(), {
+      sessionId: 'session-b',
+      skills: [skillB],
+      loading: false,
+      unavailable: false,
+    });
+  });
+}
+
+test('a same-context refresh keeps the settled skills visible until it resolves', async (t) => {
+  const renderer = installCatalogRenderer(t);
+  await renderer.render('session-a');
+  await renderer.settleNext('session-a', [skillA]);
+
+  // A catalog revision reloads the same backend surface without changing its key.
+  await renderer.render('session-a', 1);
+  assert.deepEqual(renderer.latest(), {
+    sessionId: 'session-a',
+    skills: [skillA],
+    loading: true,
+    unavailable: false,
+  });
+
+  await renderer.settleNext('session-a', [skillB]);
+  assert.deepEqual(renderer.latest(), {
+    sessionId: 'session-a',
+    skills: [skillB],
+    loading: false,
+    unavailable: false,
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4892

Add three regression tests for `ComposerMentionsProvider` using the existing `node:test` + `linkedom` setup:

- Observe the first committed context value after switching sessions, before passive effects can hide stale Skills or an unavailable verdict.
- Cover switches from both populated and empty catalogs.
- Keep settled Skills visible during a same-context refresh until its response resolves.

Production code, dependencies, compiler configuration, and test locations are unchanged.

## Verification

- `npm --workspace @maka/desktop run build:main` — passed.
- New suite: `node --test --test-concurrency=4 dist/main/__tests__/composer-mentions.test.js` from `apps/desktop` — 3 passed; also passed in 20 consecutive fresh processes.
- Existing `agent-graph-panel` and `composer-directories` suites — 23 passed.
- Mutation checks, each rebuilt from source:
  - Invert the context comparison — all 3 tests fail.
  - Remove the render guard — both session-switch tests fail.
  - Clear Skills during same-context refresh — the refresh test fails.
  - Restore production code and rebuild — all 3 tests pass.
- `npm run lint`, `npm run format:check`, `npm run build`, and `npm run typecheck` — passed.
- `npx knip --workspace apps/desktop` and `npx knip --workspace packages/ui` — passed.
- Desktop architecture checks — passed, including 101 checker tests.

Not run: full-repository `npm test`, Storybook browser smoke, or Electron GUI E2E.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:
- OpenAI Codex: test implementation and local verification.
- DeepSeek Harness (`deepseek-v4-pro`, reasoning effort `max`): independent read-only review and focused test execution.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
