### PR TITLE
perf: queue the heaviest workspace first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         run: >-
           node --test --test-concurrency=1 scripts/ci-test-plan.test.mjs
           scripts/ci-workflow-policy.test.mjs scripts/verify-windows-harness.test.mjs
+          scripts/run-workspace-tests-parallel.test.mjs
 
       # Pure Node like the planner test, and the labelling workflow imports this
       # module directly, so a tier or exclusion change is caught here rather

--- a/scripts/run-workspace-tests-parallel.mjs
+++ b/scripts/run-workspace-tests-parallel.mjs
@@ -22,8 +22,10 @@
  * Run each workspace's `test:dist` script.
  *
  * `--concurrency N`: cap the batch to avoid overloading small runners.
- *   `--concurrency=1` runs every workspace in package.json workspaces order.
  * `--workspaces a,b`: run only the selected workspace paths.
+ *
+ * Workspaces are queued heaviest first so a long suite cannot be picked up once
+ * the other slots have drained.
  *
  * Each workspace owns how its dist tests run via package.json `test:dist`.
  * This script owns scheduling, bounded process residency, failure reporting, and
@@ -31,7 +33,7 @@
  */
 
 import { spawn as defaultSpawn } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -48,6 +50,54 @@ const PROCESS_TERMINATION_POLL_MS = 20;
 export function loadWorkspaceDirs(repoRoot, readFile = readFileSync) {
   const rootPkg = JSON.parse(readFile(join(repoRoot, 'package.json'), 'utf8'));
   return Array.isArray(rootPkg.workspaces) ? rootPkg.workspaces : [];
+}
+
+const TEST_SOURCE_PATTERN = /\.test\.[cm]?[jt]sx?$/u;
+// Build output would double-count the same suites and dependencies are not ours
+// to weigh, so neither tree is walked.
+const UNWEIGHED_DIRECTORIES = new Set(['node_modules', 'dist', '.git']);
+
+/**
+ * Bytes of test source under a workspace, the cheapest stand-in available here
+ * for how long its suite runs. A tree that cannot be read weighs nothing, which
+ * leaves the workspace in its declared position rather than failing the run.
+ */
+export function testSourceWeight(repoRoot, dir) {
+  let bytes = 0;
+  const pending = [join(repoRoot, dir)];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!UNWEIGHED_DIRECTORIES.has(entry.name)) pending.push(join(current, entry.name));
+      } else if (entry.isFile() && TEST_SOURCE_PATTERN.test(entry.name)) {
+        try {
+          bytes += statSync(join(current, entry.name)).size;
+        } catch {
+          // A file that vanished between the listing and the stat weighs nothing.
+        }
+      }
+    }
+  }
+  return bytes;
+}
+
+/**
+ * Heaviest workspace first, so no slot picks up a long suite once the others
+ * have drained. Ties keep their declared order.
+ */
+export function orderByDescendingWeight(dirs, weigh) {
+  // Nothing to reorder, and weighing would walk the tree for an answer no
+  // schedule can use.
+  if (dirs.length < 2) return [...dirs];
+  const weights = new Map(dirs.map((dir) => [dir, weigh(dir)]));
+  return [...dirs].sort((left, right) => weights.get(right) - weights.get(left));
 }
 
 export function nameForDir(dir) {
@@ -198,7 +248,10 @@ export async function runWorkspaceTests(options = {}) {
     throw new Error('workspaceTimeoutMs must be greater than zero');
   }
   const spawn = options.spawn ?? defaultSpawn;
-  const workspaceDirs = options.workspaceDirs ?? loadWorkspaceDirs(repoRoot);
+  const workspaceDirs = orderByDescendingWeight(
+    options.workspaceDirs ?? loadWorkspaceDirs(repoRoot),
+    (dir) => testSourceWeight(repoRoot, dir),
+  );
   const runOptions = {
     repoRoot,
     spawn,

--- a/scripts/run-workspace-tests-parallel.test.mjs
+++ b/scripts/run-workspace-tests-parallel.test.mjs
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { EventEmitter } from 'node:events';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  orderByDescendingWeight,
+  runWorkspaceTests,
+  testSourceWeight,
+} from './run-workspace-tests-parallel.mjs';
+
+function immediateSuccessSpawn(started) {
+  return (_command, options) => {
+    started.push(options.cwd);
+    const child = new EventEmitter();
+    queueMicrotask(() => child.emit('close', 0));
+    return child;
+  };
+}
+
+function withWorkspaceTree(files, body) {
+  const root = mkdtempSync(join(tmpdir(), 'maka-workspace-order-'));
+  try {
+    for (const [path, contents] of Object.entries(files)) {
+      const absolute = join(root, path);
+      mkdirSync(join(absolute, '..'), { recursive: true });
+      writeFileSync(absolute, contents);
+    }
+    return body(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('the heaviest workspace is scheduled first', () => {
+  const weights = { light: 1, heavy: 100, middle: 50 };
+  assert.deepEqual(
+    orderByDescendingWeight(['light', 'heavy', 'middle'], (dir) => weights[dir]),
+    ['heavy', 'middle', 'light'],
+  );
+});
+
+test('a single workspace is never weighed', () => {
+  let weighed = 0;
+  assert.deepEqual(
+    orderByDescendingWeight(['only'], () => {
+      weighed += 1;
+      return 1;
+    }),
+    ['only'],
+  );
+  assert.equal(weighed, 0);
+});
+
+test('equally weighted workspaces keep their declared order', () => {
+  assert.deepEqual(
+    orderByDescendingWeight(['b', 'a', 'c'], () => 7),
+    ['b', 'a', 'c'],
+  );
+});
+
+test('build output and dependencies do not count toward a workspace weight', () => {
+  withWorkspaceTree(
+    {
+      'ws-one/src/a.test.ts': 'x'.repeat(40),
+      'ws-one/dist/a.test.js': 'x'.repeat(9000),
+      'ws-one/node_modules/dep/dep.test.js': 'x'.repeat(9000),
+      'ws-one/src/a.ts': 'x'.repeat(9000),
+    },
+    (root) => {
+      assert.equal(testSourceWeight(root, 'ws-one'), 40);
+    },
+  );
+});
+
+test('an unreadable workspace weighs nothing instead of failing the run', () => {
+  assert.equal(testSourceWeight(tmpdir(), 'no/such/workspace'), 0);
+});
+
+test('the run queues the heaviest workspace ahead of the lighter one', async () => {
+  await withWorkspaceTree(
+    {
+      'ws-light/src/a.test.ts': 'x'.repeat(10),
+      'ws-heavy/src/a.test.ts': 'x'.repeat(5000),
+    },
+    async (root) => {
+      const started = [];
+      await runWorkspaceTests({
+        repoRoot: root,
+        workspaceDirs: ['ws-light', 'ws-heavy'],
+        concurrency: 1,
+        spawn: immediateSuccessSpawn(started),
+      });
+      assert.deepEqual(
+        started.map((cwd) => cwd.slice(root.length + 1)),
+        ['ws-heavy', 'ws-light'],
+      );
+    },
+  );
+});

--- a/scripts/run-workspace-tests-parallel.test.mjs
+++ b/scripts/run-workspace-tests-parallel.test.mjs
@@ -18,7 +18,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -31,6 +31,7 @@ import {
 
 function immediateSuccessSpawn(started) {
   return (_command, options) => {
+    assert.ok(existsSync(options.cwd), `spawned into a missing directory: ${options.cwd}`);
     started.push(options.cwd);
     const child = new EventEmitter();
     queueMicrotask(() => child.emit('close', 0));
@@ -38,7 +39,7 @@ function immediateSuccessSpawn(started) {
   };
 }
 
-function withWorkspaceTree(files, body) {
+async function withWorkspaceTree(files, body) {
   const root = mkdtempSync(join(tmpdir(), 'maka-workspace-order-'));
   try {
     for (const [path, contents] of Object.entries(files)) {
@@ -46,7 +47,7 @@ function withWorkspaceTree(files, body) {
       mkdirSync(join(absolute, '..'), { recursive: true });
       writeFileSync(absolute, contents);
     }
-    return body(root);
+    return await body(root);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -79,8 +80,8 @@ test('equally weighted workspaces keep their declared order', () => {
   );
 });
 
-test('build output and dependencies do not count toward a workspace weight', () => {
-  withWorkspaceTree(
+test('build output and dependencies do not count toward a workspace weight', async () => {
+  await withWorkspaceTree(
     {
       'ws-one/src/a.test.ts': 'x'.repeat(40),
       'ws-one/dist/a.test.js': 'x'.repeat(9000),


### PR DESCRIPTION
## Summary

`run-workspace-tests-parallel.mjs` drained its three slots in the order
`package.json` happens to declare, which has nothing to do with how long each
suite runs. A long suite declared late is picked up late, so it can end up
running alone while the other two slots sit idle. Queueing the heaviest
workspace first removes that tail.

This is Graham's LPT rule, whose worst case is bounded at `(4m - 1) / (3m)` of
the optimal makespan — 11/9 for the three slots used here. Ordering needs a
duration per workspace, and this script has none: it receives a list of
directories. Rather than pin a hand-maintained list that goes stale as packages
grow, or stand up a service that records timings, the weight is computed from
what is already on disk — bytes of test source, skipping `dist` (the same suites
again) and `node_modules` (not ours to weigh). Weighing all eleven workspaces
takes 18ms and stats files without reading them.

Jest's sequencer makes the same substitution for the same reason, ordering by
cached duration when it has one and by file size when it does not:

```typescript
} else if (testA.duration != null && testB.duration != null) {
  return testA.duration < testB.duration ? 1 : -1;
```

```typescript
} else {
  return fileSize(testA) < fileSize(testB) ? 1 : -1;
```

> if that information is not available they are sorted based on file size since
> big test files usually take longer to complete.

— `packages/jest-test-sequencer/src/index.ts`, v29.7.0

## Verification

The resulting order, weights in bytes:

```
 4747888 packages/runtime
 3867780 packages/runtime-host
 3383671 apps/desktop
 1836248 packages/storage
 1482070 packages/cli
  778777 packages/core
  464808 packages/ui
  245210 packages/mcp
  152898 packages/eval
  145103 packages/computer-use
    9842 website
```

`runtime-host` has its own CI step and never enters this queue, which leaves
runtime, desktop and storage at the head — the same three that recent CI logs
show finishing last.

The script had no test file. This adds one, covering the ordering, the stability
of ties, a single workspace never being weighed, the excluded trees, and an
unreadable workspace weighing nothing rather than failing the run. Replacing the
sort with the declared order fails two of them.

```
$ node --test scripts/run-workspace-tests-parallel.test.mjs
ℹ tests 6
ℹ pass 6
ℹ fail 0

$ node --test --test-concurrency=1 scripts/ci-workflow-policy.test.mjs scripts/ci-test-plan.test.mjs
ℹ tests 76
ℹ pass 76
ℹ fail 0
```

The new file is added to the planner step so it actually runs in CI.

Weighing test source rather than the `dist/**/*.test.js` the suites actually
execute is a real approximation, and one file skews it: `ai-sdk-backend.test.ts`
is 541,107 bytes across 215 tests, mostly generated wire-format fixtures. So the
two weights were compared directly, in bytes:

```
workspace                      src      dist
packages/runtime           4747888   4981207
packages/runtime-host      3867780   3946765
apps/desktop               3239329   2955212
packages/storage           1836248   1897846
packages/cli               1482070   1456889
packages/core               778777    828156
packages/ui                 464808    483860
packages/mcp                245210    253990
packages/eval               152898    148116
packages/computer-use       145103    145849
website                          0         0
```

Both produce the same order, so the skew does not reach the schedule. Weighing
`dist` instead was rejected for that reason: it buys no different order and it
reads nothing when the tree has not been built. `apps/desktop` restricts its
suite to `dist/main/**`, and every `.test.*` file under its `src` already lives
in `src/main`, so nothing counted there goes unrun.

Ordering real durations would be better still, which is why Jest prefers them.
But its durations come from a `perf-cache` file written by a previous run, and a
CI runner starts without one — the size fallback is the path a fresh runner
takes either way, absent a step that persists the cache between runs.

## What this PR does not establish

The wall-clock gain has not been measured. A fixed-duration model over recent
logs puts it at 34-51s for the wider selections, but that model assumes a
workspace takes the same time wherever it is scheduled, and this lane is three
concurrent processes on one four-vCPU runner. Reordering changes which suites
contend with which, so the model is an upper bound rather than a prediction —
starting the three heaviest together could plausibly slow each of them down.

Settling it means running the same selection under both orders on a runner of
this shape and comparing totals. Reviewers who want that number before merging
are right to ask; it is not in this PR.

A single workspace is returned unweighed, so the `--concurrency=1
--workspaces=packages/storage` lane does not walk a tree to sort one entry.

`--concurrency=1` no longer follows `package.json` order. The doc comment is
updated. Ordering is unconditional because a single slot takes the same total
either way, and gating on the concurrency made the behavior untestable through
the public entry point.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code wrote the ordering, the weight function, the new
test file and this description, and located the prior art cited above. Reviewed
by the author.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, and the affected suites pass locally, including
      `check:release`'s contract tests — an earlier revision claimed this
      without having run them, and CI caught a fixture path of the shape
      `packages/<name>/dist/*.js` that `release-cli-file-policy` reserves for
      real workspace modules. The fixture tree no longer uses that shape.

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No


