### PR TITLE
refactor(runtime): unify per-model protocol routing

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -3070,6 +3070,7 @@
           "../assets/provider-brands/xiaomimimo.svg": 1,
           "../assets/provider-brands/zai.svg": 1,
           "../assets/provider-brands/zenmux.svg": 1,
+          "../features/connection-settings": 1,
           "simple-icons": 1
         }
       },

--- a/apps/desktop/src/renderer/features/connection-settings/generic-provider-mark.tsx
+++ b/apps/desktop/src/renderer/features/connection-settings/generic-provider-mark.tsx
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Cpu, ICON_SIZE } from '@maka/ui/icons';
+
+export function GenericProviderMark() {
+  return <Cpu size={ICON_SIZE.plate} aria-hidden="true" />;
+}

--- a/apps/desktop/src/renderer/features/connection-settings/index.ts
+++ b/apps/desktop/src/renderer/features/connection-settings/index.ts
@@ -43,3 +43,5 @@ export type { ProviderSettingsCopy } from './settings-provider-copy.js';
 export type {
   CredentialPresenceStatus,
 } from './provider-panel-shared.js';
+
+export { GenericProviderMark } from './generic-provider-mark.js';

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -31,6 +31,7 @@
 // legible in both light and dark themes; viewBox is the upstream 24×24.
 
 import type { ProviderType } from '@maka/core/llm-connections';
+import { GenericProviderMark } from '../features/connection-settings';
 import type { ReactElement } from 'react';
 import { siMinimax } from 'simple-icons';
 import alibabaBrandMark from '../assets/provider-brands/alibabacloud.svg';
@@ -338,15 +339,6 @@ function MiniMaxMark(): ReactElement {
   return (
     <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
       <path fill={`#${siMinimax.hex}`} d={siMinimax.path} />
-    </svg>
-  );
-}
-
-function GenericProviderMark(): ReactElement {
-  return (
-    <svg viewBox="0 0 24 24" role="img" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
-      <circle cx="12" cy="12" r="8" />
-      <path d="M8 9.5h6.5a2 2 0 010 4H9.5a2 2 0 000 4H16" />
     </svg>
   );
 }

--- a/apps/desktop/src/renderer/settings/provider-display-copy.ts
+++ b/apps/desktop/src/renderer/settings/provider-display-copy.ts
@@ -294,6 +294,11 @@ export const PROVIDER_DISPLAY_COPY = {
     'zh-TW': { name: 'OpenCode Free', description: '免費匿名 OpenCode Zen 模型，無需金鑰，按 IP 限速', badge: 'Free' },
     en: { name: 'OpenCode Free', description: 'Free anonymous OpenCode Zen models — no API key, IP-limited.', badge: 'Free' },
   },
+  commandcode: {
+    'zh-CN': { name: 'Command Code', description: '使用 Command Code 套餐额度，连接后自动获取模型。', badge: 'Coding' },
+    'zh-TW': { name: 'Command Code', description: '使用 Command Code 方案額度，連線後自動取得模型。', badge: 'Coding' },
+    en: { name: 'Command Code', description: 'Use your Command Code plan credits. Models are fetched when you connect.', badge: 'Coding' },
+  },
   groq: {
     'zh-CN': { name: 'Groq', description: 'LPU 高速推理托管开源模型', badge: 'API' },
     'zh-TW': { name: 'Groq', description: 'LPU 高速推理託管開源模型', badge: 'API' },

--- a/apps/desktop/src/renderer/settings/provider-endpoint-presentation.ts
+++ b/apps/desktop/src/renderer/settings/provider-endpoint-presentation.ts
@@ -24,7 +24,7 @@ import {
   type LlmConnection,
 } from '@maka/core/llm-connections';
 import {
-  lookupModelProviderOverride,
+  lookupModelRuntimeOverride,
   modelMetadataIdsForProvider,
 } from '@maka/core/model-metadata';
 import { redactSecrets } from '@maka/core/display-redaction';
@@ -96,7 +96,7 @@ function providerRoutesModelsElsewhere(
   if (cached !== undefined) return cached;
   let routes = false;
   for (const modelId of modelMetadataIdsForProvider(connection.providerType)) {
-    const api = lookupModelProviderOverride(connection.providerType, modelId)?.api;
+    const api = lookupModelRuntimeOverride(connection.providerType, modelId)?.baseUrl;
     if (api && api !== defaultBaseUrl) {
       routes = true;
       break;

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -6,7 +6,7 @@ Generated against `@astryxdesign/core@0.5.2` (194 component exports).
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 252 files — blocker 0, reimplementation 0, polish 1, aligned 251.
+**Totals:** 253 files — blocker 0, reimplementation 0, polish 1, aligned 252.
 
 ## Exclusions (explicit)
 
@@ -45,6 +45,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/error-boundary.tsx` | other | Button, Card | aligned — uses Astryx (Button, Card) | aligned |
 | `apps/desktop/src/renderer/features/app-update/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/app-update/ui/app-update-provider.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
+| `apps/desktop/src/renderer/features/connection-settings/generic-provider-mark.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/connection-settings/onboarding-step-form.tsx` | dialog-overlay | VStack | aligned — uses Astryx (VStack) | aligned |
 | `apps/desktop/src/renderer/features/connection-settings/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/features/goals/services-context.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |

--- a/docs/astryx-surface-file-inventory.paths
+++ b/docs/astryx-surface-file-inventory.paths
@@ -16,6 +16,7 @@ apps/desktop/src/renderer/custom-pet-companion.tsx
 apps/desktop/src/renderer/error-boundary.tsx
 apps/desktop/src/renderer/features/app-update/services-context.tsx
 apps/desktop/src/renderer/features/app-update/ui/app-update-provider.tsx
+apps/desktop/src/renderer/features/connection-settings/generic-provider-mark.tsx
 apps/desktop/src/renderer/features/connection-settings/onboarding-step-form.tsx
 apps/desktop/src/renderer/features/connection-settings/services-context.tsx
 apps/desktop/src/renderer/features/goals/services-context.tsx

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import type { ModelInfo, ProviderType } from './llm-connections.js';
+import type { ModelInfo, ProviderType, ProviderRuntimeAdapter } from './llm-connections.js';
 import type { ThinkingOptions } from './model-thinking.js';
 import {
   GENERATED_MODELS_DEV_METADATA,
@@ -75,9 +75,6 @@ export function installRefreshedModelMetadata(metadata: ModelsDevMetadata | unde
 function activeMetadata(): ModelsDevMetadata {
   return refreshedMetadata ?? bundledModelMetadata;
 }
-const generatedModelProviderOverrides: Partial<
-  Record<ProviderType, Record<string, { npm: string; api?: string }>>
-> = GENERATED_MODELS_DEV_MODEL_PROVIDER_OVERRIDES;
 
 /** Access paths that serve a canonical provider's model catalog. */
 const GENERATED_METADATA_PROVIDER_ALIASES: Partial<Record<ProviderType, ProviderType>> = {
@@ -140,11 +137,14 @@ export function modelMetadataIdsForProvider(providerType: ProviderType): string[
   );
 }
 
-export function lookupModelProviderOverride(
+export function lookupModelRuntimeOverride(
   providerType: ProviderType,
   modelId: string,
-): { npm: string; api?: string } | undefined {
-  return generatedModelProviderOverrides[providerType]?.[modelId.trim()];
+): { adapter: ProviderRuntimeAdapter; baseUrl?: string } | undefined {
+  const overrides: Partial<
+    Record<ProviderType, Record<string, { adapter: ProviderRuntimeAdapter; baseUrl?: string }>>
+  > = GENERATED_MODELS_DEV_MODEL_PROVIDER_OVERRIDES;
+  return overrides[providerType]?.[modelId.trim()];
 }
 
 /**

--- a/packages/core/src/model-web-search.ts
+++ b/packages/core/src/model-web-search.ts
@@ -51,6 +51,7 @@ export function resolveHostedWebSearchCapability(
   providerType: ProviderType,
   models: readonly ModelInfo[] | undefined,
   modelId: string,
+  effectiveWire?: string,
 ): HostedWebSearchCapability | null {
   const id = modelId.trim();
   if (!id) return null;
@@ -59,10 +60,11 @@ export function resolveHostedWebSearchCapability(
 
   const adapter = providerHostedWebSearchAdapter(providerType);
   if (!adapter) return null;
+  const wire = effectiveWire ?? stored?.apiProtocol;
   if (
-    stored?.apiProtocol !== undefined &&
-    ((adapter.adapter === 'openai-responses' && stored.apiProtocol !== 'openai-responses') ||
-      (adapter.adapter === 'anthropic-messages' && stored.apiProtocol !== 'anthropic-messages'))
+    wire !== undefined &&
+    ((adapter.adapter === 'openai-responses' && wire !== 'openai-responses') ||
+      (adapter.adapter === 'anthropic-messages' && wire !== 'anthropic-messages'))
   ) {
     return null;
   }

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -1202,6 +1202,10 @@ const providerRegistry = {
     fallbackModels: opencodeGoModelIds,
     status: 'ready',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    protocolAdapters: {
+      'anthropic-messages': { kind: 'anthropic', auth: 'api-key', normalizeBaseUrl: true },
+      'openai-responses': { kind: 'openai', apiProtocol: 'openai-responses' },
+    },
     modelDiscovery: { kind: 'protocol' },
     category: 'overseas',
     catalogGroup: 'plans',

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -54,6 +54,8 @@ type OpenAiCompatibleRuntimeAdapterBase = {
   requireBaseUrl?: boolean;
   replayAssistantReasoningAs?: 'reasoning';
   replayAssistantReasoningDetails?: true;
+  normalizeUsage?: true;
+  normalizeBaseUrl?: true;
 };
 
 type OpenAiCompatibleRuntimeAdapter = OpenAiCompatibleRuntimeAdapterBase &
@@ -80,7 +82,6 @@ type ProviderRuntimeAdapterDefinition =
   | { kind: 'openai'; apiProtocol?: 'openai-chat' | 'openai-responses' }
   | { kind: 'openai-codex' }
   | { kind: 'google'; normalizeBaseUrl?: boolean }
-  | { kind: 'github-copilot' }
   | { kind: 'cohere' }
   | OpenAiCompatibleRuntimeAdapter;
 
@@ -96,6 +97,7 @@ export type ProviderModelDiscovery =
       path?: string;
       query?: Readonly<Record<string, string>>;
       responseShape?: 'array-or-data';
+      modelProtocols?: 'commandcode';
       filter?: 'language-models' | 'tool-capable';
     }
   | {
@@ -134,6 +136,10 @@ export interface ProviderDefaults {
   enableShippedModelsByDefault?: true;
   status: 'ready' | 'phase3-experimental';
   runtimeAdapter: ProviderRuntimeAdapter;
+  /** Additional request protocols; omitted models still use runtimeAdapter. */
+  protocolAdapters?: Partial<
+    Record<'openai-chat' | 'openai-responses' | 'anthropic-messages', ProviderRuntimeAdapter>
+  >;
   /**
    * Maka used to offer this provider and no longer does. The entry stays
    * registered so stored connections still decode; it just cannot be used.
@@ -285,15 +291,15 @@ if (zenmux.api !== 'https://zenmux.ai/api/v1') {
 }
 const zenmuxModelProviderOverrides = GENERATED_MODELS_DEV_MODEL_PROVIDER_OVERRIDES.zenmux;
 if (
-  zenmuxModelProviderOverrides['anthropic/claude-sonnet-4.6']?.npm !== '@ai-sdk/anthropic' ||
-  zenmuxModelProviderOverrides['anthropic/claude-sonnet-4.6']?.api !==
+  zenmuxModelProviderOverrides['anthropic/claude-sonnet-4.6']?.adapter.kind !== 'anthropic' ||
+  zenmuxModelProviderOverrides['anthropic/claude-sonnet-4.6']?.baseUrl !==
     'https://zenmux.ai/api/anthropic/v1'
 ) {
   throw new Error(
     'models.dev ZenMux snapshot is missing its Anthropic model-level protocol override',
   );
 }
-if (zenmuxModelProviderOverrides['openai/gpt-5.4']?.npm !== '@ai-sdk/openai') {
+if (zenmuxModelProviderOverrides['openai/gpt-5.4']?.adapter.kind !== 'openai') {
   throw new Error(
     'models.dev ZenMux snapshot is missing its native OpenAI model-level protocol override',
   );
@@ -784,6 +790,14 @@ const providerRegistry = {
     fallbackModels: [...kimiCodingPlanModelIds],
     status: 'ready',
     runtimeAdapter: { kind: 'anthropic', auth: 'api-key', normalizeBaseUrl: true },
+    protocolAdapters: {
+      'openai-chat': {
+        kind: 'openai-compatible',
+        name: 'provider',
+        normalizeUsage: true,
+        normalizeBaseUrl: true,
+      },
+    },
     modelDiscovery: { kind: 'protocol' },
     category: 'domestic',
     catalogGroup: 'plans',
@@ -1171,6 +1185,10 @@ const providerRegistry = {
     fallbackModels: opencodeModelIds,
     status: 'ready',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    protocolAdapters: {
+      'anthropic-messages': { kind: 'anthropic', auth: 'api-key', normalizeBaseUrl: true },
+      'openai-responses': { kind: 'openai', apiProtocol: 'openai-responses' },
+    },
     modelDiscovery: { kind: 'protocol' },
     category: 'overseas',
     catalogGroup: 'plans',
@@ -1464,6 +1482,22 @@ const providerRegistry = {
     signupUrl: 'https://modelstudio.console.alibabacloud.com/',
     catalogOrder: 41.4,
   },
+  commandcode: {
+    label: 'Command Code',
+    baseUrl: 'https://api.commandcode.ai/provider/v1',
+    authKind: 'api_key',
+    fallbackModels: [],
+    status: 'ready',
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    protocolAdapters: {
+      'anthropic-messages': { kind: 'anthropic', auth: 'bearer', normalizeBaseUrl: true },
+    },
+    modelDiscovery: { kind: 'protocol', modelProtocols: 'commandcode' },
+    category: 'overseas',
+    catalogGroup: 'plans',
+    signupUrl: 'https://commandcode.ai/docs/plans/goat',
+    catalogOrder: 41.5,
+  },
   'cloudflare-workers-ai': {
     label: cloudflareWorkersAi.name,
     baseUrl: '',
@@ -1581,7 +1615,11 @@ const providerRegistry = {
     authKind: 'oauth_token',
     fallbackModels: githubCopilotModelIds,
     status: 'ready',
-    runtimeAdapter: { kind: 'github-copilot' },
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider', includeUsage: false },
+    protocolAdapters: {
+      'anthropic-messages': { kind: 'anthropic', auth: 'bearer', normalizeBaseUrl: true },
+      'openai-responses': { kind: 'openai', apiProtocol: 'openai-responses' },
+    },
     modelDiscovery: { kind: 'protocol', auth: 'github-copilot' },
     category: 'oauth',
     signupUrl: 'https://github.com/features/copilot/plans',

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -73,7 +73,12 @@ type OpenAiCompatibleRuntimeAdapter = OpenAiCompatibleRuntimeAdapterBase &
   );
 
 type ProviderRuntimeAdapterDefinition =
-  | { kind: 'anthropic'; auth: 'api-key' | 'bearer'; normalizeBaseUrl: boolean }
+  | {
+      kind: 'anthropic';
+      auth: 'api-key' | 'bearer';
+      normalizeBaseUrl: boolean;
+      includeBetaHeaders?: false;
+    }
   /**
    * No Runtime adapter claims this provider, so nothing can be sent through it.
    * Distinct from a provider that was never wired: see `retired`.
@@ -1621,7 +1626,12 @@ const providerRegistry = {
     status: 'ready',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider', includeUsage: false },
     protocolAdapters: {
-      'anthropic-messages': { kind: 'anthropic', auth: 'bearer', normalizeBaseUrl: true },
+      'anthropic-messages': {
+        kind: 'anthropic',
+        auth: 'bearer',
+        normalizeBaseUrl: true,
+        includeBetaHeaders: false,
+      },
       'openai-responses': { kind: 'openai', apiProtocol: 'openai-responses' },
     },
     modelDiscovery: { kind: 'protocol', auth: 'github-copilot' },

--- a/packages/runtime-host/src/server/execution-model-authority.ts
+++ b/packages/runtime-host/src/server/execution-model-authority.ts
@@ -53,7 +53,7 @@ import {
   type ToolFreeModelCallContent,
   ProviderPrefixModelCallUnavailableError,
 } from '@maka/runtime/tool-free-model-call';
-import { modelUsesAnthropicMessages } from '@maka/runtime/model-runtime';
+import { resolveModelRuntime } from '@maka/runtime/model-runtime';
 import { type BackendFactoryContext } from '@maka/runtime/session-manager';
 import { type GoalEvaluatorResource } from '@maka/runtime/goal-evaluator';
 import { type ModelMessage } from '@maka/runtime/model-protocol';
@@ -508,10 +508,12 @@ async function runHostAuxiliaryModelCall(
       | Awaited<ReturnType<typeof generateProviderPrefixModelCall>>;
     try {
       result = await readDuringBackendCreation(() => {
+        const runtime = resolveModelRuntime(target.connection, target.model);
         const providerOptions = buildProviderOptions(
           target.connection,
           target.model,
           input.header.thinkingLevel,
+          runtime,
         );
         const model = getAIModel({
           sessionId: input.transportContextId,
@@ -520,14 +522,13 @@ async function runHostAuxiliaryModelCall(
           modelId: target.model,
           fetch: modelFetch,
           requestHeaders: target.requestHeaders,
+          resolvedRuntime: runtime,
         });
         return request.tools !== undefined
           ? generateProviderPrefixModelCall({
               model,
               ...request,
-              toolChoicePolicy: modelUsesAnthropicMessages(target.connection, target.model)
-                ? 'omit'
-                : 'none',
+              toolChoicePolicy: runtime.wire === 'anthropic-messages' ? 'omit' : 'none',
               abortSignal: input.abortSignal,
               providerOptions: request.providerOptions ?? providerOptions,
             })

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -1145,3 +1145,46 @@ test('explicit Chat selection keeps Grok thinking options on the Chat wire', () 
     xai: { reasoningEffort: 'high' },
   });
 });
+
+test('Copilot Messages preserves bearer auth without the generic Anthropic beta opt-ins', async () => {
+  for (const providerType of ['github-copilot', 'anthropic'] as const) {
+    let headers = new Headers();
+    const model = getAIModel({
+      connection: {
+        ...conn(providerType),
+        models: [{ id: 'claude-test', apiProtocol: 'anthropic-messages' }],
+      },
+      apiKey: 'test-key',
+      modelId: 'claude-test',
+      fetch: async (_input, init) => {
+        headers = new Headers(init?.headers);
+        return new Response(
+          JSON.stringify({
+            id: 'msg-test',
+            type: 'message',
+            role: 'assistant',
+            model: 'claude-test',
+            content: [{ type: 'text', text: 'ok' }],
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      },
+    });
+    await model.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    });
+    assert.equal(
+      headers.get('anthropic-beta'),
+      providerType === 'github-copilot'
+        ? null
+        : 'interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14',
+    );
+    if (providerType === 'github-copilot') {
+      assert.equal(headers.get('authorization'), 'Bearer test-key');
+      assert.equal(headers.get('x-api-key'), null);
+    }
+  }
+});

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -772,18 +772,18 @@ describe('getAIModel: models.dev registry providers', () => {
     );
   });
 
-  test('routes OpenCode Zen and Go models through their registry-owned protocol overrides', () => {
-    const cases = [
-      ['opencode', 'gpt-5.5', 'openai.responses'],
-      ['opencode', 'claude-opus-4-8', 'anthropic.messages'],
-      ['opencode', 'gemini-3.5-flash', 'google.generative-ai'],
-      ['opencode-go', 'kimi-k2.7-code', 'opencode-go.chat'],
-      ['opencode-go', 'minimax-m3', 'anthropic.messages'],
-    ] as const;
-
-    for (const [providerType, modelId, expectedProvider] of cases) {
-      const model = getAIModel({ connection: conn(providerType), apiKey: 'test-key', modelId });
-      assert.equal(model.provider, expectedProvider, `${providerType}/${modelId}`);
+  test('OpenCode Go accepts explicit protocols without a static model entry', () => {
+    for (const [apiProtocol, expectedProvider] of [
+      ['openai-responses', 'openai.responses'],
+      ['anthropic-messages', 'anthropic.messages'],
+    ] as const) {
+      const modelId = 'unlisted-model';
+      const model = getAIModel({
+        connection: { ...conn('opencode-go'), models: [{ id: modelId, apiProtocol }] },
+        apiKey: 'test-key',
+        modelId,
+      });
+      assert.equal(model.provider, expectedProvider);
       assert.equal(model.modelId, modelId);
     }
   });

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -768,7 +768,7 @@ describe('getAIModel: models.dev registry providers', () => {
           apiKey: 'test-key',
           modelId: 'k3',
         }),
-      /Kimi Coding Plan.*openai-chat.*anthropic-messages/,
+      /Kimi Coding Plan does not support openai-responses/,
     );
   });
 
@@ -1131,5 +1131,17 @@ describe('buildProviderOptions: openai-compatible namespace', () => {
       false,
       JSON.stringify(result.warnings),
     );
+  });
+});
+
+test('explicit Chat selection keeps Grok thinking options on the Chat wire', () => {
+  const connection = {
+    slug: 'xai',
+    defaultModel: 'grok-4.5',
+    providerType: 'xai' as const,
+    models: [{ id: 'grok-4.5', apiProtocol: 'openai-chat' as const }],
+  };
+  assert.deepEqual(buildProviderOptions(connection, 'grok-4.5', 'high'), {
+    xai: { reasoningEffort: 'high' },
   });
 });

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -783,24 +783,35 @@ describe('models.dev provider conformance', () => {
             policy: { state: 'enabled' },
             capabilities: { supports: { tool_calls: true } },
           },
+          {
+            id: 'claude-sonnet-4.6',
+            model_picker_enabled: true,
+            supported_endpoints: ['/v1/messages'],
+            policy: { state: 'enabled' },
+            capabilities: { supports: { tool_calls: true } },
+          },
         ],
       });
     });
-    const result = await testConnection(
-      {
-        slug: 'github-copilot',
-        name: 'GitHub Copilot',
-        providerType: 'github-copilot',
-        baseUrl: server.url,
-        defaultModel: 'gpt-5.4',
-        enabled: true,
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      'github-account-token',
-    );
-
-    assert.deepEqual(result, { ok: true, latencyMs: result.latencyMs, modelTested: 'gpt-5.4' });
+    const connection: LlmConnection = {
+      slug: 'github-copilot',
+      name: 'GitHub Copilot',
+      providerType: 'github-copilot',
+      baseUrl: server.url,
+      defaultModel: 'gpt-5.4',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    connection.models = await fetchProviderModels(connection, 'github-account-token');
+    assert.deepEqual(connection.models.map((model) => model.id).sort(), [
+      'claude-sonnet-4.6',
+      'gpt-5.4',
+    ]);
+    for (const model of connection.models) {
+      const result = await testConnection(connection, 'github-account-token', model.id);
+      assert.deepEqual(result, { ok: true, latencyMs: result.latencyMs, modelTested: model.id });
+    }
   });
 
   test('GitHub Copilot connection probe rejects an account that cannot discover models', async () => {

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -18,17 +18,28 @@
  */
 
 import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { IncomingMessage } from 'node:http';
 import { after, describe, test } from 'node:test';
 import { PROVIDER_REGISTRY, type LlmConnection } from '@maka/core/llm-connections';
 import { anthropic } from '@ai-sdk/anthropic';
 import { generateText, isStepCount, streamText, tool, type ModelMessage } from 'ai';
 import { z } from 'zod';
-import { fetchProviderModels } from '../model-fetcher.js';
+import { fetchProviderModels, runConnectionModelDiscoveryEffect } from '../model-fetcher.js';
 import { resetStreamUsageFallbackMemory } from '../stream-usage-fallback-fetch.js';
 import { buildProviderOptions, getAIModel } from '../model-factory.js';
 import { resolveOAuthSubscriptionAccessToken } from '../subscription-credentials.js';
 import { testConnection } from '../test-connection.js';
+import { ModelAdapter } from '../model-adapter.js';
+import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
+import {
+  resolveStorageRoot,
+  tryAcquireInteractiveRootOwner,
+  resolveRootControlNamespace,
+  resolveRootOwnershipNamespace,
+} from '@maka/storage/root-authority';
 import {
   closeAllJsonServers,
   readBody,
@@ -40,6 +51,253 @@ import {
 after(closeAllJsonServers);
 
 describe('models.dev provider conformance', () => {
+  test('mixed discovery survives persistence and user overrides through both SDK tool loops', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-mixed-routing-'));
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    const calls = new Map<string, number>();
+    const paths: string[] = [];
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.headers.authorization, 'Bearer routing-key');
+      if (request.url === '/provider/v1/models') {
+        respondJson(response, 200, { data: [{ id: 'claude-route' }, { id: 'new-route' }] });
+        return;
+      }
+      const body = JSON.parse(await readBody(request));
+      const messages = request.url === '/provider/v1/messages';
+      assert.ok(messages || request.url === '/provider/v1/chat/completions');
+      const key = `${request.url}:${body.model}`;
+      const count = (calls.get(key) ?? 0) + 1;
+      calls.set(key, count);
+      paths.push(key);
+      if (messages) {
+        if (count === 2) {
+          assert.ok(
+            body.messages.some((item: { content: Array<{ type: string; signature?: string }> }) =>
+              item.content.some((part) => part.type === 'tool_result'),
+            ),
+          );
+          assert.ok(JSON.stringify(body.messages).includes('signature-route'));
+        }
+        respondJson(response, 200, {
+          id: `msg_${count}`,
+          type: 'message',
+          role: 'assistant',
+          model: body.model,
+          content:
+            count === 1
+              ? [
+                  { type: 'thinking', thinking: 'Use echo.', signature: 'signature-route' },
+                  { type: 'tool_use', id: 'tool_route', name: 'echo', input: { text: 'hello' } },
+                ]
+              : [{ type: 'text', text: 'Done.' }],
+          stop_reason: count === 1 ? 'tool_use' : 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 4, output_tokens: 3 },
+        });
+      } else {
+        if (count === 2) {
+          assert.ok(body.messages.some((item: { role: string }) => item.role === 'tool'));
+          assert.equal(
+            body.messages.find((item: { role: string }) => item.role === 'assistant')
+              .reasoning_content,
+            'Use echo.',
+          );
+        }
+        respondJson(response, 200, {
+          id: `chat_${count}`,
+          object: 'chat.completion',
+          created: 0,
+          model: body.model,
+          choices: [
+            {
+              index: 0,
+              message:
+                count === 1
+                  ? {
+                      role: 'assistant',
+                      content: null,
+                      reasoning_content: 'Use echo.',
+                      tool_calls: [
+                        {
+                          id: 'tool_route',
+                          type: 'function',
+                          function: { name: 'echo', arguments: '{"text":"hello"}' },
+                        },
+                      ],
+                    }
+                  : { role: 'assistant', content: 'Done.' },
+              finish_reason: count === 1 ? 'tool_calls' : 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 4, completion_tokens: 3, total_tokens: 7 },
+        });
+      }
+    });
+    try {
+      const stores = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+      const created = await stores.connectionCatalog.create({
+        expectedCatalogRevision: 0,
+        connection: {
+          slug: 'mixed',
+          name: 'Mixed',
+          providerType: 'commandcode',
+          baseUrl: `${server.url}/provider/v1`,
+          enabled: true,
+          enabledModelIds: ['claude-route', 'new-route'],
+        },
+      });
+      assert.equal(created.kind, 'committed');
+      if (created.kind !== 'committed') throw new Error('Connection was not created');
+      const connectionId = created.snapshot.connections[0]!.connectionId;
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: { scope: 'connection', connectionId, kind: 'api_key' },
+            expected: null,
+            secret: 'routing-key',
+          })
+        ).kind,
+        'committed',
+      );
+      const discover = async () => {
+        const prepared = await stores.operations.beginModelFetch(connectionId);
+        assert.equal(prepared.kind, 'ready');
+        if (prepared.kind !== 'ready') throw new Error('Discovery was not admitted');
+        const discovery = await runConnectionModelDiscoveryEffect(
+          prepared.connection,
+          'routing-key',
+          { fetch: globalThis.fetch },
+        );
+        assert.equal(discovery.ok, true);
+        if (!discovery.ok) throw new Error('Discovery failed');
+        assert.equal(
+          (
+            await stores.operations.completeModelFetch(prepared.ticket, {
+              models: discovery.models,
+              source: 'fetched',
+              fetchedAt: Date.now(),
+            })
+          ).kind,
+          'committed',
+        );
+      };
+      const send = async (modelId: string) => {
+        const prepared = await stores.operations.resolveExecutionConnection({
+          kind: 'catalog_slug',
+          connectionSlug: 'mixed',
+        });
+        assert.equal(prepared.kind, 'ready');
+        if (prepared.kind !== 'ready') throw new Error('Execution was not admitted');
+        const adapter = new ModelAdapter({
+          connection: {
+            slug: prepared.connection.slug,
+            providerType: prepared.connection.providerType,
+            baseUrl: prepared.connection.baseUrl,
+            models: [...prepared.connection.models],
+            defaultModel: modelId,
+          },
+          modelId,
+          apiKey: 'routing-key',
+          modelFactory: getAIModel,
+          newId: () => 'route',
+          now: Date.now,
+        });
+        const result = await generateText({
+          model: adapter.resolveModel() as ReturnType<typeof getAIModel>,
+          prompt: 'Echo hello',
+          maxRetries: 0,
+          maxOutputTokens: 128,
+          stopWhen: isStepCount(2),
+          tools: {
+            echo: tool({
+              inputSchema: z.object({ text: z.string() }),
+              execute: ({ text }) => text,
+            }),
+          },
+        });
+        assert.equal(result.text, 'Done.');
+      };
+      await discover();
+      await send('claude-route');
+      await send('new-route');
+      await writeFile(
+        join(root, 'model-facts.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          overrides: { 'commandcode:new-route': { apiProtocol: 'anthropic-messages' } },
+        }),
+      );
+      await discover();
+      await send('new-route');
+      await writeFile(
+        join(root, 'model-facts.json'),
+        JSON.stringify({ schemaVersion: 1, overrides: {} }),
+      );
+      await send('new-route');
+      assert.deepEqual(paths, [
+        '/provider/v1/messages:claude-route',
+        '/provider/v1/messages:claude-route',
+        '/provider/v1/chat/completions:new-route',
+        '/provider/v1/chat/completions:new-route',
+        '/provider/v1/messages:new-route',
+        '/provider/v1/messages:new-route',
+        '/provider/v1/chat/completions:new-route',
+      ]);
+    } finally {
+      await owner.close();
+      await rm(root, { recursive: true, force: true });
+      await rm(join(resolveRootControlNamespace(), capability.rootId), {
+        recursive: true,
+        force: true,
+      });
+      await rm(join(resolveRootOwnershipNamespace(), `${capability.rootId}.lock`), { force: true });
+    }
+  });
+
+  test('an explicit model protocol overrides the provider default and a static SDK override', async () => {
+    const paths: string[] = [];
+    const server = await startJsonServer(async (request, response) => {
+      paths.push(request.url ?? '');
+      const body = JSON.parse(await readBody(request));
+      if (request.url !== '/v1/messages') {
+        respondJson(response, 400, { error: { message: 'This model requires Messages' } });
+        return;
+      }
+      assert.equal(request.headers['x-api-key'], 'routing-key');
+      respondJson(response, 200, {
+        id: 'msg_route',
+        type: 'message',
+        role: 'assistant',
+        model: body.model,
+        content: [{ type: 'text', text: 'Routed.' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 2, output_tokens: 1 },
+      });
+    });
+    for (const modelId of ['new-model', 'gpt-5.5']) {
+      const result = await generateText({
+        model: getAIModel({
+          connection: {
+            slug: 'mixed',
+            providerType: 'opencode',
+            defaultModel: modelId,
+            baseUrl: `${server.url}/v1`,
+            models: [{ id: modelId, apiProtocol: 'anthropic-messages' }],
+          },
+          apiKey: 'routing-key',
+          modelId,
+        }),
+        prompt: 'Hello',
+        maxRetries: 0,
+      });
+      assert.equal(result.text, 'Routed.');
+    }
+    assert.deepEqual(paths, ['/v1/messages', '/v1/messages']);
+  });
+
   test('native Anthropic sends automatic prompt caching on the Messages wire', async () => {
     let requestBody: Record<string, unknown> | undefined;
     const server = await startJsonServer(async (request, response) => {

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -172,6 +172,13 @@ describe('models.dev provider conformance', () => {
         );
         assert.equal(discovery.ok, true);
         if (!discovery.ok) throw new Error('Discovery failed');
+        assert.deepEqual(
+          discovery.models.map(({ id, apiProtocol }) => ({ id, apiProtocol })),
+          [
+            { id: 'claude-route', apiProtocol: 'anthropic-messages' },
+            { id: 'new-route', apiProtocol: undefined },
+          ],
+        );
         assert.equal(
           (
             await stores.operations.completeModelFetch(prepared.ticket, {

--- a/packages/runtime/src/__tests__/provider-contract-matrix.ts
+++ b/packages/runtime/src/__tests__/provider-contract-matrix.ts
@@ -43,7 +43,7 @@
  * Pure: no IO, no network, no clock. Given the registry it is a total function.
  */
 
-import { lookupModelProviderOverride, openAiAdapterApiProtocol } from '@maka/core/model-metadata';
+import { lookupModelRuntimeOverride, openAiAdapterApiProtocol } from '@maka/core/model-metadata';
 import {
   PROVIDER_REGISTRY,
   type ProviderDefaults,
@@ -71,11 +71,12 @@ export type ProviderContractWire =
   | 'google-generate'
   | 'cohere-v2';
 
-/** Runtime-adapter kinds whose request wire is provider-specific (auth, headers,
+/** Providers whose request wire is provider-specific (auth, headers,
  * per-model protocol) and therefore cannot be generated from the declaration. */
-export const SUBSCRIPTION_WIRE_ADAPTER_KINDS: ReadonlySet<ProviderRuntimeAdapter['kind']> = new Set(
-  ['openai-codex', 'github-copilot'],
-);
+export const SUBSCRIPTION_WIRE_PROVIDER_TYPES: ReadonlySet<ProviderType> = new Set([
+  'openai-codex',
+  'github-copilot',
+]);
 
 /**
  * The wire a provider's Runtime adapter speaks, which its `/models` endpoint
@@ -224,7 +225,7 @@ function wireForProtocol(protocol: ProviderWireProtocol): ProviderContractWire {
  */
 function sampleModelIdFor(providerType: ProviderType, def: ProviderDefaults): string {
   const usesDefaultWire = (id: string): boolean => {
-    if (lookupModelProviderOverride(providerType, id)) return false;
+    if (lookupModelRuntimeOverride(providerType, id)) return false;
     if (usesOpenAiResponsesWire(providerType, def, id)) return false;
     return true;
   };
@@ -245,60 +246,16 @@ function usesOpenAiResponsesWire(
   );
 }
 
-/**
- * Edge-shaped model ids each provider's account surface can really serve —
- * slashes, dots, colon-suffixed quantization/cloud tags, vendor casing — that
- * the plain first-fallback sample does not exercise. The generated wire
- * executor drives every declared id end-to-end (exact-model-id + tool-loop) on
- * the wire resolved for that id, proving exact-id preservation is not an
- * artifact of simple ids. Future providers enter by declaration alone.
- */
-const EDGE_WIRE_SAMPLE_MODEL_IDS: Partial<Record<ProviderType, readonly string[]>> = {
-  'opencode-go': ['kimi-k2.7-code'],
-  localai: ['localai/Qwen3-8B-Instruct-GGUF:Q4_K_M'],
-  'lm-studio': ['lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-GGUF'],
-  'minimax-coding-plan': ['MiniMax-M2.7-highspeed'],
-  'tencent-tokenhub': ['hy3-preview'],
-};
-
-/**
- * Resolve the wire a declared edge id executes on, mirroring the runtime's
- * per-model resolution order: a models.dev per-model override wins, then the
- * native OpenAI adapter's declared per-id protocol, then the provider's
- * default protocol wire. Ids that resolve outside the four executable wires
- * (e.g. OpenAI Responses) must be owned by a named override instead of an edge
- * declaration; declaring one here is a plan-construction error.
- */
-function edgeWireSamplesFor(
-  providerType: ProviderType,
-  def: ProviderDefaults,
-): ProviderContractEdgeWireSample[] {
-  return (EDGE_WIRE_SAMPLE_MODEL_IDS[providerType] ?? []).map((modelId) => {
-    const override = lookupModelProviderOverride(providerType, modelId);
-    if (override) {
-      switch (override.npm) {
-        case '@ai-sdk/anthropic':
-          return { modelId, wire: 'anthropic-messages' as const };
-        case '@ai-sdk/google':
-          return { modelId, wire: 'google-generate' as const };
-        case '@ai-sdk/openai-compatible':
-          return { modelId, wire: 'openai-chat' as const };
-        default:
-          throw new Error(
-            `edge wire sample ${providerType}/${modelId} resolves to ${override.npm}, which has no ` +
-              'generated wire; own it with a named override binding instead of an edge declaration',
-          );
-      }
-    }
-    if (usesOpenAiResponsesWire(providerType, def, modelId)) {
-      throw new Error(
-        `edge wire sample ${providerType}/${modelId} routes to the OpenAI Responses wire, which has no ` +
-          'generated executor; own it with a named override binding instead of an edge declaration',
-      );
-    }
-    return { modelId, wire: wireForProtocol(wireProtocolFor(def)) };
-  });
-}
+const EDGE_WIRE_SAMPLES: Partial<Record<ProviderType, readonly ProviderContractEdgeWireSample[]>> =
+  {
+    'opencode-go': [{ modelId: 'kimi-k2.7-code', wire: 'openai-chat' }],
+    localai: [{ modelId: 'localai/Qwen3-8B-Instruct-GGUF:Q4_K_M', wire: 'openai-chat' }],
+    'lm-studio': [
+      { modelId: 'lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-GGUF', wire: 'openai-chat' },
+    ],
+    'minimax-coding-plan': [{ modelId: 'MiniMax-M2.7-highspeed', wire: 'anthropic-messages' }],
+    'tencent-tokenhub': [{ modelId: 'hy3-preview', wire: 'openai-chat' }],
+  };
 
 function discoveryCell(providerType: ProviderType, def: ProviderDefaults): ProviderContractCell {
   const discovery = def.modelDiscovery;
@@ -384,7 +341,7 @@ function wireDimensionCell(
       reason: `${providerType} has no Runtime adapter and cannot send`,
     };
   }
-  if (SUBSCRIPTION_WIRE_ADAPTER_KINDS.has(def.runtimeAdapter.kind)) {
+  if (SUBSCRIPTION_WIRE_PROVIDER_TYPES.has(providerType)) {
     return {
       state: 'override',
       dimension,
@@ -419,7 +376,7 @@ function reasoningReplayCell(
       reason: `${providerType} has no Runtime adapter and cannot send`,
     };
   }
-  if (SUBSCRIPTION_WIRE_ADAPTER_KINDS.has(adapter.kind)) {
+  if (SUBSCRIPTION_WIRE_PROVIDER_TYPES.has(providerType)) {
     return {
       state: 'override',
       dimension: 'reasoning-replay',
@@ -487,7 +444,7 @@ export function buildProviderContractRow(
     adapterKind: def.runtimeAdapter.kind,
     discoveryKind: def.modelDiscovery.kind,
     sampleModelId: sampleModelIdFor(providerType, def),
-    edgeWireSamples: edgeWireSamplesFor(providerType, def),
+    edgeWireSamples: EDGE_WIRE_SAMPLES[providerType] ?? [],
     cells: {
       discovery: discoveryCell(providerType, def),
       'exact-model-id': wireDimensionCell('exact-model-id', providerType, def),

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -72,7 +72,7 @@ import {
   type MemoryExtractionSourceSnapshot,
   type MemoryExtractionTrigger,
 } from './memory-extraction.js';
-import { modelUsesNativeOpenAiResponses, resolveModelRuntime } from './model-runtime.js';
+import { resolveModelRuntime } from './model-runtime.js';
 import { routeApplyPatchTools } from './apply-patch-profile.js';
 import { bindToolResultArchiveDecoder } from './tool-result-archive-capability.js';
 import { resolveSelectedModelContextWindow } from './context-budget-policy.js';
@@ -307,15 +307,17 @@ export class AiSdkBackend implements AgentBackend {
     // One resolved options value for every reader: the main call, the
     // auxiliary memory-extraction call, and the provider request all use the
     // same options value, so they cannot disagree on what was sent.
+    const runtime = resolveModelRuntime(input.connection, input.modelId);
     this.resolvedProviderOptions =
       input.providerOptions ??
-      buildProviderOptions(input.connection, input.modelId, input.header.thinkingLevel);
+      buildProviderOptions(input.connection, input.modelId, input.header.thinkingLevel, runtime);
     this.modelAdapter = new ModelAdapter({
       sessionId: input.sessionId,
       connection: input.connection,
       apiKey: input.apiKey,
       modelId: input.modelId,
       modelFactory: input.modelFactory,
+      resolvedRuntime: runtime,
       // `input.providerOptions` is an override escape hatch: when set it owns
       // the whole provider-options namespace (including reasoning effort), and
       // the computed defaults are dropped entirely. Keep providerOptions the
@@ -344,7 +346,6 @@ export class AiSdkBackend implements AgentBackend {
       assertModelCallAccountingReady: input.assertModelCallAccountingReady,
       beforeRunProviderDispatch: input.beforeRunProviderDispatch,
     });
-    const runtime = resolveModelRuntime(input.connection, input.modelId);
     const applyPatchProfile = runtime.applyPatchProfile;
     this.messageProjection = new AiSdkMessageProjection({
       modelAdapter: this.modelAdapter,
@@ -394,7 +395,7 @@ export class AiSdkBackend implements AgentBackend {
             );
             if (turn) turn.memoryExtractRequested = true;
           },
-          ...(modelUsesNativeOpenAiResponses(input.connection, input.modelId)
+          ...(input.connection.providerType === 'openai' && runtime.wire === 'openai-responses'
             ? { unsupportedReason: 'provider_unsupported' as const }
             : {}),
         })

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -112,6 +112,7 @@ export interface ModelAdapterInput {
   apiKey: string;
   modelId: string;
   modelFactory: ModelFactory;
+  resolvedRuntime?: ResolvedModelRuntime;
   providerOptions?: Record<string, unknown>;
   newId: () => string;
   now: () => number;
@@ -162,7 +163,7 @@ export class ModelAdapter {
   private readonly openAiResponsesTransportState: OpenAiResponsesTransportState;
 
   constructor(private readonly input: ModelAdapterInput) {
-    this.runtime = resolveModelRuntime(input.connection, input.modelId);
+    this.runtime = input.resolvedRuntime ?? resolveModelRuntime(input.connection, input.modelId);
     this.openAiChatReasoningTransportState = createOpenAiChatReasoningTransportState(
       this.runtime.reasoningReplay.kind === 'openai-chat-plaintext'
         ? this.runtime.reasoningReplay.requestField

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -50,12 +50,7 @@ import {
   type OpenAiChatReasoningTransportState,
 } from './openai-chat-reasoning-transport.js';
 import type { OpenAiResponsesTransportState } from './openai-responses-websocket.js';
-import {
-  anthropicV1BaseUrl,
-  googleV1BetaBaseUrl,
-  openAiResponsesBaseUrl,
-  openResponsesUrl,
-} from './provider-urls.js';
+import { openResponsesUrl } from './provider-urls.js';
 import { createOpenResponsesCompatibilityFinalizer } from './open-responses-compatibility.js';
 import { resolveModelRuntime, type ResolvedModelRuntime } from './model-runtime.js';
 import { runtimeProviderName, type RuntimeProviderAdapter } from './provider-runtime-policy.js';
@@ -106,24 +101,14 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
   } as const;
   const requestFetch = createRequestCustomizationFetch(baseFetch, requestCustomization);
 
-  if (adapter.kind === 'google' && adapter.normalizeBaseUrl === false) {
-    return createGoogle({ apiKey, baseURL, fetch: requestFetch }).chat(modelId);
-  }
-
   switch (adapter.kind) {
     case 'anthropic':
       return createAnthropic({
         ...(adapter.auth === 'bearer' ? { authToken: apiKey } : { apiKey }),
-        baseURL: adapter.normalizeBaseUrl ? anthropicV1BaseUrl(baseURL) : baseURL,
+        baseURL,
         fetch: requestFetch,
         headers: { 'anthropic-beta': ANTHROPIC_BETA },
       }).chat(modelId);
-
-    case 'unavailable':
-      // A retired provider must never reach model construction. The pickers
-      // filter it out and `resolveModelRuntime` refuses earlier; this is the
-      // backstop that keeps a stored connection from silently sending.
-      throw new Error('This provider is retired and can no longer be used to send.');
 
     case 'openai-codex':
       return createOpenAI({
@@ -136,40 +121,10 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
         headers: openAiCodexHeaders(apiKey),
       }).responses(modelId);
 
-    case 'github-copilot': {
-      if (wire === 'openai-responses') {
-        return createOpenAI({ apiKey, baseURL, fetch: requestFetch }).responses(modelId);
-      }
-      if (wire === 'anthropic-messages') {
-        return createAnthropic({
-          authToken: apiKey,
-          baseURL: anthropicV1BaseUrl(baseURL),
-          fetch: requestFetch,
-        }).chat(modelId);
-      }
-      if (reasoningReplay.kind !== 'openai-chat-plaintext') {
-        throw new Error('Copilot OpenAI Chat wire requires plaintext reasoning replay');
-      }
-      const reasoningTransport = createOpenAiChatReasoningTransport(
-        requestFetch,
-        openAiChatReasoningTransportState ??
-          createOpenAiChatReasoningTransportState(reasoningReplay.requestField),
-      );
-      return createOpenAICompatible({
-        name: 'github-copilot',
-        apiKey,
-        baseURL,
-        fetch: reasoningTransport.fetch,
-        transformRequestBody: reasoningTransport.transformRequestBody,
-      }).chatModel(modelId);
-    }
-
     case 'openai': {
       const openai = createOpenAI({
         apiKey,
-        // The native adapter appends `/responses`; reduce endpoint-form
-        // overrides back to their base so probe-approved relay URLs work.
-        baseURL: wire === 'openai-responses' && baseURL ? openAiResponsesBaseUrl(baseURL) : baseURL,
+        baseURL,
         fetch:
           !hasRequestCustomization && openAiResponsesTransportState
             ? openAiResponsesTransportState.wrapFetch(requestFetch)
@@ -181,7 +136,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
     case 'google':
       return createGoogle({
         apiKey,
-        baseURL: googleV1BetaBaseUrl(baseURL),
+        baseURL,
         fetch: requestFetch,
       }).chat(modelId);
 
@@ -195,9 +150,6 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
         );
       }
       if (wire === 'openai-responses') {
-        if (reasoningReplay.kind !== 'responses') {
-          throw new Error('Responses wire requires a Responses continuation contract');
-        }
         if (reasoningReplay.contract.adapter === 'open-responses') {
           const finalizeBody = createOpenResponsesCompatibilityFinalizer(
             reasoningReplay.contract.compatibility,
@@ -220,9 +172,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
         }
         return createOpenAI({
           apiKey,
-          // Endpoint-form overrides (`…/responses`) probe successfully; the
-          // native adapter appends `/responses` itself, so pass the base.
-          baseURL: baseURL ? openAiResponsesBaseUrl(baseURL) : baseURL,
+          baseURL,
           fetch: requestFetch,
         }).responses(modelId);
       }
@@ -233,7 +183,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
         requestFetch,
         openAiChatReasoningTransportState ??
           createOpenAiChatReasoningTransportState(reasoningReplay.requestField),
-        connection.providerType === 'kimi-coding-plan',
+        adapter.normalizeUsage,
       );
       const transformRequestBody = adapter.replayAssistantReasoningDetails
         ? composeRequestTransforms(
@@ -497,11 +447,13 @@ export function buildProviderOptions(
   connection: RuntimeExecutionConnection,
   modelId: string,
   thinkingLevel?: ThinkingLevel,
+  runtime = resolveModelRuntime(connection, modelId),
 ): SharedV4ProviderOptions {
   return withParallelToolCallOptions(
     connection,
     modelId,
-    buildThinkingProviderOptions(connection, modelId, thinkingLevel),
+    buildThinkingProviderOptions(connection, modelId, thinkingLevel, runtime),
+    runtime,
   );
 }
 
@@ -509,6 +461,7 @@ function buildThinkingProviderOptions(
   connection: RuntimeExecutionConnection,
   modelId: string,
   thinkingLevel?: ThinkingLevel,
+  runtime = resolveModelRuntime(connection, modelId),
 ): SharedV4ProviderOptions {
   const thinkingOptions = thinkingOptionsForModel(connection.providerType, modelId);
   const level = resolveThinkingLevel(connection, modelId, thinkingLevel);
@@ -523,7 +476,7 @@ function buildThinkingProviderOptions(
       // sweep keeps that tripwire armed.
       if (thinkingLevel === 'off') return {};
       const effort = level ?? 'max';
-      if (connection.models?.find((model) => model.id === modelId)?.apiProtocol === 'openai-chat') {
+      if (runtime.wire === 'openai-chat') {
         // The kimiCodingPlan provider-options namespace is the
         // openai-compatible adapter name; ai-sdk resolves its camelCase
         // alias to the kimi-coding-plan schema key (reasoning_effort).
@@ -599,7 +552,7 @@ function buildThinkingProviderOptions(
       };
     }
     case 'openai': {
-      const usesResponses = resolveModelRuntime(connection, modelId).wire === 'openai-responses';
+      const usesResponses = runtime.wire === 'openai-responses';
       const reasoningEffort =
         level === 'off'
           ? 'none'
@@ -622,9 +575,7 @@ function buildThinkingProviderOptions(
       };
     case 'xai':
     case 'xai-oauth':
-      // Only grok-4.5 needs the Responses reasoning extras; every other xAI
-      // model serves the plain OpenAI-compatible chat wire handled below.
-      if (modelId === 'grok-4.5') {
+      if (runtime.wire === 'openai-responses') {
         return {
           openai: {
             store: false,
@@ -635,7 +586,7 @@ function buildThinkingProviderOptions(
           },
         };
       }
-      return buildFamilyWire(connection, modelId, level, thinkingOptions, thinkingLevel);
+      return buildFamilyWire(connection, modelId, level, thinkingOptions, thinkingLevel, runtime);
     case 'volcengine-ark':
       return {
         [toCamelCase(connection.providerType)]: {
@@ -680,7 +631,7 @@ function buildThinkingProviderOptions(
     // above (level is defined only when metadata declares it) is what makes
     // this safe to generalize: undeclared models never reach the wire.
     default:
-      return buildFamilyWire(connection, modelId, level, thinkingOptions, thinkingLevel);
+      return buildFamilyWire(connection, modelId, level, thinkingOptions, thinkingLevel, runtime);
   }
 }
 
@@ -688,8 +639,8 @@ function withParallelToolCallOptions(
   connection: RuntimeExecutionConnection,
   modelId: string,
   options: SharedV4ProviderOptions,
+  runtime: ResolvedModelRuntime,
 ): SharedV4ProviderOptions {
-  const runtime = resolveModelRuntime(connection, modelId);
   if (runtime.parallelToolCalls === undefined) return options;
 
   let providerKey: string;
@@ -697,16 +648,9 @@ function withParallelToolCallOptions(
   if (runtime.adapter.kind === 'openai' || runtime.adapter.kind === 'openai-codex') {
     providerKey = 'openai';
     optionKey = 'parallelToolCalls';
-  } else if (runtime.adapter.kind === 'github-copilot') {
-    if (runtime.wire === 'anthropic-messages') return options;
-    providerKey = runtime.wire === 'openai-responses' ? 'openai' : 'githubCopilot';
-    optionKey = runtime.wire === 'openai-responses' ? 'parallelToolCalls' : 'parallel_tool_calls';
   } else if (runtime.adapter.kind === 'openai-compatible') {
     if (runtime.wire === 'openai-responses') {
-      if (
-        runtime.reasoningReplay.kind !== 'responses' ||
-        runtime.reasoningReplay.contract.adapter !== 'openai'
-      ) {
+      if (runtime.reasoningReplay.contract.adapter !== 'openai') {
         return options;
       }
       providerKey = 'openai';
@@ -735,8 +679,9 @@ function buildFamilyWire(
   level: ThinkingLevel | undefined,
   thinkingOptions: ThinkingOptions | undefined,
   requestedLevel: ThinkingLevel | undefined,
+  runtime: ResolvedModelRuntime,
 ): SharedV4ProviderOptions {
-  const { adapter, wire, reasoningReplay } = resolveModelRuntime(connection, modelId);
+  const { adapter, wire, reasoningReplay } = runtime;
   const explicitReasoningEffort = level ? (level === 'off' ? 'none' : level) : undefined;
   const serviceTier =
     wire === 'openai-responses' &&
@@ -750,9 +695,6 @@ function buildFamilyWire(
   // consumes a provider-native reasoningEffort through the same namespace,
   // keyed by the provider name getAIModel passes to createOpenResponses.
   if (wire === 'openai-responses') {
-    if (reasoningReplay.kind !== 'responses') {
-      throw new Error('Responses wire requires a Responses continuation contract');
-    }
     // Connection-aware: a relay model's declared variants count too.
     const reasons = thinkingVariantsForConnection(connection, modelId).length > 0;
     if (reasoningReplay.contract.adapter === 'open-responses') {
@@ -834,16 +776,6 @@ function buildFamilyWire(
             ? { thinking: { type: 'disabled' as const } }
             : {},
       };
-    case 'github-copilot': {
-      // Copilot routes per account-declared model protocol (mirrors the
-      // getAIModel case), defaulting to its OpenAI-compatible chat wire. Its
-      // Responses protocol is answered by the wire branch above.
-      const copilotProtocol = connection.models?.find((model) => model.id === modelId)?.apiProtocol;
-      if (copilotProtocol === 'anthropic-messages') {
-        return level !== 'off' ? { anthropic: { effort: level } } : {};
-      }
-      return { githubCopilot: { reasoningEffort: explicitReasoningEffort } };
-    }
     default:
       return {};
   }

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -107,7 +107,8 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
         ...(adapter.auth === 'bearer' ? { authToken: apiKey } : { apiKey }),
         baseURL,
         fetch: requestFetch,
-        headers: { 'anthropic-beta': ANTHROPIC_BETA },
+        headers:
+          adapter.includeBetaHeaders === false ? undefined : { 'anthropic-beta': ANTHROPIC_BETA },
       }).chat(modelId);
 
     case 'openai-codex':

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -280,6 +280,13 @@ async function fetchProviderModelsStrict(
         .filter((model) => discovery.filter !== 'language-models' || model.type === 'language')
         .map(toModelInfo)
         .filter((model): model is ModelInfo => model !== null);
+      if (discovery.modelProtocols === 'commandcode') {
+        for (const model of models) {
+          model.apiProtocol = /^(?:anthropic\/)?claude-/i.test(model.id)
+            ? 'anthropic-messages'
+            : 'openai-chat';
+        }
+      }
       return filterDiscoveredModels(models, discovery.filter);
     }
     case 'google': {

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -282,9 +282,9 @@ async function fetchProviderModelsStrict(
         .filter((model): model is ModelInfo => model !== null);
       if (discovery.modelProtocols === 'commandcode') {
         for (const model of models) {
-          model.apiProtocol = /^(?:anthropic\/)?claude-/i.test(model.id)
-            ? 'anthropic-messages'
-            : 'openai-chat';
+          if (/^(?:anthropic\/)?claude-/i.test(model.id)) {
+            model.apiProtocol = 'anthropic-messages';
+          }
         }
       }
       return filterDiscoveredModels(models, discovery.filter);

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -21,15 +21,19 @@ import {
   PROVIDER_REGISTRY,
   effectiveBaseUrl,
   type ModelInfo,
-  type ProviderRuntimeAdapter,
   type ProviderType,
 } from '@maka/core/llm-connections';
 import {
   lookupModelMetadata,
-  lookupModelProviderOverride,
+  lookupModelRuntimeOverride,
   openAiAdapterApiProtocol,
 } from '@maka/core/model-metadata';
 import { isRetiredProvider } from '@maka/core/provider-registry';
+import {
+  anthropicV1BaseUrl,
+  googleV1BetaBaseUrl,
+  openAiResponsesBaseUrl,
+} from './provider-urls.js';
 import { resolveApplyPatchProfile, type ApplyPatchProfile } from './apply-patch-profile.js';
 import {
   resolveRuntimeProviderAdapter,
@@ -51,15 +55,38 @@ export type ReasoningReplayContract =
   | { kind: 'openai-chat-plaintext'; requestField: 'observed' | 'reasoning' }
   | { kind: 'responses'; contract: RuntimeProviderResponsesContract };
 
-export interface ResolvedModelRuntime {
-  adapter: RuntimeProviderAdapter;
+type ModelRuntimeCall =
+  | {
+      wire: 'anthropic-messages';
+      adapter: Extract<RuntimeProviderAdapter, { kind: 'anthropic' }>;
+      reasoningReplay: { kind: 'anthropic-signed' };
+    }
+  | {
+      wire: 'openai-chat';
+      adapter: Extract<RuntimeProviderAdapter, { kind: 'openai' | 'openai-compatible' }>;
+      reasoningReplay: Extract<ReasoningReplayContract, { kind: 'none' | 'openai-chat-plaintext' }>;
+    }
+  | {
+      wire: 'openai-responses';
+      adapter: Extract<
+        RuntimeProviderAdapter,
+        { kind: 'openai' | 'openai-compatible' | 'openai-codex' }
+      >;
+      reasoningReplay: Extract<ReasoningReplayContract, { kind: 'responses' }>;
+    }
+  | {
+      wire: 'google-generate';
+      adapter: Extract<RuntimeProviderAdapter, { kind: 'google' }>;
+      reasoningReplay: { kind: 'none' };
+    }
+  | {
+      wire: 'cohere-v2';
+      adapter: Extract<RuntimeProviderAdapter, { kind: 'cohere' }>;
+      reasoningReplay: { kind: 'none' };
+    };
+
+export type ResolvedModelRuntime = ModelRuntimeCall & {
   baseUrl: string;
-  /** Account-advertised request wire for adapters that route per model. */
-  apiProtocol?: ModelInfo['apiProtocol'];
-  /** Effective wire after account, adapter, and model defaults are resolved. */
-  wire: ModelRuntimeWire;
-  /** Durable reasoning replay semantics carried by that wire. */
-  reasoningReplay: ReasoningReplayContract;
   /** Effective parallel-tool-call support after model facts and wire defaults are resolved. */
   parallelToolCalls?: boolean;
   /** Provider-options namespace used by durable plaintext-summary replay. */
@@ -68,7 +95,7 @@ export interface ResolvedModelRuntime {
   responsesReplayProfile?: string;
   /** Effective ApplyPatch contract after provider, model, and request wire are resolved. */
   applyPatchProfile: ApplyPatchProfile | null;
-}
+};
 
 export interface ModelRuntimeConnection {
   readonly slug?: string;
@@ -81,64 +108,58 @@ export function resolveModelRuntime(
   connection: ModelRuntimeConnection,
   modelId: string,
 ): ResolvedModelRuntime {
-  // Ahead of the override lookup: an override builds its own active adapter,
-  // so consulting it first would let a per-model entry hand a retired provider
-  // a working adapter and skip the `unavailable` refusal below entirely. No
-  // such entry exists today, but that table is generated from an external
-  // source — one row should not be able to undo a retirement.
+  // Model metadata cannot reactivate a retired provider.
   if (isRetiredProvider(connection.providerType)) {
     throw new Error(
       `"${connection.providerType}" is retired and can no longer resolve a model runtime.`,
     );
   }
-  const override = lookupModelProviderOverride(connection.providerType, modelId);
+  const override = lookupModelRuntimeOverride(connection.providerType, modelId);
   const defaults = PROVIDER_REGISTRY[connection.providerType];
-  // Unknown providerType with no per-model override → can't resolve an adapter.
-  // Throw a clear error rather than crashing on `.runtimeAdapter`. Mirrors
-  // `isRealConnection` in @maka/core/connection-readiness.ts.
   if (!override && !defaults) {
     throw new Error(
       `Unknown provider type "${connection.providerType}"; cannot resolve model runtime.`,
     );
   }
   const apiProtocol = connection.models?.find((model) => model.id === modelId)?.apiProtocol;
-  if (
-    connection.providerType === 'kimi-coding-plan' &&
-    apiProtocol !== undefined &&
-    apiProtocol !== 'anthropic-messages' &&
-    apiProtocol !== 'openai-chat'
-  ) {
-    throw new Error(
-      `Kimi Coding Plan protocol must be openai-chat or anthropic-messages, received ${apiProtocol}`,
-    );
-  }
-  const baseAdapter: ProviderRuntimeAdapter =
-    connection.providerType === 'kimi-coding-plan' && apiProtocol === 'openai-chat'
-      ? ({
-          kind: 'openai-compatible',
-          name: 'provider',
-          includeUsage: true,
-        } as const)
-      : override
-        ? runtimeAdapterOverride(override.npm)
-        : defaults.runtimeAdapter;
-  const adapter = resolveRuntimeProviderAdapter(baseAdapter);
+  const baseAdapter = resolveRuntimeProviderAdapter(override?.adapter ?? defaults.runtimeAdapter);
+  const calls = adapterCalls(baseAdapter);
+  const preferred = openAiAdapterApiProtocol(modelId, connection.providerType);
+  const defaultCall = calls.find((call) => call.wire === preferred) ?? calls[0]!;
+  const declared = apiProtocol ? defaults.protocolAdapters?.[apiProtocol] : undefined;
+  const call =
+    apiProtocol === undefined
+      ? defaultCall
+      : (calls.find((candidate) => candidate.wire === apiProtocol) ??
+        (declared
+          ? adapterCalls(resolveRuntimeProviderAdapter(declared)).find(
+              (candidate) => candidate.wire === apiProtocol,
+            )
+          : undefined) ??
+        adapterCalls(resolveRuntimeProviderAdapter(defaults.runtimeAdapter)).find(
+          (candidate) => candidate.wire === apiProtocol,
+        ));
+  if (!call)
+    throw new Error(`${defaults.label} does not support ${apiProtocol} for model ${modelId}`);
+  const { adapter, wire, reasoningReplay: replay } = call;
   const configuredBaseUrl = connection.baseUrl?.trim();
   const resolvedBaseUrl = configuredBaseUrl
     ? effectiveBaseUrl(connection)
-    : (override?.api ?? effectiveBaseUrl(connection));
-  const wire = resolveModelRuntimeWire(connection.providerType, modelId, adapter, apiProtocol);
-  const parallelToolCalls = resolveParallelToolCalls(connection, modelId, adapter);
-  const replay = reasoningReplayContract(adapter, wire);
+    : ((calls.includes(call) ? override?.baseUrl : undefined) ?? effectiveBaseUrl(connection));
+  const baseUrl =
+    adapter.kind === 'anthropic' && adapter.normalizeBaseUrl
+      ? anthropicV1BaseUrl(resolvedBaseUrl)
+      : adapter.kind === 'google' && adapter.normalizeBaseUrl !== false
+        ? googleV1BetaBaseUrl(resolvedBaseUrl)
+        : adapter.kind === 'openai-compatible' && adapter.normalizeBaseUrl
+          ? anthropicV1BaseUrl(resolvedBaseUrl)
+          : wire === 'openai-responses' && resolvedBaseUrl
+            ? openAiResponsesBaseUrl(resolvedBaseUrl)
+            : resolvedBaseUrl;
+  const parallelToolCalls = resolveParallelToolCalls(connection, modelId, baseAdapter);
   return {
-    adapter,
-    baseUrl:
-      connection.providerType === 'kimi-coding-plan' && apiProtocol === 'openai-chat'
-        ? kimiOpenAiBaseUrl(resolvedBaseUrl)
-        : resolvedBaseUrl,
-    ...(apiProtocol ? { apiProtocol } : {}),
-    wire,
-    reasoningReplay: replay,
+    ...call,
+    baseUrl,
     ...(parallelToolCalls === undefined ? {} : { parallelToolCalls }),
     ...(replay.kind === 'responses' &&
     replay.contract.adapter === 'open-responses' &&
@@ -176,13 +197,6 @@ function resolveParallelToolCalls(
   return adapter.kind === 'openai' || adapter.kind === 'openai-codex' ? true : undefined;
 }
 
-export function modelUsesAnthropicMessages(
-  connection: ModelRuntimeConnection,
-  modelId: string,
-): boolean {
-  return resolveModelRuntime(connection, modelId).wire === 'anthropic-messages';
-}
-
 /** Native OpenAI lanes keep mutable continuation state inside ModelAdapter. */
 export function modelUsesNativeOpenAiResponses(
   connection: ModelRuntimeConnection,
@@ -194,92 +208,62 @@ export function modelUsesNativeOpenAiResponses(
   );
 }
 
-function resolveModelRuntimeWire(
-  providerType: ProviderType,
-  modelId: string,
-  adapter: RuntimeProviderAdapter,
-  apiProtocol: ModelInfo['apiProtocol'] | undefined,
-): ModelRuntimeWire {
+function adapterCalls(adapter: RuntimeProviderAdapter): ModelRuntimeCall[] {
   switch (adapter.kind) {
     case 'anthropic':
-      return 'anthropic-messages';
-    case 'unavailable':
-      // Reached only if something selected a retired provider despite the
-      // pickers filtering it out; failing here beats sending on a wire we
-      // cannot name.
-      throw new Error('This provider has no Runtime adapter and cannot resolve a wire.');
-    case 'openai-codex':
-      return 'openai-responses';
-    case 'github-copilot':
-      return apiProtocol === 'anthropic-messages'
-        ? 'anthropic-messages'
-        : apiProtocol === 'openai-responses'
-          ? 'openai-responses'
-          : 'openai-chat';
-    case 'openai':
-      return (adapter.apiProtocol ??
-        apiProtocol ??
-        openAiAdapterApiProtocol(modelId, providerType)) === 'openai-responses'
-        ? 'openai-responses'
-        : 'openai-chat';
-    case 'openai-compatible':
-      return adapter.responses !== undefined &&
-        (apiProtocol ?? openAiAdapterApiProtocol(modelId, providerType)) === 'openai-responses'
-        ? 'openai-responses'
-        : 'openai-chat';
+      return [
+        { adapter, wire: 'anthropic-messages', reasoningReplay: { kind: 'anthropic-signed' } },
+      ];
     case 'google':
-      return 'google-generate';
+      return [{ adapter, wire: 'google-generate', reasoningReplay: { kind: 'none' } }];
     case 'cohere':
-      return 'cohere-v2';
-  }
-}
-
-function reasoningReplayContract(
-  adapter: RuntimeProviderAdapter,
-  wire: ModelRuntimeWire,
-): ReasoningReplayContract {
-  switch (wire) {
-    case 'anthropic-messages':
-      return { kind: 'anthropic-signed' };
-    case 'openai-responses':
-      return { kind: 'responses', contract: responsesContract(adapter) };
-    case 'openai-chat':
-      return adapter.kind === 'openai-compatible' || adapter.kind === 'github-copilot'
-        ? {
+      return [{ adapter, wire: 'cohere-v2', reasoningReplay: { kind: 'none' } }];
+    case 'openai-codex':
+      return [
+        {
+          adapter,
+          wire: 'openai-responses',
+          reasoningReplay: {
+            kind: 'responses',
+            contract: { adapter: 'openai', reasoningReplay: 'encrypted-content' },
+          },
+        },
+      ];
+    case 'openai': {
+      const calls: ModelRuntimeCall[] = [];
+      if (adapter.apiProtocol !== 'openai-responses')
+        calls.push({ adapter, wire: 'openai-chat', reasoningReplay: { kind: 'none' } });
+      if (adapter.apiProtocol !== 'openai-chat')
+        calls.push({
+          adapter,
+          wire: 'openai-responses',
+          reasoningReplay: {
+            kind: 'responses',
+            contract: { adapter: 'openai', reasoningReplay: 'encrypted-content' },
+          },
+        });
+      return calls;
+    }
+    case 'openai-compatible': {
+      const calls: ModelRuntimeCall[] = [
+        {
+          adapter,
+          wire: 'openai-chat',
+          reasoningReplay: {
             kind: 'openai-chat-plaintext',
-            requestField:
-              adapter.kind === 'openai-compatible' &&
-              adapter.replayAssistantReasoningAs === 'reasoning'
-                ? 'reasoning'
-                : 'observed',
-          }
-        : { kind: 'none' };
-    case 'google-generate':
-    case 'cohere-v2':
-      return { kind: 'none' };
-  }
-}
-
-function responsesContract(adapter: RuntimeProviderAdapter): RuntimeProviderResponsesContract {
-  if (adapter.kind === 'openai-compatible' && adapter.responses) return adapter.responses;
-  return { adapter: 'openai', reasoningReplay: 'encrypted-content' };
-}
-
-function kimiOpenAiBaseUrl(baseUrl: string): string {
-  return `${baseUrl.replace(/\/+$/, '').replace(/\/v1$/i, '')}/v1`;
-}
-
-function runtimeAdapterOverride(packageName: string): ProviderRuntimeAdapter {
-  switch (packageName) {
-    case '@ai-sdk/anthropic':
-      return { kind: 'anthropic', auth: 'api-key', normalizeBaseUrl: true };
-    case '@ai-sdk/google':
-      return { kind: 'google', normalizeBaseUrl: false };
-    case '@ai-sdk/openai':
-      return { kind: 'openai' };
-    case '@ai-sdk/openai-compatible':
-      return { kind: 'openai-compatible', name: 'provider' };
-    default:
-      throw new Error(`models.dev model runtime package ${packageName} is unsupported`);
+            requestField: adapter.replayAssistantReasoningAs ?? 'observed',
+          },
+        },
+      ];
+      if (adapter.responses)
+        calls.push({
+          adapter,
+          wire: 'openai-responses',
+          reasoningReplay: { kind: 'responses', contract: adapter.responses },
+        });
+      return calls;
+    }
+    case 'unavailable':
+      throw new Error('This provider has no Runtime adapter and cannot resolve a wire.');
   }
 }

--- a/packages/runtime/src/native-web-search-tool.ts
+++ b/packages/runtime/src/native-web-search-tool.ts
@@ -19,6 +19,7 @@
 
 import { z } from 'zod';
 import { resolveHostedWebSearchCapability } from '@maka/core/model-web-search';
+import { resolveModelRuntime } from './model-runtime.js';
 import type { HostedWebSearchAdapter } from '@maka/core/model-web-search';
 import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
 import type { WebSearchSettings } from '@maka/core/web-search';
@@ -88,6 +89,7 @@ export function routeWebSearchTools(input: {
       input.connection.providerType,
       input.connection.models,
       input.model,
+      resolveModelRuntime(input.connection, input.model).wire,
     );
     if (
       (firstSearchIndex >= 0 || input.allowAddNative === true) &&

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -20,6 +20,7 @@
 import { randomUUID } from 'node:crypto';
 import {
   PROVIDER_REGISTRY,
+  effectiveBaseUrl,
   providerDefaultsOf,
   providerFallbackModelIds,
   connectionModelsEnumerateAccount,
@@ -230,11 +231,11 @@ async function testConnectionModel(
   if (providerDefaultsOf(connection.providerType)?.runtimeAdapter.kind === 'unavailable') {
     return retiredProviderTestResult(connection.providerType);
   }
+  if (connection.providerType === 'github-copilot') {
+    return probeGitHubCopilot(effectiveBaseUrl(connection), secret, testModel, t0, fetchFn);
+  }
   const { adapter, baseUrl, wire } = resolveModelRuntime(connection, testModel);
   const requestHeaders = withOpenCodeSessionHeader(connection.providerType, sessionId);
-  if (connection.providerType === 'github-copilot') {
-    return probeGitHubCopilot(baseUrl, secret, testModel, t0, fetchFn);
-  }
 
   switch (adapter.kind) {
     case 'anthropic':

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -28,7 +28,7 @@ import {
   type ConnectionTestResult,
   type LlmConnection,
 } from '@maka/core/llm-connections';
-import { anthropicV1Url, googleApiUrl, openResponsesUrl } from './provider-urls.js';
+import { openResponsesUrl } from './provider-urls.js';
 import { resolveModelRuntime } from './model-runtime.js';
 import { fetchGitHubCopilotModels } from './model-fetcher.js';
 import {
@@ -232,22 +232,13 @@ async function testConnectionModel(
   }
   const { adapter, baseUrl, wire } = resolveModelRuntime(connection, testModel);
   const requestHeaders = withOpenCodeSessionHeader(connection.providerType, sessionId);
+  if (connection.providerType === 'github-copilot') {
+    return probeGitHubCopilot(baseUrl, secret, testModel, t0, fetchFn);
+  }
 
   switch (adapter.kind) {
     case 'anthropic':
-      return await probeAnthropic(
-        connection,
-        baseUrl,
-        secret,
-        testModel,
-        t0,
-        fetchFn,
-        requestHeaders,
-      );
-    case 'unavailable':
-      // Unreachable: the guard above returns first. The arm keeps the switch
-      // exhaustive so a newly retired provider cannot slip past it.
-      return retiredProviderTestResult(connection.providerType);
+      return await probeAnthropic(adapter, baseUrl, secret, testModel, t0, fetchFn, requestHeaders);
     case 'openai':
       return wire === 'openai-responses'
         ? await probeOpenAIResponses(baseUrl, secret, testModel, t0, fetchFn, requestHeaders)
@@ -276,8 +267,6 @@ async function testConnectionModel(
             timeoutMs,
             requestHeaders,
           );
-    case 'github-copilot':
-      return await probeGitHubCopilot(baseUrl, secret, testModel, t0, fetchFn);
     case 'google':
       return await probeGoogle(
         baseUrl,
@@ -367,7 +356,10 @@ function retiredProviderTestResult(providerType: string): ConnectionTestResult {
 }
 
 async function probeAnthropic(
-  connection: Pick<ConnectionEffectConnection, 'providerType'>,
+  adapter: Extract<
+    import('./provider-runtime-policy.js').RuntimeProviderAdapter,
+    { kind: 'anthropic' }
+  >,
   baseUrl: string,
   secret: string,
   model: string,
@@ -377,12 +369,15 @@ async function probeAnthropic(
 ): Promise<ConnectionTestResult> {
   const headers: Record<string, string> = {
     ...requestHeaders,
-    'x-api-key': secret,
+    ...(adapter.auth === 'bearer'
+      ? { authorization: `Bearer ${secret}` }
+      : { 'x-api-key': secret }),
     'anthropic-version': '2023-06-01',
     'content-type': 'application/json',
   };
 
-  const r = await fetchForConnectionEffect(fetchFn, anthropicV1Url(baseUrl, '/messages'), {
+  const url = `${stripTrailing(baseUrl)}/messages`;
+  const r = await fetchForConnectionEffect(fetchFn, url, {
     method: 'POST',
     headers,
     body: JSON.stringify({
@@ -482,9 +477,7 @@ async function probeGoogle(
   normalizeBaseUrl: boolean,
   fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ConnectionTestResult> {
-  const url = normalizeBaseUrl
-    ? googleApiUrl(baseUrl, `/models/${encodeURIComponent(model)}:generateContent`, apiKey)
-    : `${stripTrailing(baseUrl)}/models/${encodeURIComponent(model)}:generateContent`;
+  const url = `${stripTrailing(baseUrl)}/models/${encodeURIComponent(model)}:generateContent${normalizeBaseUrl ? `?key=${encodeURIComponent(apiKey)}` : ''}`;
   const r = await fetchForConnectionEffect(fetchFn, url, {
     method: 'POST',
     headers: {

--- a/scripts/sync-model-metadata.mjs
+++ b/scripts/sync-model-metadata.mjs
@@ -127,10 +127,12 @@ export async function main(argv = process.argv) {
   }
   lines.push('};', '');
   lines.push(
-    `export const GENERATED_MODELS_DEV_MODEL_PROVIDER_OVERRIDES: Record<${providerTypeUnion}, Record<string, { npm: string; api?: string }>> = {`,
+    `export const GENERATED_MODELS_DEV_MODEL_PROVIDER_OVERRIDES: Record<${providerTypeUnion}, Record<string, { adapter: import('./provider-registry.js').ProviderRuntimeAdapter; baseUrl?: string }>> = {`,
   );
   for (const [provider, overrides] of Object.entries(generatedModelProviderOverrides)) {
-    lines.push(`  ${JSON.stringify(provider)}: ${JSON.stringify(overrides)},`);
+    lines.push(
+      `  ${JSON.stringify(provider)}: ${JSON.stringify(normalizeRuntimeOverrides(overrides))},`,
+    );
   }
   lines.push('};', '');
   lines.push(
@@ -527,7 +529,12 @@ async function assertGeneratedOutputs(metadataPath, pricingPath, source) {
   );
   assert.deepEqual(
     metadataModule.GENERATED_MODELS_DEV_MODEL_PROVIDER_OVERRIDES,
-    source.projection.providerOverrides,
+    Object.fromEntries(
+      Object.entries(source.projection.providerOverrides).map(([provider, overrides]) => [
+        provider,
+        normalizeRuntimeOverrides(overrides),
+      ]),
+    ),
     `${metadataPath} is stale; run npm run sync:model-metadata`,
   );
   assert.deepEqual(
@@ -567,10 +574,27 @@ function toModelProviderOverride(providerId, modelId, override) {
       `models.dev model ${providerId}/${modelId} has an unsupported provider override`,
     );
   }
-  return {
-    npm: override.npm,
-    ...(override.api ? { api: override.api } : {}),
+  return { npm: override.npm, ...(override.api ? { api: override.api } : {}) };
+}
+
+function normalizeRuntimeOverrides(overrides) {
+  const adapters = {
+    '@ai-sdk/anthropic': { kind: 'anthropic', auth: 'api-key', normalizeBaseUrl: true },
+    '@ai-sdk/google': { kind: 'google', normalizeBaseUrl: false },
+    '@ai-sdk/openai': { kind: 'openai' },
+    '@ai-sdk/openai-compatible': { kind: 'openai-compatible', name: 'provider' },
   };
+  return Object.fromEntries(
+    Object.entries(overrides).map(([modelId, override]) => {
+      if (!Object.hasOwn(adapters, override.npm)) {
+        throw new Error(`models.dev model ${modelId} uses unsupported SDK ${override.npm}`);
+      }
+      return [
+        modelId,
+        { adapter: adapters[override.npm], ...(override.api ? { baseUrl: override.api } : {}) },
+      ];
+    }),
+  );
 }
 
 export function toPricing(providerType, modelId, model) {

--- a/scripts/sync-model-metadata.test.mjs
+++ b/scripts/sync-model-metadata.test.mjs
@@ -407,7 +407,7 @@ test('drift reports the projection sections that carry no model metadata', async
     const upstream = join(root, 'upstream.json');
     const snapshot = join(root, 'snapshot.json');
     const before = fixtureCatalog();
-    before.anthropic.models.model.provider = { npm: '@example/before' };
+    before.anthropic.models.model.provider = { npm: '@ai-sdk/anthropic' };
     await writeFile(committed, JSON.stringify(before));
     await main([
       'node',
@@ -425,7 +425,7 @@ test('drift reports the projection sections that carry no model metadata', async
     // metadata or its pricing, which is all the report used to compare.
     const after = JSON.parse(JSON.stringify(before));
     after.anthropic.name = 'Anthropic Renamed';
-    after.anthropic.models.model.provider = { npm: '@example/after' };
+    after.anthropic.models.model.provider = { npm: '@ai-sdk/google' };
     await writeFile(upstream, JSON.stringify(after));
 
     const { report } = await drift(['--snapshot', snapshot, '--refresh-input', upstream]);


### PR DESCRIPTION
## Summary

One connection can now route models through different supported protocols. For example, Command Code's discovered Claude models use Messages while its other models keep Chat Completions, using the same connection and credential. Unannotated compatible models still use the provider default.

The runtime resolves effective model facts before choosing a concrete SDK, endpoint, thinking parameters and replay contract. User overrides survive discovery refreshes; explicit protocols can override a static model SDK when the provider supports that protocol. Dedicated relay protocol boundaries remain enforced. Static models.dev SDK data is normalized during generation, without granting metadata hot refresh new execution privileges.

Command Code discovery stamps only recognized Claude IDs as Messages; unmatched IDs remain unannotated and retain the default Chat path. This preserves unknown facts rather than claiming automatic detection of future model IDs.

Copilot explicitly opts out of the generic Anthropic beta headers in its protocol adapter declaration, preserving its pre-refactor request behavior. Other Anthropic adapters retain their existing beta headers.

Kimi and Copilot use declared protocol adapters instead of separate dispatch branches. Downstream consumers share the resolved contract, and edge-model tests use independent wire expectations instead of copying resolution logic.

Fixes #4948. Includes the Command Code catalog/UI changes from #4943; that draft remains unchanged. These are one complete integration and should not be merged as competing implementations.

## Verification

- Review follow-up: Core/Runtime builds and 95 focused catalog, discovery, factory and conformance tests pass. Both regressions were observed before their fixes: unmatched IDs carried an explicit Chat stamp, and Copilot SDK requests included the two generic beta opt-ins. The tests also preserve default Chat/tool continuation, user overrides through refresh, bearer auth and native Anthropic beta headers. Format, lint and ASF header checks pass. No new live-provider test was performed for these follow-up changes.

- Core, Storage, Runtime and Runtime Host builds passed. Desktop typecheck and renderer build passed.
- 510 focused Core/Storage/Runtime tests passed. After final simplification, all 216 protocol, factory, conformance and matrix tests passed (overlaps the earlier set).
- All 65 affected Host tests passed. One child-process case initially timed out under the grouped run; the isolated test and the complete grouped rerun passed.
- All 15 metadata generator tests and 101 renderer architecture checker tests passed; renderer architecture validation passed against current main `b06eb02e`.
- Format, lint, ASF headers and diff whitespace checks passed.
- Independent review found a Copilot Claude probe URL regression; fixed at the account-probe boundary, reproduced with the old URL, and rechecked by the reviewer. That review reported no remaining findings in its scope.
- Regression tests exercised discovery → durable catalog → effective user overrides → actual SDK requests → tool-result continuation on both Chat and Messages. Protocol override and Grok thinking tests failed before their corresponding fixes.
- Live Command Code: discovered 67 models; DeepSeek completed a two-step Chat tool loop through Maka's model factory. Claude requests reached `/provider/v1/messages`, but the account returned HTTP 403 `MODEL_NOT_IN_PLAN`. No credentials were committed or copied into Maka settings.
- Live OpenCode Go, same account and connection: DeepSeek V4 Flash (Chat), MiniMax M2.7 (Messages), and GPT-5.6 Luna (Responses) each completed streaming tool-result continuation through ModelAdapter and the model factory, with two HTTP 200 requests, one tool execution and the exact expected final text. Streaming usage was populated.
- The additional live check exposed missing Go protocol declarations: Muse Spark 1.3 defaulted to Chat and failed; an explicit Responses setting was rejected locally. Declaring Go's two supported alternative protocols fixes that rejection. After the fix, Muse Spark 1.3 with explicit Responses and Qwen 3.8 Max with explicit Messages also completed the same streaming tool loop through the normal resolver. The targeted 216 tests, Core/Runtime builds, format and lint pass; independent review found no outstanding issues in this follow-up.
- OpenCode Go `/models` returns IDs without protocol fields. New IDs absent from bundled routing metadata still need explicit model facts or a metadata update; this change does not claim automatic protocol detection for every newly listed model.
- No full repository test run or full Desktop session E2E was performed. The reused catalog UI is unchanged from #4943's recorded light/dark acceptance.

## Remaining validation

- [ ] Complete a live Claude Messages tool loop with an account whose plan permits Claude. Local Messages SDK/tool/reasoning replay coverage and live OpenCode Go Messages tool loops pass; the Command Code account restriction remains unresolved.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented and tested the routing consolidation and performed an independent review. The included #4943 catalog work was originally authored with Maka and Codex. Preserve Generated-by trailers when squashing.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

