### PR TITLE
refactor(core): share canonical JSON serializer with eval and storage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "./durable-tool-result-projection": "./dist/durable-tool-result-projection.js",
     "./model-projection-transition": "./dist/model-projection-transition.js",
     "./canonical-runtime-event": "./dist/canonical-runtime-event.js",
+    "./canonical-json": "./dist/canonical-json.js",
     "./runtime-boundary": "./dist/runtime-boundary.js",
     "./runtime-event": "./dist/runtime-event.js",
     "./tool-args-identity": "./dist/tool-args-identity.js",

--- a/packages/core/src/__tests__/canonical-json.test.ts
+++ b/packages/core/src/__tests__/canonical-json.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { stableJsonStringify } from '../canonical-json.js';
+
+test('serializes nested objects and arrays in one deterministic order', () => {
+  assert.equal(
+    stableJsonStringify({ z: [{ b: 2, a: 1 }], a: true }),
+    '{"a":true,"z":[{"a":1,"b":2}]}',
+  );
+  assert.equal(
+    stableJsonStringify({ a: true, z: [{ a: 1, b: 2 }] }),
+    stableJsonStringify({ z: [{ b: 2, a: 1 }], a: true }),
+  );
+});
+
+test('rejects values that JSON would otherwise coerce or omit', () => {
+  for (const value of [
+    { missing: undefined },
+    { nonFinite: Number.NaN },
+    { infinite: Number.POSITIVE_INFINITY },
+    { bigint: 1n },
+    Object.create({ inherited: true }),
+  ]) {
+    assert.throws(() => stableJsonStringify(value), /strict JSON/);
+  }
+});

--- a/packages/core/src/canonical-json.ts
+++ b/packages/core/src/canonical-json.ts
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Neutral entrypoint for the strict, key-sorted JSON serializer shared by
+ * identity and persistence authorities.
+ *
+ * The implementation remains in `tool-args-identity` so its existing import
+ * path and wire behavior stay compatible while other packages use a domain-
+ * neutral name.
+ */
+export { stableJsonStringify } from './tool-args-identity.js';

--- a/packages/eval/src/__tests__/experiment-directory.test.ts
+++ b/packages/eval/src/__tests__/experiment-directory.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { openExperimentDirectory } from '../experiment-directory.js';
+import type { ExperimentSpec } from '../experiment.js';
+
+test('writes canonical nested spec bytes and accepts equivalent key order', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-eval-experiment-directory-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const first = experiment({
+    z: [{ b: 2, a: 1 }],
+    a: true,
+  });
+
+  const opened = await openExperimentDirectory(root, first);
+  const text = await readFile(opened.specPath, 'utf8');
+  assert.equal(text.endsWith('\n'), true);
+  assert.match(text, /"config":\{"a":true,"z":\[\{"a":1,"b":2\}\]\}/);
+
+  await openExperimentDirectory(
+    root,
+    experiment({
+      a: true,
+      z: [{ a: 1, b: 2 }],
+    }),
+  );
+});
+
+test('rejects non-finite spec values instead of silently writing null', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-eval-experiment-directory-invalid-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await assert.rejects(
+    openExperimentDirectory(
+      root,
+      experiment({ invalid: Number.NaN } as unknown as ExperimentSpec['benchmark']['config']),
+    ),
+    /strict JSON/,
+  );
+});
+
+function experiment(config: ExperimentSpec['benchmark']['config']): ExperimentSpec {
+  return {
+    schemaVersion: 'maka.eval.v1',
+    id: 'canonical-experiment',
+    benchmark: { id: 'benchmark', version: '1', config },
+    executor: { kind: 'test', config: {} },
+    execution: { maxConcurrentTaskGroups: 1 },
+    subjects: [{ id: 'subject', kind: 'external', credentials: [], config: {} }],
+    tasks: [{ id: 'task', input: 'solve', config: {} }],
+    repetitions: 1,
+    budget: {},
+    verifier: {},
+  };
+}

--- a/packages/eval/src/experiment-directory.ts
+++ b/packages/eval/src/experiment-directory.ts
@@ -20,15 +20,16 @@
 import { randomUUID } from 'node:crypto';
 import { link, mkdir, open, readFile, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
+import { stableJsonStringify } from '@maka/core/canonical-json';
 import { FileAttemptStore } from './attempt-store.js';
-import type { ExperimentSpec, JsonValue } from './experiment.js';
+import type { ExperimentSpec } from './experiment.js';
 import { parseExperimentSpec } from './spec.js';
 
 export async function openExperimentDirectory(root: string, spec: ExperimentSpec) {
   await mkdir(root, { recursive: true });
   const specPath = join(root, 'experiment.json');
   const temporaryPath = join(root, `.experiment-${randomUUID()}.tmp`);
-  const canonical = `${canonicalJson(spec)}\n`;
+  const canonical = `${stableJsonStringify(spec)}\n`;
   const temporary = await open(temporaryPath, 'wx', 0o600);
   try {
     await temporary.writeFile(canonical);
@@ -38,21 +39,12 @@ export async function openExperimentDirectory(root: string, spec: ExperimentSpec
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
     const existing = parseExperimentSpec(JSON.parse(await readFile(specPath, 'utf8')));
-    if (canonicalJson(existing) !== canonicalJson(spec)) throw new Error('experiment spec differs');
+    if (stableJsonStringify(existing) !== stableJsonStringify(spec)) {
+      throw new Error('experiment spec differs');
+    }
   } finally {
     await temporary.close().catch(() => undefined);
     await unlink(temporaryPath).catch(() => undefined);
   }
   return { root, specPath, attempts: new FileAttemptStore(join(root, 'attempts')) };
-}
-
-function canonicalJson(value: JsonValue | ExperimentSpec): string {
-  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
-  if (value && typeof value === 'object') {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child as JsonValue)}`)
-      .join(',')}}`;
-  }
-  return JSON.stringify(value);
 }

--- a/packages/storage/src/session-bundle-manifest.ts
+++ b/packages/storage/src/session-bundle-manifest.ts
@@ -33,6 +33,7 @@ import {
   SessionBundleFileError,
   type SessionBundleManifestV1,
 } from './session-bundle-contract.js';
+import { stableJsonStringify } from '@maka/core/canonical-json';
 
 const MANIFEST_KEYS = ['codec', 'envelope', 'payload', 'schemaVersion', 'stateIdentity'] as const;
 const CODEC_KEYS = [
@@ -205,19 +206,11 @@ function decodePayload(value: unknown): SessionBundleManifestV1['payload'] {
 }
 
 function canonicalJson(value: unknown): string {
-  if (value === null) return 'null';
-  if (typeof value === 'string') return JSON.stringify(value);
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) throw invalidManifest();
-    return JSON.stringify(value);
+  try {
+    return stableJsonStringify(value);
+  } catch {
+    throw invalidManifest();
   }
-  if (typeof value === 'boolean') return value ? 'true' : 'false';
-  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
-  if (!isRecord(value)) throw invalidManifest();
-  return `{${Object.keys(value)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
-    .join(',')}}`;
 }
 
 function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {


### PR DESCRIPTION
Fixes #4927

## Summary
- expose the existing strict canonical JSON serializer through `@maka/core/canonical-json`
- replace the eval experiment and session-bundle manifest serializer copies
- preserve eval's trailing newline and collision behavior
- map manifest serializer failures back to `SessionBundleFileError('invalid_manifest', ...)`

## Motivation
Eval identities and portable bundle bytes were produced by separate serializers. Sharing the strict core authority keeps key ordering and rejection of unsupported JSON values consistent across both persistence boundaries.

## Validation
- npm --workspace @maka/core run build
- npm --workspace @maka/runtime run build
- npm --workspace @maka/runtime-host run build
- npm --workspace @maka/eval run build
- npm --workspace @maka/storage run build
- node --test packages/core/dist/__tests__/canonical-json.test.js packages/core/dist/__tests__/tool-args-identity.test.js packages/eval/dist/__tests__/experiment-directory.test.js packages/storage/dist/__tests__/session-bundle-manifest.test.js (16/16)
- npx biome check on changed sources and tests