### PR TITLE
refactor(storage): centralize safe persisted identifier validation

### DIFF
--- a/packages/storage/src/__tests__/storage-id.test.ts
+++ b/packages/storage/src/__tests__/storage-id.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { assertSafeStorageId, isSafeStorageId } from '../storage-id.js';
+
+test('accepts the complete safe storage identifier boundary', () => {
+  assert.equal(isSafeStorageId('a'), true);
+  assert.equal(isSafeStorageId('A0_-'), true);
+  assert.equal(isSafeStorageId('x'.repeat(128)), true);
+});
+
+test('rejects unsafe storage identifier values', () => {
+  for (const value of [
+    '',
+    'x'.repeat(129),
+    ' leading',
+    'trailing ',
+    'nested/path',
+    'punctuation.',
+    undefined,
+    null,
+    42,
+    {},
+  ]) {
+    assert.equal(isSafeStorageId(value), false, `expected rejection for ${String(value)}`);
+  }
+  assert.throws(() => assertSafeStorageId('bad/id', 'custom storage id error'), {
+    name: 'TypeError',
+    message: 'custom storage id error',
+  });
+});

--- a/packages/storage/src/goal-authority.ts
+++ b/packages/storage/src/goal-authority.ts
@@ -28,6 +28,7 @@ import {
   StorageRootAuthorityError,
   type StorageRootLease,
 } from './root-authority.js';
+import { assertSafeStorageId } from './storage-id.js';
 
 const writerBrand: unique symbol = Symbol('InteractiveGoalAuthorityWriter');
 const writers = new WeakSet<object>();
@@ -300,5 +301,5 @@ function cloneSnapshot(snapshot: GoalAuthoritySnapshot): GoalAuthoritySnapshot {
 }
 
 function requireId(value: string, label: string): void {
-  if (!/^[A-Za-z0-9_-]{1,128}$/.test(value)) throw new TypeError(`${label} identity is invalid`);
+  assertSafeStorageId(value, `${label} identity is invalid`);
 }

--- a/packages/storage/src/interaction-store.ts
+++ b/packages/storage/src/interaction-store.ts
@@ -46,8 +46,8 @@ import {
   acquireOperationalStateDatabase,
   type OperationalStateDatabaseLease,
 } from './operational-state-store.js';
+import { isSafeStorageId } from './storage-id.js';
 
-const SAFE_ID = /^[A-Za-z0-9_-]{1,128}$/;
 const REMEMBER_SCOPE_ID = /^[0-9a-f]{64}$/;
 export const STORED_INTERACTION_REQUEST_MAX_BYTES = 20 * 1024;
 export const STORED_INTERACTION_OUTCOME_MAX_BYTES = 12 * 1024;
@@ -788,7 +788,7 @@ function assertId(
   source: DecodeSource = 'input',
   message = 'Invalid Interaction identity',
 ): string {
-  if (typeof value !== 'string' || !SAFE_ID.test(value)) decodeFailure(source, message);
+  if (!isSafeStorageId(value)) decodeFailure(source, message);
   return value;
 }
 

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -28,6 +28,7 @@ import {
   acquireOperationalStateDatabase,
   OPERATIONAL_STATE_DATABASE_NAME,
 } from './operational-state-store.js';
+import { isSafeStorageId } from './storage-id.js';
 
 export const SESSION_BUNDLE_STATE_ENTRIES = ['artifacts', OPERATIONAL_STATE_DATABASE_NAME] as const;
 export const SESSION_BUNDLE_PROTECTED_ENTRIES = [] as const;
@@ -377,7 +378,7 @@ function assertRootsSeparate(left: string, right: string, allowSame: boolean): v
 }
 
 function assertSafeSessionId(sessionId: string): void {
-  if (!/^[A-Za-z0-9_-]{1,128}$/.test(sessionId)) {
+  if (!isSafeStorageId(sessionId)) {
     throw new SessionBundleExportError('invalid_root', `Invalid session id: ${sessionId}`);
   }
 }

--- a/packages/storage/src/session-copy-cleanup.ts
+++ b/packages/storage/src/session-copy-cleanup.ts
@@ -27,6 +27,7 @@ import {
   type ProcessLifetimeOwner,
   type ProcessLifetimeRecoveryClaim,
 } from './process-lifetime-owner.js';
+import { isSafeStorageId } from './storage-id.js';
 
 export interface SessionCopyCreationLease {
   sessionId: string;
@@ -534,7 +535,7 @@ function samePersistedCreation(
 function normalizeSessionId(value: unknown): string {
   if (typeof value !== 'string') throw new Error('Invalid Session copy id');
   const normalized = value.trim();
-  if (!/^[A-Za-z0-9_-]{1,128}$/.test(normalized)) {
+  if (!isSafeStorageId(normalized)) {
     throw new Error('Invalid Session copy id');
   }
   return normalized;

--- a/packages/storage/src/storage-id.ts
+++ b/packages/storage/src/storage-id.ts
@@ -17,20 +17,17 @@
  * under the License.
  */
 
-import type { RuntimeEvent } from '@maka/core/runtime-event';
-import { isSafeStorageId } from './storage-id.js';
+const SAFE_STORAGE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 
-export function isRuntimeStorageSafeId(value: string): boolean {
-  return isSafeStorageId(value);
+/** Returns whether a value can safely be used as a persisted storage identity. */
+export function isSafeStorageId(value: unknown): value is string {
+  return typeof value === 'string' && SAFE_STORAGE_ID_PATTERN.test(value);
 }
 
-export function immutableSteeringMessageId(event: RuntimeEvent): string | undefined {
-  const messageId = event.refs?.providerEventId;
-  return event.partial === false &&
-    typeof messageId === 'string' &&
-    isRuntimeStorageSafeId(messageId) &&
-    event.content?.kind === 'text' &&
-    event.content.steering === true
-    ? messageId
-    : undefined;
+/** Throws a TypeError unless the value is a safe persisted storage identity. */
+export function assertSafeStorageId(
+  value: unknown,
+  message = 'Storage identity is invalid',
+): asserts value is string {
+  if (!isSafeStorageId(value)) throw new TypeError(message);
 }


### PR DESCRIPTION
Fixes #4926

## Summary
- add a storage-local safe persisted identifier predicate and asserter
- migrate runtime event, interaction, session bundle, session copy, and Goal authority boundaries
- preserve caller-specific trimming, errors, and owner-id semantics
- add 1/128 boundary and invalid-value regression coverage

## Motivation
The same persisted identifier grammar was implemented in several storage authorities. Centralizing the grammar prevents future policy changes from leaving one persistence boundary weaker or accepting a different set of values.

## Validation
- npm --workspace @maka/core run build
- npm --workspace @maka/storage run build
- node --test packages/storage/dist/__tests__/storage-id.test.js packages/storage/dist/__tests__/session-bundle-policy.test.js packages/storage/dist/__tests__/session-copy-cleanup.test.js packages/storage/dist/__tests__/goal-authority.test.js packages/storage/dist/__tests__/client-capability-session-grant-store.test.js packages/storage/dist/__tests__/sqlite-core-execution-store.test.js (40/40)
- npx biome check on changed storage sources and tests