### PR TITLE
test(desktop): pin the About reader's missing-provider throw

### DIFF
--- a/apps/desktop/src/main/__tests__/app-update-provider-scope.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-provider-scope.test.ts
@@ -256,4 +256,13 @@ describe('AppUpdateProvider render scope', () => {
     });
     await act(async () => root.unmount());
   });
+
+  test('throws for an About reader mounted outside AppUpdateProvider', () => {
+    const { root } = installReactRenderer();
+    assert.throws(
+      () => act(() => root.render(createElement(AboutProbe))),
+      { message: 'AppUpdateProvider is missing' },
+    );
+    assert.equal(aboutRenders, 0);
+  });
 });

--- a/apps/desktop/src/renderer/settings/about-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/about-settings-page.tsx
@@ -63,12 +63,8 @@ const linkInRowEnd = { paddingInline: 'var(--spacing-3)' } as const;
 type AboutCopy = ReturnType<typeof getSettingsPreferencesCopy>['about'];
 
 /**
- * The updater's row, rendered only for a packaged install. Update state is not
- * this page's to own: the App Update feature holds the renderer's sole updater
- * subscription above AppShell and publishes About's projection, so the row
- * reads status from the consumer and issues the feature's guarded check
- * instead of touching the bridge. A component rather than the consumer's
- * render callback because the action guard is a hook.
+ * About's update row for a packaged install. A component rather than the
+ * consumer's render callback because the action guard is a hook.
  */
 function AboutUpdateStatusRow(props: {
   readonly update: AppUpdateAboutProjection;


### PR DESCRIPTION
## Summary

Follow-up to #4498, taking the two non-blocking P3s from the re-review; the commit carrying them was pushed after the merge, so it lands here.

- `AppUpdateAboutProjectionConsumer` throws when mounted outside `AppUpdateProvider`, but `app-update-provider-scope.test.ts` covered only the mounted path. Add the `assert.throws` render case (React's `act` rethrows the uncaught render error) and assert the reader's callback never ran.
- trim the `AboutUpdateStatusRow` doc comment to the sentence the next editor needs, that it is a component because the action guard is a hook; the ownership argument lives in #4498's body.

Refs #4582

## Verification

- Node 24: desktop `test:dist` 2312/2312, `@maka/desktop` typecheck, lint, format:check
- `check:renderer-architecture --base upstream/main`, `check:app-shell-hooks`, Astryx inventory, Knip (`apps/desktop`), ASF headers, `git diff --check`
- the new case fails when the Consumer's throw is replaced by `return null` (checked locally before pushing)

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code wrote the test case and the comment trim and ran the verification; the human contributor reviewed the work and chose to submit it.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
