### PR TITLE
ci: report lint and format before the arch gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,14 @@ jobs:
         if: steps.plan.outputs.asf_source == 'true'
         run: npm run check:asf-source
 
+      - name: Lint
+        if: steps.plan.outputs.code == 'true'
+        run: npm run lint
+
+      - name: Check formatting
+        if: steps.plan.outputs.code == 'true'
+        run: npm run format:check
+
       # Parsed dependency rules and an exact legacy-debt ledger keep the
       # renderer root from absorbing new feature or Desktop ownership while
       # the existing AppShell is migrated behind stable boundaries.
@@ -227,14 +235,6 @@ jobs:
           else
             npm run check:renderer-architecture
           fi
-
-      - name: Lint
-        if: steps.plan.outputs.code == 'true'
-        run: npm run lint
-
-      - name: Check formatting
-        if: steps.plan.outputs.code == 'true'
-        run: npm run format:check
 
       # This generated artifact describes the whole renderer/UI tree, so every
       # code-validation run checks it even when the triggering diff is outside


### PR DESCRIPTION
## Summary

`Check renderer architecture` runs for about 53s and sat ahead of `Lint` and
`Check formatting`, which finish in under a second each. A diff whose only
problem was a formatting slip therefore paid the architecture gate before CI
told it anything. Moving the two fast checks ahead reports that class of failure
about a minute sooner.

Neither ordering is a dependency: all three run after `npm ci`, and the
architecture gate reads the working tree rather than any lint output. Green runs
are unaffected — this only changes when a failing run reports.

## Verification

```
$ node --test --test-concurrency=1 scripts/ci-workflow-policy.test.mjs scripts/ci-test-plan.test.mjs
ℹ tests 76
ℹ pass 76
ℹ fail 0
```

Step order after the move:

```
- name: Lint
- name: Check formatting
- name: Check renderer architecture
```

## Review focus

The `if:` conditions, `env:`, and the comment above the architecture gate move
with their steps unchanged; the diff is a relocation, not an edit.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code measured the step costs, spotted the inversion,
and wrote the workflow edit and this description. Reviewed by the author.

## Checklist

- [ ] Tests cover the change and fail without it — no test pins step order, so
      nothing fails without this edit
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
