### PR TITLE
refactor(runtime-host): centralize Node errno error guard

### DIFF
--- a/packages/runtime-host/src/__tests__/node-error.test.ts
+++ b/packages/runtime-host/src/__tests__/node-error.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { isNodeError } from '../node-error.js';
+
+test('narrows only Error instances with the requested exact errno code', () => {
+  const missing = Object.assign(new Error('missing'), { code: 'ENOENT' });
+  const denied = Object.assign(new Error('denied'), { code: 'EPERM' });
+
+  assert.equal(isNodeError(missing, 'ENOENT'), true);
+  if (isNodeError(missing, 'ENOENT')) assert.equal(missing.code, 'ENOENT');
+  assert.equal(isNodeError(missing, 'EPERM'), false);
+  assert.equal(isNodeError(denied, 'ENOENT'), false);
+  assert.equal(isNodeError({ code: 'ENOENT' }, 'ENOENT'), false);
+  assert.equal(isNodeError('ENOENT', 'ENOENT'), false);
+  assert.equal(isNodeError(new Error('missing'), 'ENOENT'), false);
+});

--- a/packages/runtime-host/src/control/endpoint.ts
+++ b/packages/runtime-host/src/control/endpoint.ts
@@ -22,6 +22,7 @@ import { chmod, lstat, mkdtemp, readdir, rm, rmdir, unlink } from 'node:fs/promi
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { truncateUtf8 } from '@maka/core/diagnostic-log';
+import { isNodeError } from '../node-error.js';
 
 const FALLBACK_ENDPOINT_ROOT = '/tmp';
 const PORTABLE_UNIX_SOCKET_PATH_LIMIT = 100;
@@ -377,10 +378,4 @@ function currentUid(): number {
     );
   }
   return process.getuid();
-}
-
-function isNodeError(error: unknown, code: string): boolean {
-  return (
-    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code
-  );
 }

--- a/packages/runtime-host/src/node-error.ts
+++ b/packages/runtime-host/src/node-error.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** Narrows a caught value to a Node errno error with one exact error code. */
+export function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error && error.code === code;
+}

--- a/packages/runtime-host/src/operator/managed-deployment.ts
+++ b/packages/runtime-host/src/operator/managed-deployment.ts
@@ -43,6 +43,7 @@ import {
   isSha512PackageIntegrity,
   resolveRuntimeHostNpmDeploymentLayout,
 } from './update-package-evidence.js';
+import { isNodeError } from '../node-error.js';
 
 export const RUNTIME_HOST_MANAGED_DEPLOYMENT_CONFIG_FILE = 'runtime-host-deployment.json';
 
@@ -1258,8 +1259,4 @@ function deploymentIo(message: string, cause: unknown): RuntimeHostManagedDeploy
     : new RuntimeHostManagedDeploymentError('deployment_io_failed', message, {
         cause,
       });
-}
-
-function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
-  return error instanceof Error && 'code' in error && error.code === code;
 }

--- a/packages/runtime-host/src/peer-reachability/publisher.ts
+++ b/packages/runtime-host/src/peer-reachability/publisher.ts
@@ -35,6 +35,7 @@ import {
   type PeerReachabilityLeaseReceipt,
   type SignedPeerReachabilityLeaseV1,
 } from './model.js';
+import { isNodeError } from '../node-error.js';
 
 const STATE_FILE = 'peer-reachability.json';
 const MAX_STATE_BYTES = 64 * 1_024;
@@ -286,8 +287,4 @@ async function syncDirectory(path: string): Promise<void> {
   } finally {
     await handle.close();
   }
-}
-
-function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
-  return error instanceof Error && 'code' in error && error.code === code;
 }


### PR DESCRIPTION
Fixes #4928

## Summary
- add a Runtime Host-local `isNodeError` type predicate
- migrate control endpoint, managed deployment, and peer reachability publisher
- preserve Error-only, exact errno matching for ENOENT, EPERM, and other codes
- add focused narrowing and mismatch regression coverage

## Motivation
The same Node errno guard was duplicated across Runtime Host modules, with inconsistent return typing. A shared predicate keeps filesystem error handling auditable while preserving each module's conservative behavior.

## Validation
- npm --workspace @maka/core run build
- npm --workspace @maka/storage run build
- npm --workspace @maka/mcp run build
- npm --workspace @maka/runtime run build
- npm --workspace @maka/runtime-host run build
- node --test packages/runtime-host/dist/__tests__/node-error.test.js packages/runtime-host/dist/__tests__/control-endpoint.test.js packages/runtime-host/dist/__tests__/managed-activation.test.js packages/runtime-host/dist/__tests__/peer-reachability.test.js (16 passed, 1 platform skip)
- npx biome check on changed Runtime Host sources and tests