### PR TITLE
test(desktop): unbreak main after #4694 (E2E budget, workbar story)

### DIFF
--- a/apps/desktop/e2e-budget.json
+++ b/apps/desktop/e2e-budget.json
@@ -30,8 +30,8 @@
       "electron": "needs a second real Session (Host round trip) to switch to; the focus and draft-restore halves alone would not earn a window"
     },
     "session-workbar.spec.ts": {
-      "tests": 5,
-      "electron": "Git changes re-read on window focus, terminal PTY ownership across Sessions, Side Chat's fork lifecycle, and a first send that has to reach the Host; the composer-usage test is renderer-only and rides along on those windows until app-shell.tsx's composer-to-workbar wiring has a story host"
+      "tests": 6,
+      "electron": "Git changes re-read on window focus, terminal PTY ownership across Sessions, Side Chat's fork lifecycle, a first send that has to reach the Host, and per-Session collapse persisted across a renderer reload; the composer-usage test is renderer-only and rides along on those windows until app-shell.tsx's composer-to-workbar wiring has a story host"
     },
     "settings.spec.ts": {
       "tests": 4,

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -42,6 +42,7 @@ import { WorkbarSurface } from '../src/renderer/features/workbar/stories';
 import {
   createFakeWorkbarServices,
   createSessionWorkbarPanelsState,
+  isSessionWorkbarCollapsed,
   reduceWorkbarLayout,
   SESSION_BOTTOM_PANEL_DEFAULT_HEIGHT,
   SESSION_WORKBAR_DEFAULT_WIDTH,
@@ -2971,7 +2972,8 @@ export const RailStaysOnTheVisiblePrompt: Story = {
 const workbarLayoutWithOneFace: WorkbarLayoutState = reduceWorkbarLayout(
   {
     panels: createSessionWorkbarPanelsState(),
-    rightCollapsed: true,
+    activeSessionId: 'session-active',
+    collapsedBySession: {},
     bottomOpen: false,
     rightWidth: SESSION_WORKBAR_DEFAULT_WIDTH,
     bottomHeight: SESSION_BOTTOM_PANEL_DEFAULT_HEIGHT,
@@ -2983,12 +2985,13 @@ function WorkbarInShell() {
   const [layout, dispatch] = useReducer(reduceWorkbarLayout, workbarLayoutWithOneFace);
   const collapseRight = (collapsed: boolean) =>
     dispatch({ type: 'collapse', placement: 'right', collapsed });
+  const rightCollapsed = isSessionWorkbarCollapsed(layout);
   return (
     <ToastProvider>
       <WorkbarServicesProvider services={createFakeWorkbarServices()}>
         <ComposedShell
-          workbarCollapsed={layout.rightCollapsed}
-          onToggleWorkbar={() => collapseRight(!layout.rightCollapsed)}
+          workbarCollapsed={rightCollapsed}
+          onToggleWorkbar={() => collapseRight(!rightCollapsed)}
           detailChildren={
             <div
               className="maka-detail-with-artifacts"
@@ -3002,7 +3005,7 @@ function WorkbarInShell() {
                 hidden={false}
                 onDismissPanel={() => collapseRight(true)}
                 panelsState={layout.panels}
-                rightCollapsed={layout.rightCollapsed}
+                rightCollapsed={rightCollapsed}
                 bottomOpen={layout.bottomOpen}
                 onActivateTab={(placement, tabId) =>
                   dispatch({ type: 'activate', placement, tabId })


### PR DESCRIPTION
## Summary

`check:e2e-budget` fails on `main`: `session-workbar.spec.ts: budget records 5 test(s), the file has 6`. #4694 added `right workbar visibility belongs to each Session and survives reload` to that spec without updating `apps/desktop/e2e-budget.json`; its CI ran on a base that predated #4877's budget check, so the mismatch only appeared after merge (reported on #4894).

The test belongs in the Electron tier: the per-Session collapse bit has to survive a renderer reload, which the budget policy lists explicitly. This records it and names the mechanism. Tier is now 31 tests in 16 files.

Second break from the same merge: #4694 replaced `WorkbarLayoutState.rightCollapsed` with `activeSessionId` + `collapsedBySession`, and #4877 landed `stories/app-shell.stories.tsx` building the old shape, so `tsc -p tsconfig.storybook.json` fails on `main`. The story now builds the new state and reads the collapse bit through `isSessionWorkbarCollapsed`, as the controller does. #4829's current head carries the same two edits; whichever merges second resolves a same-text conflict.

Refs #4694, #4761, #4877

## Verification

- `node apps/desktop/scripts/check-e2e-budget.mjs`: `E2E budget holds: 31 tests in 16 files.`
- `tsc -p tsconfig.storybook.json --noEmit`: no errors in `stories/app-shell.stories.tsx` (the three pre-existing `packages/ui` Astryx prop errors are local-only and unrelated).
- `biome check` on the story: clean.
- Not run: the E2E suite and Storybook (no code under test changed; the story's play is unchanged).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code drafted the budget entry text and this description.

## Checklist

- [x] Tests cover the change and fail without it (the budget check itself fails on `main` and passes here)
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
