### PR TITLE
ci: drop duplicate AX audit test invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Test Storybook audit contracts
         run: node --test scripts/ax-tree-audit.test.mjs scripts/storybook-visual-smoke.test.mjs
       - name: Test Computer Use script contracts
-        run: node --test scripts/ax-tree-audit.test.mjs scripts/computer-use/lab-root.test.mjs
+        run: node --test scripts/computer-use/lab-root.test.mjs
 
       - name: Test script entrypoint contracts
         run: node --test scripts/script-entrypoints.test.mjs


### PR DESCRIPTION
## Summary

`Test Storybook audit contracts` and `Test Computer Use script contracts` both
passed `scripts/ax-tree-audit.test.mjs` to `node --test`, so every CI run
executed that file twice. Drop it from the Computer Use step; the Storybook step
keeps it and the coverage is unchanged.

## Verification

```
$ node --test scripts/ax-tree-audit.test.mjs scripts/storybook-visual-smoke.test.mjs
ℹ tests 19
ℹ pass 19
ℹ fail 0

$ node --test scripts/computer-use/lab-root.test.mjs
ℹ tests 4
ℹ pass 4
ℹ fail 0

$ node --test --test-concurrency=1 scripts/ci-workflow-policy.test.mjs scripts/ci-test-plan.test.mjs
ℹ tests 76
ℹ pass 76
ℹ fail 0
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code found the duplicate invocation while profiling CI
step costs and wrote the workflow edit and this description. Reviewed by the
author.

## Checklist

- [ ] Tests cover the change and fail without it — no test pins the step's
      command string, so nothing fails without this edit
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

