### PR TITLE
fix(desktop): keep default project badge at action size

### DIFF
--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -291,7 +291,11 @@ export function ProjectsSettingsPage(props: {
               const endCluster = (
                     <>
                       {capabilities.setLocalDefault && isDefault ? (
-                        <Badge variant="neutral" label={copy.defaultBadge} />
+                        <Badge
+                          className="settingsProjectDefaultBadge"
+                          variant="neutral"
+                          label={copy.defaultBadge}
+                        />
                       ) : capabilities.setLocalDefault ? (
                         <Button
                           variant="secondary"

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -147,6 +147,13 @@
   max-width: var(--settings-row-end-cap);
 }
 
+/* The default-project badge replaces the neighboring "set as default"
+   action in the same slot. Keep its label on the action type tier so the
+   settled state does not visually shrink after the user clicks the button. */
+.settingsProjectDefaultBadge {
+  font: var(--maka-text-label);
+}
+
 /* A Selector layer is min-width: anchor-size(width), but its intrinsic option
    width may still make it wider than the right-aligned end slot. The selected
    font decides that intrinsic width, so a label that fits on macOS can push

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -1211,6 +1211,70 @@ const withProjectsCachedRevalidationBridge = withScopedMakaBridge({
   },
 } satisfies Record<string, unknown>);
 
+const projectDefaultTypographySettings = storyRuntimeSettings(
+  mergeSettings(createDefaultSettings(), {
+    projects: { defaultProjectId: 'project-maka' },
+  }),
+);
+
+function seedProjectDefaultTypographySnapshotCache(cache: SettingsSnapshotCache): void {
+  seedGeneralSnapshotCache(cache);
+  cache.commitClientRead(projectDefaultTypographySettings);
+}
+
+const projectDefaultTypographyProjects: ProjectRecord[] = [
+  {
+    id: 'project-hbase',
+    name: 'hbase',
+    locations: [{ path: '/Users/storybook/Development/Code/Github/hbase', isWorktree: false }],
+    available: true,
+    preferredPath: '/Users/storybook/Development/Code/Github/hbase',
+  },
+  {
+    id: 'project-maka',
+    name: 'maka',
+    locations: [{ path: '/Users/storybook/Development/Code/Github/maka', isWorktree: false }],
+    available: true,
+    preferredPath: '/Users/storybook/Development/Code/Github/maka',
+  },
+  {
+    id: 'project-jdhadoop',
+    name: 'JDHadoop',
+    locations: [{ path: '/Users/storybook/Development/Code/Repository/JDHadoop', isWorktree: false }],
+    available: true,
+    preferredPath: '/Users/storybook/Development/Code/Repository/JDHadoop',
+  },
+];
+
+const withProjectDefaultTypographyBridge = withScopedMakaBridge({
+  ...makaBridge,
+  localRuntimeHostRemoteAccess: {
+    getSnapshot: async () => ({ state: 'off' as const }),
+    enable: async () => ({ kind: 'active_tasks' as const }),
+    createConnectionCode: async () => 'storybook-connection-code',
+    revokeSharedAccess: async () => ({ state: 'off' as const }),
+    disable: async () => ({ state: 'off' as const }),
+  },
+  settings: {
+    ...makaBridge.settings,
+    getClient: async () => projectDefaultTypographySettings,
+    get: async () => projectDefaultTypographySettings,
+  },
+  projects: {
+    getSnapshot: async () => ({
+      projects: projectDefaultTypographyProjects,
+      capabilities: {
+        chooseClientDirectory: false,
+        chooseHostDirectory: false,
+        selectNoProject: false,
+        setLocalDefault: true,
+        viewClientPath: true,
+      },
+    }),
+    subscribeChanges: () => () => undefined,
+  },
+} satisfies Record<string, unknown>);
+
 const withGeneralHostSettingsErrorBridge = withScopedMakaBridge({
   ...makaBridge,
   settings: {
@@ -2171,6 +2235,31 @@ export const ProjectsCachedHostRevalidation: Story = {
     await expect(getComputedStyle(mutedProjectContent).opacity).toBe('0.5');
     await expect(cachedProjectsSnapshotRead).not.toHaveBeenCalled();
     await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+// Real path: 设置 → 工作区, after one project has been made the default.
+// The settled default state occupies the same action slot as 设为默认, so its
+// text must keep the action label's type tier instead of shrinking to generic
+// supporting metadata.
+export const ProjectsDefaultBadgeTypography: Story = {
+  decorators: [withProjectDefaultTypographyBridge],
+  render: () => (
+    <SettingsStory
+      section="projects"
+      seedSnapshotCache={seedProjectDefaultTypographySnapshotCache}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const defaultLabel = await canvas.findByText('默认');
+    const defaultBadge = defaultLabel.closest<HTMLElement>('.astryx-badge');
+    const setDefaultButton = (await canvas.findAllByRole('button', { name: '设为默认' }))[0];
+    if (!defaultBadge || !setDefaultButton) {
+      throw new Error('Project default-state controls did not render');
+    }
+    await expect(getComputedStyle(defaultBadge).fontSize).toBe(
+      getComputedStyle(setDefaultButton).fontSize,
+    );
   },
 };
 // Real path: 设置 → 通用, after selecting Git Bash for the current Runtime Host.


### PR DESCRIPTION
## Summary

The Workspace project list replaced the 14px **Set as default** action with a generic 12px supporting-text Badge after selection, so the settled **Default** state visibly shrank.

Keep only the default-project badge on the action-label type tier while preserving the shared neutral Badge colors and layout. Add a rendered Storybook regression that compares the computed font size of the **Default** badge with a neighboring **Set as default** button.

Fixes #4902

## Verification

- Regression story before the fix: default badge `12px`, neighboring button `14px`; the assertion fails.
- Regression story after the fix: both controls are `14px` with the same computed line-height; no console errors or alerts.
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:renderer-architecture` — 101 checker tests and the architecture check pass.
- `npm --workspace @maka/desktop run build-storybook -- --quiet`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- Changed-file Biome check and `git diff --check`

### Visual evidence

| Before — Default 12px / Set as default 14px | After — both 14px |
| --- | --- |
| ![Workspace project rows before the typography fix](https://raw.githubusercontent.com/liuxiaocs7/maka/pr-assets-4902/pr-assets/4902-before.png) | ![Workspace project rows after the typography fix](https://raw.githubusercontent.com/liuxiaocs7/maka/pr-assets-4902/pr-assets/4902-after.png) |

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the typography mismatch, authored the scoped style and rendered regression story, ran local verification, and prepared the issue and PR. Commit `7d6afc237` carries `Generated-by: OpenAI Codex`; please retain the trailer when squashing.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
