### PR TITLE
fix(desktop): keep context gauge stable at the transcript tail

### DIFF
--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -40,6 +40,18 @@
   max-width: var(--maka-reading-measure);
 }
 
+/* Reaching the transcript tail fades the scroll-to-bottom control while the
+   composer below it stays still. Both otherwise share the dock's filtered
+   compositing surface, so Chromium may re-raster the thin context-gauge paths
+   for that opacity transition: their DOM box does not move, but the icon
+   visibly hops by a device pixel. Keep the fading control in its own small
+   paint/compositing boundary. `astryx-chat-layout-scroll-button` is Astryx's
+   published theme class; the child is its fixed 32px transition container. */
+.astryx-chat-layout-scroll-button > div {
+  contain: layout style paint;
+  will-change: opacity, transform;
+}
+
 .maka-composer-queue {
   width: min(var(--maka-reading-measure), calc(100% - (2 * var(--space-6))));
   max-width: var(--maka-reading-measure);

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -2071,7 +2071,13 @@ const HISTORY_BATCH = 4;
 const HISTORY_BATCHES_AVAILABLE = 8;
 
 /** A settled transcript with a turn the play function can make arrive. */
-function SettledTranscriptHarness({ turns }: { turns: number }) {
+function SettledTranscriptHarness({
+  turns,
+  composer,
+}: {
+  turns: number;
+  composer?: Partial<ComposerProps>;
+}) {
   const [extra, setExtra] = useState(0);
   useEffect(() => {
     appendTurn = () => setExtra((count) => count + 1);
@@ -2079,7 +2085,7 @@ function SettledTranscriptHarness({ turns }: { turns: number }) {
       appendTurn = undefined;
     };
   }, []);
-  return <ComposedShell chat={{ messages: transcriptTurns(0, turns + extra) }} />;
+  return <ComposedShell chat={{ messages: transcriptTurns(0, turns + extra) }} composer={composer} />;
 }
 
 /** The history seam is two props: `hasOlderHistory`, and a loader that prepends. */
@@ -2135,9 +2141,31 @@ export const TailFollowsGrowthOutsideTurns: Story = {
 };
 
 export const ReaderScrolledUpIsNotPulledBack: Story = {
-  render: () => <SettledTranscriptHarness turns={12} />,
+  render: () => (
+    <SettledTranscriptHarness
+      turns={12}
+      composer={{
+        contextUsage: {
+          usageTokens: 37_000,
+          declaredContextWindow: 100_000,
+          onOpen: noop,
+        },
+      }}
+    />
+  ),
   play: async () => {
     const root = tailScroller();
+    const contextGauge = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="打开用量追踪"]',
+    );
+    const scrollButtonPaintBoundary = dockButton().parentElement;
+    if (!contextGauge?.querySelector('svg') || !scrollButtonPaintBoundary) {
+      throw new Error('the context gauge or scroll-button paint boundary is missing');
+    }
+    const boundaryStyle = getComputedStyle(scrollButtonPaintBoundary);
+    // Chromium canonicalizes `layout style paint` to the equivalent `content`.
+    expect(boundaryStyle.contain).toBe('content');
+    expect(boundaryStyle.willChange).toContain('opacity');
     await waitFor(() => expect(tailMetrics().distance).toBeLessThanOrEqual(4));
 
     root.scrollTop -= 500;
@@ -2169,6 +2197,20 @@ export const ReaderScrolledUpIsNotPulledBack: Story = {
         JSON.stringify({ anchorTurnId, anchorTop, afterTop, ...tailMetrics() }),
       ).toBeLessThanOrEqual(4);
     });
+
+    // Returning to the tail fades the dock button. That transition must not
+    // re-raster the context gauge on the same compositing surface (#4973).
+    // Geometry alone cannot see a device-pixel repaint, so the boundary above
+    // pins the causal contract; these samples separately ensure the fix never
+    // turns into a real footer movement.
+    const iconTops: number[] = [];
+    root.scrollTop = root.scrollHeight;
+    root.dispatchEvent(new Event('scroll'));
+    for (let frame = 0; frame < 16; frame += 1) {
+      await painted(1);
+      iconTops.push(contextGauge.querySelector('svg')!.getBoundingClientRect().top);
+    }
+    expect(Math.max(...iconTops) - Math.min(...iconTops)).toBeLessThanOrEqual(0.25);
   },
 };
 


### PR DESCRIPTION
## Summary

Keep the composer context gauge visually stable when the transcript reaches the live tail.

The tail transition fades the scroll-to-bottom control inside the same filtered dock surface as the composer. Chromium can re-raster that shared surface even though the gauge, model-control group, and composer DOM boxes never move; the thin gauge paths then visibly hop by a device pixel. This patch adds paint containment and a compositing hint to the scroll button’s existing 32px transition container, limiting the opacity repaint to that control.

The existing reader-scroll Storybook scenario now includes a real context gauge and asserts both sides of the contract: the scroll-button paint boundary is present, and the gauge SVG stays within 0.25px while returning to the tail.

Fixes #4973

## Verification

- `npm --workspace @maka/desktop run typecheck:stories`
- `node --test packages/ui/dist/__tests__/composer-context-usage.test.js` (2/2)
- `npm --workspace @maka/desktop run build-storybook`
- `node scripts/storybook-visual-smoke.mjs apps/desktop/storybook-static` (312 stories, 339 theme renders)
- `npm run check:renderer-architecture -- --base origin/main` (101/101 fixtures; check passed)
- `npm run astryx:surface-inventory`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool and scope: Codex — diagnosis, implementation, browser verification, and test coverage.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck, and affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — the context gauge no longer visually jumps during the tail transition
- [ ] No