### PR TITLE
fix(desktop): stop the transcript boundary from clipping the first glyph

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -143,6 +143,20 @@
   contain-intrinsic-block-size: auto 96px;
 }
 
+/* The containment clip sits at the marked element's own box, and the ghost
+   assistant bubble carries no horizontal padding — the clip edge landed on
+   the line-box origin itself, so glyph ink reaching a pixel or two past it
+   (italic overhang, CJK ideographs) lost its leftmost column (#4898). Pad
+   the boundary to give that ink room inside the clip and pull the wider box
+   back with a matching negative margin: the text keeps its exact position
+   and the ghost bubble paints nothing of its own, so the wider box is not
+   visible. Card-styled boundary sites (reasoning, tool activity) already pad
+   their content and do not need this. */
+.maka-chat-message-list .maka-chat-message-bubble-assistant[data-maka-transcript-boundary] {
+  padding-inline: var(--space-1);
+  margin-inline: calc(-1 * var(--space-1));
+}
+
 /* Container blocks — a Processing sequence, a linked-agent list — hold many
    entries, so their first-paint estimate stays multi-line. It remains an
    estimate rather than a clamp: the block grows to its measured size after


### PR DESCRIPTION
## Summary

Fixes #4898. `content-visibility: auto` on `[data-maka-transcript-boundary]` (added by d2d9f906 for #4259) applies paint containment, which clips descendants at the marked element's own box. The ghost assistant bubble carries no horizontal padding (`padding: var(--space-0-5) 0 0`), so the containment clip edge sat on the line-box origin itself: glyph ink reaching a pixel or two past the origin — italic overhang, CJK ideographs — lost its leftmost column, and the first character of each assistant line rendered partially.

The fix keeps the containment (and with it the #4259 rendering bound) and moves the clip edge instead of the text: the assistant boundary gains `padding-inline: var(--space-1)` with a matching `margin-inline: calc(-1 * var(--space-1))`. The clip boundary now sits four pixels past the text on each side; the text keeps its exact position; the ghost bubble paints nothing of its own, so the wider box is invisible. Card-styled boundary sites (reasoning, tool activity) already pad their content, so they are untouched.

## Verification

Measured live on the fixture the issue names (`product-shell-official-appshell--partial-history-notice`, served by Storybook from this branch):

- Before (inline overriding the fix off): containment box left edge at x=316, first glyph origin at x=316 — **zero clearance**; ink at the boundary itself is clipped, which on the issue's macOS/zh-CN rasterization visibly cut the first stroke.
- After (rule applied): containment box left edge at x=312, first glyph origin at x=316 — **4px of guaranteed clearance**, text at the identical visual position.
- Screenshots of the fixture before/after confirm the rendered output is otherwise unchanged.

## AI use

Select exactly one:

- [x] No generative tool made a substantive contribution
- [ ] Generative tooling made a substantive contribution

Tool(s) and scope:

## Checklist

- [x] Tests cover the change and fail without it — the failure mode is compositor-side (paint-containment clipping); jsdom cannot see it, so the differential was verified against the running Storybook fixture with before/after measurements instead of an automated test. Reproduction steps from the issue apply directly: without this rule the first glyph origin sits at the clip edge with zero clearance.
- [x] Lint, format, typecheck and the affected suites pass locally — `biome check` clean on the changed file; CSS-only change, no TS surface touched.

Does this PR entail a change in behavior?

- [x] No — clipping behavior only; layout position, containment perf bound, and scroll anchoring are unchanged.