### PR TITLE
test(desktop): wait for narrative fixture workbar

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -681,13 +681,24 @@ export const test = base.extend<E2eTestFixtures>({
   // beside it. Shown because the accessibility journey follows real native
   // focus order through the transcript into the composer controls.
   accessibilityNarrativeWindow: async ({}, use) => {
-    await withE2eWindow({
-      seed: false,
-      readinessSelector: '[data-turn-id]',
-      e2eFixtureScenario: 'turn-narrative',
-      locale: 'zh-CN',
-      showWindow: true,
-    }, use);
+    await withE2eWindow(
+      {
+        seed: false,
+        readinessSelector: '[data-turn-id]',
+        e2eFixtureScenario: 'turn-narrative',
+        locale: 'zh-CN',
+        showWindow: true,
+      },
+      async (page) => {
+        // `[data-turn-id]` can render before the deferred fixture application
+        // finishes opening its seeded Review face. Handing the page to a test
+        // at that point lets a test-opened face lose to the later fixture
+        // action. The visible seeded panel is the convergence point for both
+        // the transcript and the fixture-owned workbar state.
+        await expect(page.getByRole('region', { name: 'Git 变更' })).toBeVisible();
+        await use(page);
+      },
+    );
   },
 });
 


### PR DESCRIPTION
## Summary

Wait for the seeded Git changes panel to become visible before the narrative fixture hands its page to tests. This closes the initialization gap where the fixture could select Review after the usage action had already selected Trace.

Fixes #4968

## Verification

- `npm exec -- biome check apps/desktop/e2e/fixtures.ts`
- `npm --workspace @maka/desktop run build:workspace-deps && npm --workspace @maka/desktop run typecheck`
- `npm exec -w @maka/desktop -- playwright test --config e2e/playwright.config.ts e2e/session-workbar.spec.ts --grep "the composer usage action opens Task trace in the right workbar" --repeat-each=10` (10 passed)
- `git diff origin/main...HEAD --check`

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the CI failure, implemented the fixture synchronization, and ran verification. The commit includes the required `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
