### PR TITLE
fix(runtime-host): defer bounded storage maintenance until ready

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-composition.test.ts
@@ -70,6 +70,34 @@ const require = createRequire(import.meta.url);
 const FAKE_CONNECTION_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 const CONTEXT_OFFLOAD_DATABASE_NAME = 'context-offload.sqlite';
 
+test('production recovery leaves upgrade residue for explicitly started maintenance', async () => {
+  await withCompositionRoot(async ({ root, owner }) => {
+    const composition = await createExecutionRuntimeHostComposition(compositionContext(owner));
+    const directory = join(root, 'artifacts', 'retired');
+    const path = join(directory, 'orphan');
+    await mkdir(directory, { recursive: true });
+    await writeFile(path, 'old bytes');
+    const database = new DatabaseSync(join(root, 'runtime.sqlite'));
+    try {
+      database
+        .prepare('INSERT INTO artifact_upgrade_orphan_paths VALUES (?)')
+        .run('retired/orphan');
+      await composition.recover();
+      assert.equal((await stat(path)).size, 9);
+      composition.startMaintenance?.();
+      await waitFor(async () => {
+        return (
+          database.prepare('SELECT count(*) AS n FROM artifact_upgrade_orphan_paths').get()?.n === 0
+        );
+      });
+      await assert.rejects(stat(path), { code: 'ENOENT' });
+    } finally {
+      await composition.close();
+      database.close();
+    }
+  });
+});
+
 test('filesystem worker follows the candidate executable runtime', () => {
   assert.equal(runtimeHostFilesystemWorkerRuntime({ electron: '43.1.1' }), 'electron');
   assert.equal(runtimeHostFilesystemWorkerRuntime({}), 'node');

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -21,6 +21,7 @@ import { withTimeout } from '@maka/core/test-only/async-primitives';
 import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import { defineInteractiveRuntimeHostComposition } from '../server/host-composition.js';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { execFile, fork, type ChildProcess } from 'node:child_process';
 import {
   chmod,
@@ -55,7 +56,7 @@ import {
   type DetachedCandidateLaunch,
   type DetachedCandidateInput,
 } from '../client/launcher.js';
-import { readHostRegistration } from '../control/registration.js';
+import { readHostRegistration, RUNTIME_HOST_REGISTRATION_FILE } from '../control/registration.js';
 import {
   readCandidateStartupDiagnostic,
   writeCandidateStartupDiagnostic,
@@ -836,6 +837,7 @@ describe('non-serving Runtime Host kernel', () => {
       const factoryReleased = new Promise<void>((resolve) => {
         releaseFactory = resolve;
       });
+      let maintenanceStarts = 0;
       const unavailable = async () =>
         ({
           ok: false,
@@ -866,6 +868,13 @@ describe('non-serving Runtime Host kernel', () => {
             },
             beginDrain() {},
             async recover() {},
+            startMaintenance() {
+              const registration = JSON.parse(
+                readFileSync(join(owner.controlDirectory, RUNTIME_HOST_REGISTRATION_FILE), 'utf8'),
+              );
+              assert.equal(registration.state, 'ready');
+              maintenanceStarts += 1;
+            },
             async close() {},
           };
         }),
@@ -877,6 +886,7 @@ describe('non-serving Runtime Host kernel', () => {
         const registration = await readHostRegistration(owner.controlDirectory);
         assert.ok(registration);
         assert.equal(registration.state, 'recovering');
+        assert.equal(maintenanceStarts, 0);
         transport = new FramedTransport(await openSocket(registration.endpoint));
         await writeClientFrame(transport, {
           kind: 'hello',
@@ -916,6 +926,7 @@ describe('non-serving Runtime Host kernel', () => {
         host = await hostTask.catch(() => undefined);
         await host?.close().catch(() => undefined);
       }
+      assert.equal(maintenanceStarts, 1);
     });
   });
 
@@ -1525,6 +1536,7 @@ describe('non-serving Runtime Host kernel', () => {
           lifecycle.push('factory-return');
           return testComposition({
             beginDrain: () => lifecycle.push('begin-drain'),
+            startMaintenance: () => lifecycle.push('maintenance'),
             recover: async () => {
               lifecycle.push('recover');
             },
@@ -3350,7 +3362,9 @@ describe('non-serving Runtime Host kernel', () => {
 });
 
 function testComposition(
-  overrides: Partial<Pick<RuntimeHostComposition, 'beginDrain' | 'recover' | 'close'>> = {},
+  overrides: Partial<
+    Pick<RuntimeHostComposition, 'beginDrain' | 'recover' | 'close' | 'startMaintenance'>
+  > = {},
 ): RuntimeHostComposition {
   return {
     handlers: createUnavailableDomainOperationHandlers(),

--- a/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
@@ -167,7 +167,7 @@ describe('Host Session retirement coordinator', () => {
     });
   });
 
-  test('retires context refs before draining every physical garbage batch', async () => {
+  test('retires only its own context refs without draining global garbage', async () => {
     const contextActions: string[] = [];
     let garbageBatches = 0;
     await purgeSessionSidecars(
@@ -179,10 +179,12 @@ describe('Host Session retirement coordinator', () => {
             contextActions.push(`retire:${sessionId}`);
             return { releasedReferences: 1, releasedLogicalBytes: 10 };
           },
-          collectGarbage: async (input) => {
-            contextActions.push(`collect:${input.maxBlobs}`);
-            garbageBatches += 1;
-            return { deletedBlobs: 1, deletedBytes: 10, hasMore: garbageBatches < 3 };
+          ...{
+            collectGarbage: async (input: { maxBlobs: number }) => {
+              contextActions.push(`collect:${input.maxBlobs}`);
+              garbageBatches += 1;
+              return { deletedBlobs: 1, deletedBytes: 10, hasMore: garbageBatches < 3 };
+            },
           },
         },
         purgeOperationalState: async () => {},
@@ -190,12 +192,8 @@ describe('Host Session retirement coordinator', () => {
       'session-context',
     );
 
-    assert.deepEqual(contextActions, [
-      'retire:session-context',
-      'collect:64',
-      'collect:64',
-      'collect:64',
-    ]);
+    assert.deepEqual(contextActions, ['retire:session-context']);
+    assert.equal(garbageBatches, 0);
   });
 
   test('rejects ordinary archive and remove operations for the Coordination Session', async () => {
@@ -1384,7 +1382,6 @@ async function withHarness(
           actions.retiredContext.push(sessionId);
           return { releasedReferences: 0, releasedLogicalBytes: 0 };
         },
-        collectGarbage: async () => ({ deletedBlobs: 0, deletedBytes: 0, hasMore: false }),
       },
       purgeOperationalState: async (sessionId) => {
         actions.purgedOperationalState.push(sessionId);

--- a/packages/runtime-host/src/__tests__/storage-maintenance.test.ts
+++ b/packages/runtime-host/src/__tests__/storage-maintenance.test.ts
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { HostStorageMaintenance } from '../server/storage-maintenance.js';
+
+// Settle async lane continuations without advancing the next scheduled timer.
+async function settle(): Promise<void> {
+  for (let i = 0; i < 12; i += 1) await Promise.resolve();
+}
+
+test('maintenance waits for start, yields between bounded batches, and stops on close', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'], now: 1_000 });
+  const cursors: (string | undefined)[] = [];
+  let collections = 0;
+  const maintenance = new HostStorageMaintenance({
+    artifacts: {
+      reclaimUpgradeResidue: async (input) => {
+        assert.equal(input.maxPaths, 64);
+        cursors.push(input.after);
+        return {
+          nextAfter: cursors.length === 1 ? 'page-1' : null,
+          processedPaths: 64,
+          failedPaths: 0,
+        };
+      },
+    },
+    contextOffload: {
+      collectGarbage: async (input) => {
+        assert.equal(input.maxBlobs, 64);
+        assert.equal(input.maxBytes, 16 * 1024 * 1024);
+        assert.equal(input.olderThan, Date.now());
+        collections += 1;
+        return { deletedBlobs: 64, deletedBytes: 1024, hasMore: true };
+      },
+    },
+    onError: assert.fail,
+  });
+  t.mock.timers.tick(60_000);
+  await settle();
+  assert.equal(collections, 0);
+  maintenance.start();
+  maintenance.start();
+  assert.equal(collections, 0);
+  t.mock.timers.tick(100);
+  await settle();
+  assert.equal(collections, 1);
+  assert.deepEqual(cursors, [undefined]);
+  t.mock.timers.tick(99);
+  await settle();
+  assert.equal(collections, 1);
+  t.mock.timers.tick(1);
+  await settle();
+  assert.equal(collections, 2);
+  assert.deepEqual(cursors, [undefined, 'page-1']);
+  await maintenance.close();
+  maintenance.start();
+  t.mock.timers.tick(60_000);
+  await settle();
+  assert.equal(collections, 2);
+});
+
+test('failed lanes back off independently, retry, and reset after success', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let attempts = 0;
+  let pages = 0;
+  const errors: string[] = [];
+  const maintenance = new HostStorageMaintenance({
+    artifacts: {
+      reclaimUpgradeResidue: async () => {
+        pages += 1;
+        return { nextAfter: String(pages), processedPaths: 64, failedPaths: 0 };
+      },
+    },
+    contextOffload: {
+      collectGarbage: async () => {
+        attempts += 1;
+        if (attempts < 3) throw new Error('disk failure');
+        return { deletedBlobs: 0, deletedBytes: 0, hasMore: false };
+      },
+    },
+    onError: (name) => {
+      errors.push(name);
+    },
+  });
+  maintenance.start();
+  t.mock.timers.tick(100);
+  await settle();
+  assert.equal(attempts, 1);
+  t.mock.timers.tick(999);
+  await settle();
+  assert.equal(attempts, 1);
+  assert.ok(pages > 1);
+  t.mock.timers.tick(1);
+  await settle();
+  assert.equal(attempts, 2);
+  t.mock.timers.tick(1999);
+  await settle();
+  assert.equal(attempts, 2);
+  t.mock.timers.tick(1);
+  await settle();
+  assert.equal(attempts, 3);
+  assert.equal(errors.length, 2);
+  t.mock.timers.tick(60_000);
+  await settle();
+  assert.equal(attempts, 4);
+  await maintenance.close();
+});
+
+test('close waits only for an admitted batch and never starts another one', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let release!: () => void;
+  const blocked = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let calls = 0;
+  const maintenance = new HostStorageMaintenance({
+    artifacts: {
+      reclaimUpgradeResidue: async () => {
+        calls += 1;
+        await blocked;
+        return { nextAfter: 'more', processedPaths: 64, failedPaths: 0 };
+      },
+    },
+    onError: assert.fail,
+  });
+  maintenance.start();
+  t.mock.timers.tick(100);
+  await settle();
+  let closed = false;
+  const closing = maintenance.close().then(() => {
+    closed = true;
+  });
+  await settle();
+  assert.equal(closed, false);
+  release();
+  await closing;
+  t.mock.timers.tick(60_000);
+  await settle();
+  assert.equal(calls, 1);
+});
+
+test('failed paths do not pin the pagination cursor, and another sweep retries them', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const cursors: (string | undefined)[] = [];
+  const maintenance = new HostStorageMaintenance({
+    artifacts: {
+      reclaimUpgradeResidue: async (input) => {
+        cursors.push(input.after);
+        return {
+          nextAfter: cursors.length === 1 ? 'failed-path' : null,
+          processedPaths: 1,
+          failedPaths: 1,
+        };
+      },
+    },
+    onError: () => {
+      throw new Error('broken logger');
+    },
+  });
+  maintenance.start();
+  t.mock.timers.tick(100);
+  await settle();
+  t.mock.timers.tick(100);
+  await settle();
+  t.mock.timers.tick(60_000);
+  await settle();
+  assert.deepEqual(cursors, [undefined, 'failed-path', undefined]);
+  await maintenance.close();
+});

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -169,6 +169,7 @@ import { SessionAdmissionGate } from './session-admission-gate.js';
 import { HostSessionCatalogCoordinator } from './session-catalog-coordinator.js';
 import { HostWorkspaceResolver } from './workspace-resolver.js';
 import { HostSessionRetirementCoordinator } from './session-retirement-coordinator.js';
+import { HostStorageMaintenance } from './storage-maintenance.js';
 import { HostSessionRevisionCoordinator } from './session-revision-coordinator.js';
 import { HostSessionEffectCoordinator } from './session-effect-coordinator.js';
 import { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
@@ -309,12 +310,6 @@ export async function createExecutionRuntimeHostComposition(
               throw new Error('Context-offload Store is unavailable during Session retirement', {
                 cause: storage.contextOffloadUnavailable?.cause,
               });
-            },
-            collectGarbage: async (): Promise<never> => {
-              throw new Error(
-                'Context-offload Store is unavailable during context garbage collection',
-                { cause: storage.contextOffloadUnavailable?.cause },
-              );
             },
           }
         : undefined;
@@ -1784,7 +1779,18 @@ export async function createExecutionRuntimeHostComposition(
       context.requestDrain,
     );
     let recoverySessions: Awaited<ReturnType<typeof stores.sessionStore.listForRecovery>> = [];
+    const storageMaintenance = new HostStorageMaintenance({
+      artifacts: openedArtifactStore,
+      contextOffload: openedContextOffloadStore,
+      onError: (name, error) =>
+        console.error(`[runtime-host] ${name} will retry: ${generalizedErrorMessage(error)}`),
+    });
     domainModules = [
+      createRuntimeHostDomainModule({
+        id: 'storage-maintenance',
+        drain: [() => storageMaintenance.beginDrain()],
+        close: [() => storageMaintenance.close()],
+      }),
       createRuntimeHostDomainModule({
         id: 'plugin-platform',
         handlers: [pluginPlatformCoordinator.handlers],
@@ -1852,18 +1858,7 @@ export async function createExecutionRuntimeHostComposition(
           configuration.handlers,
         ],
         recovery: {
-          state: async () => {
-            await skills.recover();
-            try {
-              await openedArtifactStore.reclaimUpgradeResidue();
-            } catch (error) {
-              // Leftover bytes are not worth refusing to start over; the next
-              // start tries again.
-              console.error(
-                `[runtime-host] upgrade residue could not be reclaimed: ${generalizedErrorMessage(error)}`,
-              );
-            }
-          },
+          state: () => skills.recover(),
         },
         drain: [
           () => connectionEffects.beginDrain(),
@@ -2067,6 +2062,7 @@ export async function createExecutionRuntimeHostComposition(
       },
       beginDrain,
       recover,
+      startMaintenance: () => storageMaintenance.start(),
       close,
     };
   } catch (error) {

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -148,6 +148,8 @@ export interface RuntimeHostComposition {
   releaseConnection?(connectionId: string): void;
   beginDrain(): void;
   recover(): Promise<void>;
+  /** Synchronously schedules optional work after Ready registration is published. */
+  startMaintenance?(): void;
   close(): Promise<void>;
 }
 
@@ -401,6 +403,7 @@ export class RuntimeHostKernel {
     }
     this.#state = 'ready';
     await this.#publishRegistration();
+    if (!this.#shutdownRequested) this.#composition?.startMaintenance?.();
     this.#scheduleIdleIfNeeded();
   }
 

--- a/packages/runtime-host/src/server/session-retirement-coordinator.ts
+++ b/packages/runtime-host/src/server/session-retirement-coordinator.ts
@@ -123,10 +123,7 @@ export interface HostSessionRetirementCoordinatorOptions {
   readonly continuity: RetirementContinuity;
   readonly artifacts: Pick<InteractiveArtifactStoreWriter, 'purgeSessionArtifacts'>;
   readonly sessionTodo: Pick<InteractiveSessionTodoWriter, 'purgeSessionState'>;
-  readonly contextOffload?: Pick<
-    InteractiveContextOffloadWriter,
-    'retireSession' | 'collectGarbage'
-  >;
+  readonly contextOffload?: Pick<InteractiveContextOffloadWriter, 'retireSession'>;
   readonly purgeOperationalState: (sessionId: string) => Promise<void>;
   readonly purgeAgentGraphState: (sessionId: string) => Promise<void>;
   readonly worktrees?: Pick<SubagentWorktreeExecutor, 'retire'>;

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -111,7 +111,7 @@ export interface HostSessionRevisionCoordinatorOptions {
   readonly sessionTodo: InteractiveSessionTodoWriter;
   readonly contextOffload?: Pick<
     InteractiveContextOffloadWriter,
-    'copyReferences' | 'retireSession' | 'collectGarbage'
+    'copyReferences' | 'retireSession'
   >;
   readonly manager: SessionManager;
   readonly admission: SessionAdmissionGate;

--- a/packages/runtime-host/src/server/session-sidecar-purge.ts
+++ b/packages/runtime-host/src/server/session-sidecar-purge.ts
@@ -24,28 +24,8 @@ import type { InteractiveContextOffloadWriter } from '@maka/storage/context-offl
 export interface SessionSidecarPurgeAuthority {
   readonly artifacts: Pick<InteractiveArtifactStoreWriter, 'purgeSessionArtifacts'>;
   readonly sessionTodo: Pick<InteractiveSessionTodoWriter, 'purgeSessionState'>;
-  readonly contextOffload?: Pick<
-    InteractiveContextOffloadWriter,
-    'retireSession' | 'collectGarbage'
-  >;
+  readonly contextOffload?: Pick<InteractiveContextOffloadWriter, 'retireSession'>;
   readonly purgeOperationalState: (sessionId: string) => Promise<void>;
-}
-
-const CONTEXT_GARBAGE_BATCH_BLOBS = 64;
-
-async function retireContextSession(
-  contextOffload: Pick<InteractiveContextOffloadWriter, 'retireSession' | 'collectGarbage'>,
-  sessionId: string,
-): Promise<void> {
-  await contextOffload.retireSession(sessionId);
-  for (;;) {
-    const collected = await contextOffload.collectGarbage({
-      olderThan: Number.MAX_SAFE_INTEGER,
-      maxBlobs: CONTEXT_GARBAGE_BATCH_BLOBS,
-      maxBytes: Number.MAX_SAFE_INTEGER,
-    });
-    if (!collected.hasMore) return;
-  }
 }
 
 export async function purgeSessionSidecars(
@@ -55,9 +35,7 @@ export async function purgeSessionSidecars(
   const outcomes = await Promise.allSettled([
     authority.artifacts.purgeSessionArtifacts(sessionId),
     authority.sessionTodo.purgeSessionState(sessionId),
-    ...(authority.contextOffload
-      ? [retireContextSession(authority.contextOffload, sessionId)]
-      : []),
+    ...(authority.contextOffload ? [authority.contextOffload.retireSession(sessionId)] : []),
     authority.purgeOperationalState(sessionId),
   ]);
   const failures = outcomes.flatMap((outcome) =>

--- a/packages/runtime-host/src/server/storage-maintenance.ts
+++ b/packages/runtime-host/src/server/storage-maintenance.ts
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { InteractiveArtifactStoreWriter } from '@maka/storage/artifact-stores';
+import type { InteractiveContextOffloadWriter } from '@maka/storage/context-offload-store';
+
+const ACTIVE_DELAY_MS = 100;
+const IDLE_DELAY_MS = 60_000;
+const MAX_BATCH_ITEMS = 64;
+const MAX_BATCH_BYTES = 16 * 1024 * 1024;
+
+interface MaintenanceLane {
+  readonly name: string;
+  readonly run: () => Promise<boolean>;
+  timer?: ReturnType<typeof setTimeout>;
+  pending?: Promise<void>;
+  failures: number;
+}
+
+/** Physical cleanup is optional work, admitted only after the Host publishes Ready. */
+export class HostStorageMaintenance {
+  readonly #lanes: MaintenanceLane[];
+  readonly #onError: (name: string, error: unknown) => void;
+  #started = false;
+  #draining = false;
+
+  constructor(input: {
+    artifacts: Pick<InteractiveArtifactStoreWriter, 'reclaimUpgradeResidue'>;
+    contextOffload?: Pick<InteractiveContextOffloadWriter, 'collectGarbage'>;
+    onError: (name: string, error: unknown) => void;
+  }) {
+    this.#onError = input.onError;
+    let after: string | undefined;
+    this.#lanes = [
+      {
+        name: 'artifact upgrade cleanup',
+        failures: 0,
+        run: async () => {
+          const result = await input.artifacts.reclaimUpgradeResidue({
+            after,
+            maxPaths: MAX_BATCH_ITEMS,
+          });
+          after = result.nextAfter ?? undefined;
+          if (result.failedPaths > 0) {
+            this.#report(
+              'artifact upgrade cleanup',
+              new Error(`${result.failedPaths} paths remain pending`),
+            );
+          }
+          return result.nextAfter !== null;
+        },
+      },
+    ];
+    const context = input.contextOffload;
+    if (context)
+      this.#lanes.push({
+        name: 'context garbage collection',
+        failures: 0,
+        run: async () =>
+          (
+            await context.collectGarbage({
+              olderThan: Date.now(),
+              maxBlobs: MAX_BATCH_ITEMS,
+              maxBytes: MAX_BATCH_BYTES,
+            })
+          ).hasMore,
+      });
+  }
+
+  start(): void {
+    if (this.#started || this.#draining) return;
+    this.#started = true;
+    for (const lane of this.#lanes) this.#schedule(lane, ACTIVE_DELAY_MS);
+  }
+
+  beginDrain(): void {
+    this.#draining = true;
+    for (const lane of this.#lanes) clearTimeout(lane.timer);
+  }
+
+  async close(): Promise<void> {
+    this.beginDrain();
+    await Promise.all(this.#lanes.map((lane) => lane.pending));
+  }
+
+  #schedule(lane: MaintenanceLane, delay: number): void {
+    if (this.#draining) return;
+    lane.timer = setTimeout(() => {
+      lane.pending = this.#run(lane);
+    }, delay);
+    lane.timer.unref();
+  }
+
+  async #run(lane: MaintenanceLane): Promise<void> {
+    if (this.#draining) return;
+    let delay: number;
+    try {
+      const more = await lane.run();
+      lane.failures = 0;
+      delay = more ? ACTIVE_DELAY_MS : IDLE_DELAY_MS;
+    } catch (error) {
+      lane.failures = Math.min(lane.failures + 1, 7);
+      delay = Math.min(IDLE_DELAY_MS, 1000 * 2 ** (lane.failures - 1));
+      this.#report(lane.name, error);
+    }
+    this.#schedule(lane, delay);
+  }
+
+  #report(name: string, error: unknown): void {
+    try {
+      this.#onError(name, error);
+    } catch {
+      // Diagnostics must not terminate a maintenance lane or poison Host readiness.
+    }
+  }
+}

--- a/packages/storage/src/__tests__/artifact-stores.test.ts
+++ b/packages/storage/src/__tests__/artifact-stores.test.ts
@@ -45,6 +45,65 @@ import {
 after(removeTrackedControlDirectories);
 
 describe('interactive artifact store authority', () => {
+  for (const unrelated of [0, 1_000, 12_000]) {
+    test(`upgrade cleanup addresses one page without decoding ${unrelated} unrelated records`, async (t) => {
+      await withInteractiveOwner(async (owner, root, track) => {
+        const store = track(await openInteractiveArtifactStoreForWrite(owner.lease));
+        const db = new DatabaseSync(join(root, 'runtime.sqlite'));
+        try {
+          db.prepare(`WITH RECURSIVE numbers(n) AS (
+            SELECT 1 UNION ALL SELECT n + 1 FROM numbers WHERE n < ?
+          ) INSERT INTO artifact_records
+            SELECT 'other-' || n, 'other', 0, 'other/' || n, '{}' FROM numbers WHERE n <= ?`).run(
+            unrelated,
+            unrelated,
+          );
+          db.exec(`WITH RECURSIVE numbers(n) AS (
+            SELECT 1 UNION ALL SELECT n + 1 FROM numbers WHERE n < 12000
+          ) INSERT INTO artifact_upgrade_orphan_paths
+            SELECT printf('removed/%05d', n) FROM numbers`);
+          const queries: string[] = [];
+          const prepare = DatabaseSync.prototype.prepare;
+          const spy = t.mock.method(
+            DatabaseSync.prototype,
+            'prepare',
+            function (this: DatabaseSync, sql: string) {
+              queries.push(sql);
+              assert.doesNotMatch(sql, /SELECT record_json\s+FROM artifact_records/);
+              return prepare.call(this, sql);
+            },
+          );
+          const result = await store.reclaimUpgradeResidue({ maxPaths: 3 });
+          spy.mock.restore();
+          assert.deepEqual(result, {
+            nextAfter: 'removed/00003',
+            processedPaths: 3,
+            failedPaths: 0,
+          });
+          assert.equal(
+            queries.filter((sql) => sql.includes('SELECT 1 FROM artifact_records')).length,
+            3,
+          );
+          assert.equal(
+            db.prepare('SELECT count(*) AS n FROM artifact_upgrade_orphan_paths').get()?.n,
+            11997,
+          );
+          const plan = db
+            .prepare(`EXPLAIN QUERY PLAN SELECT relative_path FROM artifact_upgrade_orphan_paths
+            WHERE relative_path > ? ORDER BY relative_path LIMIT ?`)
+            .all('', 4);
+          assert.match(JSON.stringify(plan), /SEARCH.*INDEX/);
+          const claimedPlan = db
+            .prepare('EXPLAIN QUERY PLAN SELECT 1 FROM artifact_records WHERE relative_path = ?')
+            .all('other/1');
+          assert.match(JSON.stringify(claimedPlan), /artifact_records_relative_path/);
+        } finally {
+          db.close();
+        }
+      });
+    });
+  }
+
   test('reads retained v1 payloads after upgrade without reviving retired rows', async () => {
     await withInteractiveOwner(async (owner, root, track) => {
       const initial = await openInteractiveArtifactStoreForWrite(owner.lease);
@@ -210,8 +269,15 @@ describe('interactive artifact store authority', () => {
         content: 'uploaded again',
         source: 'user_upload',
       });
-      await store.reclaimUpgradeResidue();
-      await store.reclaimUpgradeResidue();
+      let after: string | undefined;
+      do {
+        const batch = await store.reclaimUpgradeResidue({ after, maxPaths: 2 });
+        assert.ok(batch.processedPaths <= 2);
+        after = batch.nextAfter ?? undefined;
+      } while (after);
+      const retry = await store.reclaimUpgradeResidue({ maxPaths: 2 });
+      assert.equal(retry.failedPaths, 1);
+      assert.equal(retry.nextAfter, null);
 
       const path = (id: string) =>
         join(root, 'artifacts', `session-1/${id}-${rows.find((row) => row.id === id)!.name}`);

--- a/packages/storage/src/__tests__/sqlite-context-offload-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-context-offload-store.test.ts
@@ -387,7 +387,7 @@ test('recovers deterministic managed-file staging after process exit', async (t)
   assert.equal((await recovered.usage()).physicalBytes, 0);
 });
 
-test('reports continuation while pending managed-file deletions remain', async (t) => {
+test('bounds pending managed-file deletion bytes and reports continuation', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'maka-context-offload-pending-files-'));
   t.after(() => rm(root, { recursive: true, force: true }));
   const values = ['pending-one', 'pending-two', 'pending-three'];
@@ -413,11 +413,14 @@ test('reports continuation while pending managed-file deletions remain', async (
   t.after(() => recovered.close());
   const totalBytes = values.reduce((total, value) => total + Buffer.byteLength(value), 0);
   assert.equal((await recovered.usage()).physicalBytes, totalBytes);
+  const byteBudget = Math.max(...values.map((value) => Buffer.byteLength(value)));
   for (const hasMore of [true, true, false]) {
+    const before = (await recovered.usage()).physicalBytes;
     assert.deepEqual(
-      await recovered.collectGarbage({ olderThan: 1, maxBlobs: 1, maxBytes: totalBytes }),
+      await recovered.collectGarbage({ olderThan: 1, maxBlobs: 64, maxBytes: byteBudget }),
       { deletedBlobs: 0, deletedBytes: 0, hasMore },
     );
+    assert.ok(before - (await recovered.usage()).physicalBytes <= byteBudget);
   }
   assert.equal((await recovered.usage()).physicalBytes, 0);
 });

--- a/packages/storage/src/__tests__/sqlite-context-offload-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-context-offload-store.test.ts
@@ -917,6 +917,126 @@ test('migrates v1 orphan blobs into the indexed garbage candidate set', async (t
   });
 });
 
+test('bounds payload reads before collecting migrated v2 inline images', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-context-v2-gc-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const path = join(root, CONTEXT_OFFLOAD_DATABASE_NAME);
+  const legacy = new DatabaseSync(path);
+  // Schema from the released v2 authority (8b93dd52b), before managed values.
+  legacy.exec(`PRAGMA auto_vacuum = INCREMENTAL;
+  CREATE TABLE context_blobs (
+    blob_id BLOB PRIMARY KEY CHECK(length(blob_id) = 32),
+    payload BLOB NOT NULL,
+    size_bytes INTEGER NOT NULL CHECK(size_bytes >= 0 AND length(payload) = size_bytes),
+    created_at INTEGER NOT NULL CHECK(created_at >= 0)
+  );
+
+  CREATE TABLE context_refs (
+    ref_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    owner_kind TEXT NOT NULL CHECK(
+      owner_kind IN ('read_image_snapshot', 'tool_result_archive')
+    ),
+    owner_id TEXT NOT NULL,
+    blob_id BLOB NOT NULL REFERENCES context_blobs(blob_id) ON DELETE RESTRICT,
+    media_type TEXT NOT NULL,
+    created_at INTEGER NOT NULL CHECK(created_at >= 0),
+    UNIQUE(session_id, owner_kind, owner_id)
+  );
+
+  CREATE INDEX context_refs_session
+    ON context_refs(session_id, created_at, ref_id);
+
+  CREATE INDEX context_refs_blob
+    ON context_refs(blob_id);
+
+  CREATE TABLE context_gc_candidates (
+    blob_id BLOB PRIMARY KEY
+      REFERENCES context_blobs(blob_id) ON DELETE CASCADE,
+    unreferenced_at INTEGER NOT NULL CHECK(unreferenced_at >= 0)
+  );
+
+  CREATE INDEX context_gc_candidates_eligible
+    ON context_gc_candidates(unreferenced_at, blob_id);
+
+  CREATE TABLE context_session_usage (
+    session_id TEXT PRIMARY KEY,
+    reference_count INTEGER NOT NULL CHECK(reference_count >= 0),
+    logical_bytes INTEGER NOT NULL CHECK(logical_bytes >= 0)
+  );
+
+  CREATE TABLE context_store_usage (
+    singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+    blob_count INTEGER NOT NULL CHECK(blob_count >= 0),
+    physical_bytes INTEGER NOT NULL CHECK(physical_bytes >= 0)
+  );
+
+  INSERT INTO context_store_usage(singleton, blob_count, physical_bytes)
+    VALUES (1, 0, 0);
+
+    PRAGMA user_version = 2;
+  `);
+  const mib = 1024 * 1024;
+  try {
+    const insert = legacy.prepare('INSERT INTO context_blobs VALUES (?, ?, ?, ?)');
+    const orphan = legacy.prepare('INSERT INTO context_gc_candidates VALUES (?, ?)');
+    legacy.exec('BEGIN');
+    for (let i = 0; i < 65; i += 1) {
+      const bytes = Buffer.alloc(mib, i);
+      const hash = createHash('sha256').update(bytes).digest();
+      insert.run(hash, bytes, bytes.length, 1);
+      orphan.run(hash, 2);
+    }
+    legacy
+      .prepare('UPDATE context_store_usage SET blob_count = 65, physical_bytes = ?')
+      .run(65 * mib);
+    legacy.exec('COMMIT');
+  } finally {
+    legacy.close();
+  }
+  const store = new SqliteContextOffloadStore(path, { limits: defaultLimits() });
+  t.after(() => store.close());
+  const inspect = new DatabaseSync(path);
+  t.after(() => inspect.close());
+  assert.equal(pragmaNumber(inspect, 'user_version'), 3);
+  assert.equal(
+    inspect.prepare("SELECT count(*) AS n FROM context_blobs WHERE storage_kind = 'inline'").get()
+      ?.n,
+    65,
+  );
+
+  let payloadBytes = 0;
+  const countPayload = (row: Record<string, unknown> | undefined) => {
+    if (row?.payload instanceof Uint8Array) payloadBytes += row.payload.byteLength;
+  };
+  const prepare = DatabaseSync.prototype.prepare;
+  t.mock.method(DatabaseSync.prototype, 'prepare', function (this: DatabaseSync, sql: string) {
+    const statement = prepare.call(this, sql);
+    const all = statement.all.bind(statement);
+    const get = statement.get.bind(statement);
+    t.mock.method(statement, 'all', (...args: Parameters<typeof all>) => {
+      const rows = all(...args);
+      for (const row of rows) countPayload(row);
+      return rows;
+    });
+    t.mock.method(statement, 'get', (...args: Parameters<typeof get>) => {
+      const row = get(...args);
+      countPayload(row);
+      return row;
+    });
+    return statement;
+  });
+  await assert.rejects(
+    store.collectGarbage({ olderThan: 3, maxBlobs: 64, maxBytes: mib - 1 }),
+    /byte limit/,
+  );
+  assert.equal(payloadBytes, 0, 'a rejected batch must not materialize any payload');
+  const result = await store.collectGarbage({ olderThan: 3, maxBlobs: 64, maxBytes: 16 * mib });
+  assert.deepEqual(result, { deletedBlobs: 16, deletedBytes: 16 * mib, hasMore: true });
+  assert.equal(payloadBytes, 16 * mib, 'only admitted inline payloads are materialized');
+  assert.equal((await store.usage()).physicalBytes, 49 * mib);
+});
+
 test('lifecycle queries use Session and garbage eligibility indexes', async (t) => {
   const fixture = await createFixture(t);
   fixture.store.close();

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -175,6 +175,17 @@ export type ArtifactUserDeleteResult =
   | { readonly kind: 'protected' }
   | { readonly kind: 'not_found' };
 
+export interface ArtifactUpgradeCleanupInput {
+  readonly after?: string;
+  readonly maxPaths: number;
+}
+
+export interface ArtifactUpgradeCleanupResult {
+  readonly nextAfter: string | null;
+  readonly processedPaths: number;
+  readonly failedPaths: number;
+}
+
 export interface ArtifactAuthorityStore extends DurableArtifactAttachmentReader {
   create(input: CreateArtifactInput): Promise<ArtifactRecord>;
   close(): void;
@@ -182,7 +193,7 @@ export interface ArtifactAuthorityStore extends DurableArtifactAttachmentReader 
     input: ConversationArtifactCopyInput,
   ): Promise<ConversationArtifactCopyResult>;
   purgeSessionArtifacts(sessionId: string): Promise<void>;
-  reclaimUpgradeResidue(): Promise<void>;
+  reclaimUpgradeResidue(input: ArtifactUpgradeCleanupInput): Promise<ArtifactUpgradeCleanupResult>;
   deleteOwnedArtifactInSession(
     sessionId: string,
     artifactId: string,
@@ -481,17 +492,26 @@ class SqliteArtifactStore implements ArtifactAuthorityStore {
    * once its file is gone, and a file that will not go keeps only its own note
    * rather than holding up the ones behind it.
    */
-  async reclaimUpgradeResidue(): Promise<void> {
-    await this.enqueueMutation(async () => {
-      await this.prepareMutationUnlocked();
-      const recorded = this.metadataRepository.readUpgradeOrphanPaths();
-      if (recorded.length === 0) return;
-      const claimed = new Set(this.records.map((record) => record.relativePath));
+  async reclaimUpgradeResidue(
+    input: ArtifactUpgradeCleanupInput,
+  ): Promise<ArtifactUpgradeCleanupResult> {
+    if (!Number.isSafeInteger(input.maxPaths) || input.maxPaths < 1 || input.maxPaths > 1024) {
+      throw new TypeError('Artifact cleanup path limit must be between 1 and 1024');
+    }
+    const after = input.after ?? '';
+    const maxPaths = input.maxPaths;
+    return this.enqueueMutation(async () => {
+      const recorded = this.metadataRepository.readUpgradeOrphanPaths(after, maxPaths + 1);
+      const selected = recorded.slice(0, maxPaths);
       const directories = new Set<string>();
       const discharged: string[] = [];
+      let failedPaths = 0;
       try {
-        for (const relativePath of recorded) {
-          if (claimed.has(relativePath) || !isSafeRelativeArtifactPath(relativePath)) {
+        for (const relativePath of selected) {
+          if (
+            this.metadataRepository.hasRelativePath(relativePath) ||
+            !isSafeRelativeArtifactPath(relativePath)
+          ) {
             discharged.push(relativePath);
             continue;
           }
@@ -500,7 +520,10 @@ class SqliteArtifactStore implements ArtifactAuthorityStore {
             await unlink(target);
             directories.add(dirname(target));
           } catch (error) {
-            if (!isNotFound(error)) continue;
+            if (!isNotFound(error)) {
+              failedPaths += 1;
+              continue;
+            }
           }
           discharged.push(relativePath);
         }
@@ -508,6 +531,11 @@ class SqliteArtifactStore implements ArtifactAuthorityStore {
         for (const directory of directories) await syncDirectory(directory);
       }
       if (discharged.length > 0) this.metadataRepository.forgetUpgradeOrphanPaths(discharged);
+      return {
+        nextAfter: recorded.length > selected.length ? selected.at(-1)! : null,
+        processedPaths: selected.length,
+        failedPaths,
+      };
     });
   }
 

--- a/packages/storage/src/artifact-stores.ts
+++ b/packages/storage/src/artifact-stores.ts
@@ -72,7 +72,7 @@ export interface InteractiveArtifactStoreWriter extends DurableArtifactAttachmen
     input: ConversationArtifactCopyInput,
   ): Promise<ConversationArtifactCopyResult>;
   purgeSessionArtifacts(sessionId: string): Promise<void>;
-  reclaimUpgradeResidue(): Promise<void>;
+  reclaimUpgradeResidue: ArtifactAuthorityStore['reclaimUpgradeResidue'];
   listPage: ArtifactAuthorityStore['listPage'];
   listTurnArtifacts: ArtifactAuthorityStore['listTurnArtifacts'];
   getInSession: ArtifactAuthorityStore['getInSession'];
@@ -178,7 +178,7 @@ function createWriterFacade(
       return run(() => store.copyConversationArtifacts(acceptedInput));
     },
     purgeSessionArtifacts: (sessionId) => run(() => store.purgeSessionArtifacts(sessionId)),
-    reclaimUpgradeResidue: () => run(() => store.reclaimUpgradeResidue()),
+    reclaimUpgradeResidue: (input) => run(() => store.reclaimUpgradeResidue(input)),
     deleteUserArtifactInSession: (sessionId, artifactId) =>
       run(() => store.deleteUserArtifactInSession(sessionId, artifactId)),
     close: () => {

--- a/packages/storage/src/sqlite-artifact-metadata.ts
+++ b/packages/storage/src/sqlite-artifact-metadata.ts
@@ -92,12 +92,22 @@ class SqliteArtifactMetadataRepository {
     });
   }
 
-  readUpgradeOrphanPaths(): string[] {
+  readUpgradeOrphanPaths(after: string, limit: number): string[] {
     this.assertOpen();
     const rows = this.#lease.database
-      .prepare('SELECT relative_path FROM artifact_upgrade_orphan_paths ORDER BY relative_path')
-      .all() as Array<{ relative_path: string }>;
+      .prepare(`SELECT relative_path FROM artifact_upgrade_orphan_paths
+        WHERE relative_path > ? ORDER BY relative_path LIMIT ?`)
+      .all(after, limit) as Array<{ relative_path: string }>;
     return rows.map((row) => row.relative_path);
+  }
+
+  hasRelativePath(relativePath: string): boolean {
+    this.assertOpen();
+    return Boolean(
+      this.#lease.database
+        .prepare('SELECT 1 FROM artifact_records WHERE relative_path = ?')
+        .get(relativePath),
+    );
   }
 
   forgetUpgradeOrphanPaths(relativePaths: readonly string[]): void {

--- a/packages/storage/src/sqlite-context-offload-store.ts
+++ b/packages/storage/src/sqlite-context-offload-store.ts
@@ -103,7 +103,6 @@ interface GarbageCandidateRow {
   blob_id: unknown;
   size_bytes: unknown;
   storage_kind: unknown;
-  payload: unknown;
 }
 
 interface ManagedFilePublication {
@@ -397,7 +396,7 @@ export class SqliteContextOffloadStore implements ContextOffloadStore {
       const collected = this.#writeTransaction(() => {
         const rows = this.#database
           .prepare(
-            `SELECT c.blob_id, b.size_bytes, b.storage_kind, b.payload
+            `SELECT c.blob_id, b.size_bytes, b.storage_kind
            FROM context_gc_candidates c INDEXED BY context_gc_candidates_eligible
            JOIN context_blobs b ON b.blob_id = c.blob_id
            WHERE c.unreferenced_at < ?
@@ -412,14 +411,16 @@ export class SqliteContextOffloadStore implements ContextOffloadStore {
         }> = [];
         let deletedBytes = 0;
         let inlineDeletedBytes = 0;
+        // Admit by metadata before SQLite materializes legacy inline BLOBs.
+        const readValue = this.#database.prepare(
+          'SELECT storage_kind, size_bytes, payload FROM context_blobs WHERE blob_id = ?',
+        );
         for (const row of rows) {
           if (selected.length === input.maxBlobs) break;
           const blobId = decodeBlobId(row.blob_id);
           if (!blobId || !isNonNegativeSafeInteger(row.size_bytes)) {
             throw new Error('Invalid context garbage candidate');
           }
-          const value = decodeBlobValue(row, Buffer.from(blobId).toString('hex'));
-          if (!value) throw new Error('Invalid context garbage candidate value');
           if (exceedsLimit(deletedBytes, row.size_bytes, input.maxBytes)) {
             if (selected.length === 0) {
               throw new Error(
@@ -428,6 +429,16 @@ export class SqliteContextOffloadStore implements ContextOffloadStore {
             }
             break;
           }
+          const stored = readValue.get(blobId) as unknown as ContextBlobRow | undefined;
+          if (
+            !stored ||
+            stored.size_bytes !== row.size_bytes ||
+            stored.storage_kind !== row.storage_kind
+          ) {
+            throw new Error('Invalid context garbage candidate metadata');
+          }
+          const value = decodeBlobValue(stored, Buffer.from(blobId).toString('hex'));
+          if (!value) throw new Error('Invalid context garbage candidate value');
           deletedBytes = addSafeInteger(deletedBytes, row.size_bytes, 'Collected context bytes');
           selected.push({
             blobId,

--- a/packages/storage/src/sqlite-context-offload-store.ts
+++ b/packages/storage/src/sqlite-context-offload-store.ts
@@ -387,7 +387,7 @@ export class SqliteContextOffloadStore implements ContextOffloadStore {
     return this.#runManagedValueMutation(async () => {
       this.#assertOpen();
       if (this.#hasPendingFileDeletions()) {
-        await this.#drainPendingFileDeletions(input.maxBlobs);
+        await this.#drainPendingFileDeletions(input.maxBlobs, input.maxBytes);
         return {
           deletedBlobs: 0,
           deletedBytes: 0,
@@ -482,7 +482,7 @@ export class SqliteContextOffloadStore implements ContextOffloadStore {
           hasMore: rows.length > selected.length,
         };
       });
-      await this.#drainPendingFileDeletions(input.maxBlobs);
+      await this.#drainPendingFileDeletions(input.maxBlobs, input.maxBytes);
       return {
         ...collected,
         hasMore: collected.hasMore || this.#hasPendingFileDeletions(),
@@ -1001,11 +1001,20 @@ export class SqliteContextOffloadStore implements ContextOffloadStore {
     });
   }
 
-  async #drainPendingFileDeletions(limit: number): Promise<void> {
+  async #drainPendingFileDeletions(limit: number, maxBytes: number): Promise<void> {
     const rows = this.#database
-      .prepare('SELECT locator FROM context_file_deletions ORDER BY enqueued_at, locator LIMIT ?')
-      .all(limit) as Array<{ locator?: unknown }>;
+      .prepare(
+        'SELECT locator, size_bytes FROM context_file_deletions ORDER BY enqueued_at, locator LIMIT ?',
+      )
+      .all(limit) as Array<{ locator?: unknown; size_bytes: number }>;
+    let bytes = 0;
     for (const row of rows) {
+      const size = readNonNegativeInteger(row.size_bytes, 'Pending context file deletion bytes');
+      if (exceedsLimit(bytes, size, maxBytes)) {
+        if (bytes === 0) throw new Error('Context garbage byte limit cannot fit pending file');
+        break;
+      }
+      bytes += size;
       const locator = decodeManagedFileLocator(row.locator);
       if (!locator) throw new Error('Invalid pending context file deletion locator');
       await this.#drainFileDeletion(locator);


### PR DESCRIPTION
## Summary

Refs #4071. First slice of the [revised plan](https://github.com/apache/maka/issues/4071#issuecomment-5565910520).

Session retirement released its own context refs and then drained the entire global garbage queue. Host recovery also awaited all artifact upgrade-residue cleanup before Ready.

- Add an explicit post-registration maintenance start: no maintenance timer starts until the Host publishes Ready.
- Retire only the Session's context refs. Move physical GC to independent, single-flight maintenance lanes.
- Limit context GC to 64 candidates / 16 MiB per batch, including pending managed-file deletions. Limit upgrade cleanup to 64 paths with keyset pagination and indexed exact-path ownership checks, without loading the artifact population.
- Yield 100 ms between active batches; poll idle queues every 60 seconds and back off failed calls from 1 to 60 seconds. Failed upgrade paths remain durable and do not pin the cursor.
- Stop scheduling at drain; close waits only for already-admitted batches. Maintenance failures do not request Host drain.

## Verification

- Builds: core, storage, runtime and runtime-host passed; storage/runtime-host were also clean-built.
- Storage full suite: **1177 passed, 8 skipped, 0 failed**.
- Focused Host suites (kernel, production composition, retirement, maintenance): **128 passed, 0 failed/cancelled**.
- Negative control: temporarily reintroducing retirement-triggered GC makes the new regression fail; restored before final verification.
- SQLite cleanup tests cover 0/1k/12k unrelated records, a 12k-path cleanup queue, bounded page queries, index plans, retained live paths and retry past a stuck path.
- Root lint, format check, ASF headers, affected storage/runtime-host typechecks and diff check passed.

**The complete Runtime Host suite is not green locally:** 1735 passed, 12 skipped, 0 assertion failures, **6 cancelled** in the unmodified `resumable-peer-stream.test.ts`, starting with “one-way blackhole triggers automatic recovery and preserves the pending read” (`Promise resolution is still pending but the event loop has already resolved`). Running that file alone reproduces 4 passes / 6 cancellations on Node 22.19.0. No network-layer changes are included.

Local setup: installed the lockfile-pinned systeminformation 5.33.8 dependency separately after the root install hit the existing Slack/undici peer conflict; dependency manifests and lockfile are unchanged. Clean builds removed a stale dist-only test from the initial storage run.

Not run: full repository build/typecheck, Desktop E2E, Linux/Windows execution, a real 6 GiB migration or latency/RSS benchmarks.

## Scope

No durable-format or schema migration. The existing GC candidates and orphan-path records remain the retry authority; no new task table.

This does not fix all #4027 startup costs: legacy schema upgrades, ordinary ArtifactStore global scans and other Session recovery paths remain. Backup/export completeness and ledger-backed archives are subsequent #4071 slices. No checkpoint/vacuum worker is introduced here. Batch limits bound work, not the latency of an individual filesystem or synchronous SQLite operation.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex inspected the implementation, authored changes/tests, ran verification and prepared this PR. The commit includes `Generated-by: Codex`.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally (focused suites pass; full Host cancellation noted above)

Does this PR entail a change in behavior?

- [x] Yes — physical cleanup is deferred and bounded; logical retirement remains durable.
- [ ] No
