### PR TITLE
fix(desktop): bound the workbar panel grid row to stop terminal fit/resize loop

### DIFF
--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -186,7 +186,7 @@ test('Git changes re-read the workspace after the app regains focus', async ({
   await expect(panel.getByText('新增 5 行')).toBeVisible();
 });
 
-test('Terminal ownership follows the active Session and stops the old resource', async ({
+test('Terminal fits its panel without growing and stops when its Session changes', async ({
   window: page,
 }) => {
   const { composer, sessionId, sidebar } = await createSession(
@@ -209,6 +209,23 @@ test('Terminal ownership follows the active Session and stops the old resource',
         ?.result.status,
     )
     .toBe('running');
+
+  // Exercise real layout across frames: a Section's implicit grid row used to
+  // grow with xterm, continuously triggering fit/resize even at an idle prompt.
+  const fitsPanel = () => terminal.evaluate(async (element) => {
+    const panel = element.closest('.maka-session-workbar-panel')!;
+    const host = element.querySelector('.maka-session-terminal-xterm')!;
+    for (let frame = 0; frame < 12; frame += 1) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      const bounds = panel.getBoundingClientRect();
+      const terminalBounds = host.getBoundingClientRect();
+      if (terminalBounds.height <= 0 || terminalBounds.bottom > bounds.bottom + 1) {
+        return false;
+      }
+    }
+    return true;
+  });
+  await expect.poll(fitsPanel).toBe(true);
 
   await sidebar.getByRole('button', { name: '新任务', exact: true }).click();
   await expect(terminal).toHaveCount(0);

--- a/apps/desktop/src/renderer/styles/workbar/shell.css
+++ b/apps/desktop/src/renderer/styles/workbar/shell.css
@@ -133,6 +133,11 @@
 }
 
 .maka-session-workbar-panel[data-overlay] {
+  display: grid;
+  /* Section adds an inner wrapper with height: 100%. An implicit auto row
+     can grow with xterm's content, feeding ResizeObserver -> fit -> resize
+     back into layout indefinitely. Bound the row to the available panel. */
+  grid-template-rows: minmax(0, 1fr);
   position: relative;
   z-index: 1;
   overflow: hidden;
@@ -147,6 +152,8 @@
      leaving its own overflow scroller with nothing to scroll. */
   display: grid;
   grid-template-rows: minmax(0, 1fr);
+  /* One stretched track, like the frame: the face fills the height and the
+     column can be aligned as a whole. */
   padding-top: var(--maka-plate-titlebar-clearance);
 }
 


### PR DESCRIPTION
## Summary

Fixes #4966 
Root cause — a layout feedback loop:

- `.maka-session-workbar-panel[data-overlay][data-placement="right"]` is `display: grid` but declared **no explicit row track**, so content fell into an implicit `auto` row;
- an `auto` row's size includes its contents' min-content contribution, so the Section inner wrapper (`height: 100%`) and the terminal panel (`height: 100%`) grew with xterm's output;
- that fired `ResizeObserver` → xterm `fit()` → layout changed → observer fired again: a `ResizeObserver → fit → resize → grow` loop on every burst of output.

The fix declares an explicit track, `grid-template-rows: minmax(0, 1fr)`: the `1fr` sizes the track purely from the container's definite height so content no longer participates in track sizing, and `min 0` removes the auto row's min-content floor — cutting the loop at its root.

## Testing

- Added an e2e assertion (`Terminal fits its panel without growing and stops when its Session changes`): across 12 consecutive `requestAnimationFrame` ticks the xterm host stays within the panel bounds. Fails without the CSS change, passes with it.
- Full `session-workbar.spec.ts` passes (6/6); verified the other overlay panels (review / browser / files / inspector / side-chat) have `height: 100%` roots and are unaffected, and the wide-window collapse animation's `display: grid` restore rule still applies.
- `npm run typecheck` and `check:e2e-budget` pass.
