### PR TITLE
test(runtime): deduplicate backend fixtures

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -106,15 +106,11 @@ describe('AiSdkBackend ApplyPatch routing', () => {
       ['anthropic', connection().defaultModel, false],
     ] as const) {
       const model = completionModel();
-      const backend = createTestAiSdkBackend({
-        sessionId: 'session-1',
-        header: header(),
-        appendMessage: async () => {},
+      const backend = createBackend({
         connection:
           providerType === 'openai'
             ? { ...connection(), slug: 'openai', providerType }
             : connection(),
-        apiKey: 'sk-test',
         modelId,
         modelFactory: () => model,
         tools: [
@@ -122,8 +118,6 @@ describe('AiSdkBackend ApplyPatch routing', () => {
           testTool('Write', z.object({})),
           testTool('Edit', z.object({})),
         ],
-        newId: idGenerator(),
-        now: monotonicClock(),
       });
 
       await drain(backend.send({ turnId: 'turn-1', text: 'edit', context: [] }));
@@ -136,17 +130,13 @@ describe('AiSdkBackend ApplyPatch routing', () => {
 
   test('keeps Write and Edit when DeepSeek cannot carry custom apply_patch', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         ...connection(),
         slug: 'deepseek',
         providerType: 'deepseek',
         defaultModel: 'deepseek-v4-flash',
       },
-      apiKey: 'sk-test',
       modelId: 'deepseek-v4-flash',
       modelFactory: () => model,
       tools: [
@@ -154,8 +144,6 @@ describe('AiSdkBackend ApplyPatch routing', () => {
         testTool('Write', z.object({})),
         testTool('Edit', z.object({})),
       ],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(backend.send({ turnId: 'turn-1', text: 'edit', context: [] }));
@@ -168,17 +156,11 @@ describe('AiSdkBackend ApplyPatch routing', () => {
 
   test('replays a durable apply_patch failure as native provider JSON', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: { ...connection(), slug: 'openai', providerType: 'openai' },
-      apiKey: 'sk-test',
       modelId: 'gpt-5.4',
       modelFactory: () => model,
       tools: [nativeApplyPatchTool()],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -240,17 +222,11 @@ describe('AiSdkBackend ApplyPatch routing', () => {
     modelId: string,
   ) => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: targetConnection,
-      apiKey: 'sk-test',
       modelId,
       modelFactory: () => model,
       tools: [nativeApplyPatchTool()],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -341,17 +317,11 @@ describe('AiSdkBackend ApplyPatch routing', () => {
 
   test('preserves a durable projection failure when apply_patch history is downgraded', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [nativeApplyPatchTool()],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -413,17 +383,11 @@ describe('AiSdkBackend ApplyPatch routing', () => {
 
   test('preserves a multi-file ApplyPatch fact when structured replay cannot represent it', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: { ...connection(), slug: 'openai', providerType: 'openai' },
-      apiKey: 'sk-test',
       modelId: 'gpt-5.4',
       modelFactory: () => model,
       tools: [nativeApplyPatchTool()],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const patch = [
       '*** Begin Patch',
@@ -497,17 +461,11 @@ describe('AiSdkBackend ApplyPatch routing', () => {
 
   test('preserves every multi-file ApplyPatch fact from one provider step', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: { ...connection(), slug: 'openai', providerType: 'openai' },
-      apiKey: 'sk-test',
       modelId: 'gpt-5.4',
       modelFactory: () => model,
       tools: [nativeApplyPatchTool()],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const firstPatch = [
       '*** Begin Patch',
@@ -630,12 +588,8 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
     const model = completionModel();
     const recorded: HistoryCompactCheckpoint[] = [];
     let dispatches = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       systemPrompt: async () => {
@@ -658,8 +612,6 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
           dispatches += 1;
         },
       },
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -711,12 +663,8 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
       },
     });
     const durable = durableTurnHarness('turn-1', 'hello');
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: { ...connection(), providerType: 'openai' },
-      apiKey: 'sk-test',
       modelId: 'gpt-5.4',
       modelFactory: () => model,
       tools: [],
@@ -732,8 +680,6 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
           memoryCalled = true;
         },
       },
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drainDurably(
@@ -786,12 +732,8 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
       },
     });
     const durable = durableTurnHarness('turn-memory', 'Remember that I prefer concise Chinese.');
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
@@ -808,8 +750,6 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
         },
         extract: () => {},
       },
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drainDurably(
@@ -877,12 +817,8 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
       },
     });
     const durable = durableTurnHarness('turn-memory-tool', 'Remember only what I explicitly said.');
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -903,8 +839,6 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
         },
         extract: () => {},
       },
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drainDurably(
@@ -960,12 +894,8 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
       },
     });
     const durable = durableTurnHarness('turn-memory', 'This is durable project context.');
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
@@ -978,8 +908,6 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
           extractionSnapshot = snapshot;
         },
       },
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drainDurably(
@@ -1077,12 +1005,9 @@ describe('AiSdkBackend sandbox boundary convergence', () => {
       | undefined;
     let createCalls = 0;
     let bashImplCalls = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: { ...header(), cwd, workspaceRoot: cwd },
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -1120,8 +1045,6 @@ describe('AiSdkBackend sandbox boundary convergence', () => {
       },
       maxSteps: 5,
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
     const consuming = collectEvents(backend.send(durable.input()), events, durable.record);
@@ -1231,12 +1154,8 @@ describe('AiSdkBackend sandbox boundary convergence', () => {
         | Awaited<ReturnType<NonNullable<AiSdkBackendInput['createSandboxBoundaryRequest']>>>
         | undefined;
       let createCalls = 0;
-      const backend = createTestAiSdkBackend({
-        sessionId: 'session-1',
-        header: header(),
-        appendMessage: async () => {},
+      const backend = createBackend({
         connection: connection(),
-        apiKey: 'sk-test',
         modelId: 'mock-model-id',
         modelFactory: () => model,
         tools: [buildRequestSandboxBoundaryTool()],
@@ -1389,12 +1308,8 @@ describe('AiSdkBackend sandbox boundary convergence', () => {
     });
     const durable = durableTurnHarness('turn-invalid-boundary', 'Use the current boundary.');
     let createCalls = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [buildRequestSandboxBoundaryTool()],
@@ -1409,8 +1324,6 @@ describe('AiSdkBackend sandbox boundary convergence', () => {
       },
       maxSteps: 4,
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
     await collectEvents(backend.send(durable.input()), events, durable.record);
@@ -1433,19 +1346,15 @@ describe('AiSdkBackend model history', () => {
   test('records structured sandbox failure metadata on tool failure traces', async () => {
     const traces: RunTraceEvent[] = [];
     const messages: ToolResultMessage[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('bypass'),
       appendMessage: async (message) => {
         if (message.type === 'tool_result') messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     turnScope(backend, 'turn-1').runTrace = new RunTrace({
       sessionId: 'session-1',
@@ -1499,19 +1408,15 @@ describe('AiSdkBackend model history', () => {
   test('persists a sandbox denial signal for explicit filesystem worker sandbox denials', async () => {
     const messages: ToolResultMessage[] = [];
     const events: SessionEvent[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('bypass'),
       appendMessage: async (message) => {
         if (message.type === 'tool_result') messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const tool: MakaTool = {
       name: 'Grep',
@@ -1553,19 +1458,15 @@ describe('AiSdkBackend model history', () => {
 
   test('does not label ordinary filesystem permission errors as sandbox denials', async () => {
     const messages: ToolResultMessage[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('bypass'),
       appendMessage: async (message) => {
         if (message.type === 'tool_result') messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const tool: MakaTool = {
       name: 'Read',
@@ -1596,22 +1497,16 @@ describe('AiSdkBackend model history', () => {
 
   test('prefers the connection-advertised Kimi output limit over catalog metadata', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         slug: 'kimi-coding-plan',
         providerType: 'kimi-coding-plan',
         defaultModel: 'k3',
         models: [{ id: 'k3', maxOutputTokens: 65_536 }],
       },
-      apiKey: 'sk-test',
       modelId: 'k3',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -1627,16 +1522,12 @@ describe('AiSdkBackend model history', () => {
 
   test('reserves Kimi fixed thinking inside the provider wire output limit', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         slug: 'kimi-coding-plan',
         providerType: 'kimi-coding-plan',
         defaultModel: 'kimi-for-coding',
       },
-      apiKey: 'sk-test',
       modelId: 'kimi-for-coding',
       providerOptions: {
         anthropic: {
@@ -1646,8 +1537,6 @@ describe('AiSdkBackend model history', () => {
       },
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -1664,21 +1553,15 @@ describe('AiSdkBackend model history', () => {
 
   test('leaves OpenAI-compatible output limits to their provider adapter', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         slug: 'mistral',
         providerType: 'mistral',
         defaultModel: 'mistral-large-latest',
       },
-      apiKey: 'sk-test',
       modelId: 'mistral-large-latest',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -1694,17 +1577,11 @@ describe('AiSdkBackend model history', () => {
 
   test('prefers RuntimeEvent prior messages and appends current user once', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -1757,17 +1634,11 @@ describe('AiSdkBackend model history', () => {
 
   test('safe-boundary continuation does not append a duplicate current user message', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -1802,17 +1673,11 @@ describe('AiSdkBackend model history', () => {
 
   test('continuation replays the original user after diagnostic terminal errors with no StoredMessage context', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -1855,17 +1720,11 @@ describe('AiSdkBackend model history', () => {
   test('continuation fails before the provider when replay materializes no messages', async () => {
     const trace: RunTraceEvent[] = [];
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       recordRunTrace: (event) => trace.push(event),
     });
 
@@ -1915,17 +1774,11 @@ describe('AiSdkBackend model history', () => {
 
   test('continuation materializes validated RuntimeEvents when provider-native replay is unavailable', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: { ...connection(), providerType: 'openai' },
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -1965,17 +1818,11 @@ describe('AiSdkBackend model history', () => {
 
   test('continuation never substitutes StoredMessages when RuntimeEvent replay has blocking diagnostics', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -2058,17 +1905,11 @@ describe('AiSdkBackend model history', () => {
 
   test('continuation replay may end with an assistant message without an active user head anchor', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -2109,17 +1950,11 @@ describe('AiSdkBackend model history', () => {
 
   test('continuation replay may end at a paired tool boundary without an active user head anchor', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -2176,17 +2011,11 @@ describe('AiSdkBackend model history', () => {
 
   test('does not recover provider history from StoredMessages when RuntimeEvent replay is empty', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -2229,17 +2058,11 @@ describe('AiSdkBackend model history', () => {
 
   test('RuntimeEvent replay describes an attachment that is not safely addressable', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -2297,17 +2120,11 @@ describe('AiSdkBackend model history', () => {
 
   test('current and replayed directory references expose paths without eager listings', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const currentReference = { hostId: 'host-a', path: '/workspace/current-source' };
     const historicalReference = { hostId: 'host-a', path: '/workspace/prior-source' };
@@ -2361,17 +2178,11 @@ describe('AiSdkBackend model history', () => {
   test('RuntimeEvent replay renders image attachments as image parts when a reader is wired', async () => {
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 4, 5, 6]);
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       readAttachmentBytes: async () => ({ ok: true, bytes: pngBytes }),
       supportsVision: true,
     } as never);
@@ -2429,17 +2240,11 @@ describe('AiSdkBackend model history', () => {
   test('current-turn image attachment keeps its Read reference unless vision support is explicit', async () => {
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]);
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       readAttachmentBytes: async () => ({ ok: true, bytes: pngBytes }),
     } as never);
 
@@ -2482,17 +2287,11 @@ describe('AiSdkBackend model history', () => {
 
   test('reports unavailable attachment reads without consuming image budget', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       supportsVision: true,
       maxProviderImageRequestBytes: 15,
       readAttachmentBytes: async (ref: StorageRef) =>
@@ -2533,17 +2332,11 @@ describe('AiSdkBackend model history', () => {
 
   test('charges attachment image budget from the bytes actually read', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       supportsVision: true,
       maxProviderImageRequestBytes: 15,
       readAttachmentBytes: async () => ({ ok: true, bytes: new Uint8Array(10) }),
@@ -2577,17 +2370,11 @@ describe('AiSdkBackend model history', () => {
 
   test('degrades excess current-turn image attachments once the per-request budget is exceeded', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       supportsVision: true,
       maxProviderImageRequestBytes: 25,
       readAttachmentBytes: async () => ({ ok: true, bytes: new Uint8Array(10) }),
@@ -2627,17 +2414,11 @@ describe('AiSdkBackend model history', () => {
   test('counts the same attachment ref separately in replay and the current turn', async () => {
     const bytes = new Uint8Array(10);
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       supportsVision: true,
       maxProviderImageRequestBytes: 15,
       readAttachmentBytes: async () => ({ ok: true, bytes }),
@@ -2716,18 +2497,12 @@ describe('AiSdkBackend model history', () => {
         attachments: [attachment],
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
       loadTurnRuntimeEvents: async () => [anchor],
-      newId: idGenerator(),
-      now: monotonicClock(),
       supportsVision: true,
       maxProviderImageRequestBytes: 15,
       readAttachmentBytes: async () => ({ ok: true, bytes }),
@@ -2754,17 +2529,11 @@ describe('AiSdkBackend model history', () => {
   test('degrades excess replayed image tool results once the per-request budget is exceeded', async () => {
     const bytes = new Uint8Array(10);
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       supportsVision: true,
       maxProviderImageRequestBytes: 25,
       readAttachmentBytes: async () => ({ ok: true, bytes }),
@@ -2847,17 +2616,11 @@ describe('AiSdkBackend model history', () => {
   test('budgets replayed image tool results by durable occurrence instead of reused tool-call ids', async () => {
     const bytes = new Uint8Array(10);
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       supportsVision: true,
       maxProviderImageRequestBytes: 15,
       readAttachmentBytes: async () => ({ ok: true, bytes }),
@@ -2949,17 +2712,11 @@ describe('AiSdkBackend model history', () => {
   test('RuntimeEvent replay renders historical image attachments as image parts', async () => {
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 9, 8, 7]);
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       readAttachmentBytes: async () => ({ ok: true, bytes: pngBytes }),
       supportsVision: true,
     } as never);
@@ -3016,17 +2773,11 @@ describe('AiSdkBackend model history', () => {
 
   test('preserves RuntimeEvent tool calls and results as structured AI SDK parts', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -3122,17 +2873,11 @@ describe('AiSdkBackend model history', () => {
 
   test('replays provider-executed CC web search with encrypted result content intact', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [buildNativeWebSearchTool({ adapter: 'anthropic-messages' })],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -3205,17 +2950,11 @@ describe('AiSdkBackend model history', () => {
 
   test('replays provider-executed web search before its grounded assistant text', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [buildNativeWebSearchTool({ adapter: 'openai-responses' })],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -3414,10 +3153,7 @@ describe('AiSdkBackend model history', () => {
 
   test('falls back to grounded text when Open Responses cannot replay a hosted tool pair', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         slug: 'deepseek',
         providerType: 'deepseek',
@@ -3427,8 +3163,6 @@ describe('AiSdkBackend model history', () => {
       modelId: 'deepseek-v4-flash',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -3498,10 +3232,7 @@ describe('AiSdkBackend model history', () => {
 
   test('keeps unrelated client tool history when degrading a hosted tool pair', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         slug: 'deepseek',
         providerType: 'deepseek',
@@ -3511,8 +3242,6 @@ describe('AiSdkBackend model history', () => {
       modelId: 'deepseek-v4-flash',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -3612,17 +3341,11 @@ describe('AiSdkBackend model history', () => {
   test('replays an image tool result as provider image data', async () => {
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]);
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       supportsVision: true,
       readAttachmentBytes: async () => ({ ok: true, bytes: pngBytes }),
     });
@@ -3738,12 +3461,8 @@ describe('AiSdkBackend model history', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -3769,8 +3488,6 @@ describe('AiSdkBackend model history', () => {
         return { ok: true, bytes: pngBytes };
       },
       loadTurnRuntimeEvents: async () => ledger,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send({
@@ -3876,12 +3593,8 @@ describe('AiSdkBackend model history', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -3905,8 +3618,6 @@ describe('AiSdkBackend model history', () => {
         },
       ],
       loadTurnRuntimeEvents: async () => ledger,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const emitted: SessionEvent[] = [];
@@ -4037,17 +3748,11 @@ describe('AiSdkBackend model history', () => {
 
   test('replays interleaved parallel RuntimeEvent tool calls as one provider tool-call block', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -4320,17 +4025,11 @@ describe('AiSdkBackend model history', () => {
         }),
       ),
     ];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -4370,17 +4069,11 @@ describe('AiSdkBackend model history', () => {
     }> = [];
     const oldResult = { body: 'x'.repeat(500) };
     const transitions: ModelProjectionTransition[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'archive-test',
         staleToolResultPrune: {
@@ -4463,17 +4156,12 @@ describe('AiSdkBackend model history', () => {
     // would stay green if the call site stopped passing them; this drives the
     // entry `/compact` actually uses.
     const attemptedCoverage: string[][] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: { ...header(), llmConnectionId: 'test-connection-id', model: 'mock-model-id' },
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: { name: 'standalone-retreat-test', charsPerToken: 1 },
       summarizeHistoryCompact: async ({ source }) => {
         attemptedCoverage.push(source.foldedRuntimeEvents.map((event) => event.id));
@@ -4536,17 +4224,11 @@ describe('AiSdkBackend model history', () => {
   test('manual compactHistory writes a V2 checkpoint without the legacy artifact writer', async () => {
     const recorded: HistoryCompactCheckpoint[] = [];
     let memoryDispatches = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'manual-v2-compact-test',
         charsPerToken: 1,
@@ -4606,17 +4288,11 @@ describe('AiSdkBackend model history', () => {
 
   test('manual compactHistory compacts one completed turn with multiple agent steps', async () => {
     const recorded: HistoryCompactCheckpoint[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'manual-single-turn-compact-test',
         charsPerToken: 1,
@@ -4686,17 +4362,11 @@ describe('AiSdkBackend model history', () => {
     });
     const summaryInputs: Array<{ previous?: string; newlyFoldedIds: string[] }> = [];
     const recorded: HistoryCompactCheckpoint[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'manual-v2-roll-test',
         charsPerToken: 1,
@@ -4772,17 +4442,11 @@ describe('AiSdkBackend model history', () => {
     });
     let summarizeCalls = 0;
     let recordCalls = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'manual-v2-reuse-test',
         charsPerToken: 1,
@@ -4812,17 +4476,11 @@ describe('AiSdkBackend model history', () => {
   });
 
   test('manual compactHistory reports output-length exhaustion instead of empty_summary', async () => {
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'manual-v2-output-length-test',
         charsPerToken: 1,
@@ -4865,17 +4523,11 @@ describe('AiSdkBackend model history', () => {
     // #3029: the summarizer validates its own completions, but the WRITE gate
     // must enforce the invariant even for a producer that skipped that path —
     // a malformed summary never replaces folded history.
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'manual-v2-write-gate-test',
         charsPerToken: 1,
@@ -4922,17 +4574,11 @@ describe('AiSdkBackend model history', () => {
 
   test('does not redispatch unchanged compaction content for unrelated run provenance', async () => {
     let calls = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'malformed-summary-circuit-test',
         charsPerToken: 1,
@@ -5023,17 +4669,11 @@ describe('AiSdkBackend model history', () => {
           : { text: '## Goal\npartial summary', finishReason: 'length' };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'malformed-summary-repair-circuit-test',
         charsPerToken: 1,
@@ -5108,17 +4748,11 @@ describe('AiSdkBackend model history', () => {
         });
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'malformed-summary-cancel-circuit-test',
         charsPerToken: 1,
@@ -5285,17 +4919,11 @@ describe('AiSdkBackend model history', () => {
   });
 
   test('manual compactHistory is a no-op when context budget is disabled', async () => {
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const result = await backend.compactHistory({
@@ -5323,17 +4951,11 @@ describe('AiSdkBackend model history', () => {
   });
 
   test('manual compactHistory is a no-op when no durable writer is configured', async () => {
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'manual-compact-test',
         charsPerToken: 1,
@@ -5388,17 +5010,11 @@ describe('AiSdkBackend model history', () => {
         text: 'manual recent retained context',
       }),
     ];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'manual-compact-test',
         charsPerToken: 1,
@@ -5429,17 +5045,11 @@ describe('AiSdkBackend model history', () => {
       summarizeStarted = resolve;
     });
     let recordCalls = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => textCompletionModel('NEXT_OK'),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'manual-compact-abort-test',
         charsPerToken: 1,
@@ -5517,19 +5127,14 @@ describe('AiSdkBackend model history', () => {
       },
     });
     const appended: string[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message: StoredMessage) => {
         appended.push(message.type);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
     const sendPromise = (async () => {
@@ -5605,19 +5210,14 @@ describe('AiSdkBackend model history', () => {
     const appended: Array<{ type: string; kind?: string; data?: unknown }> = [];
     const isFailOpenNote = (message: { type: string; kind?: string }): boolean =>
       message.type === 'system_note' && message.kind === 'context_compaction_failed_open';
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message: StoredMessage) => {
         appended.push(message as unknown as { type: string; kind?: string; data?: unknown });
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: { historyCompact: { enabled: true } },
       loadHistoryCompactCheckpoint: () => checkpoint,
     });
@@ -5682,19 +5282,14 @@ describe('AiSdkBackend model history', () => {
       summary: structuredSummary('SETTLE_STALE_CHECKPOINT_SENTINEL'),
     });
     const appended: Array<{ type: string; kind?: string }> = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message: StoredMessage) => {
         appended.push(message as unknown as { type: string; kind?: string });
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: { historyCompact: { enabled: true } },
       loadHistoryCompactCheckpoint: () => checkpoint,
     });
@@ -5746,9 +5341,7 @@ describe('AiSdkBackend model history', () => {
     const persisted: Array<{ type: string; kind?: string }> = [];
     let noteWriteAttempts = 0;
     let failNextNoteWrite = true;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message: StoredMessage) => {
         const candidate = message as unknown as { type: string; kind?: string };
         if (isFailOpenNote(candidate)) {
@@ -5761,12 +5354,9 @@ describe('AiSdkBackend model history', () => {
         persisted.push(candidate);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: { historyCompact: { enabled: true } },
       loadHistoryCompactCheckpoint: () => checkpoint,
     });
@@ -5809,18 +5399,12 @@ describe('AiSdkBackend model history', () => {
         return { ok: true };
       },
     };
-    backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => loop.model,
       tools: [stoppingTool],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
 
@@ -5854,12 +5438,8 @@ describe('AiSdkBackend model history', () => {
         reached = ready;
       });
       let effects = 0;
-      const backend = createTestAiSdkBackend({
-        sessionId: 'session-1',
-        header: header(),
-        appendMessage: async () => {},
+      const backend = createBackend({
         connection: connection(),
-        apiKey: 'sk-test',
         modelId: 'mock-model-id',
         modelFactory: () => loop.model,
         tools: [
@@ -5876,8 +5456,6 @@ describe('AiSdkBackend model history', () => {
           },
         ],
         loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-        newId: idGenerator(),
-        now: monotonicClock(),
       });
       const events: SessionEvent[] = [];
       const running = (async () => {
@@ -5929,17 +5507,11 @@ describe('AiSdkBackend model history', () => {
 
   test('a natural final answer does not enter the handoff gate', async () => {
     let boundaries = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => textCompletionModel('done'),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
     for await (const event of backend.send({
@@ -5962,22 +5534,17 @@ describe('AiSdkBackend model history', () => {
     const loop = countingToolLoopModel();
     const gate = makeGate();
     let usagePersistenceStarted = false;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type !== 'token_usage') return;
         usagePersistenceStarted = true;
         await gate.promise;
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => loop.model,
       tools: [testTool('Read', z.object({ path: z.string() }))],
       maxSteps: 1,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
     const sendPromise = (async () => {
@@ -6022,19 +5589,14 @@ describe('AiSdkBackend model history', () => {
       },
     });
     const assistants: AssistantMessage[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'assistant') assistants.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -6065,19 +5627,14 @@ describe('AiSdkBackend model history', () => {
     const storedMessages: StoredMessage[] = [];
     const events: SessionEvent[] = [];
     let recordCalls = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         storedMessages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         charsPerToken: 1,
         historyCompact: {
@@ -6456,17 +6013,11 @@ describe('AiSdkBackend model history', () => {
     const model = completionModel();
     const transitions: ModelProjectionTransition[] = [];
     const recorded: HistoryCompactCheckpoint[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'checkpoint-transition-replay-test',
         charsPerToken: 1,
@@ -6562,17 +6113,11 @@ describe('AiSdkBackend model history', () => {
     // The next turn must replay through the checkpoint, not fail open. A fresh
     // backend mirrors production: the compaction operation and the next send
     // run as separate runs with separate backend instances.
-    const replayBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const replayBackend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'checkpoint-transition-replay-test',
         charsPerToken: 1,
@@ -6621,17 +6166,11 @@ describe('AiSdkBackend model history', () => {
     const model = completionModel();
     const transitions: ModelProjectionTransition[] = [];
     const recorded: HistoryCompactCheckpoint[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'checkpoint-effective-summary-test',
         charsPerToken: 1,
@@ -6724,17 +6263,11 @@ describe('AiSdkBackend model history', () => {
     assert.match(summary, /artifact-echo-result/);
     assert.doesNotMatch(summary, /RAW_TRANSITIONED_TOOL_BODY/);
 
-    const replayBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const replayBackend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'checkpoint-effective-summary-test',
         charsPerToken: 1,
@@ -6974,17 +6507,11 @@ describe('AiSdkBackend model history', () => {
     // post-match fold of the projected [block, tail] must do the same or it
     // becomes the one consumer that replays the removed body.
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       contextBudget: {
         name: 'unreadable-target-replay-test',
         charsPerToken: 1,
@@ -7044,12 +6571,8 @@ describe('AiSdkBackend model history', () => {
     // while retaining the rest of canonical history.
     const model = completionModel();
     let imageReads = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
@@ -7058,8 +6581,6 @@ describe('AiSdkBackend model history', () => {
         imageReads += 1;
         return { ok: true, bytes: new Uint8Array([1]) };
       },
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -7116,17 +6637,11 @@ describe('AiSdkBackend model history', () => {
 
   test('keeps RuntimeEvent replay when a system error fact is diagnostic-only', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -7176,17 +6691,11 @@ describe('AiSdkBackend model history', () => {
   test('drops unsupported thinking while preserving RuntimeEvent text', async () => {
     const model = completionModel();
     const openAiConnection = { ...connection(), providerType: 'openai' as const };
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: openAiConnection,
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -7247,17 +6756,12 @@ describe('AiSdkBackend model history', () => {
 
   test('drops cross-model Anthropic reasoning while preserving text and tool history', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: { ...header(), llmConnectionId: 'connection-a', model: 'claude-b' },
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-b',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -7331,17 +6835,12 @@ describe('AiSdkBackend model history', () => {
 
   test('drops Anthropic reasoning after provider state changes under the same route id', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: { ...header(), llmConnectionId: 'connection-a', model: 'claude-a' },
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-a',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       providerStateIdentity: `sha256:${'b'.repeat(64)}`,
     });
 
@@ -7384,17 +6883,12 @@ describe('AiSdkBackend model history', () => {
 
   test('fails closed for provider reasoning with no source run provenance', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: { ...header(), llmConnectionId: 'connection-a', model: 'claude-a' },
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-a',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -7440,22 +6934,17 @@ describe('AiSdkBackend model history', () => {
       defaultModel: 'gpt-5.4',
       models: [{ id: 'gpt-5.4', apiProtocol: 'openai-chat' }],
     };
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: {
         ...header(),
         llmConnectionId: 'connection-copilot',
         llmConnectionSlug: 'github-copilot',
         model: 'gpt-5.4',
       },
-      appendMessage: async () => {},
       connection: copilotConnection,
-      apiKey: 'sk-test',
       modelId: 'gpt-5.4',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -7534,22 +7023,17 @@ describe('AiSdkBackend model history', () => {
       providerType: 'openai',
       defaultModel: 'gpt-5.4',
     };
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: {
         ...header(),
         llmConnectionId: 'connection-openai',
         llmConnectionSlug: 'openai-main',
         model: 'gpt-5.4',
       },
-      appendMessage: async () => {},
       connection: openAiConnection,
-      apiKey: 'sk-test',
       modelId: 'gpt-5.4',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -7592,17 +7076,11 @@ describe('AiSdkBackend model history', () => {
 
   test('skips unsupported unsigned thinking without dropping native tool replay', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: { ...connection(), providerType: 'openai' },
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -7662,10 +7140,7 @@ describe('AiSdkBackend model history', () => {
 
   test('skips unmarked unsigned thinking when replaying Kimi OpenAI tool history', async () => {
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         ...connection(),
         slug: 'kimi-main',
@@ -7673,12 +7148,9 @@ describe('AiSdkBackend model history', () => {
         defaultModel: 'k3',
         models: [{ id: 'k3', apiProtocol: 'openai-chat' }],
       },
-      apiKey: 'sk-test',
       modelId: 'k3',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -7743,17 +7215,11 @@ describe('AiSdkBackend model history', () => {
         throw new Error('provider failed');
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: { ...connection(), providerType: 'openai' },
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       recordRunTrace: (event) => trace.push(event),
     });
 
@@ -7805,10 +7271,7 @@ describe('AiSdkBackend model history', () => {
 
 describe('AiSdkBackend error surfaces', () => {
   test('generalizes model setup errors before emitting renderer events', async () => {
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
       apiKey: 'sk-live-secret-token-value',
       modelId: 'claude-sonnet-4-5-20250929',
@@ -7816,7 +7279,6 @@ describe('AiSdkBackend error surfaces', () => {
         throw new Error('401 Authorization: Bearer sk-live-secret-token-value');
       },
       tools: [],
-      newId: idGenerator(),
       now: () => 1,
     });
 
@@ -7889,14 +7351,11 @@ describe('AiSdkBackend error surfaces', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -7917,8 +7376,6 @@ describe('AiSdkBackend error surfaces', () => {
         commitToolOutcome: async () => ({ created: true, runtimeEventSeq: 2 }),
       },
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send(
@@ -7955,18 +7412,14 @@ describe('AiSdkBackend error surfaces', () => {
   test('tool settlement never persists raw secret-shaped synthetic errors', async () => {
     const messages: ToolResultMessage[] = [];
     const events: SessionEvent[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'tool_result') messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
       now: () => 1,
     });
 
@@ -7994,18 +7447,14 @@ describe('AiSdkBackend error surfaces', () => {
   test('failed Bash results preserve terminal stdout and stderr as an error card', async () => {
     const messages: ToolResultMessage[] = [];
     const events: SessionEvent[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'tool_result') messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
       now: () => 1,
     });
     const tool: MakaTool = {
@@ -8178,19 +7627,14 @@ describe('AiSdkBackend usage telemetry', () => {
       },
     });
     const appended: StoredMessage[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -8205,18 +7649,12 @@ describe('AiSdkBackend usage telemetry', () => {
   test('lets an unconfigured turn continue past the former 50-step default', async () => {
     const loop = countingToolLoopModel(51);
     const durable = durableTurnHarness('turn-1', 'hi');
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => loop.model,
       tools: [testTool('Read', z.object({ path: z.string() }))],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events = await drainDurably(backend.send(durable.input()), durable);
@@ -8261,18 +7699,12 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
       providerRetrySleep: async () => {},
     });
 
@@ -8322,18 +7754,12 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
       providerRetrySleep: async () => {},
     });
 
@@ -8380,18 +7806,12 @@ describe('AiSdkBackend usage telemetry', () => {
           };
         },
       });
-      const backend = createTestAiSdkBackend({
-        sessionId: 'session-1',
-        header: header(),
-        appendMessage: async () => {},
+      const backend = createBackend({
         connection: connection(),
-        apiKey: 'sk-test',
         modelId: 'mock-model-id',
         modelFactory: () => model,
         tools: [],
         loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-        newId: idGenerator(),
-        now: monotonicClock(),
         providerRetrySleep: async () => {},
       });
 
@@ -8433,12 +7853,8 @@ describe('AiSdkBackend usage telemetry', () => {
   test('rejects continuation-capable tools before side effects without a durable reader', async () => {
     const loop = countingToolLoopModel(1);
     let executions = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => loop.model,
       tools: [
@@ -8451,8 +7867,6 @@ describe('AiSdkBackend usage telemetry', () => {
         },
       ],
       maxSteps: 2,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
 
@@ -8470,12 +7884,8 @@ describe('AiSdkBackend usage telemetry', () => {
     const durable = durableTurnHarness('turn-1', 'hi');
     let reads = 0;
     let executions = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => loop.model,
       tools: [
@@ -8493,8 +7903,6 @@ describe('AiSdkBackend usage telemetry', () => {
         if (reads === 2) throw new Error('runtime ledger unavailable');
         return await durable.loadTurnRuntimeEvents(turnId);
       },
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events = await drainDurably(backend.send(durable.input()), durable);
@@ -8507,19 +7915,13 @@ describe('AiSdkBackend usage telemetry', () => {
   test('lets a trusted turn override the configured step limit', async () => {
     const loop = countingToolLoopModel();
     const durable = durableTurnHarness('turn-1', 'hi');
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => loop.model,
       tools: [testTool('Read', z.object({ path: z.string() }))],
       maxSteps: 3,
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drainDurably(backend.send({ ...durable.input(), maxSteps: 1 }), durable);
@@ -8579,19 +7981,14 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: { ...header(), collaborationMode: 'agent' },
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [testTool('Read', z.object({ path: z.string() }))],
       maxSteps: 2,
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events = await drainDurably(backend.send(durable.input()), durable);
@@ -8645,12 +8042,8 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -8666,8 +8059,6 @@ describe('AiSdkBackend usage telemetry', () => {
       ],
       maxSteps: 5,
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events = await drainDurably(backend.send(durable.input()), durable);
@@ -8742,12 +8133,8 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -8765,8 +8152,6 @@ describe('AiSdkBackend usage telemetry', () => {
       ],
       maxSteps: 5,
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events = await drainDurably(backend.send(durable.input()), durable);
@@ -8854,12 +8239,8 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -8884,8 +8265,6 @@ describe('AiSdkBackend usage telemetry', () => {
       ],
       maxSteps: 5,
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events = await drainDurably(backend.send(durable.input()), durable);
@@ -8943,21 +8322,16 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [testTool('Read', z.object({ path: z.string() }))],
       maxSteps: 2,
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events = await drainDurably(backend.send(durable.input()), durable);
@@ -9144,17 +8518,11 @@ describe('AiSdkBackend usage telemetry', () => {
         }),
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
@@ -9190,17 +8558,11 @@ describe('AiSdkBackend usage telemetry', () => {
         }),
       }),
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'unpriced-model',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       lookupPricing: () => null,
       recordUsageCheckpoint: async (usage: { costUsd?: number }) => {
         usageCheckpoints.push(usage);
@@ -9271,12 +8633,8 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -9312,8 +8670,6 @@ describe('AiSdkBackend usage telemetry', () => {
         },
       }),
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send(durable.input())) durable.record(event);
@@ -9416,14 +8772,11 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -9450,8 +8803,6 @@ describe('AiSdkBackend usage telemetry', () => {
         },
       }),
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send(durable.input())) {
@@ -9538,14 +8889,11 @@ describe('AiSdkBackend usage telemetry', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -9568,8 +8916,6 @@ describe('AiSdkBackend usage telemetry', () => {
         archiveToolResult: async () => ({ artifactId: 'artifact-read-1' }),
       }),
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send(durable.input())) durable.record(event);
@@ -9631,19 +8977,14 @@ describe('AiSdkBackend usage telemetry', () => {
         }),
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       systemPrompt: 'durable system prompt',
       lookupPricing: (modelKey) => {
         pricingLookupCalls += 1;
@@ -9762,12 +9103,8 @@ describe('AiSdkBackend tool availability diagnostics', () => {
   test('backend full mode keeps the complete tool surface and omits the connector', async () => {
     const model = completionModel();
     const events: SessionEvent[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       // No toolAvailability ⇒ full surface: every tool visible, no connector.
@@ -9775,8 +9112,6 @@ describe('AiSdkBackend tool availability diagnostics', () => {
         testTool('Read', z.object({ path: z.string() })),
         testTool('WebFetch', z.object({ url: z.string() })),
       ],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
@@ -9929,17 +9264,11 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
   test('usage events keep context budget diagnostics without live prompt estimates', async () => {
     const model = completionModel();
     const events: SessionEvent[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [testTool('Read', z.object({ path: z.string() }))],
-      newId: idGenerator(),
-      now: monotonicClock(),
       systemPrompt: 'durable system',
       contextBudget: {
         name: 'test-budget',
@@ -10095,18 +9424,12 @@ describe('AiSdkBackend RunTrace', () => {
           };
         },
       });
-      const backend = createTestAiSdkBackend({
-        sessionId: 'session-1',
-        header: header(),
-        appendMessage: async () => {},
+      const backend = createBackend({
         connection: connection(),
-        apiKey: 'sk-test',
         modelId: 'mock-model-id',
         modelFactory: () => model,
         tools: [testTool('Read', z.object({ path: z.string() }))],
         loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-        newId: idGenerator(),
-        now: monotonicClock(),
         recordModelCallAttempt: ({ attempt }) => {
           attempts.push(attempt);
         },
@@ -10167,20 +9490,14 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         ...connection(),
         models: [{ id: 'mock-model-id', contextWindow: 200_000 }],
       },
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       recordModelCallAttempt: async ({ attempt }) => {
         attempts.push(attempt);
       },
@@ -10229,9 +9546,7 @@ describe('AiSdkBackend RunTrace', () => {
         }),
       }),
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message: StoredMessage) => {
         messages.push(message);
       },
@@ -10243,8 +9558,6 @@ describe('AiSdkBackend RunTrace', () => {
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -10285,9 +9598,7 @@ describe('AiSdkBackend RunTrace', () => {
         }),
       }),
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message: StoredMessage) => {
         messages.push(message);
       },
@@ -10297,8 +9608,6 @@ describe('AiSdkBackend RunTrace', () => {
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
@@ -10344,17 +9653,11 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       recordModelCallAttempt: ({ attempt }) => {
         attempts.push(attempt);
       },
@@ -10405,17 +9708,11 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       providerRetrySleep: async () => {},
     });
 
@@ -10479,19 +9776,14 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'assistant') assistants.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -10574,20 +9866,15 @@ describe('AiSdkBackend RunTrace', () => {
         return { stream: failing.stream };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'assistant') assistants.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
       providerRetrySleep: async () => {},
     });
 
@@ -10668,18 +9955,12 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
       providerRetrySleep: async () => {},
     });
 
@@ -10726,20 +10007,15 @@ describe('AiSdkBackend RunTrace', () => {
         return { stream: failing.stream };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'assistant') assistants.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
       providerRetrySleep: async () => {},
     });
 
@@ -10812,18 +10088,12 @@ describe('AiSdkBackend RunTrace', () => {
         return { stream: failing.stream };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
       providerRetrySleep: async () => {},
     });
 
@@ -10886,10 +10156,7 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         ...connection(),
         slug: 'deepseek',
@@ -10901,8 +10168,6 @@ describe('AiSdkBackend RunTrace', () => {
       modelId: 'deepseek-v4-pro',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -10949,19 +10214,14 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async () => {
         throw new Error('assistant append failed');
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -11052,18 +10312,12 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [testTool('Read', z.object({ path: z.string() }))],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -11116,17 +10370,11 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -11196,18 +10444,12 @@ describe('AiSdkBackend RunTrace', () => {
         return 'notes contents';
       },
     };
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [readTool],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -11268,12 +10510,8 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -11293,8 +10531,6 @@ describe('AiSdkBackend RunTrace', () => {
         }
         return durable.loadTurnRuntimeEvents(turnId);
       },
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -11326,17 +10562,11 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
       recordRunTrace: (event) => traces.push(event),
@@ -11404,9 +10634,7 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
@@ -11416,12 +10644,9 @@ describe('AiSdkBackend RunTrace', () => {
         providerType: 'openai',
         models: [{ id: 'gpt-5.6', apiProtocol: 'openai-responses' }],
       },
-      apiKey: 'sk-test',
       modelId: 'gpt-5.6',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -11484,17 +10709,11 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -11544,17 +10763,11 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -11599,17 +10812,11 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -11636,17 +10843,11 @@ describe('AiSdkBackend RunTrace', () => {
     const timers = manualWatchdogTimer();
     const finishConsumed = makeGate();
     let calls = 0;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
     });
@@ -11720,17 +10921,11 @@ describe('AiSdkBackend RunTrace', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async (_delayMs, signal) =>
         await new Promise<void>((_resolve, reject) => {
@@ -11765,17 +10960,11 @@ describe('AiSdkBackend RunTrace', () => {
         throw new Error('provider failed');
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       recordRunTrace: (event) => trace.push(event),
     });
 
@@ -11848,17 +11037,11 @@ describe('AiSdkBackend RunTrace', () => {
         }),
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       recordRunTrace: (event) => {
         trace.push(event);
       },
@@ -11925,17 +11108,11 @@ describe('AiSdkBackend RunTrace', () => {
         }),
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       recordRunTrace: () => {
         throw new Error('trace sink unavailable');
       },
@@ -11955,17 +11132,11 @@ describe('AiSdkBackend RunTrace', () => {
 
   test('records abort trace when stop is requested', async () => {
     const trace: RunTraceEvent[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     turnScope(backend, 'turn-1').runTrace = {
       abortRequested: (reason: string) => {
@@ -11993,17 +11164,12 @@ describe('AiSdkBackend RunTrace', () => {
 describe('AiSdkBackend tool execution', () => {
   test('WebSearch telemetry never copies the user-derived query', async () => {
     const telemetry: Array<{ argsSummary?: string }> = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('bypass'),
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       recordToolInvocation: (record) => {
         telemetry.push({ argsSummary: record.argsSummary });
       },
@@ -12034,19 +11200,15 @@ describe('AiSdkBackend tool execution', () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];
     const telemetry: Array<{ status: string; errorClass?: string; bytesOut: number }> = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('ask'),
       appendMessage: async (message) => {
         messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
       recordToolInvocation: (record) => {
         telemetry.push({
           status: record.status,
@@ -12090,17 +11252,12 @@ describe('AiSdkBackend tool execution', () => {
 
   test('flushes output deltas before successful and failed tool results', async () => {
     const events: SessionEvent[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('ask'),
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const successTool: MakaTool = {
       name: 'Streamer',
@@ -12154,16 +11311,12 @@ describe('AiSdkBackend tool execution', () => {
   });
 
   test('pauses stream watchdog while a foreground subagent tool is running', async () => {
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('explore'),
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
       now: () => 1,
     });
     let pauseCount = 0;
@@ -12217,16 +11370,12 @@ describe('AiSdkBackend tool execution', () => {
   test('pauses stream watchdog while a regular (non-subagent) tool is running', async () => {
     // A long Bash command (apt-get install, a build) must not trip the model
     // stream idle timeout: the model is between steps while the tool runs.
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('explore'),
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
       now: () => 1,
     });
     let pauseCount = 0;
@@ -12316,18 +11465,14 @@ describe('AiSdkBackend tool execution', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('bypass'),
-      appendMessage: async () => {},
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => model,
       tools: [],
       streamConnectTimeoutMs: 1_000,
       streamIdleTimeoutMs: 100,
-      newId: idGenerator(),
       now: Date.now,
     });
 
@@ -12350,18 +11495,15 @@ describe('AiSdkBackend tool execution', () => {
   test('caps concurrent subagent tools in one turn', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('explore'),
       appendMessage: async (message) => {
         messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
       now: () => 1,
     });
     let implStarted = 0;
@@ -12416,18 +11558,15 @@ describe('AiSdkBackend tool execution', () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];
     const telemetry: Array<{ status: string; toolCallId?: string }> = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: header('explore'),
       appendMessage: async (message) => {
         messages.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => ({}),
       tools: [],
-      newId: idGenerator(),
       now: () => 1,
       recordToolInvocation: (record) => {
         telemetry.push({ status: record.status, toolCallId: record.toolCallId });
@@ -12638,12 +11777,8 @@ describe('AiSdkBackend concurrent turns', () => {
       },
     });
 
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -12664,8 +11799,6 @@ describe('AiSdkBackend concurrent turns', () => {
       },
       loadTurnRuntimeEvents: async (turnId: string) =>
         (ledgers.get(turnId) ?? first).loadTurnRuntimeEvents(turnId),
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const overlapping = drainDurably(
@@ -12699,17 +11832,11 @@ describe('AiSdkBackend concurrent turns', () => {
   // provider pump exists, and a throw there used to strand the scope forever:
   // nothing overwrites a Set entry, and stop()/dispose() only iterate.
   test('a send that throws during setup leaves no scope registered', async () => {
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await assert.rejects(
@@ -12742,17 +11869,11 @@ describe('AiSdkBackend concurrent turns', () => {
   // parks the sibling forever: that turn's own send() cleanup is itself waiting
   // on the tool the skipped endTurn was supposed to reject.
   test('stop() closes every turn even when one turn fails to close', async () => {
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const aborted: string[] = [];
@@ -12879,17 +12000,11 @@ describe('AiSdkBackend thinking persistence', () => {
         stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }),
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -12961,19 +12076,14 @@ describe('AiSdkBackend thinking persistence', () => {
       },
     });
     const appended: unknown[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -13066,17 +12176,11 @@ describe('AiSdkBackend thinking persistence', () => {
         }),
       },
     });
-    const firstBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const firstBackend = createBackend({
       connection: openCodeClaudeConnection,
-      apiKey: 'sk-test',
       modelId: 'claude-opus-4-8',
       modelFactory: () => firstModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const firstEvents: SessionEvent[] = [];
@@ -13113,17 +12217,11 @@ describe('AiSdkBackend thinking persistence', () => {
 
     // Turn 2: replay the prior ledger and capture the outgoing provider request.
     const secondModel = completionModel();
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const secondBackend = createBackend({
       connection: openCodeClaudeConnection,
-      apiKey: 'sk-test',
       modelId: 'claude-opus-4-8',
       modelFactory: () => secondModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -13214,17 +12312,11 @@ describe('AiSdkBackend thinking persistence', () => {
     );
 
     const secondModel = completionModel();
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const secondBackend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => secondModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -13334,10 +12426,7 @@ describe('AiSdkBackend thinking persistence', () => {
             headers: { 'content-type': 'text/event-stream' },
           });
         }) as unknown as typeof globalThis.fetch;
-        const secondBackend = createTestAiSdkBackend({
-          sessionId: 'session-1',
-          header: header(),
-          appendMessage: async () => {},
+        const secondBackend = createBackend({
           connection: {
             slug: 'openai',
             providerType: 'openai',
@@ -13347,8 +12436,6 @@ describe('AiSdkBackend thinking persistence', () => {
           modelId: 'gpt-5.5',
           modelFactory: (input) => getAIModel({ ...input, fetch }),
           tools: [],
-          newId: idGenerator(),
-          now: monotonicClock(),
         });
 
         await drain(
@@ -13486,10 +12573,7 @@ describe('AiSdkBackend thinking persistence', () => {
       mapSessionEventToRuntimeEvent(event, ctx, memory),
     );
     const secondModel = completionModel();
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const secondBackend = createBackend({
       connection: {
         slug: 'volcengine-agent-plan',
         providerType: 'volcengine-agent-plan',
@@ -13499,8 +12583,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'ark-code-latest',
       modelFactory: () => secondModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -13597,10 +12679,7 @@ describe('AiSdkBackend thinking persistence', () => {
       mapSessionEventToRuntimeEvent(event, ctx, memory),
     );
     const secondModel = completionModel();
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const secondBackend = createBackend({
       connection: {
         slug: 'deepseek',
         providerType: 'deepseek',
@@ -13610,8 +12689,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'deepseek-v4-flash',
       modelFactory: () => secondModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -13749,17 +12826,12 @@ describe('AiSdkBackend thinking persistence', () => {
         status: 200,
         headers: { 'content-type': 'text/event-stream' },
       })) as unknown as typeof globalThis.fetch;
-    const firstBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const firstBackend = createBackend({
       connection: tokenPlanConnection,
       apiKey: 'alibaba-token',
       modelId: 'qwen3.8-max',
       modelFactory: (input) => getAIModel({ ...input, fetch }),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const firstEvents: SessionEvent[] = [];
     for await (const event of firstBackend.send({
@@ -13817,17 +12889,12 @@ describe('AiSdkBackend thinking persistence', () => {
         headers: { 'content-type': 'text/event-stream' },
       });
     }) as unknown as typeof globalThis.fetch;
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const secondBackend = createBackend({
       connection: tokenPlanConnection,
       apiKey: 'alibaba-token',
       modelId: 'qwen3.8-max',
       modelFactory: (input) => getAIModel({ ...input, fetch: replayFetch }),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -13910,9 +12977,7 @@ describe('AiSdkBackend thinking persistence', () => {
         status: 200,
         headers: { 'content-type': 'text/event-stream' },
       })) as unknown as typeof globalThis.fetch;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'assistant') appended.push(message);
       },
@@ -13925,8 +12990,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'qwen3.8-max',
       modelFactory: (input) => getAIModel({ ...input, fetch: mismatchFetch }),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -13952,10 +13015,7 @@ describe('AiSdkBackend thinking persistence', () => {
     const memory = createSessionEventMapMemory();
     const runtimeContext = events.map((event) => mapSessionEventToRuntimeEvent(event, ctx, memory));
     const recoveryModel = completionModel();
-    const recoveryBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const recoveryBackend = createBackend({
       connection: {
         slug: 'alibaba-token-plan-cn',
         providerType: 'alibaba-token-plan-cn',
@@ -13965,8 +13025,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'qwen3.8-max',
       modelFactory: () => recoveryModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -14024,9 +13082,7 @@ describe('AiSdkBackend thinking persistence', () => {
       );
     }) as unknown as typeof globalThis.fetch;
     const appended: AssistantMessage[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'assistant') appended.push(message);
       },
@@ -14039,8 +13095,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'qwen3.8-max',
       modelFactory: (input) => getAIModel({ ...input, fetch }),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -14120,9 +13174,7 @@ describe('AiSdkBackend thinking persistence', () => {
       providerType: 'alibaba-token-plan-cn',
       defaultModel: 'qwen3.8-max',
     } as const;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'assistant') appended.push(message);
       },
@@ -14131,8 +13183,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'qwen3.8-max',
       modelFactory: (input) => getAIModel({ ...input, fetch }),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
     for await (const event of backend.send({ turnId: 'turn-1', text: 'question', context: [] })) {
@@ -14163,17 +13213,12 @@ describe('AiSdkBackend thinking persistence', () => {
     const memory = createSessionEventMapMemory();
     const runtimeContext = events.map((event) => mapSessionEventToRuntimeEvent(event, ctx, memory));
     const recoveryModel = completionModel();
-    const recoveryBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const recoveryBackend = createBackend({
       connection,
       apiKey: 'alibaba-token',
       modelId: 'qwen3.8-max',
       modelFactory: () => recoveryModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -14263,9 +13308,7 @@ describe('AiSdkBackend thinking persistence', () => {
         headers: { 'content-type': 'text/event-stream' },
       })) as unknown as typeof globalThis.fetch;
     const appended: AssistantMessage[] = [];
-    const firstBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const firstBackend = createBackend({
       appendMessage: async (message) => {
         if (message.type === 'assistant') appended.push(message);
       },
@@ -14274,8 +13317,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'qwen3.8-max',
       modelFactory: (input) => getAIModel({ ...input, fetch }),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
     for await (const event of firstBackend.send({
@@ -14308,17 +13349,12 @@ describe('AiSdkBackend thinking persistence', () => {
     const memory = createSessionEventMapMemory();
     const runtimeContext = events.map((event) => mapSessionEventToRuntimeEvent(event, ctx, memory));
     const recoveryModel = completionModel();
-    const recoveryBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const recoveryBackend = createBackend({
       connection,
       apiKey: 'alibaba-token',
       modelId: 'qwen3.8-max',
       modelFactory: () => recoveryModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -14348,10 +13384,7 @@ describe('AiSdkBackend thinking persistence', () => {
     const foreignSummary = 'summary issued by a different provider profile';
     const futureSummary = 'summary issued by a future durable state version';
     const model = completionModel();
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         slug: 'alibaba-token-plan-cn',
         providerType: 'alibaba-token-plan-cn',
@@ -14361,8 +13394,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'qwen3.8-max',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const runtimeContext: RuntimeEvent[] = [
       runtimeEvent({
@@ -14439,10 +13470,7 @@ describe('AiSdkBackend thinking persistence', () => {
   });
 
   test('Alibaba Responses rejects malformed state owned by its profile', async () => {
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         slug: 'alibaba-token-plan-cn',
         providerType: 'alibaba-token-plan-cn',
@@ -14452,8 +13480,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'qwen3.8-max',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const runtimeContext: RuntimeEvent[] = [
       runtimeEvent({
@@ -14515,10 +13541,8 @@ describe('AiSdkBackend thinking persistence', () => {
         { status: 200, headers: { 'content-type': 'text/event-stream' } },
       );
     }) as unknown as typeof globalThis.fetch;
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
+    const backend = createBackend({
       header: { ...header(), thinkingLevel: 'max' },
-      appendMessage: async () => {},
       connection: {
         slug: 'deepseek',
         providerType: 'deepseek',
@@ -14528,8 +13552,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'deepseek-v4-flash',
       modelFactory: (input) => getAIModel({ ...input, fetch }),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(backend.send({ turnId: 'turn-current', text: 'think', context: [] }));
@@ -14602,9 +13624,7 @@ describe('AiSdkBackend thinking persistence', () => {
       updatedAt: 1,
     };
     const appended: StoredMessage[] = [];
-    const firstBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const firstBackend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
@@ -14613,8 +13633,6 @@ describe('AiSdkBackend thinking persistence', () => {
       modelId: 'ark-code-latest',
       modelFactory: () => firstModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const events: SessionEvent[] = [];
@@ -14697,17 +13715,12 @@ describe('AiSdkBackend thinking persistence', () => {
     );
 
     const secondModel = completionModel();
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const secondBackend = createBackend({
       connection: planConnection,
       apiKey: 'ark-plan-token',
       modelId: 'ark-code-latest',
       modelFactory: () => secondModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -14805,17 +13818,11 @@ describe('AiSdkBackend thinking persistence', () => {
     );
 
     const secondModel = completionModel();
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const secondBackend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => secondModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -14916,17 +13923,11 @@ describe('AiSdkBackend thinking persistence', () => {
     );
 
     const secondModel = completionModel();
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const secondBackend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => secondModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -14989,19 +13990,14 @@ describe('AiSdkBackend thinking persistence', () => {
       },
     });
     const persisted: AssistantMessage[] = [];
-    const firstBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const firstBackend = createBackend({
       appendMessage: async (m) => {
         if (m.type === 'assistant') persisted.push(m);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => firstModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     const firstEvents: SessionEvent[] = [];
@@ -15036,17 +14032,11 @@ describe('AiSdkBackend thinking persistence', () => {
     );
 
     const secondModel = completionModel();
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const secondBackend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => secondModel,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(
@@ -15069,19 +14059,14 @@ describe('AiSdkBackend thinking persistence', () => {
     // thinking stream ends abruptly without a finish-step / finish event.
     const appended: StoredMessage[] = [];
     const events: SessionEvent[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => completionModel(),
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     type FakeStreamInput = {
       abortSignal: AbortSignal;
@@ -15200,20 +14185,15 @@ describe('AiSdkBackend thinking persistence', () => {
     const assistants: AssistantMessage[] = [];
     const events: SessionEvent[] = [];
     const durable = durableTurnHarness('turn-1', 'hi');
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (m) => {
         if (m.type === 'assistant') assistants.push(m);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [testTool('Read', z.object({ path: z.string() }))],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send(durable.input())) {
@@ -15346,10 +14326,7 @@ describe('AiSdkBackend thinking persistence', () => {
       },
     });
     const durable = durableTurnHarness('turn-1', 'inspect it');
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: {
         slug: 'openai-main',
         providerType: 'openai',
@@ -15361,8 +14338,6 @@ describe('AiSdkBackend thinking persistence', () => {
       tools: [testTool('Read', z.object({ path: z.string() }))],
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
       openAiResponsesTransportState: transport,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drainDurably(backend.send(durable.input()), durable);
@@ -15964,12 +14939,8 @@ describe('AiSdkBackend steering durability and identity', () => {
         };
       },
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
@@ -15981,8 +14952,6 @@ describe('AiSdkBackend steering durability and identity', () => {
         },
       ],
       loadTurnRuntimeEvents: async () => ledger,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send({
@@ -16061,18 +15030,12 @@ describe('AiSdkBackend steering durability and identity', () => {
         }),
       }),
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
       loadTurnRuntimeEvents: async () => ledger,
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     for await (const event of backend.send({
@@ -16142,19 +15105,14 @@ describe('AiSdkBackend steering durability and identity', () => {
       }),
     });
     const appended: StoredMessage[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(backend.send({ turnId: 'turn-1', text: 'cite twice', context: [] }));
@@ -16222,9 +15180,7 @@ describe('AiSdkBackend steering durability and identity', () => {
       }),
     });
     const appended: StoredMessage[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
@@ -16234,12 +15190,9 @@ describe('AiSdkBackend steering durability and identity', () => {
         providerType: 'openai',
         defaultModel: 'gpt-5',
       },
-      apiKey: 'sk-test',
       modelId: 'gpt-5',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(backend.send({ turnId: 'turn-1', text: 'inspect it', context: [] }));
@@ -16315,9 +15268,7 @@ describe('AiSdkBackend steering durability and identity', () => {
       }),
     });
     const appended: StoredMessage[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
@@ -16327,12 +15278,9 @@ describe('AiSdkBackend steering durability and identity', () => {
         providerType: 'openai',
         defaultModel: 'gpt-5',
       },
-      apiKey: 'sk-test',
       modelId: 'gpt-5',
       modelFactory: () => model,
       tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
 
     await drain(backend.send({ turnId: 'turn-1', text: 'finish it', context: [] }));
@@ -16410,19 +15358,14 @@ describe('AiSdkBackend steering durability and identity', () => {
       }),
     });
     const appended: StoredMessage[] = [];
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
+    const backend = createBackend({
       appendMessage: async (message) => {
         appended.push(message);
       },
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [buildNativeWebSearchTool()],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
 
@@ -16538,17 +15481,11 @@ describe('AiSdkBackend steering durability and identity', () => {
         }),
       }),
     });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
+    const backend = createBackend({
       connection: connection(),
-      apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [buildNativeWebSearchTool({ adapter: 'anthropic-messages' })],
-      newId: idGenerator(),
-      now: monotonicClock(),
     });
     const events: SessionEvent[] = [];
 
@@ -16772,12 +15709,8 @@ async function runPlanToolBoundary(input: {
       };
     },
   });
-  const backend = createTestAiSdkBackend({
-    sessionId: 'session-1',
-    header: header(),
-    appendMessage: async () => {},
+  const backend = createBackend({
     connection: connection(),
-    apiKey: 'sk-test',
     modelId: 'mock-model-id',
     modelFactory: () => model,
     tools: [
@@ -16789,8 +15722,6 @@ async function runPlanToolBoundary(input: {
       },
     ],
     loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-    newId: idGenerator(),
-    now: monotonicClock(),
   });
   const events = await drainDurably(backend.send(durable.input()), durable);
   return { calls, events };
@@ -16956,17 +15887,11 @@ async function replayPrompt(
   runtimeContext: RuntimeEvent[],
 ): Promise<Array<{ role: string; content: any[] }>> {
   const model = completionModel();
-  const backend = createTestAiSdkBackend({
-    sessionId: 'session-1',
-    header: header(),
-    appendMessage: async () => {},
+  const backend = createBackend({
     connection: connection(),
-    apiKey: 'sk-test',
     modelId: 'mock-model-id',
     modelFactory: () => model,
     tools: [],
-    newId: idGenerator(),
-    now: monotonicClock(),
   });
   await drain(
     backend.send({
@@ -17205,6 +16130,23 @@ function hangingProviderStream(
       if (signal?.aborted) abort();
       else signal?.addEventListener('abort', abort, { once: true });
     },
+  });
+}
+
+type BackendTestInput = Parameters<typeof createTestAiSdkBackend>[0];
+type BackendTestDefaultKey = 'sessionId' | 'header' | 'appendMessage' | 'apiKey' | 'newId' | 'now';
+type BackendTestOverrides = Omit<BackendTestInput, BackendTestDefaultKey> &
+  Partial<Pick<BackendTestInput, BackendTestDefaultKey>>;
+
+function createBackend(input: BackendTestOverrides): AiSdkBackend {
+  return createTestAiSdkBackend({
+    sessionId: 'session-1',
+    header: header(),
+    appendMessage: async () => {},
+    apiKey: 'sk-test',
+    newId: idGenerator(),
+    now: monotonicClock(),
+    ...input,
   });
 }
 


### PR DESCRIPTION
## Summary

`ai-sdk-backend.test.ts` carries 204 direct `createTestAiSdkBackend` call sites on `origin/main`; 195 of them repeat the same six fixture properties byte-for-byte (`sessionId: 'session-1'`, `header: header()`, `appendMessage: async () => {}`, `apiKey: 'sk-test'`, `newId: idGenerator()`, `now: monotonicClock()`). A suite-local `createBackend` wrapper supplies those defaults once; the 195 eligible calls now pass only scenario-specific input, and a final spread keeps explicit overrides authoritative.

Result: the backend fixture now exists once instead of 195 times — net −1058 lines (17,373 → 16,315), runtime test count matches origin/main's suite (232 pass / 0 fail, before and after), test-name inventory byte-identical to origin/main's source (219 `test()` sites, including both parameterized loops), no test deleted, no assertion or scenario value changed.

The remaining `createTestAiSdkBackend` constructions are intentionally untouched: 9 direct call sites — 8 that deliberately rely on the constructor's internal defaults by omitting `apiKey` and/or `newId`/`now`/`appendMessage` (including the 4 Codex checkpoint calls), and 1 whose input spreads a dynamically built object — plus the internals of 3 suite helpers (`imageReplayBackend`, the durable replay helper, and `createBackend` itself), which already centralize their own defaults.

Rebased onto current `origin/main` (`554b86445`): conflicts with #4958 and #4951 were resolved by keeping main's parameterized tests (`inheritedDenial` × false/true, `output` × text/tool) and migrating their fixture calls to `createBackend`; main's newly added eligible call sites were migrated in the same sweep.

Part of the [2026-09 scavenger sweep](https://github.com/apache/maka/issues/4726) T1 claim; plan and measured targets in #4945. A follow-up consolidation PR (#4945 stage 2) lands after this one merges.

Refs #4945

## Verification

- `npm --workspace @maka/runtime run build` ✓
- `node --test --test-reporter=tap packages/runtime/dist/__tests__/ai-sdk-backend.test.js` → **232 pass / 0 fail** before and after; test-name inventory (219 `test()` sites) is byte-identical to origin/main's source (sorted diff empty)
- `npm --workspace @maka/runtime run typecheck` ✓
- `biome format` / `biome lint` on the target → no fixes needed; `git diff --check` clean
- Input preservation: every removed property line is byte-identical to a default the wrapper re-supplies ahead of its spread, so each migrated input expands to the original input; verified per call site (each of the 195 migrated sites lost exactly its six expected default lines; the 9 exempt direct calls and 2 helper internals are byte-identical to origin/main)

Before/after (one representative site):

```ts
// before
const backend = createTestAiSdkBackend({
  sessionId: 'session-1',
  header: header(),
  appendMessage: async () => {},
  connection: connection(),
  apiKey: 'sk-test',
  modelId: 'mock-model-id',
  modelFactory: () => completionModel(),
  tools: [],
  newId: idGenerator(),
  now: monotonicClock(),
});

// after
const backend = createBackend({
  connection: connection(),
  modelId: 'mock-model-id',
  modelFactory: () => completionModel(),
  tools: [],
});
```

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude (via pi coding agent) implemented the migration as a source codemod with per-call input-preservation assertions, rebased the PR onto updated `origin/main` (resolving the #4958/#4951 parameterized-test conflicts by keeping main's tests and migrating their fixture calls), migrated the newly added eligible call sites, ran the verification commands, and refreshed this description. The affected commit carries a `Generated-by` trailer.

## Checklist

- [x] Tests cover the change and fail without it — no new tests and no changed assertions by design; the safety argument is the per-call input-preservation check over all 195 migrated calls (sensitivity-evidence grouping for this fixture-only PR is discussed in #4945)
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] No