### PR TITLE
Add Command Code GOAT provider

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -3070,6 +3070,7 @@
           "../assets/provider-brands/xiaomimimo.svg": 1,
           "../assets/provider-brands/zai.svg": 1,
           "../assets/provider-brands/zenmux.svg": 1,
+          "../features/connection-settings": 1,
           "simple-icons": 1
         }
       },

--- a/apps/desktop/src/renderer/features/connection-settings/generic-provider-mark.tsx
+++ b/apps/desktop/src/renderer/features/connection-settings/generic-provider-mark.tsx
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Cpu, ICON_SIZE } from '@maka/ui/icons';
+
+export function GenericProviderMark() {
+  return <Cpu size={ICON_SIZE.plate} aria-hidden="true" />;
+}

--- a/apps/desktop/src/renderer/features/connection-settings/index.ts
+++ b/apps/desktop/src/renderer/features/connection-settings/index.ts
@@ -43,3 +43,5 @@ export type { ProviderSettingsCopy } from './settings-provider-copy.js';
 export type {
   CredentialPresenceStatus,
 } from './provider-panel-shared.js';
+
+export { GenericProviderMark } from './generic-provider-mark.js';

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -31,7 +31,7 @@
 // legible in both light and dark themes; viewBox is the upstream 24×24.
 
 import type { ProviderType } from '@maka/core/llm-connections';
-import { Cpu, ICON_SIZE } from '@maka/ui/icons';
+import { GenericProviderMark } from '../features/connection-settings';
 import type { ReactElement } from 'react';
 import { siMinimax } from 'simple-icons';
 import alibabaBrandMark from '../assets/provider-brands/alibabacloud.svg';
@@ -406,7 +406,7 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
     case 'github-copilot':
       // Primer Octicons does not license GitHub logos under its MIT terms.
       // Keep the provider identifiable by name without redistributing the mark.
-      return <Cpu size={ICON_SIZE.plate} aria-hidden="true" />;
+      return <GenericProviderMark />;
     case 'google':
       return <Gemini />;
     case 'deepseek':
@@ -456,6 +456,6 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
     case 'volcengine-agent-plan':
       return <img src={volcengineBrandMark} alt="" />;
     default:
-      return <Cpu size={ICON_SIZE.plate} aria-hidden="true" />;
+      return <GenericProviderMark />;
   }
 }

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -31,6 +31,7 @@
 // legible in both light and dark themes; viewBox is the upstream 24×24.
 
 import type { ProviderType } from '@maka/core/llm-connections';
+import { Cpu, ICON_SIZE } from '@maka/ui/icons';
 import type { ReactElement } from 'react';
 import { siMinimax } from 'simple-icons';
 import alibabaBrandMark from '../assets/provider-brands/alibabacloud.svg';
@@ -342,15 +343,6 @@ function MiniMaxMark(): ReactElement {
   );
 }
 
-function GenericProviderMark(): ReactElement {
-  return (
-    <svg viewBox="0 0 24 24" role="img" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
-      <circle cx="12" cy="12" r="8" />
-      <path d="M8 9.5h6.5a2 2 0 010 4H9.5a2 2 0 000 4H16" />
-    </svg>
-  );
-}
-
 // Vendored unchanged from @lobehub/icons-static-svg@1.91.0:
 // https://github.com/lobehub/lobe-icons/blob/32f4083f7a20b67ecdc7b29c0af031ada5a29c52/packages/static-svg/icons/ollama.svg
 // Lobe Icons is MIT licensed; this path is consumed verbatim, not redrawn here.
@@ -414,7 +406,7 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
     case 'github-copilot':
       // Primer Octicons does not license GitHub logos under its MIT terms.
       // Keep the provider identifiable by name without redistributing the mark.
-      return <GenericProviderMark />;
+      return <Cpu size={ICON_SIZE.plate} aria-hidden="true" />;
     case 'google':
       return <Gemini />;
     case 'deepseek':
@@ -464,6 +456,6 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
     case 'volcengine-agent-plan':
       return <img src={volcengineBrandMark} alt="" />;
     default:
-      return <GenericProviderMark />;
+      return <Cpu size={ICON_SIZE.plate} aria-hidden="true" />;
   }
 }

--- a/apps/desktop/src/renderer/settings/provider-display-copy.ts
+++ b/apps/desktop/src/renderer/settings/provider-display-copy.ts
@@ -295,9 +295,9 @@ export const PROVIDER_DISPLAY_COPY = {
     en: { name: 'OpenCode Free', description: 'Free anonymous OpenCode Zen models — no API key, IP-limited.', badge: 'Free' },
   },
   commandcode: {
-    'zh-CN': { name: 'Command Code', description: 'GOAT 套餐 · OpenAI 兼容', badge: 'Coding' },
-    'zh-TW': { name: 'Command Code', description: 'GOAT 套餐 · OpenAI 相容', badge: 'Coding' },
-    en: { name: 'Command Code', description: 'Command Code GOAT plan · OpenAI-compatible.', badge: 'Coding' },
+    'zh-CN': { name: 'Command Code', description: '使用 Command Code 套餐额度，连接后自动获取模型。', badge: 'Coding' },
+    'zh-TW': { name: 'Command Code', description: '使用 Command Code 方案額度，連線後自動取得模型。', badge: 'Coding' },
+    en: { name: 'Command Code', description: 'Use your Command Code plan credits. Models are fetched when you connect.', badge: 'Coding' },
   },
   groq: {
     'zh-CN': { name: 'Groq', description: 'LPU 高速推理托管开源模型', badge: 'API' },

--- a/apps/desktop/src/renderer/settings/provider-display-copy.ts
+++ b/apps/desktop/src/renderer/settings/provider-display-copy.ts
@@ -294,6 +294,11 @@ export const PROVIDER_DISPLAY_COPY = {
     'zh-TW': { name: 'OpenCode Free', description: '免費匿名 OpenCode Zen 模型，無需金鑰，按 IP 限速', badge: 'Free' },
     en: { name: 'OpenCode Free', description: 'Free anonymous OpenCode Zen models — no API key, IP-limited.', badge: 'Free' },
   },
+  commandcode: {
+    'zh-CN': { name: 'Command Code', description: 'GOAT 套餐 · OpenAI 兼容', badge: 'Coding' },
+    'zh-TW': { name: 'Command Code', description: 'GOAT 套餐 · OpenAI 相容', badge: 'Coding' },
+    en: { name: 'Command Code', description: 'Command Code GOAT plan · OpenAI-compatible.', badge: 'Coding' },
+  },
   groq: {
     'zh-CN': { name: 'Groq', description: 'LPU 高速推理托管开源模型', badge: 'API' },
     'zh-TW': { name: 'Groq', description: 'LPU 高速推理託管開源模型', badge: 'API' },

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -6,7 +6,7 @@ Generated against `@astryxdesign/core@0.5.2` (194 component exports).
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 252 files — blocker 0, reimplementation 0, polish 1, aligned 251.
+**Totals:** 253 files — blocker 0, reimplementation 0, polish 1, aligned 252.
 
 ## Exclusions (explicit)
 
@@ -45,6 +45,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/error-boundary.tsx` | other | Button, Card | aligned — uses Astryx (Button, Card) | aligned |
 | `apps/desktop/src/renderer/features/app-update/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/app-update/ui/app-update-provider.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
+| `apps/desktop/src/renderer/features/connection-settings/generic-provider-mark.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/connection-settings/onboarding-step-form.tsx` | dialog-overlay | VStack | aligned — uses Astryx (VStack) | aligned |
 | `apps/desktop/src/renderer/features/connection-settings/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/goals/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |

--- a/docs/astryx-surface-file-inventory.paths
+++ b/docs/astryx-surface-file-inventory.paths
@@ -16,6 +16,7 @@ apps/desktop/src/renderer/custom-pet-companion.tsx
 apps/desktop/src/renderer/error-boundary.tsx
 apps/desktop/src/renderer/features/app-update/services-context.tsx
 apps/desktop/src/renderer/features/app-update/ui/app-update-provider.tsx
+apps/desktop/src/renderer/features/connection-settings/generic-provider-mark.tsx
 apps/desktop/src/renderer/features/connection-settings/onboarding-step-form.tsx
 apps/desktop/src/renderer/features/connection-settings/services-context.tsx
 apps/desktop/src/renderer/features/goals/services-context.tsx

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -306,6 +306,62 @@ const zenmuxOpenAICompatibleMetadata = Object.fromEntries(
 const zenmuxModelIds = toolCallingModelIds('ZenMux', zenmuxOpenAICompatibleMetadata, [
   'moonshotai/kimi-k2.5',
 ]).filter((id) => GENERATED_MODELS_DEV_METADATA.zenmux[id]?.lifecycle !== 'deprecated');
+/**
+ * Command Code GOAT plan baseline, transcribed from the GOAT catalog on
+ * commandcode.ai/models. Command Code is not on models.dev, so this shipped
+ * list is the offline offer; the remote /provider/v1/models response becomes
+ * authoritative as soon as the user saves a plan credential.
+ */
+const commandcodeModelIds = [
+  'deepseek-v4-flash',
+  'deepseek-v4-flash-fast',
+  'deepseek-v4-flash-vision-exp',
+  'deepseek-v4-pro',
+  'glm-5-3',
+  'glm-5-3-flash',
+  'glm-5-2',
+  'glm-5-2-fast',
+  'glm-5-1',
+  'glm-5',
+  'qwen3-8-max',
+  'qwen3-8-max-0902',
+  'qwen3-8-flash',
+  'qwen3-8-27b',
+  'qwen3-7-max',
+  'qwen3-7-plus',
+  'qwen3-7-flash',
+  'qwen3-6-max-preview',
+  'qwen3-6-plus',
+  'kimi-k3',
+  'kimi-k2-7-code',
+  'kimi-k2-7-code-highspeed',
+  'kimi-k2-6',
+  'kimi-k2-5',
+  'minimax-m3',
+  'minimax-m2-7',
+  'minimax-m2-5',
+  'mimo-v2-5',
+  'mimo-v2-5-pro',
+  'gpt-5-6-sol',
+  'gpt-5-6-luna',
+  'grok-4-6',
+  'grok-4-5',
+  'gemini-3-8-flash',
+  'gemini-3-7-flash',
+  'step-3-7-flash',
+  'step-3-5-flash',
+  'tencent-hy3',
+  'hy4-preview',
+  'nemotron-3-ultra-550b-a55b',
+  'inkling',
+  'inkling-small',
+  'muse-spark-1-3',
+  'muse-spark-1-3-contributor',
+  'muse-spark-1-2',
+  'muse-spark-1-2-contributor',
+  'longcat-2-0-free',
+  'laguna-s-2-1-free',
+] as const;
 const fireworks = GENERATED_MODELS_DEV_PROVIDER_FACTS['fireworks-ai'];
 if (fireworks.id !== 'fireworks-ai') {
   throw new Error('models.dev Fireworks AI provider facts are missing stable id fireworks-ai');
@@ -1463,6 +1519,19 @@ const providerRegistry = {
     catalogGroup: 'plans',
     signupUrl: 'https://modelstudio.console.alibabacloud.com/',
     catalogOrder: 41.4,
+  },
+  commandcode: {
+    label: 'Command Code',
+    baseUrl: 'https://api.commandcode.ai/provider/v1',
+    authKind: 'api_key',
+    fallbackModels: [...commandcodeModelIds],
+    status: 'ready',
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    modelDiscovery: { kind: 'protocol' },
+    category: 'overseas',
+    catalogGroup: 'plans',
+    signupUrl: 'https://commandcode.ai/docs/plans/goat',
+    catalogOrder: 41.5,
   },
   'cloudflare-workers-ai': {
     label: cloudflareWorkersAi.name,

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -306,62 +306,6 @@ const zenmuxOpenAICompatibleMetadata = Object.fromEntries(
 const zenmuxModelIds = toolCallingModelIds('ZenMux', zenmuxOpenAICompatibleMetadata, [
   'moonshotai/kimi-k2.5',
 ]).filter((id) => GENERATED_MODELS_DEV_METADATA.zenmux[id]?.lifecycle !== 'deprecated');
-/**
- * Command Code GOAT plan baseline, transcribed from the GOAT catalog on
- * commandcode.ai/models. Command Code is not on models.dev, so this shipped
- * list is the offline offer; the remote /provider/v1/models response becomes
- * authoritative as soon as the user saves a plan credential.
- */
-const commandcodeModelIds = [
-  'deepseek-v4-flash',
-  'deepseek-v4-flash-fast',
-  'deepseek-v4-flash-vision-exp',
-  'deepseek-v4-pro',
-  'glm-5-3',
-  'glm-5-3-flash',
-  'glm-5-2',
-  'glm-5-2-fast',
-  'glm-5-1',
-  'glm-5',
-  'qwen3-8-max',
-  'qwen3-8-max-0902',
-  'qwen3-8-flash',
-  'qwen3-8-27b',
-  'qwen3-7-max',
-  'qwen3-7-plus',
-  'qwen3-7-flash',
-  'qwen3-6-max-preview',
-  'qwen3-6-plus',
-  'kimi-k3',
-  'kimi-k2-7-code',
-  'kimi-k2-7-code-highspeed',
-  'kimi-k2-6',
-  'kimi-k2-5',
-  'minimax-m3',
-  'minimax-m2-7',
-  'minimax-m2-5',
-  'mimo-v2-5',
-  'mimo-v2-5-pro',
-  'gpt-5-6-sol',
-  'gpt-5-6-luna',
-  'grok-4-6',
-  'grok-4-5',
-  'gemini-3-8-flash',
-  'gemini-3-7-flash',
-  'step-3-7-flash',
-  'step-3-5-flash',
-  'tencent-hy3',
-  'hy4-preview',
-  'nemotron-3-ultra-550b-a55b',
-  'inkling',
-  'inkling-small',
-  'muse-spark-1-3',
-  'muse-spark-1-3-contributor',
-  'muse-spark-1-2',
-  'muse-spark-1-2-contributor',
-  'longcat-2-0-free',
-  'laguna-s-2-1-free',
-] as const;
 const fireworks = GENERATED_MODELS_DEV_PROVIDER_FACTS['fireworks-ai'];
 if (fireworks.id !== 'fireworks-ai') {
   throw new Error('models.dev Fireworks AI provider facts are missing stable id fireworks-ai');
@@ -1524,7 +1468,7 @@ const providerRegistry = {
     label: 'Command Code',
     baseUrl: 'https://api.commandcode.ai/provider/v1',
     authKind: 'api_key',
-    fallbackModels: [...commandcodeModelIds],
+    fallbackModels: [],
     status: 'ready',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
     modelDiscovery: { kind: 'protocol' },


### PR DESCRIPTION
Superseded by #4957, merged as `2dd98419aba3cefc9ffa935c341ed354137610fc`. That PR includes this provider registration, catalog copy and generic Cpu mark together with per-model protocol routing. This draft is closed without a separate merge.

## Summary

Adds a Command Code connection using its Provider API. Models are fetched from the service when connecting; no Command Code model list is shipped. The catalog copy explains plan credits and automatic model discovery.

Providers without a dedicated brand mark reuse the existing Lucide Cpu icon. The custom fallback SVG is removed, with no new dependency or third-party brand asset. The generic mark is owned by the connection-settings feature and exposed through its public entry point, keeping the legacy brand mapping within the renderer dependency rules.

Refs #4948.

## Remaining work

- [ ] Support the mixed model catalog through per-model protocol routing (#4948). Claude requires Anthropic Messages; this draft still uses Chat Completions and is not ready to merge.

## Verification

- Core build and focused provider/catalog tests: 32 passed.
- Format, lint, Desktop typecheck, and Storybook build passed.
- Renderer architecture check against CI base `492ff80f0f4abf3a917ce8f2c41b32fa9e3fc60c`, all 101 checker tests, renderer build, and ASF source headers passed after the ownership fix.
- Light/dark Storybook checks confirm the new Chinese copy and Cpu fallback.
- Direct API checks: canonical DeepSeek ID and streaming tool calls succeeded; incorrect IDs and Claude on Chat Completions returned HTTP 400. Full Maka session validation remains pending.

![Light provider icon comparison](https://github.com/user-attachments/assets/5ef960cb-c23d-40e9-b694-c6df723cce7f)

![Dark provider icon comparison](https://github.com/user-attachments/assets/a95f7de4-5004-4a6d-8757-a88ef696a960)

![Command Code Chinese copy, light](https://github.com/user-attachments/assets/2fd33950-439e-4220-867a-2818032a8ec6)

![Command Code Chinese copy, dark](https://github.com/user-attachments/assets/6855c51b-48f9-4078-8c4f-3411c07f1c87)

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka authored the initial provider registration. Codex removed the static model list, revised the catalog copy, reused the Cpu icon, and verified the changes. Preserve all Generated-by trailers when squashing.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
