### PR TITLE
test(runtime-host): assert liveness deadlines on a virtual clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,9 @@ jobs:
       - name: Report CLI Rust build cache
         if: steps.plan.outputs.cli_package == 'true'
         shell: bash
-        run: kache report --format github >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          set -o pipefail
+          kache report --format github | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Save CLI Rust build cache
         if: steps.plan.outputs.cli_package == 'true' && github.ref_name == github.event.repository.default_branch

--- a/.github/workflows/cli-package-validation.yml
+++ b/.github/workflows/cli-package-validation.yml
@@ -164,7 +164,9 @@ jobs:
           node native/runtime-host-windows-task-launcher/build.mjs
       - name: Report Rust build cache
         shell: bash
-        run: kache report --format github >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          set -o pipefail
+          kache report --format github | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Save Rust build cache
         if: github.ref_name == github.event.repository.default_branch
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/gitoxide-helper-admission.yml
+++ b/.github/workflows/gitoxide-helper-admission.yml
@@ -97,7 +97,9 @@ jobs:
         run: cargo test --locked
       - name: Report Rust build cache
         shell: bash
-        run: kache report --format github >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          set -o pipefail
+          kache report --format github | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Save Rust build cache
         if: github.ref_name == github.event.repository.default_branch
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/release-windows-check.yml
+++ b/.github/workflows/release-windows-check.yml
@@ -172,7 +172,9 @@ jobs:
         run: npm run test:windows-archives
 
       - name: Report Rust build cache
-        run: kache report --format github >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          set -o pipefail
+          kache report --format github | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Save Rust build cache
         if: github.ref_name == github.event.repository.default_branch

--- a/.github/workflows/runtime-host-peer-admission.yml
+++ b/.github/workflows/runtime-host-peer-admission.yml
@@ -108,7 +108,9 @@ jobs:
         run: cargo test --locked
       - name: Report Rust build cache
         shell: bash
-        run: kache report --format github >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          set -o pipefail
+          kache report --format github | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Save Rust build cache
         if: github.ref_name == github.event.repository.default_branch
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/windows-sandbox-w0.yml
+++ b/.github/workflows/windows-sandbox-w0.yml
@@ -94,7 +94,9 @@ jobs:
         run: cargo test --locked
       - name: Report Rust build cache
         shell: bash
-        run: kache report --format github >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          set -o pipefail
+          kache report --format github | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Save Rust build cache
         if: github.ref_name == github.event.repository.default_branch
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/packages/runtime-host/src/__tests__/resumable-peer-stream.test.ts
+++ b/packages/runtime-host/src/__tests__/resumable-peer-stream.test.ts
@@ -23,6 +23,7 @@ import { setImmediate as tick, setTimeout as delay } from 'node:timers/promises'
 import { test } from 'node:test';
 import { connect, createServer, type Socket } from 'node:net';
 import { once } from 'node:events';
+import { performance } from 'node:perf_hooks';
 import { createRuntimeHostPeerListener } from '../server/peer-listener.js';
 import { RuntimeHostConnectionSession } from '../server/connection-session.js';
 import { LOCAL_OWNER_CONNECTION_AUTHORITY } from '../server/connection-authority.js';
@@ -468,6 +469,19 @@ test('close has a hard deadline even when a healthy peer never drains its receiv
 test('failed proactive upgrade preserves transit; a later direct attachment keeps the logical stream', {
   timeout: 13_000,
 }, async (t) => {
+  let now = 0;
+  t.mock.method(performance, 'now', () => now);
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  const advance = async (milliseconds: number): Promise<void> => {
+    const target = now + milliseconds;
+    while (now < target) {
+      const step = Math.min(250, target - now);
+      now += step;
+      t.mock.timers.tick(step);
+      // Flush real duplex I/O between heartbeats instead of simulating a blackhole.
+      await tick();
+    }
+  };
   let right!: ResumablePeerStream;
   let upgrades = 0;
   const left = new ResumablePeerStream({
@@ -515,10 +529,16 @@ test('failed proactive upgrade preserves transit; a later direct attachment keep
   });
   await left.write(Buffer.from('before-upgrade'));
   assert.deepEqual(await right.read(), Buffer.from('before-upgrade'));
+  await advance(4_999);
+  assert.equal(upgrades, 0);
+  await advance(1);
   assert.deepEqual(await left.read(), Buffer.from('rejected-upgrade-retains-old'));
   assert.equal(left.path?.kind, 'transit');
   await left.write(Buffer.from('old-path-still-live'));
   assert.deepEqual(await right.read(), Buffer.from('old-path-still-live'));
+  await advance(4_999);
+  assert.equal(upgrades, 1);
+  await advance(1);
   assert.deepEqual(await left.read(), Buffer.from('during-path-change'));
   assert.equal(left.path?.kind, 'direct');
   assert.equal(upgrades, 2);

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -1363,9 +1363,13 @@ test('tolerates a short Host stall without abandoning the connection', {
 
 test('closes an unresponsive request path even while Host notifications continue', {
   timeout: 12_000,
-}, async () => {
+}, async (t) => {
   let received = 0;
   let probes = 0;
+  const probeReceived = deferred<void>();
+  const notificationsReceived = deferred<void>();
+  const finalNotificationReceived = deferred<void>();
+  let sendFinalNotification!: () => Promise<void>;
   await withProtocolPeer(
     async (transport, hostEpoch, rootId) => {
       await transport.read(1_000);
@@ -1381,6 +1385,12 @@ test('closes an unresponsive request path even while Host notifications continue
         state: 'ready',
       });
       let revision = 0;
+      sendFinalNotification = () =>
+        writeProtocolFrame(transport, {
+          kind: 'session.catalog.changed',
+          revision: ++revision,
+          sessionId: 'final-notification',
+        });
       const notifications = setInterval(() => {
         void writeProtocolFrame(transport, {
           kind: 'session.catalog.changed',
@@ -1392,15 +1402,30 @@ test('closes an unresponsive request path even while Host notifications continue
         const probe = decodeClientFrame(await transport.read(1_000));
         assert.ok(!('kind' in probe));
         assert.equal(probe.operation, 'host.status');
+        probeReceived.resolve();
         await transport.closed;
       } finally {
         clearInterval(notifications);
       }
     },
     async (connection) => {
-      connection.subscribeSessionCatalogChanges(() => {
-        received += 1;
+      let closed = false;
+      void connection.closed.then(() => {
+        closed = true;
       });
+      connection.subscribeSessionCatalogChanges((event) => {
+        received += 1;
+        if (received > 10) notificationsReceived.resolve();
+        if (event.sessionId === 'final-notification') finalNotificationReceived.resolve();
+      });
+      t.mock.timers.tick(20);
+      await probeReceived.promise;
+      await notificationsReceived.promise;
+      t.mock.timers.tick(7_999);
+      await sendFinalNotification().catch(() => undefined);
+      await Promise.race([finalNotificationReceived.promise, connection.closed]);
+      assert.equal(closed, false, 'inbound events must not end the pending probe early');
+      t.mock.timers.tick(1);
       await connection.closed;
       assert.ok(received > 10, 'inbound events must remain active during the failed probe');
       assert.equal(probes, 0, 'one-way events cannot acknowledge a probe');
@@ -1411,6 +1436,7 @@ test('closes an unresponsive request path even while Host notifications continue
         probes += 1;
       },
     },
+    () => t.mock.timers.enable({ apis: ['setTimeout'] }),
   );
 });
 
@@ -1422,6 +1448,7 @@ async function withProtocolPeer(
     readonly onLivenessProbe?: () => void;
     readonly onHostStatus?: (status: HostStatusResult) => void;
   } = {},
+  beforeConnect?: () => void,
 ): Promise<void> {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-subscription-'));
   const capability = await resolveStorageRoot({
@@ -1459,6 +1486,7 @@ async function withProtocolPeer(
       pid: process.pid,
       createdAt: new Date().toISOString(),
     });
+    beforeConnect?.();
     const connected = await connectRuntimeHost({
       rootPath: join(base, 'root'),
       protocol: PROTOCOL,

--- a/scripts/ci-workflow-policy.test.mjs
+++ b/scripts/ci-workflow-policy.test.mjs
@@ -291,6 +291,13 @@ test('Rust build caches publish immutable source generations only from the defau
       name,
     );
     assert.doesNotMatch(workflow, /kache report [^\n]*--since/u, name);
+    const reports = [...workflow.matchAll(/^\s+(?:run: )?(kache report[^\n]*)$/gmu)].map(
+      ([, command]) => command,
+    );
+    assert.equal(reports.length, 1, name);
+    // The report must reach the raw log, not only the rendered summary panel.
+    assert.equal(reports[0], 'kache report --format github | tee -a "$GITHUB_STEP_SUMMARY"', name);
+    assert.match(workflow, /run: \|\n\s+set -o pipefail\n\s+kache report/u, name);
   }
 });
 


### PR DESCRIPTION
## Summary

Two `@maka/runtime-host` tests slept through real deadlines — the 5s proactive
upgrade interval and the 8s liveness probe deadline — costing 18s per run while
only observing the end state. Because they never checked the boundary, they also
passed against a broken threshold. Driving the mocked clock to each side of the
deadline pins the threshold and removes the waiting.

Separately, `kache report` wrote only to `$GITHUB_STEP_SUMMARY`, so Rust build
cache hit rates were visible in the run page panel but absent from the raw log —
not greppable in a downloaded log, not comparable across runs. All six workflows
that run kache now `tee` the report into both, unified rather than fixed one at a
time.

The tests keep real socket I/O and every original assertion; only the clock is
mocked, at the seams production already uses (`performance.now`, the heartbeat
`setInterval`, and the probe deadline `setTimeout`). No production logic, no
threshold, no runner and no cache key changes.

## Verification

`node --test` on the two suites, the five CI policy scripts, and biome on the
touched files — all pass. The targeted cases ran 10 consecutive times with no
failure or cancellation.

Wall clock, same machine and build:

```
before:
resumable-peer-stream.test.js        12s   10 pass
session-subscription-client.test.js  11s   27 pass
failed proactive upgrade                     duration_ms: 10034.729667
closes an unresponsive request path          duration_ms:  8061.532459

after:
resumable-peer-stream.test.js         2s   10 pass
session-subscription-client.test.js   3s   27 pass
failed proactive upgrade                     duration_ms:     5.623125
closes an unresponsive request path          duration_ms:   160.268125
```

The new boundary assertions were mutation-tested. Lowering the upgrade interval
in `transport/resumable-peer-stream.ts` from `5_000` to `3_000`:

```
old assertions, mutated production code:
ok 1 - failed proactive upgrade preserves transit; a later direct attachment keeps the logical stream
  duration_ms: 6028.081083
# pass 1

new assertions, same mutated production code:
not ok 1 - failed proactive upgrade preserves transit; a later direct attachment keeps the logical stream
  expected: 0
  actual: 1
  operator: 'strictEqual'
# fail 1
```

Lowering `DEFAULT_LIVENESS_TIMEOUT_MS` in `client/connection.ts` from `8_000` to
`6_000` fails the probe-deadline assertion the same way. Reverting one workflow
to `>>` fails the policy check:

```
all six workflows unified:
ℹ pass 40   ℹ fail 0

one workflow reverted to >>:
ℹ pass 39   ℹ fail 1
    actual:   'kache report --format github >> "$GITHUB_STEP_SUMMARY"'
    expected: 'kache report --format github | tee -a "$GITHUB_STEP_SUMMARY"'
```

Not run: Linux and Node 24. These suites interleave mocked timers with real
socket I/O, so CI is the first run on the platform that matters.

## Review focus

`set -o pipefail` makes a failing `kache report` fail its step instead of being
swallowed by the pipe. That is the intent, but a runner with a flaky kache exit
code would surface here for the first time.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — wrote the virtual-clock test changes and the
workflow/policy edits, and ran the timing and mutation verification above. The
approach, the assertion placement and the final review are the author's.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

