### PR TITLE
fix(storage): preserve context images in offline snapshots

### DIFF
--- a/packages/storage/src/__tests__/context-offload-snapshot.test.ts
+++ b/packages/storage/src/__tests__/context-offload-snapshot.test.ts
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { test, type TestContext } from 'node:test';
+import { createSessionStore } from '../session-store.js';
+import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
+import { openInteractiveContextOffloadStoreForWrite } from '../context-offload-store.js';
+import { createReadImageSnapshotStore } from '../read-image-snapshot-store.js';
+import { SqliteContextOffloadStore } from '../sqlite-context-offload-store.js';
+import {
+  createOperationalStateBackup,
+  restoreOperationalStateBackup,
+  validateOperationalStateBackup,
+} from '../operational-state-backup.js';
+import { exportSessionBundleState } from '../session-bundle-policy.js';
+import { withOfflineContextSnapshot } from '../context-offload-snapshot.js';
+import {
+  trackControlDirectory,
+  removeTrackedControlDirectories,
+} from './fixtures/control-directory-hygiene.js';
+import { after } from 'node:test';
+
+after(removeTrackedControlDirectories);
+const limits = {
+  ownerMaxBytes: { read_image_snapshot: 5 * 1024 * 1024, tool_result_archive: 4 * 1024 * 1024 },
+  sessionLogicalBytes: 1024 * 1024 * 1024,
+  workspacePhysicalBytes: 20 * 1024 * 1024 * 1024,
+};
+
+async function fixture(t: TestContext) {
+  const base = await mkdtemp(join(tmpdir(), 'maka-context-snapshot-'));
+  t.after(() => rm(base, { recursive: true, force: true }));
+  const root = join(base, 'source');
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: root, kind: 'interactive' }),
+  );
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  t.after(() => owner.close());
+  const sessions = createSessionStore(root);
+  const selected = await sessions.create({
+    cwd: base,
+    llmConnectionSlug: 'fake',
+    model: 'fake',
+    permissionMode: 'ask',
+  });
+  const other = await sessions.create({
+    cwd: base,
+    llmConnectionSlug: 'fake',
+    model: 'fake',
+    permissionMode: 'ask',
+  });
+  const writer = await openInteractiveContextOffloadStoreForWrite(owner.lease, { limits });
+  const bytes = Buffer.from('snapshot bytes that cannot be recovered from the changed workspace');
+  const ref = await createReadImageSnapshotStore(writer, selected.id).snapshot({
+    ownerId: 'image-1',
+    bytes,
+    mimeType: 'image/png',
+  });
+  await createReadImageSnapshotStore(writer, other.id).snapshot({
+    ownerId: 'shared',
+    bytes,
+    mimeType: 'image/png',
+  });
+  const privateBytes = Buffer.from('OTHER-SESSION-PRIVATE-CONTEXT');
+  const inlinePrivate = Buffer.from('OTHER-SESSION-PRIVATE-INLINE');
+  assert.equal(
+    (
+      await writer.put({
+        sessionId: other.id,
+        owner: { kind: 'tool_result_archive', ownerId: 'inline' },
+        bytes: inlinePrivate,
+        mediaType: 'application/json',
+      })
+    ).ok,
+    true,
+  );
+  const otherRef = await createReadImageSnapshotStore(writer, other.id).snapshot({
+    ownerId: 'private',
+    bytes: privateBytes,
+    mimeType: 'image/png',
+  });
+  const orphan = await createReadImageSnapshotStore(writer, selected.id).snapshot({
+    ownerId: 'orphan',
+    bytes: Buffer.from('orphan bytes'),
+    mimeType: 'image/png',
+  });
+  await writer.releaseReference({ sessionId: selected.id, refId: orphan.refId });
+  await sessions.appendMessage(selected.id, {
+    type: 'tool_result',
+    id: 'image-result',
+    turnId: 'turn',
+    ts: 1,
+    toolUseId: 'read',
+    isError: false,
+    content: { kind: 'image', mimeType: 'image/png', ref },
+  });
+  await sessions.close?.();
+  const runtime = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
+  try {
+    await runtime.appendRuntimeEvent(selected.id, 'run-image', {
+      id: 'call-event-image',
+      invocationId: 'invocation-image',
+      runId: 'run-image',
+      sessionId: selected.id,
+      turnId: 'turn-image',
+      ts: 1,
+      partial: false,
+      role: 'model',
+      author: 'agent',
+      content: {
+        kind: 'function_call',
+        id: 'call-image',
+        name: 'Read',
+        args: { path: 'image.png' },
+      },
+    });
+    await runtime.appendRuntimeEvent(selected.id, 'run-image', {
+      id: 'event-image',
+      invocationId: 'invocation-image',
+      runId: 'run-image',
+      sessionId: selected.id,
+      turnId: 'turn-image',
+      ts: 2,
+      partial: false,
+      role: 'tool',
+      author: 'tool',
+      content: {
+        kind: 'function_response',
+        id: 'call-image',
+        name: 'Read',
+        result: { kind: 'image', mimeType: 'image/png', ref },
+        modelProjection: {
+          version: 1,
+          kind: 'content',
+          parts: [{ kind: 'artifact', mediaType: 'image/png', ref }],
+        },
+      },
+    });
+  } finally {
+    runtime.close();
+  }
+  const close = async () => {
+    await writer.close();
+    await owner.close();
+  };
+  t.after(close);
+  const imagePath = (data: Buffer) => {
+    const hash = createHash('sha256').update(data).digest('hex');
+    return join('context-offload-values', 'sha256', hash.slice(0, 2), hash);
+  };
+  return {
+    base,
+    root,
+    owner,
+    capability,
+    close,
+    bytes,
+    privateBytes,
+    inlinePrivate,
+    ref,
+    otherRef,
+    imagePath,
+    selected,
+    other,
+  };
+}
+
+test('offline backup restores context refs and verified managed bytes into an empty root', async (t) => {
+  const f = await fixture(t);
+  await assert.rejects(
+    createOperationalStateBackup({ stateRoot: f.root, destinationRoot: join(f.base, 'busy') }),
+    /offline Storage Root/,
+  );
+  await f.close();
+  const backupRoot = join(f.base, 'backup');
+  const manifest = await createOperationalStateBackup({
+    stateRoot: f.root,
+    destinationRoot: backupRoot,
+  });
+  assert.equal(manifest.schemaVersion, 4);
+  assert.ok(manifest.files.some((file) => file.path === 'context-offload.sqlite'));
+  const restored = join(f.base, 'restored');
+  await restoreOperationalStateBackup({ backupRoot, destinationRoot: restored });
+  const store = new SqliteContextOffloadStore(join(restored, 'context-offload.sqlite'), { limits });
+  try {
+    const read = await store.read({ sessionId: f.selected.id, refId: f.ref.refId, maxBytes: 1024 });
+    assert.equal(read.ok, true);
+    if (read.ok) assert.deepEqual(Buffer.from(read.bytes), f.bytes);
+    assert.equal((await store.usage()).references, 4);
+    assert.equal(
+      (await store.usage()).physicalBytes,
+      f.bytes.length + f.privateBytes.length + f.inlinePrivate.length,
+    );
+  } finally {
+    store.close();
+  }
+});
+
+test('single-Session export contains only its refs and shared payload once, with no private free-page bytes', async (t) => {
+  const f = await fixture(t);
+  const input = {
+    stateRoot: f.root,
+    configRoot: join(f.base, 'config'),
+    destinationRoot: join(f.base, 'bundle'),
+    sessionId: f.selected.id,
+  };
+  await assert.rejects(exportSessionBundleState(input), /offline Storage Root/);
+  await f.close();
+  const plan = await exportSessionBundleState(input);
+  assert.ok(plan.includedEntries.includes('context-offload.sqlite'));
+  const store = new SqliteContextOffloadStore(
+    join(input.destinationRoot, 'context-offload.sqlite'),
+    { limits },
+  );
+  try {
+    const read = await store.read({ sessionId: f.selected.id, refId: f.ref.refId, maxBytes: 1024 });
+    assert.equal(read.ok, true);
+    if (read.ok) assert.deepEqual(Buffer.from(read.bytes), f.bytes);
+    assert.equal((await store.usage()).references, 1);
+    assert.equal((await store.usage()).physicalBytes, f.bytes.length);
+    assert.equal(
+      (await store.read({ sessionId: f.other.id, refId: f.otherRef.refId, maxBytes: 1024 })).ok,
+      false,
+    );
+  } finally {
+    store.close();
+  }
+  const database = await readFile(join(input.destinationRoot, 'context-offload.sqlite'));
+  assert.equal(database.includes(Buffer.from(f.other.id)), false);
+  assert.equal(database.includes(f.privateBytes), false);
+  assert.equal(database.includes(f.inlinePrivate), false);
+  await assert.rejects(readFile(join(input.destinationRoot, f.imagePath(f.privateBytes))), {
+    code: 'ENOENT',
+  });
+});
+
+test('missing or corrupt context bytes never publish a successful backup', async (t) => {
+  const f = await fixture(t);
+  await f.close();
+  const path = join(f.root, f.imagePath(f.bytes));
+  await writeFile(path, Buffer.alloc(f.bytes.length));
+  await assert.rejects(
+    createOperationalStateBackup({ stateRoot: f.root, destinationRoot: join(f.base, 'corrupt') }),
+    /size\/hash mismatch/,
+  );
+  await rm(path);
+  await assert.rejects(
+    createOperationalStateBackup({ stateRoot: f.root, destinationRoot: join(f.base, 'missing') }),
+  );
+  assert.deepEqual((await readdir(f.base)).sort(), ['source']);
+});
+
+test('restore rejects tampering even if the manifest is recomputed', async (t) => {
+  const f = await fixture(t);
+  await f.close();
+  const backupRoot = join(f.base, 'backup');
+  await createOperationalStateBackup({ stateRoot: f.root, destinationRoot: backupRoot });
+  const path = f.imagePath(f.bytes).split('\\').join('/');
+  const changed = Buffer.alloc(f.bytes.length);
+  await writeFile(join(backupRoot, path), changed);
+  const manifestPath = join(backupRoot, 'operational-backup.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  const file = manifest.files.find((entry: { path: string }) => entry.path === path);
+  file.sha256 = 'sha256:' + createHash('sha256').update(changed).digest('hex');
+  await writeFile(manifestPath, JSON.stringify(manifest));
+  await assert.rejects(
+    restoreOperationalStateBackup({ backupRoot, destinationRoot: join(f.base, 'restore') }),
+    /size\/hash mismatch/,
+  );
+});
+
+test('a missing context database with a durable image reference fails closed', async (t) => {
+  const f = await fixture(t);
+  await f.close();
+  await rm(join(f.root, 'context-offload.sqlite'));
+  await assert.rejects(
+    createOperationalStateBackup({ stateRoot: f.root, destinationRoot: join(f.base, 'backup') }),
+    /missing or cross-Session/,
+  );
+  await assert.rejects(
+    exportSessionBundleState({
+      stateRoot: f.root,
+      configRoot: join(f.base, 'config'),
+      destinationRoot: join(f.base, 'bundle'),
+      sessionId: f.selected.id,
+    }),
+    /missing or cross-Session/,
+  );
+});
+
+test('validates typed projection refs without interpreting opaque JSON as storage refs', async (t) => {
+  const f = await fixture(t);
+  await f.close();
+  const database = new DatabaseSync(join(f.root, 'runtime.sqlite'));
+  try {
+    const row = database
+      .prepare("SELECT payload_json FROM runtime_events WHERE event_id = 'event-image'")
+      .get()!;
+    const event = JSON.parse(String(row.payload_json));
+    event.content.result = {
+      kind: 'json',
+      value: {
+        attachments: [{ ref: { kind: 'session_context', sessionId: 'fake', refId: 'opaque' } }],
+      },
+    };
+    database
+      .prepare("UPDATE runtime_events SET payload_json = ? WHERE event_id = 'event-image'")
+      .run(JSON.stringify(event));
+    await createOperationalStateBackup({
+      stateRoot: f.root,
+      destinationRoot: join(f.base, 'opaque'),
+    });
+    event.content.modelProjection.parts[0].ref = f.otherRef;
+    database
+      .prepare("UPDATE runtime_events SET payload_json = ? WHERE event_id = 'event-image'")
+      .run(JSON.stringify(event));
+    await assert.rejects(
+      createOperationalStateBackup({ stateRoot: f.root, destinationRoot: join(f.base, 'foreign') }),
+      /cross-Session/,
+    );
+  } finally {
+    database.close();
+  }
+});
+
+test('offline snapshot authority blocks a new Host owner and releases after failure', async (t) => {
+  const f = await fixture(t);
+  await f.close();
+  await assert.rejects(
+    withOfflineContextSnapshot(f.root, async (locked) => {
+      assert.equal(locked, true);
+      assert.equal(await tryAcquireInteractiveRootOwner(f.capability), undefined);
+      throw new Error('injected snapshot failure');
+    }),
+    /injected snapshot failure/,
+  );
+  const owner = await tryAcquireInteractiveRootOwner(f.capability);
+  assert.ok(owner);
+  await owner.close();
+});
+
+test('context snapshot refuses a symlinked managed-value ancestor', async (t) => {
+  const f = await fixture(t);
+  await f.close();
+  const values = join(f.root, 'context-offload-values');
+  const outside = join(f.base, 'outside');
+  const { rename } = await import('node:fs/promises');
+  await rename(values, outside);
+  await symlink(outside, values, process.platform === 'win32' ? 'junction' : 'dir');
+  await assert.rejects(
+    createOperationalStateBackup({ stateRoot: f.root, destinationRoot: join(f.base, 'backup') }),
+    /symlinks/,
+  );
+});

--- a/packages/storage/src/__tests__/operational-state-backup.test.ts
+++ b/packages/storage/src/__tests__/operational-state-backup.test.ts
@@ -184,3 +184,26 @@ test('rejects a backup whose native Runtime version contradicts its registry', a
     await rm(base, { recursive: true, force: true });
   }
 });
+
+test('continues to validate and restore version 3 backups without context refs', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-backup-v3-'));
+  try {
+    const stateRoot = join(base, 'state');
+    const sessions = createSessionStore(stateRoot);
+    await sessions.close?.();
+    const backupRoot = join(base, 'backup');
+    await createOperationalStateBackup({ stateRoot, destinationRoot: backupRoot });
+    const path = join(backupRoot, 'operational-backup.json');
+    const manifest = JSON.parse(await readFile(path, 'utf8'));
+    manifest.schemaVersion = 3;
+    await writeFile(path, JSON.stringify(manifest));
+    assert.equal((await validateOperationalStateBackup(backupRoot)).schemaVersion, 3);
+    assert.equal(
+      (await restoreOperationalStateBackup({ backupRoot, destinationRoot: join(base, 'restored') }))
+        .schemaVersion,
+      3,
+    );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/packages/storage/src/context-offload-snapshot.ts
+++ b/packages/storage/src/context-offload-snapshot.ts
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { chmod, copyFile, lstat, mkdir, realpath } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { backup, DatabaseSync } from 'node:sqlite';
+import { isCanonicalStorageRef } from '@maka/core/events';
+import {
+  discoverMarkedStorageRoot,
+  runWithStorageRootLease,
+  tryAcquireInteractiveRootOwner,
+} from './root-authority.js';
+import {
+  migrateSqliteContextOffloadDatabase,
+  SQLITE_CONTEXT_OFFLOAD_SCHEMA_VERSION,
+} from './sqlite-context-offload-schema.js';
+import {
+  CONTEXT_OFFLOAD_DATABASE_NAME,
+  CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME,
+} from './sqlite-context-offload-store.js';
+import { syncDirectoryChain, syncFile } from './stable-storage.js';
+import { SQLITE_SESSION_MESSAGE_CHUNK_MARKER } from './sqlite-session-metadata-schema.js';
+
+/**
+ * Existing artifact-only snapshots keep their old admission contract. Context
+ * snapshots require the root owner: a Session gate does not fence global GC.
+ * The callback must recheck absence before publishing an artifact-only snapshot.
+ */
+export async function withOfflineContextSnapshot<T>(
+  root: string,
+  operation: (contextLocked: boolean) => Promise<T>,
+): Promise<T> {
+  if (!(await exists(join(root, CONTEXT_OFFLOAD_DATABASE_NAME)))) return operation(false);
+  const capability = await discoverMarkedStorageRoot({ path: root });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  if (!owner)
+    throw new Error(
+      'Context snapshot requires an offline Storage Root; stop the Runtime Host first',
+    );
+  try {
+    return await runWithStorageRootLease(owner.lease, 'interactive', 'write', () =>
+      operation(true),
+    );
+  } finally {
+    await owner.close();
+  }
+}
+
+/** Copies under the offline owner and the caller's Artifact lock; never mutates the source DB. */
+export async function copyContextSnapshot(
+  sourceRoot: string,
+  targetRoot: string,
+  contextLocked: boolean,
+  sessionId?: string,
+): Promise<boolean> {
+  const sourcePath = join(sourceRoot, CONTEXT_OFFLOAD_DATABASE_NAME);
+  if (!(await exists(sourcePath))) return false;
+  if (!contextLocked)
+    throw new Error(
+      'Context storage appeared during snapshot; retry with the Runtime Host stopped',
+    );
+  await assertRegularPath(sourceRoot, CONTEXT_OFFLOAD_DATABASE_NAME);
+  const targetPath = join(targetRoot, CONTEXT_OFFLOAD_DATABASE_NAME);
+  const source = new DatabaseSync(sourcePath, { readOnly: true });
+  try {
+    await backup(source, targetPath);
+  } finally {
+    source.close();
+  }
+  await chmod(targetPath, 0o600);
+  const target = new DatabaseSync(targetPath);
+  try {
+    target.exec('PRAGMA foreign_keys = ON');
+    migrateSqliteContextOffloadDatabase(target);
+    target.exec('BEGIN IMMEDIATE');
+    if (sessionId !== undefined)
+      target.prepare('DELETE FROM context_refs WHERE session_id <> ?').run(sessionId);
+    target.exec(`
+      DELETE FROM context_gc_candidates;
+      DELETE FROM context_file_deletions;
+      DELETE FROM context_blobs WHERE NOT EXISTS (
+        SELECT 1 FROM context_refs WHERE context_refs.blob_id = context_blobs.blob_id
+      );
+      DELETE FROM context_session_usage;
+      INSERT INTO context_session_usage
+        SELECT r.session_id, count(*), sum(b.size_bytes)
+        FROM context_refs r JOIN context_blobs b USING(blob_id) GROUP BY r.session_id;
+      UPDATE context_store_usage SET
+        blob_count = (SELECT count(*) FROM context_blobs),
+        physical_bytes = (SELECT coalesce(sum(size_bytes), 0) FROM context_blobs)
+      WHERE singleton = 1;
+      COMMIT;
+      PRAGMA journal_mode = DELETE;
+      VACUUM;
+    `);
+    // VACUUM on the private destination removes other Sessions' deleted bytes,
+    // including SQLite free pages. It is never run on the live source.
+    for (const row of target
+      .prepare(
+        "SELECT blob_id, payload, size_bytes FROM context_blobs WHERE storage_kind = 'managed_file'",
+      )
+      .iterate()) {
+      const path = managedPath(row.blob_id, row.payload);
+      await assertRegularPath(sourceRoot, path);
+      const destination = join(targetRoot, path);
+      await mkdir(dirname(destination), { recursive: true, mode: 0o700 });
+      await copyFile(join(sourceRoot, path), destination);
+      await chmod(destination, 0o600);
+      await syncFile(destination);
+      await syncDirectoryChain(dirname(destination), targetRoot);
+    }
+  } finally {
+    target.close();
+  }
+  await syncFile(targetPath);
+  await syncDirectoryChain(targetRoot, targetRoot);
+  return true;
+}
+
+export async function planContextSnapshotFiles(root: string, sessionId: string): Promise<string[]> {
+  const path = join(root, CONTEXT_OFFLOAD_DATABASE_NAME);
+  if (!(await exists(path))) return [];
+  await assertRegularPath(root, CONTEXT_OFFLOAD_DATABASE_NAME);
+  const database = new DatabaseSync(path, { readOnly: true });
+  try {
+    const version = Number(database.prepare('PRAGMA user_version').get()?.user_version);
+    if (![1, 2, SQLITE_CONTEXT_OFFLOAD_SCHEMA_VERSION].includes(version))
+      throw new Error('Unsupported context snapshot schema');
+    const files = [CONTEXT_OFFLOAD_DATABASE_NAME];
+    if (version < 3) return files;
+    for (const row of database
+      .prepare(`SELECT DISTINCT b.blob_id, b.payload FROM context_refs r
+      JOIN context_blobs b ON b.blob_id = r.blob_id
+      WHERE r.session_id = ? AND b.storage_kind = 'managed_file' ORDER BY b.blob_id`)
+      .iterate(sessionId)) {
+      const file = managedPath(row.blob_id, row.payload);
+      await assertRegularPath(root, file);
+      files.push(file);
+    }
+    return files;
+  } finally {
+    database.close();
+  }
+}
+
+/** Verifies both payload integrity and typed ledger/message references before publication. */
+export async function validateContextSnapshot(root: string): Promise<void> {
+  let context: DatabaseSync | undefined;
+  const contextPath = join(root, CONTEXT_OFFLOAD_DATABASE_NAME);
+  try {
+    if (await exists(contextPath)) {
+      await assertRegularPath(root, CONTEXT_OFFLOAD_DATABASE_NAME);
+      context = new DatabaseSync(contextPath, { readOnly: true });
+      if (
+        context.prepare('PRAGMA user_version').get()?.user_version !==
+        SQLITE_CONTEXT_OFFLOAD_SCHEMA_VERSION
+      )
+        throw new Error('Unsupported context snapshot schema');
+      if (
+        context.prepare('PRAGMA integrity_check').get()?.integrity_check !== 'ok' ||
+        context.prepare('PRAGMA foreign_key_check').get()
+      )
+        throw new Error('Invalid context snapshot database');
+      for (const row of context
+        .prepare('SELECT blob_id, storage_kind, payload, size_bytes FROM context_blobs')
+        .iterate()) {
+        const digest = blobHash(row.blob_id);
+        if (!Number.isSafeInteger(row.size_bytes) || Number(row.size_bytes) < 0)
+          throw new Error('Invalid context snapshot size');
+        if (row.storage_kind === 'managed_file') {
+          const path = managedPath(row.blob_id, row.payload);
+          await assertRegularPath(root, path);
+          const info = await lstat(join(root, path));
+          if (info.size !== row.size_bytes || (await hashFile(join(root, path))) !== digest) {
+            throw new Error('Context snapshot payload size/hash mismatch');
+          }
+        } else if (
+          row.storage_kind !== 'inline' ||
+          !(row.payload instanceof Uint8Array) ||
+          row.payload.byteLength !== row.size_bytes ||
+          createHash('sha256').update(row.payload).digest('hex') !== digest
+        ) {
+          throw new Error('Context snapshot inline payload size/hash mismatch');
+        }
+      }
+      const actual = context
+        .prepare('SELECT count(*) AS n, coalesce(sum(size_bytes), 0) AS bytes FROM context_blobs')
+        .get()!;
+      const usage = context
+        .prepare('SELECT blob_count, physical_bytes FROM context_store_usage WHERE singleton = 1')
+        .get();
+      if (usage?.blob_count !== actual.n || usage.physical_bytes !== actual.bytes)
+        throw new Error('Context snapshot usage mismatch');
+      if (
+        context
+          .prepare(`SELECT 1 FROM (
+        SELECT r.session_id, count(*) AS reference_count, sum(b.size_bytes) AS logical_bytes
+        FROM context_refs r JOIN context_blobs b USING(blob_id) GROUP BY r.session_id
+        EXCEPT SELECT session_id, reference_count, logical_bytes FROM context_session_usage
+      ) LIMIT 1`)
+          .get()
+      )
+        throw new Error('Context snapshot Session usage mismatch');
+    }
+    validateLedgerContextRefs(root, context);
+  } finally {
+    context?.close();
+  }
+}
+
+function validateLedgerContextRefs(root: string, context: DatabaseSync | undefined): void {
+  const runtime = new DatabaseSync(join(root, 'runtime.sqlite'), { readOnly: true });
+  const find = context?.prepare('SELECT 1 FROM context_refs WHERE session_id = ? AND ref_id = ?');
+  const check = (value: unknown, sessionId: string): void => {
+    const ref = record(value);
+    if (ref.kind !== 'session_context') return;
+    if (
+      !isCanonicalStorageRef(value) ||
+      ref.sessionId !== sessionId ||
+      !find?.get(sessionId, String(ref.refId))
+    )
+      throw new Error('Snapshot has a missing or cross-Session context reference');
+  };
+  const content = (value: unknown, sessionId: string): void => {
+    const item = record(value);
+    if (item.kind === 'image') check(item.ref, sessionId);
+  };
+  const attachments = (value: unknown, sessionId: string): void => {
+    const item = record(value);
+    if (Array.isArray(item.attachments)) {
+      for (const attachment of item.attachments) check(record(attachment).ref, sessionId);
+    }
+  };
+  const projection = (value: unknown, sessionId: string): void => {
+    const item = record(value);
+    if (item.kind === 'content' && Array.isArray(item.parts)) {
+      for (const part of item.parts) {
+        const entry = record(part);
+        if (entry.kind === 'artifact') check(entry.ref, sessionId);
+      }
+    }
+  };
+  try {
+    for (const row of runtime
+      .prepare('SELECT session_id, payload_json FROM runtime_events')
+      .iterate()) {
+      const event = record(JSON.parse(String(row.payload_json)));
+      const item = record(event.content);
+      const sessionId = String(row.session_id);
+      if (item.kind === 'text') attachments(item, sessionId);
+      if (item.kind === 'function_response') {
+        content(item.result, sessionId);
+        projection(item.modelProjection, sessionId);
+      }
+    }
+    for (const row of runtime
+      .prepare(
+        "SELECT session_id, record_json FROM core_agent_run_events WHERE event_type = 'model_projection_transition_recorded'",
+      )
+      .iterate()) {
+      const event = record(JSON.parse(String(row.record_json)));
+      projection(record(record(event.data).transition).replacement, String(row.session_id));
+    }
+    const chunks = runtime.prepare(
+      'SELECT data FROM session_message_chunks WHERE session_id = ? AND sequence = ? ORDER BY chunk_index',
+    );
+    for (const row of runtime
+      .prepare('SELECT session_id, sequence, record_json FROM session_messages')
+      .iterate()) {
+      const encoded =
+        row.record_json === SQLITE_SESSION_MESSAGE_CHUNK_MARKER
+          ? Buffer.concat(
+              chunks.all(row.session_id!, row.sequence!).map((chunk) => {
+                if (!(chunk.data instanceof Uint8Array))
+                  throw new Error('Invalid snapshot message chunk');
+                return Buffer.from(chunk.data);
+              }),
+            ).toString('utf8')
+          : String(row.record_json);
+      const message = record(JSON.parse(encoded));
+      const sessionId = String(row.session_id);
+      if (message.type === 'user') attachments(message, sessionId);
+      if (message.type === 'tool_result') content(message.content, sessionId);
+    }
+  } finally {
+    runtime.close();
+  }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function blobHash(value: unknown): string {
+  if (!(value instanceof Uint8Array) || value.byteLength !== 32)
+    throw new Error('Invalid context snapshot blob identity');
+  return Buffer.from(value).toString('hex');
+}
+
+function managedPath(blobId: unknown, payload: unknown): string {
+  const digest = blobHash(blobId);
+  const expected = `sha256/${digest.slice(0, 2)}/${digest}`;
+  if (!(payload instanceof Uint8Array) || !Buffer.from(payload).equals(Buffer.from(expected))) {
+    throw new Error('Invalid context snapshot managed locator');
+  }
+  return `${CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME}/${expected}`;
+}
+
+async function assertRegularPath(root: string, relativePath: string): Promise<void> {
+  const canonical = await realpath(root);
+  const parts = relativePath.split('/');
+  let path = canonical;
+  for (const [index, part] of parts.entries()) {
+    path = join(path, part);
+    const info = await lstat(path);
+    if (
+      info.isSymbolicLink() ||
+      (index === parts.length - 1 ? !info.isFile() : !info.isDirectory())
+    ) {
+      throw new Error('Context snapshot path must not contain symlinks or special files');
+    }
+  }
+  if ((await realpath(path)) !== resolve(canonical, relativePath))
+    throw new Error('Context snapshot path escaped its root');
+}
+
+async function hashFile(path: string): Promise<string> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return false;
+    throw error;
+  }
+}

--- a/packages/storage/src/operational-state-backup.ts
+++ b/packages/storage/src/operational-state-backup.ts
@@ -35,6 +35,11 @@ import { dirname, relative, resolve } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { decodeArtifactRecordJsons } from './artifact-metadata-codec.js';
 import { withArtifactWriterLock } from './artifact-writer-lock.js';
+import {
+  withOfflineContextSnapshot,
+  copyContextSnapshot,
+  validateContextSnapshot,
+} from './context-offload-snapshot.js';
 import { decodeStoredMessage } from './execution-record-codec.js';
 import {
   acquireOperationalStateDatabase,
@@ -49,7 +54,7 @@ import {
 import { syncDirectory, syncDirectoryChain, syncFile } from './stable-storage.js';
 
 export const OPERATIONAL_BACKUP_FORMAT = 'maka-operational-backup';
-export const OPERATIONAL_BACKUP_SCHEMA_VERSION = 3 as const;
+export const OPERATIONAL_BACKUP_SCHEMA_VERSION = 4 as const;
 export const OPERATIONAL_BACKUP_MANIFEST_FILE = 'operational-backup.json';
 
 export type OperationalBackupErrorCode =
@@ -78,7 +83,7 @@ export interface OperationalBackupFile {
 
 export interface OperationalBackupManifest {
   readonly format: typeof OPERATIONAL_BACKUP_FORMAT;
-  readonly schemaVersion: typeof OPERATIONAL_BACKUP_SCHEMA_VERSION;
+  readonly schemaVersion: 3 | typeof OPERATIONAL_BACKUP_SCHEMA_VERSION;
   readonly createdAt: number;
   readonly files: readonly OperationalBackupFile[];
 }
@@ -101,58 +106,61 @@ export async function createOperationalStateBackup(
   const destinationRoot = resolve(input.destinationRoot);
   assertSeparateRoots(stateRoot, destinationRoot);
   await assertMissing(destinationRoot, 'backup destination');
-  return withArtifactWriterLock(stateRoot, async (canonicalStateRoot) => {
-    assertSeparateRoots(canonicalStateRoot, destinationRoot);
-    const stagingRoot = `${destinationRoot}.${process.pid}.${randomUUID()}.tmp`;
-    try {
-      await mkdir(stagingRoot, { recursive: true, mode: 0o700 });
-      const database = acquireOperationalStateDatabase(canonicalStateRoot);
-      const databasePath = resolve(stagingRoot, OPERATIONAL_STATE_DATABASE_NAME);
+  return withOfflineContextSnapshot(stateRoot, (contextLocked) =>
+    withArtifactWriterLock(stateRoot, async (canonicalStateRoot) => {
+      assertSeparateRoots(canonicalStateRoot, destinationRoot);
+      const stagingRoot = `${destinationRoot}.${process.pid}.${randomUUID()}.tmp`;
       try {
-        await database.backup(databasePath);
-      } finally {
-        database.close();
+        await mkdir(stagingRoot, { recursive: true, mode: 0o700 });
+        const database = acquireOperationalStateDatabase(canonicalStateRoot);
+        const databasePath = resolve(stagingRoot, OPERATIONAL_STATE_DATABASE_NAME);
+        try {
+          await database.backup(databasePath);
+        } finally {
+          database.close();
+        }
+        normalizeStandaloneSqliteSnapshot(databasePath);
+        await chmod(databasePath, 0o600);
+        await syncFile(databasePath);
+        const artifactRoot = resolve(canonicalStateRoot, 'artifacts');
+        if (await pathExists(artifactRoot)) {
+          await copyRegularTree(
+            artifactRoot,
+            resolve(stagingRoot, 'artifacts'),
+            artifactRoot,
+            stagingRoot,
+          );
+        }
+        await copyContextSnapshot(canonicalStateRoot, stagingRoot, contextLocked);
+        const createdAt = (input.now ?? Date.now)();
+        if (!Number.isSafeInteger(createdAt) || createdAt < 0) {
+          throw new OperationalBackupError('corrupt_backup', 'Backup creation time is invalid');
+        }
+        const manifest: OperationalBackupManifest = {
+          format: OPERATIONAL_BACKUP_FORMAT,
+          schemaVersion: OPERATIONAL_BACKUP_SCHEMA_VERSION,
+          createdAt,
+          files: await inventory(stagingRoot),
+        };
+        const manifestPath = resolve(stagingRoot, OPERATIONAL_BACKUP_MANIFEST_FILE);
+        await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+          encoding: 'utf8',
+          flag: 'wx',
+          mode: 0o600,
+        });
+        await syncFile(manifestPath);
+        await validateOperationalStateBackup(stagingRoot);
+        await syncDirectoryChain(stagingRoot, stagingRoot);
+        await mkdir(dirname(destinationRoot), { recursive: true });
+        await rename(stagingRoot, destinationRoot);
+        await syncDirectory(dirname(destinationRoot));
+        return manifest;
+      } catch (error) {
+        await rm(stagingRoot, { recursive: true, force: true }).catch(() => {});
+        throw error;
       }
-      normalizeStandaloneSqliteSnapshot(databasePath);
-      await chmod(databasePath, 0o600);
-      await syncFile(databasePath);
-      const artifactRoot = resolve(canonicalStateRoot, 'artifacts');
-      if (await pathExists(artifactRoot)) {
-        await copyRegularTree(
-          artifactRoot,
-          resolve(stagingRoot, 'artifacts'),
-          artifactRoot,
-          stagingRoot,
-        );
-      }
-      const createdAt = (input.now ?? Date.now)();
-      if (!Number.isSafeInteger(createdAt) || createdAt < 0) {
-        throw new OperationalBackupError('corrupt_backup', 'Backup creation time is invalid');
-      }
-      const manifest: OperationalBackupManifest = {
-        format: OPERATIONAL_BACKUP_FORMAT,
-        schemaVersion: OPERATIONAL_BACKUP_SCHEMA_VERSION,
-        createdAt,
-        files: await inventory(stagingRoot),
-      };
-      const manifestPath = resolve(stagingRoot, OPERATIONAL_BACKUP_MANIFEST_FILE);
-      await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
-        encoding: 'utf8',
-        flag: 'wx',
-        mode: 0o600,
-      });
-      await syncFile(manifestPath);
-      await validateOperationalStateBackup(stagingRoot);
-      await syncDirectoryChain(stagingRoot, stagingRoot);
-      await mkdir(dirname(destinationRoot), { recursive: true });
-      await rename(stagingRoot, destinationRoot);
-      await syncDirectory(dirname(destinationRoot));
-      return manifest;
-    } catch (error) {
-      await rm(stagingRoot, { recursive: true, force: true }).catch(() => {});
-      throw error;
-    }
-  });
+    }),
+  );
 }
 
 export async function validateOperationalStateBackup(
@@ -173,6 +181,7 @@ export async function validateOperationalStateBackup(
     throw new OperationalBackupError('corrupt_backup', 'Backup file inventory does not match');
   }
   validateSqlite(resolve(root, OPERATIONAL_STATE_DATABASE_NAME), manifest.files);
+  await validateContextSnapshot(root);
   return manifest;
 }
 
@@ -201,6 +210,7 @@ export async function restoreOperationalStateBackup(
       throw new OperationalBackupError('corrupt_backup', 'Restored file inventory does not match');
     }
     validateSqlite(resolve(stagingRoot, OPERATIONAL_STATE_DATABASE_NAME), manifest.files);
+    await validateContextSnapshot(stagingRoot);
     await syncDirectoryChain(stagingRoot, stagingRoot);
     await mkdir(dirname(destinationRoot), { recursive: true });
     await rename(stagingRoot, destinationRoot);
@@ -220,7 +230,7 @@ function decodeManifest(value: unknown): OperationalBackupManifest {
   if (record.format !== OPERATIONAL_BACKUP_FORMAT) {
     throw new OperationalBackupError('corrupt_backup', 'Backup format is invalid');
   }
-  if (record.schemaVersion !== OPERATIONAL_BACKUP_SCHEMA_VERSION) {
+  if (record.schemaVersion !== 3 && record.schemaVersion !== OPERATIONAL_BACKUP_SCHEMA_VERSION) {
     throw new OperationalBackupError('unsupported_schema', 'Backup schema is unsupported');
   }
   if (
@@ -253,7 +263,7 @@ function decodeManifest(value: unknown): OperationalBackupManifest {
   }
   return {
     format: OPERATIONAL_BACKUP_FORMAT,
-    schemaVersion: OPERATIONAL_BACKUP_SCHEMA_VERSION,
+    schemaVersion: record.schemaVersion,
     createdAt: record.createdAt as number,
     files,
   };

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -25,11 +25,26 @@ import type { ArtifactRecord } from '@maka/core/artifacts';
 import { decodeArtifactRecordJsons } from './artifact-metadata-codec.js';
 import { withArtifactWriterLock } from './artifact-writer-lock.js';
 import {
+  withOfflineContextSnapshot,
+  copyContextSnapshot,
+  validateContextSnapshot,
+  planContextSnapshotFiles,
+} from './context-offload-snapshot.js';
+import {
+  CONTEXT_OFFLOAD_DATABASE_NAME,
+  CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME,
+} from './sqlite-context-offload-store.js';
+import {
   acquireOperationalStateDatabase,
   OPERATIONAL_STATE_DATABASE_NAME,
 } from './operational-state-store.js';
 
-export const SESSION_BUNDLE_STATE_ENTRIES = ['artifacts', OPERATIONAL_STATE_DATABASE_NAME] as const;
+export const SESSION_BUNDLE_STATE_ENTRIES = [
+  'artifacts',
+  OPERATIONAL_STATE_DATABASE_NAME,
+  CONTEXT_OFFLOAD_DATABASE_NAME,
+  CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME,
+] as const;
 export const SESSION_BUNDLE_PROTECTED_ENTRIES = [] as const;
 
 export type SessionBundleExportErrorCode =
@@ -61,7 +76,7 @@ export interface SessionBundleRootLayoutInput {
 export interface SessionBundleExportPlanEntry {
   relativePath: string;
   kind: 'file' | 'directory';
-  source: 'copy' | 'filtered_runtime_sqlite';
+  source: 'copy' | 'filtered_runtime_sqlite' | 'context_snapshot';
 }
 
 export interface SessionBundleExportPlan {
@@ -145,6 +160,12 @@ export async function planSessionBundleExport(
     }
     includedEntries.push('artifacts');
   }
+  const contextFiles = await planContextSnapshotFiles(stateRoot, input.sessionId);
+  for (const relativePath of contextFiles) {
+    entries.push({ relativePath, kind: 'file', source: 'context_snapshot' });
+  }
+  if (contextFiles.length > 0) includedEntries.push(CONTEXT_OFFLOAD_DATABASE_NAME);
+  if (contextFiles.length > 1) includedEntries.push(CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME);
   const allowed = new Set<string>([...SESSION_BUNDLE_STATE_ENTRIES]);
   const excludedEntries = (await readdir(stateRoot)).filter((entry) => !allowed.has(entry)).sort();
   return {
@@ -161,33 +182,38 @@ export async function planSessionBundleExport(
 export async function exportSessionBundleState(
   input: SessionBundleExportInput,
 ): Promise<SessionBundleExportPlan> {
-  return withArtifactWriterLock(input.stateRoot, async (stateRoot) => {
-    const plan = await planSessionBundleExport({ ...input, stateRoot });
-    await assertDestinationMissing(plan.destinationRoot);
-    const stagingRoot = `${plan.destinationRoot}.${process.pid}.${randomUUID()}.tmp`;
-    try {
-      await mkdir(stagingRoot, { recursive: true });
-      for (const entry of plan.entries) {
-        const destination = resolveInside(stagingRoot, entry.relativePath);
-        if (entry.kind === 'directory') {
-          await mkdir(destination, { recursive: true });
-          continue;
+  return withOfflineContextSnapshot(input.stateRoot, (contextLocked) =>
+    withArtifactWriterLock(input.stateRoot, async (stateRoot) => {
+      const plan = await planSessionBundleExport({ ...input, stateRoot });
+      await assertDestinationMissing(plan.destinationRoot);
+      const stagingRoot = `${plan.destinationRoot}.${process.pid}.${randomUUID()}.tmp`;
+      try {
+        await mkdir(stagingRoot, { recursive: true, mode: 0o700 });
+        for (const entry of plan.entries) {
+          if (entry.source === 'context_snapshot') continue;
+          const destination = resolveInside(stagingRoot, entry.relativePath);
+          if (entry.kind === 'directory') {
+            await mkdir(destination, { recursive: true });
+            continue;
+          }
+          await mkdir(dirname(destination), { recursive: true });
+          if (entry.source === 'copy') {
+            await copyFile(resolveInside(plan.stateRoot, entry.relativePath), destination);
+          } else {
+            await exportFilteredDatabase(plan.stateRoot, destination, plan.sessionId);
+          }
         }
-        await mkdir(dirname(destination), { recursive: true });
-        if (entry.source === 'copy') {
-          await copyFile(resolveInside(plan.stateRoot, entry.relativePath), destination);
-        } else {
-          await exportFilteredDatabase(plan.stateRoot, destination, plan.sessionId);
-        }
+        await copyContextSnapshot(stateRoot, stagingRoot, contextLocked, plan.sessionId);
+        await validateContextSnapshot(stagingRoot);
+        await mkdir(dirname(plan.destinationRoot), { recursive: true });
+        await rename(stagingRoot, plan.destinationRoot);
+        return plan;
+      } catch (error) {
+        await rm(stagingRoot, { recursive: true, force: true }).catch(() => {});
+        throw error;
       }
-      await mkdir(dirname(plan.destinationRoot), { recursive: true });
-      await rename(stagingRoot, plan.destinationRoot);
-      return plan;
-    } catch (error) {
-      await rm(stagingRoot, { recursive: true, force: true }).catch(() => {});
-      throw error;
-    }
-  });
+    }),
+  );
 }
 
 async function exportFilteredDatabase(
@@ -274,6 +300,7 @@ async function exportFilteredDatabase(
       .prepare('SELECT 1 AS present FROM session_metadata WHERE session_id = ?')
       .get(sessionId);
     if (!session) throw new Error(`Filtered session is missing: ${sessionId}`);
+    database.exec('PRAGMA journal_mode = DELETE');
   } catch (error) {
     try {
       database.exec('ROLLBACK');


### PR DESCRIPTION
## Summary

Refs #4071. Second slice after #4963, following the [revised plan](https://github.com/apache/maka/issues/4071#issuecomment-5565910520).

Read images already persist as Session context refs, but operational backups and Session exports only included runtime.sqlite and artifacts. A successful snapshot could therefore restore history without its image bytes.

- Include a standalone context SQLite snapshot and its referenced managed values. Verify blob sizes/hashes, database integrity, usage and typed context references before publishing backups/exports and again before publishing a restore.
- Hold the exclusive Storage Root owner across context snapshots, outside the existing Artifact lock. An active Host causes an explicit offline-required refusal; a Session quiescence interface alone does not fence global context GC.
- Filter Session exports to that Session's context refs and deduplicated payloads. Drop unreferenced blobs and maintenance queues from the destination and rebuild its usage counters. Vacuum only the private destination to remove other Sessions' deleted inline bytes.
- Preserve Session/ref identities for restoration into a separate root. No source RuntimeEvents or source context database are rewritten.
- Emit operational backup format v4 while retaining v3 decoding/restoration. Reject old snapshots that actually carry dangling context refs rather than silently presenting them as complete.
- Normalize the filtered runtime database to a standalone file so validation does not add WAL sidecars to the bundle inventory.

## Verification

- Core and storage builds passed; storage typecheck passed.
- Full storage suite: **1191 passed, 8 skipped, 0 failed**.
- Final focused backup/export/production-snapshot/Artifact-lock suites: **32 passed, 0 failed**.
- Negative control: bypassing context copying makes the restored-image regression fail on missing context references; reverted before final validation.
- New coverage: empty-root image restore, shared-blob deduplication, single-Session isolation including inline free-page bytes, active-owner refusal, exclusive-owner release after failure, missing database/files, corrupt bytes despite a recomputed manifest, cross-Session projection refs, opaque JSON non-interpretation, symlinked value ancestors and v3 backup compatibility.
- Root lint/format check, ASF headers and diff check passed.

Not run: full repository build/typecheck, Runtime Host/Desktop suites, Linux/Windows runs, cross-process snapshot race injection or multi-GiB latency/RSS benchmarks.

## Rollout and Scope

**Context-bearing roots require offline backup/export in this slice.** Stop the Runtime Host and release its root owner first. Calls through a live Host/quiescence adapter are refused, not treated as a globally consistent snapshot. Artifact-only roots retain their existing locking behavior; context appearing during such a snapshot forces a retry.

The context DB is copied using SQLite backup, migrated/filtered only in the private destination, and validated before publication. The source is not vacuumed or migrated. Root identity markers are not exported.

This covers standalone backup restore and the existing isolated Session bundle state exporter. It does **not** introduce merge-import into an already-running workspace, ref-ID remapping into an existing Session, an online snapshot protocol, a new UI/CLI surface, or automatic recovery of already-missing image bytes. Whole-root backup still has its existing operational-state scope; this is not a claim to include every independent product database.

Backup files written as v4 require this reader; older binaries need not accept them. Existing supported v3 backups remain readable when their references are complete.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex inspected storage authorities, implemented snapshot/validation changes and tests, ran local verification and prepared this PR. Commit includes Generated-by: Codex.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — context images survive snapshots, and unsafe online context exports are refused.
- [ ] No
