### PR TITLE
test(storybook): wait for plus-menu popups to settle

### DIFF
--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -1492,6 +1492,9 @@ export const PlanAndSwarmModeOn: Story = {
   ),
 };
 
+/** Settles the Skill refresh the Plan toggle below started. */
+let releaseSkillRefresh: (() => void) | undefined;
+
 function PlusMenuRefreshHarness() {
   const [planModeActive, setPlanModeActive] = useState(false);
   const [skillsLoading, setSkillsLoading] = useState(false);
@@ -1506,7 +1509,7 @@ function PlusMenuRefreshHarness() {
         onPlanModeChange(active) {
           setPlanModeActive(active);
           setSkillsLoading(true);
-          window.setTimeout(() => setSkillsLoading(false), 150);
+          releaseSkillRefresh = () => setSkillsLoading(false);
         },
       }}
     />
@@ -1535,7 +1538,7 @@ export const PlusMenuDuringSkillRefresh: Story = {
     expect(Math.abs(menu.getBoundingClientRect().height - height)).toBeLessThanOrEqual(0.5);
 
     await userEvent.click(skillsRow);
-    await expect(menu).toBeVisible();
+    await waitFor(() => expect(menu).toBeVisible(), { timeout: 5_000 });
     const editor = canvasElement.querySelector<HTMLElement>(
       '.maka-composer-editor [contenteditable="true"]',
     );
@@ -1543,6 +1546,7 @@ export const PlusMenuDuringSkillRefresh: Story = {
     await expect(editor).toHaveTextContent('');
     await expect(page.queryByRole('listbox', { name: /技能/ })).not.toBeInTheDocument();
 
+    releaseSkillRefresh?.();
     await waitFor(() => {
       const settledRow = within(
         page.getByRole('menu', { name: '添加上下文' }),
@@ -1553,9 +1557,10 @@ export const PlusMenuDuringSkillRefresh: Story = {
       page.getByRole('menu', { name: '添加上下文' }),
     ).getByRole('menuitem', { name: /选择技能/ });
     await userEvent.click(settledRow);
-    await expect(await page.findByRole('listbox', { name: /技能/ }, {
-      timeout: 5_000,
-    })).toBeVisible();
+    await waitFor(
+      () => expect(page.getByRole('listbox', { name: /技能/ })).toBeVisible(),
+      { timeout: 5_000 },
+    );
   },
 };
 

--- a/apps/desktop/stories/composer-slash-menu.stories.tsx
+++ b/apps/desktop/stories/composer-slash-menu.stories.tsx
@@ -450,8 +450,9 @@ export const ContextSwitchStartsWithALoadingCatalog: Story = {
       page.getByRole('menu', { name: '添加上下文' }),
     ).getByRole('menuitem', { name: /选择技能/ });
     await userEvent.click(settledRow);
-    await expect(await page.findByRole('listbox', { name: /技能/ }, {
-      timeout: 5_000,
-    })).toBeVisible();
+    await waitFor(
+      () => expect(page.getByRole('listbox', { name: /技能/ })).toBeVisible(),
+      { timeout: 5_000 },
+    );
   },
 };


### PR DESCRIPTION
## Summary

The Storybook smoke intermittently reads the composer's ＋ menu as hidden right after it opens, although it never closed. jest-dom's `toBeVisible` walks up to the Astryx layer and reads its computed `opacity`; the layer's entry keyframes use `animation-fill-mode: backwards`, so until the first frame ticks the animation that value is `0`, and on a loaded CI runner the assertion lands inside that window. #4889 already retries the one read in the slash-menu story; this covers the same read in the app-shell sibling and the two `findByRole('listbox')` reads that follow, using the same `waitFor` idiom.

The app-shell harness also held its Skill refresh on `setTimeout(…, 150)`. A slow runner outlives that before the story clicks the row, so the click activates the row for real and the menu closes. The harness now settles on an explicit release the story calls once the busy-row assertions are done, the way the slash-menu story already latches its projection.

Fixes #4896

## Verification

`format:check` and `node --test scripts/storybook-visual-smoke.test.mjs` pass. `typecheck:stories` reports only the four `rightCollapsed` errors main already carries from #4694, which #4895 fixes; nothing in this diff. The stories were looped in `mcr.microsoft.com/playwright:v1.62.1-noble` at `--cpus=2` with four concurrent pages, which is the only environment where this reproduces (never on macOS in 44 runs).

Before (`origin/main` d2d7efe64), slash-menu story, 40 rounds, with `getComputedStyle`/`showPopover`/animation events hooked:

```
pass=35 fail=5
1110ms showPopover div#_r_4_ inner=menu/添加上下文
1200ms click div role=menuitem label=选择技能 busy=true
1330ms gcsHit div#_r_4_ display=block opacity=0 visibility=visible popoverOpen=true :: window.getComputedStyle < Jl < Xl < Xl < Xl < Object.Zl
1343ms animationstart x1ahk7ht-B div#_r_4_ inner=menu/添加上下文
```

Before, app-shell story, 40 rounds (18 of the `toBeVisible` failures end with `"editor": "/"` and the Skill listbox open, the timer having expired before the click):

```
pass=15 fail=25
  17 HL: expect(element).toBeVisible()
   8 HL: expect(element).toHaveAttribute("aria-busy", "true")
```

After, same container, same loops:

```
### slash x40
pass=40 fail=0
### appshell x40
pass=40 fail=0
```

## Root cause

See #4896. Emulating `prefers-reduced-motion` in the smoke script would remove the animation but also switches `scroll-motion-policy.ts` to instant scrolling, and two app-shell scroll stories fail by design under it, so the fix stays in the stories.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Fable 5.1) ran the CI-log triage, built the Linux repro and instrumentation, identified the mechanism, and authored the story changes; commit carries `Generated-by: Claude Code`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
