### PR TITLE
fix(runtime): propagate OpenCode Free session identity

### DIFF
--- a/packages/runtime/src/__tests__/opencode-session-header.test.ts
+++ b/packages/runtime/src/__tests__/opencode-session-header.test.ts
@@ -21,13 +21,16 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { OPENCODE_SESSION_HEADER, withOpenCodeSessionHeader } from '../opencode-session-header.js';
 
-describe('OpenCode Go session header', () => {
-  test('adds a trimmed stable session identity only for OpenCode Go', () => {
+describe('OpenCode session header', () => {
+  test('adds a trimmed stable session identity for OpenCode Go and Free', () => {
     assert.deepEqual(withOpenCodeSessionHeader('opencode-go', '  session-a  '), {
       [OPENCODE_SESSION_HEADER]: 'session-a',
     });
     assert.equal(withOpenCodeSessionHeader('opencode', 'session-a'), undefined);
     assert.equal(withOpenCodeSessionHeader('openai', 'session-a'), undefined);
+    assert.deepEqual(withOpenCodeSessionHeader('opencode-free', '  session-a  '), {
+      [OPENCODE_SESSION_HEADER]: 'session-a',
+    });
   });
 
   test('preserves an explicitly configured header case-insensitively', () => {
@@ -40,10 +43,16 @@ describe('OpenCode Go session header', () => {
       withOpenCodeSessionHeader('opencode-go', 'automatic-session', explicitHeaders),
       explicitHeaders,
     );
+    assert.equal(
+      withOpenCodeSessionHeader('opencode-free', 'automatic-session', explicitHeaders),
+      explicitHeaders,
+    );
   });
 
   test('does not add an empty session identity', () => {
     const headers = { 'X-Maka-Test': 'preserved' };
     assert.equal(withOpenCodeSessionHeader('opencode-go', '   ', headers), headers);
+    assert.equal(withOpenCodeSessionHeader('opencode-free', '   ', headers), headers);
+    assert.equal(withOpenCodeSessionHeader('opencode-free', undefined, headers), headers);
   });
 });

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -962,6 +962,36 @@ describe('models.dev provider conformance', () => {
     assert.deepEqual(requests[2]?.body.contents, [{ role: 'user', parts: [{ text: 'Hi' }] }]);
   });
 
+  test('OpenCode Free probes reuse identity across candidates and renew it per operation', async () => {
+    const sessions: Array<string | undefined> = [];
+    const server = await startJsonServer(async (request, response) => {
+      sessions.push(request.headers['x-opencode-session'] as string | undefined);
+      respondJson(response, sessions.length % 2 === 1 ? 429 : 200, {
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      });
+    });
+    const connection: LlmConnection = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free',
+      baseUrl: `${server.url}/zen/v1`,
+      defaultModel: 'nemotron-3-ultra-free',
+      enabledModelIds: ['nemotron-3-ultra-free', 'mimo-v2.5-free'],
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    assert.equal((await testConnection(connection, '')).ok, true);
+    assert.equal((await testConnection(connection, '')).ok, true);
+    assert.equal(sessions.length, 4);
+    for (const session of sessions) {
+      assert.match(session ?? '', /^[0-9a-f-]{36}$/);
+    }
+    assert.equal(sessions[0], sessions[1]);
+    assert.equal(sessions[2], sessions[3]);
+    assert.notEqual(sessions[0], sessions[2]);
+  });
+
   test('OpenCode Go connection probes identify every supported wire request', async () => {
     const requests: Array<{
       url: string;

--- a/packages/runtime/src/__tests__/responses-wire-contract.test.ts
+++ b/packages/runtime/src/__tests__/responses-wire-contract.test.ts
@@ -193,7 +193,7 @@ describe('responses wire contract', () => {
     assert.deepEqual(sessionHeaders, ['session-opencode-go']);
   });
 
-  test('sends the OpenCode Go session identity through Chat and Messages adapters', async () => {
+  test('sends OpenCode Go and Free session identities through their model adapters', async () => {
     const requests: Array<{ url: string; sessionHeader: string | null }> = [];
     const fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const request = new Request(url, init);
@@ -229,13 +229,18 @@ describe('responses wire contract', () => {
       });
     }) as typeof globalThis.fetch;
 
-    for (const modelId of ['kimi-k2.7-code', 'minimax-m3']) {
+    for (const [providerType, modelId] of [
+      ['opencode-go', 'kimi-k2.7-code'],
+      ['opencode-go', 'minimax-m3'],
+      ['opencode-free', 'nemotron-3-ultra-free'],
+      ['opencode-free', 'nemotron-3-ultra-free'],
+    ] as const) {
       const model = getAIModel({
-        connection: conn('opencode-go'),
+        connection: conn(providerType),
         apiKey: '[redacted]',
         modelId,
         fetch,
-        sessionId: 'session-opencode-go',
+        sessionId: `session-${providerType}`,
       });
       await model.doGenerate({
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'ping' }] }],
@@ -250,6 +255,14 @@ describe('responses wire contract', () => {
       {
         url: 'https://opencode.ai/zen/go/v1/messages',
         sessionHeader: 'session-opencode-go',
+      },
+      {
+        url: 'https://opencode.ai/zen/v1/chat/completions',
+        sessionHeader: 'session-opencode-free',
+      },
+      {
+        url: 'https://opencode.ai/zen/v1/chat/completions',
+        sessionHeader: 'session-opencode-free',
       },
     ]);
   });

--- a/packages/runtime/src/opencode-session-header.ts
+++ b/packages/runtime/src/opencode-session-header.ts
@@ -21,14 +21,19 @@ import type { ProviderType } from '@maka/core/llm-connections';
 
 export const OPENCODE_SESSION_HEADER = 'x-opencode-session';
 
-/** Adds OpenCode Go's session identity without overriding an explicit header. */
+/** Adds OpenCode Go/Free session identity without overriding an explicit header. */
 export function withOpenCodeSessionHeader(
   providerType: ProviderType,
   sessionId: string | undefined,
   headers?: Readonly<Record<string, string>>,
 ): Readonly<Record<string, string>> | undefined {
   const normalizedSessionId = sessionId?.trim();
-  if (providerType !== 'opencode-go' || !normalizedSessionId) return headers;
+  if (
+    (providerType !== 'opencode-go' && providerType !== 'opencode-free') ||
+    !normalizedSessionId
+  ) {
+    return headers;
+  }
   if (Object.keys(headers ?? {}).some((name) => name.toLowerCase() === OPENCODE_SESSION_HEADER)) {
     return headers;
   }

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -159,7 +159,10 @@ async function testConnectionStrict(
   if (!defaults) {
     return { ok: false, errorMessage: `Unknown provider type "${connection.providerType}"` };
   }
-  const sessionId = connection.providerType === 'opencode-go' ? randomUUID() : undefined;
+  const sessionId =
+    connection.providerType === 'opencode-go' || connection.providerType === 'opencode-free'
+      ? randomUUID()
+      : undefined;
   const auth = defaults.authKind;
   const secret = auth === 'none' ? '' : apiKey;
   const testModel = resolveConnectionTestModel(


### PR DESCRIPTION
## Summary

OpenCode Free requests omit `x-opencode-session` and can fail with HTTP 400 `MissingSessionID`. Extend the existing Go header handling to Free so inference sends the stable Maka Session identity. Connection Test creates one identity per operation and reuses it across candidate attempts. Explicit header overrides retain precedence.

This extends #4670. The snapshot-derived model inventory and manual model switching behavior are unchanged; #3449's quarantined-model cleanup is separate.

Fixes #4960

## Verification

- Before the fix, the helper regression returned no Free header and captured model-factory requests had a null session header. Both pass after the fix.
- 90 tests passed across session-header, provider-conformance, wire-contract, anonymous Free, and ModelAdapter suites. Coverage includes candidate-attempt identity reuse, a new identity for each Connection Test operation, and explicit header precedence.
- Repository lint, format, build, typecheck, Desktop/UI knip, ASF header audit, and diff whitespace checks passed.
- No live upstream inference or full repository test suite was run. Request-capture tests verify the missing-header fix, not upstream quota or other access restrictions.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex inspected the request paths, implemented the fix and regression tests, ran validation, and drafted this PR. The commit includes a `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
