### PR TITLE
fix(desktop): keep WorkHub chat bubbles on --radius-chat

### DIFF
--- a/apps/desktop/e2e/workhub-reconstruction.spec.ts
+++ b/apps/desktop/e2e/workhub-reconstruction.spec.ts
@@ -74,24 +74,6 @@ test('WorkHub rebuilds delegated execution feedback after navigating away and ba
     page.locator('.workhub-projected-turn', { hasText: routedPrompt })
       .locator('.workhub-submitted-state'),
   ).toHaveText('关联有效 · 已完成');
-
-  // #4914: WorkHub's conversation is one surface — the user bubble rounds like
-  // the composer plate beneath it, both resolving Astryx's `--radius-chat`.
-  // `density="compact"` on WorkHub's chat primitives had pinned the bubble to
-  // `--radius-container` (12px) while the composer stayed 28px. Compared against
-  // the real composer plate rather than a literal, so an upstream `--radius-chat`
-  // change moves both or fails here.
-  const bubbleRadii = await page.evaluate(() => {
-    const round = (element: Element | null) =>
-      element ? getComputedStyle(element).borderTopLeftRadius : null;
-    return {
-      bubble: round(document.querySelector('.workhub-projected-turn .workhub-user-bubble')),
-      composerPlate: round(document.querySelector('.workhub-surface .maka-composer-astryx > *')),
-    };
-  });
-  expect(bubbleRadii.bubble).toBeTruthy();
-  expect(bubbleRadii.bubble).not.toBe('0px');
-  expect(bubbleRadii.bubble).toBe(bubbleRadii.composerPlate);
 });
 
 test('WorkHub replaces the exact linked delegation across Sessions', async ({

--- a/apps/desktop/e2e/workhub-reconstruction.spec.ts
+++ b/apps/desktop/e2e/workhub-reconstruction.spec.ts
@@ -74,6 +74,24 @@ test('WorkHub rebuilds delegated execution feedback after navigating away and ba
     page.locator('.workhub-projected-turn', { hasText: routedPrompt })
       .locator('.workhub-submitted-state'),
   ).toHaveText('关联有效 · 已完成');
+
+  // #4914: WorkHub's conversation is one surface — the user bubble rounds like
+  // the composer plate beneath it, both resolving Astryx's `--radius-chat`.
+  // `density="compact"` on WorkHub's chat primitives had pinned the bubble to
+  // `--radius-container` (12px) while the composer stayed 28px. Compared against
+  // the real composer plate rather than a literal, so an upstream `--radius-chat`
+  // change moves both or fails here.
+  const bubbleRadii = await page.evaluate(() => {
+    const round = (element: Element | null) =>
+      element ? getComputedStyle(element).borderTopLeftRadius : null;
+    return {
+      bubble: round(document.querySelector('.workhub-projected-turn .workhub-user-bubble')),
+      composerPlate: round(document.querySelector('.workhub-surface .maka-composer-astryx > *')),
+    };
+  });
+  expect(bubbleRadii.bubble).toBeTruthy();
+  expect(bubbleRadii.bubble).not.toBe('0px');
+  expect(bubbleRadii.bubble).toBe(bubbleRadii.composerPlate);
 });
 
 test('WorkHub replaces the exact linked delegation across Sessions', async ({

--- a/apps/desktop/src/renderer/workhub-surface.tsx
+++ b/apps/desktop/src/renderer/workhub-surface.tsx
@@ -398,7 +398,6 @@ export function WorkHubSurface(props: {
         <div className="maka-chat-shell">
           <ChatMessageList
             className="maka-chat-message-list maka-chatContent workhub-message-list"
-            density="compact"
             gap={4}
             isStreaming={pending}
           >
@@ -508,7 +507,6 @@ export function WorkHubCoordinationStatus(props: {
         <div className="maka-chat-shell">
           <ChatMessageList
             className="maka-chat-message-list maka-chatContent workhub-message-list"
-            density="compact"
             gap={4}
             isStreaming={resolving}
           >
@@ -769,12 +767,12 @@ function WorkHubMessageFrame(props: {
       data-state={props.state}
       data-link-state={props.linkState}
     >
-      <ChatMessage sender="user" density="compact" className="workhub-message">
+      <ChatMessage sender="user" className="workhub-message">
         <ChatMessageBubble className="maka-chat-message-bubble maka-chat-message-bubble-user workhub-user-bubble">
           <p>{props.text}</p>
         </ChatMessageBubble>
       </ChatMessage>
-      <ChatMessage sender="assistant" density="compact" className="workhub-message">
+      <ChatMessage sender="assistant" className="workhub-message">
         <ChatMessageBubble
           variant="ghost"
           width="100%"

--- a/apps/desktop/stories/workhub.stories.tsx
+++ b/apps/desktop/stories/workhub.stories.tsx
@@ -134,5 +134,26 @@ export const SubmittedWorkKeepsTargetMetadataInside: Story = {
     expect(button.getBoundingClientRect().bottom).toBeGreaterThanOrEqual(
       project.getBoundingClientRect().bottom,
     );
+
+    // #4914: WorkHub's conversation is one surface — the user bubble rounds
+    // like the composer beneath it, both resolving Astryx's `--radius-chat`
+    // (28px). `density="compact"` on WorkHub's chat primitives swapped the
+    // bubble to `--radius-container` (12px) while the composer stayed 28px,
+    // splitting a transcript and a dock on the same surface by more than 2x.
+    // Measure a probe the token paints rather than reading the token back —
+    // ink-ladder-contract.test.ts forbids the latter — so an upstream
+    // `--radius-chat` change moves both or fails here.
+    const bubble = canvasElement.querySelector<HTMLElement>(
+      '.workhub-projected-turn .workhub-user-bubble',
+    );
+    const bubbleRow = bubble?.parentElement;
+    if (!bubble || !bubbleRow) throw new Error('WorkHub user bubble is missing');
+    const probe = document.createElement('div');
+    probe.style.borderRadius = 'var(--radius-chat)';
+    bubbleRow.append(probe);
+    const chatRadius = getComputedStyle(probe).borderTopLeftRadius;
+    probe.remove();
+    expect(chatRadius).not.toBe('0px');
+    expect(getComputedStyle(bubble).borderTopLeftRadius).toBe(chatRadius);
   },
 };

--- a/apps/desktop/stories/workhub.stories.tsx
+++ b/apps/desktop/stories/workhub.stories.tsx
@@ -134,5 +134,21 @@ export const SubmittedWorkKeepsTargetMetadataInside: Story = {
     expect(button.getBoundingClientRect().bottom).toBeGreaterThanOrEqual(
       project.getBoundingClientRect().bottom,
     );
+
+    // #4914: WorkHub's conversation is one surface — the user bubble rounds
+    // like the composer plate beneath it, both resolving Astryx's
+    // `--radius-chat`. `density="compact"` on WorkHub's chat primitives had
+    // pinned the bubble to `--radius-container` (12px) while the composer
+    // stayed 28px, splitting a transcript and a dock on the same surface by
+    // more than 2x. Compared against the real composer plate, not a literal,
+    // so an upstream `--radius-chat` change moves both or fails here.
+    const bubble = canvasElement.querySelector<HTMLElement>(
+      '.workhub-projected-turn .workhub-user-bubble',
+    );
+    const plate = canvasElement.querySelector('.maka-composer-astryx')?.firstElementChild;
+    if (!bubble || !plate) throw new Error('WorkHub bubble or composer plate is missing');
+    const bubbleRadius = getComputedStyle(bubble).borderTopLeftRadius;
+    expect(bubbleRadius).not.toBe('0px');
+    expect(bubbleRadius).toBe(getComputedStyle(plate).borderTopLeftRadius);
   },
 };

--- a/apps/desktop/stories/workhub.stories.tsx
+++ b/apps/desktop/stories/workhub.stories.tsx
@@ -134,26 +134,5 @@ export const SubmittedWorkKeepsTargetMetadataInside: Story = {
     expect(button.getBoundingClientRect().bottom).toBeGreaterThanOrEqual(
       project.getBoundingClientRect().bottom,
     );
-
-    // #4914: WorkHub's conversation is one surface — the user bubble rounds
-    // like the composer beneath it, both resolving Astryx's `--radius-chat`
-    // (28px). `density="compact"` on WorkHub's chat primitives swapped the
-    // bubble to `--radius-container` (12px) while the composer stayed 28px,
-    // splitting a transcript and a dock on the same surface by more than 2x.
-    // Measure a probe the token paints rather than reading the token back —
-    // ink-ladder-contract.test.ts forbids the latter — so an upstream
-    // `--radius-chat` change moves both or fails here.
-    const bubble = canvasElement.querySelector<HTMLElement>(
-      '.workhub-projected-turn .workhub-user-bubble',
-    );
-    const bubbleRow = bubble?.parentElement;
-    if (!bubble || !bubbleRow) throw new Error('WorkHub user bubble is missing');
-    const probe = document.createElement('div');
-    probe.style.borderRadius = 'var(--radius-chat)';
-    bubbleRow.append(probe);
-    const chatRadius = getComputedStyle(probe).borderTopLeftRadius;
-    probe.remove();
-    expect(chatRadius).not.toBe('0px');
-    expect(getComputedStyle(bubble).borderTopLeftRadius).toBe(chatRadius);
   },
 };


### PR DESCRIPTION
## Summary

WorkHub's conversation surface passed `density="compact"` into Astryx's `ChatMessage` / `ChatMessageList`, and `ChatMessageBubble` maps that to `border-radius: var(--radius-container)` (12px). The WorkHub composer stayed on `--radius-chat` (28px), so a bubble and the dock on the same surface disagreed by more than 2x. The main transcript already avoids this — #3452 dropped the compact density from its `ChatMessageList`; WorkHub reintroduced it in #3497.

This drops `density="compact"` from WorkHub's chat primitives — both `ChatMessageList` calls and the user/assistant `ChatMessage` rows in `WorkHubMessageFrame` — so the bubble falls back to the primitive's `--radius-chat` and rounds together with the composer as one conversation surface, exactly as #3452 fixed the main transcript. `gap={4}` stays: it sets the row gap explicitly and never depended on density. No product CSS override is added; `chat-message.css` already documents that the bubble radius is left to the primitive on purpose.

Fixes #4914

## Verification

Before / after on the real story render (`Product/WorkHub → SubmittedWorkKeepsTargetMetadataInside`), light and dark:

![#4914 WorkHub chat-bubble radius — before/after, light and dark](https://raw.githubusercontent.com/liuxiaocs7/maka/assets-4914-radius/comparison.png)

Computed `border-top-left-radius`, measured in the running Storybook (Playwright):

| State | User bubble | Composer plate |
|---|---|---|
| Before (`density="compact"`) | **12px** | 28px |
| After (this PR) | **28px** | 28px |

Light and dark measured identical. After the fix the user bubble and the composer plate agree at 28px — matching the main transcript.

- **Regression coverage** (Storybook `play`): the existing `SubmittedWorkKeepsTargetMetadataInside` play now asserts the projected user bubble's computed `border-top-left-radius` equals the real composer plate's — compared element-to-element, so the bubble and dock on one surface must round together or it fails. This lives in the story `play` per `e2e-budget.json` (layout geometry / pure CSS is not an Electron-tier concern), the same tier #4877 moved the sibling Side Chat / WorkHub geometry into. Red without the fix (bubble 12px vs plate 28px); I ran the story both ways to confirm.
- **Biome** (`biome check` on the changed files): pass, no fixes.
- **Typecheck** (`tsc -p tsconfig.renderer.json` and `tsconfig.storybook.json`): no errors in `workhub-surface.tsx` or `workhub.stories.tsx`. Remaining diagnostics in the run are pre-existing/unrelated, because this worktree had no installed deps — I ran against a lockfile-identical sibling `node_modules`.
- **Renderer architecture snapshot**: unchanged — the edit removes a prop only; all imports/hooks/deps recorded for `workhub-surface.tsx` are untouched, so no `renderer-architecture.json` regeneration is needed. No `.tsx`/`.css` added or renamed, so the surface-inventory gate is not triggered.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — diagnosed the issue, made the fix, added the story-`play` regression assertion, and captured the before/after screenshots. Commits carry a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Biome (lint/format) and typecheck of the changed files pass locally; the `SubmittedWorkKeepsTargetMetadataInside` play was rendered both ways (fixed = green, `density="compact"` restored = red) via Playwright against the running Storybook.

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
