### PR TITLE
feat(desktop): show progress during managed host startup

### DIFF
--- a/apps/desktop/scripts/check-renderer-architecture.mjs
+++ b/apps/desktop/scripts/check-renderer-architecture.mjs
@@ -2713,6 +2713,8 @@ function validateMainWindowEntryContract(desktopRoot, violations) {
 
   const allowedNavigationFiles = new Set([
     'src/main/browser-message-box.ts',
+    // Self-contained, sandboxed startup status document without the app preload.
+    'src/main/startup-progress-window.ts',
     'src/main/browser/controller.ts',
     'src/main/computer-use/cursor-overlay-window.ts',
     'src/main/computer-use/pip-electron.ts',

--- a/apps/desktop/src/main/__tests__/main-startup-lifetime.test.ts
+++ b/apps/desktop/src/main/__tests__/main-startup-lifetime.test.ts
@@ -60,8 +60,17 @@ test('retains process lifetime before a standalone startup dialog can close', ()
   );
   assert.match(
     windowAllClosed,
-    /process\.platform !== "darwin" && !isBrowserMessageBoxPresentationActive\(\)/u,
+    /process\.platform !== "darwin" && !isBrowserMessageBoxPresentationActive\(\) &&\s*!isDesktopStartupInProgress\(\)/u,
   );
+});
+
+test('presents startup before Host boot and hands off only when the main window is shown', () => {
+  const ready = mainSource.indexOf("console.log('[startup] app ready')");
+  const presentation = mainSource.indexOf('showDesktopStartupProgress(', ready);
+  const hostBoot = mainSource.indexOf("import('./runtime-host-boot.js')", ready);
+  assert.ok(ready >= 0 && presentation > ready && hostBoot > presentation);
+  assert.match(bootSource, /onShow: closeDesktopStartupProgress/u);
+  assert.match(mainWindowSource, /mainWindow\.once\('show', \(\) => deps\.onShow\?\.\(\)\)/u);
 });
 
 test('resolves persisted locale before first post-settings recovery prompt', () => {

--- a/apps/desktop/src/main/__tests__/runtime-host-local-remote-access.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-local-remote-access.test.ts
@@ -335,6 +335,7 @@ test('repairs an existing managed Host with the current setup package and restar
   await mkdir(rootPath, { recursive: true });
   await writeManagedLifecycle(clientDataRoot, rootPath, rootId);
   const actions: string[] = [];
+  const phases: string[] = [];
   const service = createDesktopLocalRuntimeHostRemoteAccess({
     ipcMain: { handle() {}, removeHandler() {} },
     clientDataRoot,
@@ -343,14 +344,16 @@ test('repairs an existing managed Host with the current setup package and restar
     directPeerAvailable: true,
     manager: () => undefined,
     resolveSetupPackage: async () => setupPackage,
+    onUpdateProgress: (phase) => phases.push(phase),
     operator: {
       async runUpdate(input: {
         readonly setupPackage: unknown;
         readonly target: { readonly rootId: string; readonly deploymentId?: string };
         readonly allowManualUpdate?: boolean;
         readonly allowInterruptActiveTasks?: boolean;
-      }) {
+      }, onProgress: (phase: 'staging') => void) {
         actions.push('update');
+        onProgress('staging');
         assert.equal(input.setupPackage, setupPackage);
         assert.equal(input.target.rootId, rootId);
         assert.equal(input.target.deploymentId, RECOVERY_DEPLOYMENT_ID);
@@ -383,6 +386,7 @@ test('repairs an existing managed Host with the current setup package and restar
     kind: 'repaired',
   });
   assert.deepEqual(actions, ['update', 'restart']);
+  assert.deepEqual(phases, ['checking', 'staging', 'restart']);
 });
 
 test('replaces a conflicting supervised Host with the requested active-work policy', async (t) => {

--- a/apps/desktop/src/main/__tests__/startup-progress-window.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-progress-window.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { test } from 'node:test';
+import type { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
+import { createStartupProgressWindow, renderStartupProgressHtml } from '../startup-progress-window.js';
+
+function harness() {
+  let resolveLoad!: () => void;
+  let rejectLoad!: (error: Error) => void;
+  let destroyed = false;
+  let minimized = false;
+  let visible = false;
+  let copied = 0;
+  let documentUrl = '';
+  let options: BrowserWindowConstructorOptions | undefined;
+  let openWindow!: () => { action: string };
+  const scripts: string[] = [];
+  const errors: unknown[] = [];
+  const contents = Object.assign(new EventEmitter(), {
+    setWindowOpenHandler(handler: typeof openWindow) { openWindow = handler; },
+    async executeJavaScript(source: string) { scripts.push(source); },
+  });
+  const window = Object.assign(new EventEmitter(), {
+    webContents: contents,
+    setMenuBarVisibility() {},
+    isDestroyed: () => destroyed,
+    isMinimized: () => minimized,
+    destroy() { destroyed = true; },
+    minimize() { minimized = true; },
+    restore() { minimized = false; },
+    showInactive() { visible = true; },
+    show() { visible = true; },
+    focus() {},
+    loadURL: (url: string) => {
+      documentUrl = url;
+      return new Promise<void>((resolve, reject) => {
+        resolveLoad = resolve;
+        rejectLoad = reject;
+      });
+    },
+  });
+  const progress = createStartupProgressWindow({
+    locale: 'en', dark: false, icon: '/test/icon.png',
+    createWindow(input) { options = input; return window as unknown as BrowserWindow; },
+    copyDiagnostics() { copied += 1; },
+    onError(error) { errors.push(error); },
+  });
+  return {
+    progress, window, contents, scripts, errors, resolveLoad, rejectLoad,
+    get options() { return options; },
+    get copied() { return copied; },
+    get documentUrl() { return documentUrl; },
+    get destroyed() { return destroyed; },
+    get minimized() { return minimized; },
+    get visible() { return visible; },
+    get openWindow() { return openWindow; },
+  };
+}
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+test('shows the latest real phase after loading and minimizes without terminating startup', async () => {
+  const h = harness();
+  h.progress.update('staging');
+  assert.equal(h.visible, false);
+  h.resolveLoad();
+  await flush();
+  assert.equal(h.visible, true);
+  assert.match(h.scripts.at(-1) ?? '', /Installing the update/);
+  let prevented = false;
+  h.window.emit('close', { preventDefault() { prevented = true; } });
+  assert.equal(prevented, true);
+  assert.equal(h.minimized, true);
+  assert.equal(h.destroyed, false);
+  h.progress.focus();
+  assert.equal(h.minimized, false);
+  h.progress.close();
+  assert.equal(h.destroyed, true);
+  assert.equal(h.progress.window(), undefined);
+});
+
+test('handoff before HTML finishes loading cannot reveal an orphan startup window', async () => {
+  const h = harness();
+  h.progress.close();
+  h.resolveLoad();
+  await flush();
+  h.progress.update('renderer');
+  h.progress.focus();
+  assert.equal(h.visible, false);
+  assert.equal(h.scripts.length, 0);
+  assert.equal(h.destroyed, true);
+});
+
+test('presentation failure is contained and does not reject the startup operation', async () => {
+  const h = harness();
+  const error = new Error('renderer could not load');
+  h.rejectLoad(error);
+  await flush();
+  assert.deepEqual(h.errors, [error]);
+  assert.equal(h.destroyed, true);
+  h.progress.close();
+});
+
+test('diagnostics is the only permitted navigation action; the window has no app bridge', async () => {
+  const h = harness();
+  h.resolveLoad();
+  await flush();
+  assert.equal(h.options?.webPreferences?.nodeIntegration, false);
+  assert.equal(h.options?.webPreferences?.sandbox, true);
+  assert.equal(h.options?.webPreferences?.preload, undefined);
+  assert.ok(h.documentUrl.startsWith('data:text/html;charset=utf-8,'));
+  assert.deepEqual(h.openWindow(), { action: 'deny' });
+  for (const url of ['https://example.test', 'maka-startup://copy/anything', 'maka-startup://copy']) {
+    let prevented = false;
+    h.contents.emit('will-navigate', { preventDefault() { prevented = true; } }, url);
+    assert.equal(prevented, true);
+  }
+  await flush();
+  assert.equal(h.copied, 1);
+  assert.match(h.scripts.at(-1) ?? '', /Diagnostics copied/);
+  h.progress.close();
+});
+
+test('localized progress stays self-contained, accessible and has no fabricated percentage', () => {
+  for (const locale of ['en', 'zh-CN', 'zh-TW'] as const) {
+    for (const dark of [false, true]) {
+      const html = renderStartupProgressHtml(locale, dark);
+      assert.ok(html.includes('lang="' + locale + '"'));
+      assert.match(html, /default-src 'none'/);
+      assert.match(html, /aria-live="polite"/);
+      assert.match(html, /prefers-reduced-motion/);
+      assert.doesNotMatch(html, /aria-valuenow|<progress|https?:/);
+      assert.match(html, /maka-startup:\/\/copy/);
+    }
+  }
+});

--- a/apps/desktop/src/main/desktop-shell-presentation.ts
+++ b/apps/desktop/src/main/desktop-shell-presentation.ts
@@ -25,19 +25,32 @@ import type { createMainWindowController } from './main-window.js';
 import type { WindowRevealMode } from './window-reveal.js';
 
 interface DesktopShellPresentationDeps {
-  readonly revealMode: WindowRevealMode;
   readonly mainWindowController: ReturnType<typeof createMainWindowController>;
   readonly focusOrCreateWindow: () => void;
-  readonly onIconError: (error: unknown) => void;
 }
 
 /** Install the process-scoped Desktop presentation shared by both Runtime owners. */
 export function installDesktopShellPresentation(
   deps: DesktopShellPresentationDeps,
 ): void {
+  installApplicationMenu({
+    platform: process.platform,
+    isPackaged: app.isPackaged,
+    dispatch: (command) => {
+      if (deps.mainWindowController.hasOpenWindows()) {
+        deps.mainWindowController.send('window:command', { id: command });
+      } else {
+        deps.focusOrCreateWindow();
+      }
+    },
+  });
+}
+
+/** The Dock must be branded before any asynchronous Host work begins. */
+export function installDesktopStartupBranding(revealMode: WindowRevealMode): void {
   const dockPresentation = resolveDockPresentation(
     process.platform,
-    deps.revealMode,
+    revealMode,
   );
   if (app.dock) {
     if (dockPresentation === 'hide') {
@@ -54,19 +67,8 @@ export function installDesktopShellPresentation(
       // is readable synchronously — the stored `theme` preference is not. So a
       // user whose in-app theme disagrees with the OS still sees one swap, the
       // same as before; what this avoids is every default install swapping.
-      applyAppIcon(startupAppIcon(nativeTheme.shouldUseDarkColors), deps.onIconError);
+      applyAppIcon(startupAppIcon(nativeTheme.shouldUseDarkColors), (error) =>
+        console.error('[icon] failed to set startup icon:', error));
     }
   }
-
-  installApplicationMenu({
-    platform: process.platform,
-    isPackaged: app.isPackaged,
-    dispatch: (command) => {
-      if (deps.mainWindowController.hasOpenWindows()) {
-        deps.mainWindowController.send('window:command', { id: command });
-      } else {
-        deps.focusOrCreateWindow();
-      }
-    },
-  });
 }

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -100,6 +100,7 @@ interface MainWindowControllerDeps {
   // and the fake backend, so main-window.ts owns no env policy of its own.
   revealMode: WindowRevealMode;
   onClose?: () => void;
+  onShow?: () => void;
   onRendererProcessGone: (details: Electron.RenderProcessGoneDetails) => void | Promise<void>;
 }
 
@@ -436,6 +437,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     //
     // Both are gated on the URL using `http(s):` or `mailto:` — everything else
     // (file://, electron internal, etc.) is allowed/denied per Electron defaults.
+    mainWindow.once('show', () => deps.onShow?.());
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
       if (isExternalUrl(url)) {
         void shell.openExternal(url);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -33,6 +33,8 @@ import {
   copyDesktopDiagnosticReport,
   createDesktopPreviousMainProcessDiagnosticInput,
   installMainProcessLogCapture,
+  formatDesktopDiagnosticReport,
+  createDesktopStartupDiagnosticInput,
   mainProcessLogBuffer,
 } from './main-process-diagnostics.js';
 import {
@@ -45,6 +47,11 @@ import { isIsolatedE2e } from './startup-context.js';
 import { reportDevelopmentLaunchResult } from './dev-single-instance-result.js';
 import { registerPreviousMainProcessDiagnosticsIpc } from './desktop-diagnostics-ipc-main.js';
 import { showBrowserMessageBox } from './browser-message-box.js';
+import {
+  showDesktopStartupProgress,
+  updateDesktopStartupProgress,
+  desktopStartupProgressWindow,
+} from './startup-presentation.js';
 
 let recoveryJournal: MainProcessRecoveryJournal | undefined;
 installMainProcessLogCapture(mainProcessLogBuffer, () => recoveryJournal?.markDirty());
@@ -210,10 +217,28 @@ if (!app.requestSingleInstanceLock()) {
     .whenReady()
     .then(() => {
       console.log('[startup] app ready');
+      showDesktopStartupProgress((phase) => {
+        clipboard.writeText(formatDesktopDiagnosticReport(
+          createDesktopStartupDiagnosticInput({
+            title: 'Desktop startup', description: 'Startup phase: ' + phase,
+          }),
+          captureDesktopDiagnosticEnvironment({
+            appVersion: app.getVersion(), buildMode: buildInfo.mode,
+            updateChannel: desktopDiagnosticUpdateChannel({
+              isPackaged: app.isPackaged, appPath: app.getAppPath(),
+            }),
+            buildCommit: buildInfo.commit, locale: app.getLocale(),
+            workspacePath: join(app.getPath('userData'), 'workspaces', 'default'),
+          }),
+          mainProcessLogBuffer.snapshot(),
+          { ok: false, error: 'Runtime Host is not yet available during startup' },
+        ));
+      });
       return import('./runtime-host-boot.js');
     })
     .catch(async (error: unknown) => {
       console.error('[startup] fatal:', error);
+      updateDesktopStartupProgress('attention');
       try {
         // E2E runs must not hang on a modal error box (same reasoning as the
         // fixture-fatal path in runtime-host-boot.ts: print a parseable line and exit fast).
@@ -237,7 +262,7 @@ if (!app.requestSingleInstanceLock()) {
             mainLogs: () => mainProcessLogBuffer.snapshot(),
             writeClipboard: (report) => clipboard.writeText(report),
             showMessageBox: (options) =>
-              showBrowserMessageBox(options, undefined, { locale }),
+              showBrowserMessageBox(options, desktopStartupProgressWindow(), { locale }),
           });
         }
       } finally {

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -258,6 +258,12 @@ import {
 } from "./startup-context.js";
 import { resolveDesktopStorageRoot } from "./storage-root-startup.js";
 import { startupStep } from "./startup-step.js";
+import {
+  closeDesktopStartupProgress,
+  desktopStartupProgressWindow,
+  isDesktopStartupInProgress,
+  updateDesktopStartupProgress,
+} from './startup-presentation.js';
 import { registerWorkspaceSearchIpc } from "./workspace-search-ipc-main.js";
 import {
   parseDesktopSessionResourceKey,
@@ -366,7 +372,7 @@ const desktopDiagnostics: DesktopDiagnosticsDeps = {
   resolveRuntimeHost: resolveRuntimeHostDiagnostics,
   writeClipboard: (report) => clipboard.writeText(report),
 };
-let resolveBrowserDialogParent = (): BrowserWindow | undefined => undefined;
+let resolveBrowserDialogParent = desktopStartupProgressWindow;
 let resolveBrowserDialogAppearance = async (): Promise<BrowserMessageBoxAppearance> => ({
   locale: resolveSystemUiLocale(app.getPreferredSystemLanguages()),
   palette: "default",
@@ -414,6 +420,7 @@ const resolveLocalStorageRoot = () =>
           confirmRepair: () => confirmDesktopStorageRootRepair(workspaceRoot),
         }),
       );
+updateDesktopStartupProgress('storage');
 const startupLocalStorageRoot =
   await resolveLocalStorageRoot();
 if (!startupLocalStorageRoot) {
@@ -489,6 +496,7 @@ const mainWindowController = createMainWindowController({
   settingsStore,
   revealMode,
   onClose: () => onMainWindowClose(),
+  onShow: closeDesktopStartupProgress,
   onRendererProcessGone: async (details) => {
     const diagnosticInput = createDesktopMainRendererDiagnosticInput({
       title: "Maka main Renderer process exited unexpectedly",
@@ -512,7 +520,10 @@ const mainWindowController = createMainWindowController({
     app.quit();
   },
 });
-resolveBrowserDialogParent = () => mainWindowController.browserWindow();
+resolveBrowserDialogParent = () => {
+  const main = mainWindowController.browserWindow();
+  return main?.isVisible() ? main : desktopStartupProgressWindow();
+};
 const runtimeHostSshTerminal = createDesktopRuntimeHostSshTerminal({
   ipcMain,
   send: (channel, event) => mainWindowController.send(channel, event),
@@ -530,7 +541,13 @@ const localRuntimeHostRemoteAccess = createDesktopLocalRuntimeHostRemoteAccess({
   rootId: startupLocalStorageRoot.rootId,
   directPeerAvailable: runtimeHostDirectPeerAvailable,
   manager: () => runtimeHostManager,
-  resolveSetupPackage: (signal) => runtimeHostSetupPackage.resolveForThisDesktop(signal),
+  resolveSetupPackage: async (signal) => {
+    updateDesktopStartupProgress('package');
+    const result = await runtimeHostSetupPackage.resolveForThisDesktop(signal);
+    updateDesktopStartupProgress('checking');
+    return result;
+  },
+  onUpdateProgress: updateDesktopStartupProgress,
   operator: localRuntimeHostOperator,
 });
 const native = assembleDesktopNativeCapabilities({
@@ -1239,10 +1256,12 @@ const startLocalRuntimeHostManager = () => startRuntimeHostDesktopManager(
 );
 runtimeHostManager = await startDesktopRuntimeHostWithRecovery({
   start: async () => {
+    updateDesktopStartupProgress('connect');
     await localRuntimeHostRemoteAccess.recoverBeforeLocalHostStart();
     return startLocalRuntimeHostManager();
   },
   repair: async ({ allowManualUpdate, allowInterruptActiveTasks }) => {
+    updateDesktopStartupProgress('package');
     console.warn('[runtime-host] repairing the managed Local Host before startup');
     const result = await localRuntimeHostRemoteAccess.repairManagedStartup({
       allowManualUpdate,
@@ -1252,6 +1271,7 @@ runtimeHostManager = await startDesktopRuntimeHostWithRecovery({
     return result;
   },
   prompt: async (input) => {
+    updateDesktopStartupProgress('attention');
     console.error('[runtime-host] managed Local Host startup recovery requires attention:', {
       startupError: input.startupError,
       repairError: input.repairError,
@@ -1293,6 +1313,7 @@ const workBoardIpc = registerWorkBoardIpc({
   mainWindowController,
   store: createWorkBoardStore(workspaceRoot, { schemaMigration: 'require_current' }),
 });
+updateDesktopStartupProgress('renderer');
 wireLifecycle();
 runtimeHostManager.setDefaultProfile(runtimeHostStartup.preferences.defaultProfileId);
 await guestSessionMountService.start().catch((error: unknown) => {
@@ -1955,11 +1976,8 @@ function wireLifecycle(): void {
     resumeQuit: () => app.quit(),
   });
   installDesktopShellPresentation({
-    revealMode,
     mainWindowController,
     focusOrCreateWindow: quitCoordinator.focusOrCreateWindow,
-    onIconError: (error) =>
-      console.error("[icon] failed to set dock icon:", error),
   });
   app.on("second-instance", quitCoordinator.focusOrCreateWindow);
   app.on("activate", quitCoordinator.focusOrCreateWindow);
@@ -1969,7 +1987,8 @@ function wireLifecycle(): void {
   app.on("window-all-closed", () => {
     native.computerUseOverlay.destroyAll();
     native.computerUsePip.destroyAll();
-    if (process.platform !== "darwin" && !isBrowserMessageBoxPresentationActive()) app.quit();
+    if (process.platform !== "darwin" && !isBrowserMessageBoxPresentationActive() &&
+      !isDesktopStartupInProgress()) app.quit();
   });
   app.on("before-quit", quitCoordinator.handleBeforeQuit);
   powerMonitor.on("resume", wakePeerRecoveryAfterResume);

--- a/apps/desktop/src/main/runtime-host-local-remote-access.ts
+++ b/apps/desktop/src/main/runtime-host-local-remote-access.ts
@@ -32,6 +32,7 @@ import {
   decodeRuntimeHostOperatorCommand,
   resolveRuntimeHostManagedDeploymentAuthority,
   type RuntimeHostOperatorCommand,
+  type RuntimeHostServiceUpdatePhase,
 } from '@maka/runtime-host/operator';
 import type { HostPeerEndpoint, HostRegistration } from '@maka/runtime-host/protocol';
 import type {
@@ -182,6 +183,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
     signal?: AbortSignal,
   ) => DesktopRuntimeHostSetupPackage | Promise<DesktopRuntimeHostSetupPackage>;
   readonly operator: DesktopRuntimeHostLocalOperator;
+  readonly onUpdateProgress?: (phase: RuntimeHostServiceUpdatePhase | 'restart') => void;
   readonly resolveManagedDeploymentAuthority?: (
     rootId: string,
   ) => Promise<LocalManagedDeploymentAuthority | undefined>;
@@ -761,7 +763,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
                   : {}),
                 signal,
               },
-              () => undefined,
+              (phase) => input.onUpdateProgress?.(phase),
             );
             if (frame.kind === 'error') {
               if (frame.error.code === 'active_tasks') return 'active_tasks';
@@ -797,6 +799,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
         if (lifecycle?.state !== 'managed') return { kind: 'unavailable' };
 
         const setupPackage = await input.resolveSetupPackage(signal);
+        input.onUpdateProgress?.('checking');
         const frame = await input.operator.runUpdate(
           {
             setupPackage,
@@ -807,7 +810,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
               : {}),
             signal,
           },
-          () => undefined,
+          (phase) => input.onUpdateProgress?.(phase),
         );
         if (frame.kind === 'error') {
           if (frame.error.code === 'active_tasks') return { kind: 'active_tasks' };
@@ -819,6 +822,7 @@ export function createDesktopLocalRuntimeHostRemoteAccess(input: {
         if (frame.update.kind === 'active_tasks') return { kind: 'active_tasks' };
 
         if (frame.update.kind === 'already_current') {
+          input.onUpdateProgress?.('restart');
           const restarted = await input.operator.runService({
             operator: lifecycle.operator,
             action: 'restart',

--- a/apps/desktop/src/main/startup-presentation.ts
+++ b/apps/desktop/src/main/startup-presentation.ts
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { app, BrowserWindow, nativeTheme } from 'electron';
+import { resolveSystemUiLocale } from '@maka/core/ui-locale';
+import { readableAppIconPath } from './app-icon-surface.js';
+import { installApplicationMenu } from './application-menu.js';
+import { installDesktopStartupBranding } from './desktop-shell-presentation.js';
+import { isIsolatedE2e } from './startup-context.js';
+import { resolveWindowRevealMode } from './window-reveal.js';
+import {
+  createStartupProgressWindow,
+  type StartupPhase,
+  type StartupProgressWindow,
+} from './startup-progress-window.js';
+
+let progress: StartupProgressWindow | undefined;
+
+const focus = () => progress?.focus();
+
+/** Called after ready, before importing the asynchronous Runtime Host boot. */
+export function showDesktopStartupProgress(
+  copyDiagnostics: (phase: StartupPhase) => void | Promise<void>,
+): void {
+  const revealMode = resolveWindowRevealMode(
+    isIsolatedE2e || Boolean(process.env.MAKA_E2E_FIXTURE),
+    process.env.MAKA_E2E_SHOW_WINDOW === '1',
+    app.isPackaged,
+  );
+  installDesktopStartupBranding(revealMode);
+  // Automated runs retain their one-main-window contract and never steal focus.
+  if (revealMode !== 'active') return;
+  try {
+    installApplicationMenu({
+      platform: process.platform, isPackaged: app.isPackaged, dispatch: focus,
+    });
+    progress = createStartupProgressWindow({
+      locale: resolveSystemUiLocale(app.getPreferredSystemLanguages()),
+      dark: nativeTheme.shouldUseDarkColors,
+      icon: readableAppIconPath('default'),
+      createWindow: (options) => new BrowserWindow(options),
+      copyDiagnostics,
+      onError: (error) => console.error('[startup] progress presentation failed:', error),
+    });
+    app.on('activate', focus);
+    app.on('second-instance', focus);
+    app.once('before-quit', closeDesktopStartupProgress);
+  } catch (error) {
+    console.error('[startup] progress presentation failed:', error);
+    closeDesktopStartupProgress();
+  }
+}
+
+export function updateDesktopStartupProgress(phase: StartupPhase): void {
+  progress?.update(phase);
+}
+
+export function desktopStartupProgressWindow(): BrowserWindow | undefined {
+  return progress?.window();
+}
+
+export function isDesktopStartupInProgress(): boolean {
+  return progress !== undefined;
+}
+
+export function closeDesktopStartupProgress(): void {
+  app.removeListener('activate', focus);
+  app.removeListener('second-instance', focus);
+  app.removeListener('before-quit', closeDesktopStartupProgress);
+  // Destroy can synchronously emit window-all-closed before the main window
+  // exists (quit or renderer failure). Keep the startup lifetime guard then.
+  progress?.close();
+  progress = undefined;
+}

--- a/apps/desktop/src/main/startup-progress-window.ts
+++ b/apps/desktop/src/main/startup-progress-window.ts
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { MAKA_WORDMARK_PATH } from '@maka/core/maka-wordmark';
+import type { UiLocale } from '@maka/core/ui-locale';
+import type { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
+
+export type StartupPhase =
+  | 'prepare' | 'storage' | 'connect' | 'package'
+  | 'checking' | 'staging' | 'retiring' | 'replacing' | 'restart'
+  | 'attention' | 'renderer';
+
+const COPY = {
+  en: {
+    title: 'Opening your workspace',
+    detail: 'Maka is preparing your local background service.',
+    slow: 'This is taking longer than usual. Updates may need to download or build a package. You can minimize this window while Maka continues.',
+    copy: 'Copy diagnostics', copied: 'Diagnostics copied', copyFailed: 'Could not copy diagnostics',
+    elapsed: 'Elapsed',
+    phases: {
+      prepare: 'Preparing Maka', storage: 'Checking local data', connect: 'Connecting to Runtime Host',
+      package: 'Preparing the Runtime Host package', checking: 'Checking the managed service',
+      staging: 'Installing the update', retiring: 'Safely stopping the previous service',
+      replacing: 'Replacing the managed service', restart: 'Restarting Runtime Host',
+      attention: 'Waiting for your confirmation', renderer: 'Opening your workspace',
+    },
+  },
+  'zh-CN': {
+    title: '正在打开工作区', detail: 'Maka 正在准备本地后台服务。',
+    slow: '此次启动耗时较长。更新可能需要下载或构建安装包；你可以最小化此窗口，Maka 会继续处理。',
+    copy: '复制诊断信息', copied: '已复制诊断信息', copyFailed: '无法复制诊断信息', elapsed: '已用时',
+    phases: {
+      prepare: '正在准备 Maka', storage: '正在检查本地数据', connect: '正在连接 Runtime Host',
+      package: '正在准备 Runtime Host 安装包', checking: '正在检查托管服务',
+      staging: '正在安装更新', retiring: '正在安全停止旧服务',
+      replacing: '正在替换托管服务', restart: '正在重启 Runtime Host',
+      attention: '等待你的确认', renderer: '正在打开工作区',
+    },
+  },
+  'zh-TW': {
+    title: '正在開啟工作區', detail: 'Maka 正在準備本機背景服務。',
+    slow: '此次啟動耗時較長。更新可能需要下載或建置安裝套件；你可以最小化此視窗，Maka 會繼續處理。',
+    copy: '複製診斷資訊', copied: '已複製診斷資訊', copyFailed: '無法複製診斷資訊', elapsed: '已用時',
+    phases: {
+      prepare: '正在準備 Maka', storage: '正在檢查本機資料', connect: '正在連線至 Runtime Host',
+      package: '正在準備 Runtime Host 安裝套件', checking: '正在檢查託管服務',
+      staging: '正在安裝更新', retiring: '正在安全停止舊服務',
+      replacing: '正在替換託管服務', restart: '正在重新啟動 Runtime Host',
+      attention: '等待你的確認', renderer: '正在開啟工作區',
+    },
+  },
+} as const;
+
+export interface StartupProgressWindow {
+  update(phase: StartupPhase): void;
+  focus(): void;
+  close(): void;
+  window(): BrowserWindow | undefined;
+}
+
+/** Presentation only: no Host client, application preload, or migration authority. */
+export function createStartupProgressWindow(input: {
+  locale: UiLocale;
+  dark: boolean;
+  icon: string;
+  createWindow(options: BrowserWindowConstructorOptions): BrowserWindow;
+  copyDiagnostics(phase: StartupPhase): void | Promise<void>;
+  onError(error: unknown): void;
+}): StartupProgressWindow {
+  const copy = COPY[input.locale];
+  const win = input.createWindow({
+    width: 520, height: 390, title: 'Maka', icon: input.icon,
+    show: false, resizable: false, maximizable: false, fullscreenable: false,
+    backgroundColor: input.dark ? '#1c1d21' : '#ffffff',
+    webPreferences: {
+      contextIsolation: true, nodeIntegration: false, sandbox: true,
+      webSecurity: true, allowRunningInsecureContent: false,
+    },
+  });
+  let closed = false;
+  let loaded = false;
+  let phase: StartupPhase = 'prepare';
+  const execute = (source: string) => {
+    if (!closed && loaded && !win.isDestroyed()) {
+      void win.webContents.executeJavaScript(source).catch(input.onError);
+    }
+  };
+  const publish = () => execute(
+    'document.getElementById("phase").textContent = ' + JSON.stringify(copy.phases[phase]) +
+    '; document.body.dataset.phase = ' + JSON.stringify(phase) + ';',
+  );
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    if (!win.isDestroyed()) win.destroy();
+  };
+  win.setMenuBarVisibility(false);
+  win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
+  // Closing the status window minimizes it; it must not terminate an update.
+  win.on('close', (event) => {
+    if (closed) return;
+    event.preventDefault();
+    win.minimize();
+  });
+  win.webContents.on('will-navigate', (event, url) => {
+    event.preventDefault();
+    if (url !== 'maka-startup://copy') return;
+    void Promise.resolve().then(() => input.copyDiagnostics(phase)).then(
+      () => execute('document.getElementById("copy").textContent = ' + JSON.stringify(copy.copied)),
+      (error) => {
+        input.onError(error);
+        execute('document.getElementById("copy").textContent = ' + JSON.stringify(copy.copyFailed));
+      },
+    );
+  });
+  win.webContents.on('will-redirect', (event) => event.preventDefault());
+  win.webContents.on('render-process-gone', (_event, details) => {
+    input.onError(new Error('Startup renderer exited: ' + details.reason));
+    close();
+  });
+  // No await: failure to present progress must never block Host recovery.
+  void win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(
+    renderStartupProgressHtml(input.locale, input.dark),
+  )).then(() => {
+    if (closed || win.isDestroyed()) return;
+    loaded = true;
+    publish();
+    // A confirmation may already be open; never raise progress above it.
+    win.showInactive();
+  }).catch((error) => {
+    input.onError(error);
+    close();
+  });
+  return {
+    update(next) { phase = next; publish(); },
+    focus() {
+      if (closed || !loaded || win.isDestroyed()) return;
+      if (win.isMinimized()) win.restore();
+      win.show();
+      win.focus();
+    },
+    close,
+    window: () => closed || win.isDestroyed() ? undefined : win,
+  };
+}
+
+export function renderStartupProgressHtml(locale: UiLocale, dark: boolean): string {
+  const copy = COPY[locale];
+  const nonce = randomUUID().replaceAll('-', '');
+  return `<!doctype html>
+<html lang="${locale}"><head><meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}'; base-uri 'none'; form-action 'none'">
+<title>Maka</title><style nonce="${nonce}">
+:root { color-scheme: ${dark ? 'dark' : 'light'}; font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: ${dark ? '#1c1d21' : '#fff'}; color: ${dark ? '#f1f1f3' : '#202127'}; }
+* { box-sizing: border-box; } body { margin: 0; padding: 30px 36px; }
+svg { width: 94px; height: 30px; fill: currentColor; } h1 { margin: 24px 0 6px; font-size: 21px; font-weight: 600; letter-spacing: -.4px; }
+p { margin: 0; opacity: .65; } .status { display: flex; gap: 10px; align-items: center; margin-top: 26px; }
+.spinner { width: 15px; height: 15px; border: 2px solid currentColor; border-right-color: transparent; border-radius: 50%; animation: spin 1s linear infinite; opacity: .6; flex-shrink: 0; }
+#slow { margin-top: 12px; font-size: 12px; min-height: 54px; visibility: hidden; }
+body[data-phase="attention"] #slow { visibility: hidden !important; }
+body[data-phase="attention"] .spinner { animation: none; }
+footer { display: flex; justify-content: space-between; align-items: center; margin-top: 18px; font-size: 12px; }
+#elapsed { opacity: .55; font-variant-numeric: tabular-nums; }
+button { font: inherit; color: inherit; background: transparent; border: 1px solid ${dark ? '#48494f' : '#dedee3'}; border-radius: 7px; padding: 6px 10px; cursor: pointer; }
+button:hover { background: ${dark ? '#303137' : '#f4f4f6'}; } button:focus-visible { outline: 2px solid #788aff; outline-offset: 3px; }
+@keyframes spin { to { transform: rotate(360deg); } } @media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
+</style></head><body>
+<svg viewBox="0 0 460 120" role="img" aria-label="Maka"><g transform="translate(0,120) scale(0.1,-0.1)"><path d="${MAKA_WORDMARK_PATH}"/></g></svg>
+<h1>${copy.title}</h1><p>${copy.detail}</p>
+<div class="status" role="status" aria-live="polite"><span class="spinner" aria-hidden="true"></span><span id="phase">${copy.phases.prepare}</span></div>
+<p id="slow">${copy.slow}</p>
+<footer><span id="elapsed"></span><button id="copy">${copy.copy}</button></footer>
+<script nonce="${nonce}">
+const started = performance.now();
+setInterval(() => {
+  const seconds = Math.floor((performance.now() - started) / 1000);
+  document.getElementById('elapsed').textContent = ${JSON.stringify(copy.elapsed)} + ' ' + Math.floor(seconds / 60) + ':' + String(seconds % 60).padStart(2, '0');
+  if (seconds >= 20) document.getElementById('slow').style.visibility = 'visible';
+}, 1000);
+document.getElementById('copy').addEventListener('click', () => { location.href = 'maka-startup://copy'; });
+</script></body></html>`;
+}

--- a/apps/desktop/src/main/startup-step.ts
+++ b/apps/desktop/src/main/startup-step.ts
@@ -19,25 +19,9 @@
 
 // apps/desktop/src/main/startup-step.ts
 //
-// Everything before the first window is created runs at boot's top level,
-// where a promise that never settles takes the launch with it: the process
-// stays alive, the main thread sits in the event loop, no window is created,
-// and nothing at all is printed. From outside, that is indistinguishable from
-// a crash — diagnosing one instance of it cost a long bisection over workspace
-// contents, because there was no line saying which step had not come back.
-//
-// Naming the step turns that silence into one line that says where to look.
-// A step that finishes normally prints nothing, so this costs no noise.
-//
-// Who gets to read that line: whoever can see the main process's stderr — a
-// developer running from a terminal, an e2e run capturing output, a crash
-// report gathered by hand. `report` defaults to `console.warn`, and a packaged
-// .app launched from the Finder has nowhere for stderr to land, so somebody
-// who hits this in a shipped build still sees no window and nothing printed,
-// exactly as described above. This is a diagnostic for whoever goes looking,
-// not a message to the person the launch failed on. Ending the silence for
-// them would take a visible surface, which does not exist before the first
-// window and is not what this file does.
+// Name slow boot steps in the diagnostic log. The independent startup window
+// provides visible progress; these lines retain evidence for copied reports
+// and automated runs where that window is intentionally suppressed.
 //
 // What it cannot report: a step that never settles and holds no ref'd handle
 // lets the process exit before the unref'd timer ever fires, so nothing is

--- a/scripts/verify-packaged-app.mjs
+++ b/scripts/verify-packaged-app.mjs
@@ -173,9 +173,18 @@ export async function findRendererTarget(port, child, { timeoutMs = 90_000 } = {
       });
       if (response.ok) {
         const targets = await response.json();
-        const page = targets.find(
-          (target) => target.type === 'page' && target.webSocketDebuggerUrl,
-        );
+        // Startup and recovery windows can appear before the application.
+        // Only the packaged main entry owns the bridge and app-shell contract;
+        // selecting the first page pins subsequent probes to a temporary window.
+        const page = targets.find((target) => {
+          if (target.type !== 'page' || !target.webSocketDebuggerUrl) return false;
+          try {
+            const url = new URL(target.url);
+            return url.protocol === 'file:' && url.pathname.endsWith('/dist-renderer/index.html');
+          } catch {
+            return false;
+          }
+        });
         if (page) return page;
       }
     } catch (error) {

--- a/scripts/verify-windows-harness.test.mjs
+++ b/scripts/verify-windows-harness.test.mjs
@@ -21,6 +21,7 @@ import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:net';
+import { createServer as createHttpServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -29,6 +30,7 @@ import { bumpedAutoupdateVersion } from './desktop-update-contract.mjs';
 import { validateWindowsUpgradeBaseline } from './prepare-windows-upgrade-baseline.mjs';
 import {
   diffTreeManifests,
+  findRendererTarget,
   directoryTreeManifest,
   rendererLayoutMatchesViewport,
   rendererViewportMatchesNativeClient,
@@ -491,6 +493,50 @@ describe('waitForDevToolsPort', () => {
     child.exitCode = 1;
     child.emit('exit');
     await assert.rejects(() => wait, /exited before announcing/);
+  });
+});
+
+describe('findRendererTarget', () => {
+  it('waits past startup, blank and dialog targets for the packaged main entry', async () => {
+    const startupTargets = [
+      {
+        type: 'page',
+        url: 'data:text/html,<title>Maka</title>',
+        webSocketDebuggerUrl: 'ws://startup',
+      },
+      { type: 'page', url: 'about:blank', webSocketDebuggerUrl: 'ws://blank' },
+      {
+        type: 'page',
+        url: 'https://example.test/dist-renderer/index.html',
+        webSocketDebuggerUrl: 'ws://web',
+      },
+    ];
+    const main = {
+      type: 'page',
+      url: 'file:///C:/Program%20Files/Maka/resources/app.asar/dist-renderer/index.html',
+      webSocketDebuggerUrl: 'ws://main',
+    };
+    let requests = 0;
+    const server = createHttpServer((_request, response) => {
+      response.setHeader('Content-Type', 'application/json');
+      response.end(JSON.stringify(++requests === 1 ? startupTargets : [...startupTargets, main]));
+    });
+    await new Promise((resolvePromise) => server.listen(0, '127.0.0.1', resolvePromise));
+    try {
+      assert.deepEqual(
+        await findRendererTarget(
+          server.address().port,
+          { exitCode: null },
+          {
+            timeoutMs: 2_000,
+          },
+        ),
+        main,
+      );
+    } finally {
+      server.closeAllConnections();
+      await new Promise((resolvePromise) => server.close(resolvePromise));
+    }
   });
 });
 


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Show a branded startup window before Runtime Host boot, so managed repairs and upgrades no longer leave only an Electron Dock tile and no visible feedback.
- Display actual preparation/update stages, elapsed time, a long-wait explanation and Copy diagnostics. Closing this status window minimizes it instead of terminating the operation.
- Keep confirmation/error dialogs visible and hand off only when the main window is shown. Automated runs retain their existing window/focus behavior. Host migration and update permissions are unchanged.

## Verification

- Packaged renderer target selection now skips startup/dialog pages and waits for the packaged main entry; shared release-verifier tests: 64 passed.
- Desktop suite: 2,323 passed. Regression coverage includes early-close/load races, safe presentation failure, navigation isolation, managed progress and main-window handoff.
- Full build, typecheck, lint, formatting and Desktop/UI dependency checks passed.
- Isolated Linux Electron launch: startup visible at ~1.2 s; main window visible at ~2.8 s, immediately closing startup. Error-dialog display and Copy diagnostics also exercised through CDP.
- The screenshot below is a real Electron startup window with simulated package preparation, in English/light. Actual macOS Dock/launchd behavior still needs on-device verification.

![Startup progress — English, light](https://github.com/user-attachments/assets/8f8efd79-3846-4814-b224-dfb1d90ea822)

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex — implementation, tests and UI verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally
- [x] Yes — behavior changes are described under Summary

</details>

<details>
<summary>简体中文</summary>

## Summary

- 在 Runtime Host 启动前展示 Maka 启动窗口，避免 managed 修复／升级期间只有 Electron Dock 图标、没有窗口或进度反馈。
- 展示真实准备／更新阶段、耗时、长时间等待说明和诊断复制入口。关闭此状态窗口只会最小化，不终止操作。
- 确认及错误对话框保持可见，主窗口显示后才完成交接。保留自动化测试的窗口和焦点策略，不改变 Host 迁移与更新权限。

## Verification

- 打包验证会跳过启动／对话框页面，等待真正的主界面；共享发布验证测试 64 项通过。
- Desktop 全量 2,323 项通过；覆盖提前关闭与加载竞态、展示失败隔离、导航限制、managed 进度以及窗口交接。
- 全量构建、类型、lint、格式及 Desktop/UI 依赖检查通过。
- 隔离 Linux Electron 实测：约 1.2 秒显示启动窗口，约 2.8 秒显示主窗口并立即关闭启动窗口；通过 CDP 验证错误弹窗及诊断复制。
- 下方截图为真实 Electron 窗口，模拟安装包准备阶段，展示简体中文深色界面。macOS Dock／launchd 行为仍待设备实测。

![Startup progress — Simplified Chinese, dark](https://github.com/user-attachments/assets/6c64d97e-20ed-4f53-8854-5fcde757d412)

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex — 实现、测试和界面验证。

## Checklist

- [x] 测试覆盖变更并可捕获回归
- [x] 本地 lint、格式、类型及受影响测试通过
- [x] 行为变化已在 Summary 说明

</details>




