### PR TITLE
fix(computer-use): enforce JSON line UTF-8 byte limit

### DIFF
--- a/packages/computer-use/src/__tests__/stdio-json-rpc.test.ts
+++ b/packages/computer-use/src/__tests__/stdio-json-rpc.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { decodeJsonLines } from '../stdio-json-rpc.js';
+
+describe('stdio JSON-RPC framing', () => {
+  it('rejects an unparsed tail that exceeds the UTF-8 byte budget', () => {
+    let overflowed = false;
+
+    const rest = decodeJsonLines('中', '文', {
+      maxBufferBytes: 4,
+      onOverflow: () => {
+        overflowed = true;
+      },
+      onMessage: () => {},
+    });
+
+    assert.equal(rest, '中文');
+    assert.equal(overflowed, true);
+  });
+
+  it('accepts a multibyte tail exactly at the UTF-8 byte budget', () => {
+    let overflowed = false;
+
+    const rest = decodeJsonLines('中', '文', {
+      maxBufferBytes: 6,
+      onOverflow: () => {
+        overflowed = true;
+      },
+      onMessage: () => {},
+    });
+
+    assert.equal(rest, '中文');
+    assert.equal(overflowed, false);
+  });
+
+  it('preserves the existing ASCII boundary behavior', () => {
+    let overflowed = false;
+
+    decodeJsonLines('he', 'llo', {
+      maxBufferBytes: 4,
+      onOverflow: () => {
+        overflowed = true;
+      },
+      onMessage: () => {},
+    });
+
+    assert.equal(overflowed, true);
+  });
+});

--- a/packages/computer-use/src/stdio-json-rpc.ts
+++ b/packages/computer-use/src/stdio-json-rpc.ts
@@ -71,7 +71,7 @@ export function decodeJsonLines(
   handlers: JsonLineDecoderHandlers,
 ): string {
   let rest = buffer + chunk;
-  if (rest.length > handlers.maxBufferBytes) {
+  if (Buffer.byteLength(rest, 'utf8') > handlers.maxBufferBytes) {
     handlers.onOverflow();
     return rest;
   }


### PR DESCRIPTION
## Summary

Measure the accumulated stdio JSON-line tail in UTF-8 bytes before comparing it with `maxBufferBytes`. This prevents multibyte executor output from retaining substantially more memory than the negotiated byte budget.

Add focused regression coverage for an over-limit multibyte tail, an exact-limit multibyte tail, and unchanged ASCII behavior across chunks.

Fixes #4952

## Verification

- `npm --workspace @maka/computer-use run build` — passed
- `node --test packages/computer-use/dist/__tests__/stdio-json-rpc.test.js` — 3/3 passed
- `npm --workspace @maka/computer-use run test:dist` — 117/117 passed
- `npm --workspace @maka/computer-use run typecheck` — passed
- `npm run build` — passed
- `npm run typecheck` — passed after rebuilding workspace declaration output
- `npm run lint` — passed
- `npm run format:check` — passed
- `npm test` — the changed tests passed, but the repository-wide parallel run failed in unrelated timing-sensitive PTY/process tests under load (`packages/eval` lifecycle cancellation, Runtime PTY ordering/rendering, and three existing `maka-cu` process timeout cases). The affected `@maka/computer-use` suite passed when rerun independently.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Codex diagnosed the byte/code-unit mismatch, implemented the fix, added regression tests, and ran verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
