### PR TITLE
fix(desktop): preserve glyphs at transcript clip edges

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -136,6 +136,12 @@
    anchoring when a skipped block leaves and re-enters the viewport. */
 .maka-chat-message-list [data-maka-transcript-boundary] {
   content-visibility: auto;
+  /* `content-visibility` supplies paint containment as well as skipping.
+     Assistant ghost bubbles are deliberately flush-left, and Chromium can
+     rasterize the first CJK glyph a fraction outside that content box; at a
+     zero-width clip edge it then shaves the glyph's leading stroke. Preserve
+     a tiny paint apron while keeping the boundary independently skippable. */
+  overflow-clip-margin: 2px;
   /* First-paint intrinsic-size ESTIMATE for scroll-anchor stability, not a
      fixed height: `auto <n>px` still grows to the block's real size after
      paint. 96px is the single-line answer baseline; tall multi-line blocks

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -964,9 +964,16 @@ export const WideAssistantProse: Story = {
     const paragraph = await within(answer).findByRole('paragraph');
     const turn = paragraph.closest<HTMLElement>('.maka-turn');
     if (!turn) throw new Error('Wide assistant paragraph did not render inside a turn');
+    const boundary = paragraph.closest<HTMLElement>('[data-maka-transcript-boundary]');
+    if (!boundary) throw new Error('Wide assistant paragraph has no paint-containment boundary');
     const turnRect = turn.getBoundingClientRect();
     expect(turnRect.width).toBeGreaterThan(680);
     expect(turnRect.right - paragraph.getBoundingClientRect().right).toBeLessThanOrEqual(1);
+    // `content-visibility: auto` implies paint containment. CJK glyph ink can
+    // extend a fraction past its line box, so a flush-left answer needs a
+    // small clip margin or Chromium shaves the first glyph on every line.
+    expect(getComputedStyle(boundary).contentVisibility).toBe('auto');
+    expect(Number.parseFloat(getComputedStyle(boundary).overflowClipMargin)).toBeGreaterThanOrEqual(2);
   },
 };
 


### PR DESCRIPTION
## Summary

Fix assistant text whose leading glyph pixels are clipped by transcript paint containment. Keep `content-visibility: auto`, but add a 2px `overflow-clip-margin` so Chromium can paint glyph ink that extends fractionally past the flush-left boundary without changing the message box geometry.

Extend `WideAssistantProse` to assert that the assistant boundary keeps content visibility, receives the clip margin, and still reaches the existing full-width right edge.

This is an alternative implementation to #4904. It adjusts the paint clip rather than padding and margins, so transcript layout remains unchanged.

Fixes #4898

## Verification

- `npm --workspace @maka/desktop run smoke:storybook` — passed (310 stories, 337 theme renders), including `product-shell-official-appshell--wide-assistant-prose`
- `npm --workspace @maka/desktop run build-storybook` — passed
- `npm --workspace @maka/desktop run typecheck` — passed
- `npx biome check apps/desktop/src/renderer/styles/chat-message.css apps/desktop/stories/app-shell.stories.tsx` — passed
- `git diff --check` — passed
- Chromium pixel comparison: the fixed render is pixel-identical to the uncontained reference (`pixel_diff=0`); zero-margin containment removed 13 pixels within the first 1–4px of the line
- Oversized-turn check: all 96 transcript boundaries remain present and 14 offscreen boundaries remain skipped, preserving the rendering bound

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the paint-containment regression, implemented the CSS fix and Storybook contract, ran verification, and drafted this pull request. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
