### PR TITLE
fix(desktop): exclude archived sessions from startup selection

### DIFF
--- a/apps/desktop/e2e-budget.json
+++ b/apps/desktop/e2e-budget.json
@@ -14,8 +14,8 @@
       "electron": "the saved window is read back from the Host's connection snapshot, not from renderer state"
     },
     "new-task-reload.spec.ts": {
-      "tests": 1,
-      "electron": "renderer reload is the whole contract: an explicit new task must not reopen history"
+      "tests": 2,
+      "electron": "renderer reload must preserve an explicit new task and rebuild archived-only Host history as an empty, usable new-task surface"
     },
     "partial-history-notice.spec.ts": {
       "tests": 1,

--- a/apps/desktop/e2e/new-task-reload.spec.ts
+++ b/apps/desktop/e2e/new-task-reload.spec.ts
@@ -19,6 +19,58 @@
 
 import { COMPOSER_INPUT, awaitSendReady, ensureSidebarExpanded, expect, test } from './fixtures';
 
+test('archived-only history boots into a usable new task', async ({ window: page }, testInfo) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const composer = page.locator(COMPOSER_INPUT);
+  const reply = page.getByText(/Fake backend received: archived startup regression/);
+  await composer.fill('archived startup regression');
+  await awaitSendReady(page);
+  await composer.press('Enter');
+  await expect(reply).toBeVisible({ timeout: 20_000 });
+
+  // Prove bootstrap can restore this history before archiving it.
+  await page.reload();
+  await expect(reply).toBeVisible();
+  await page.evaluate(async () => {
+    const sessions = await window.maka.sessions.list();
+    for (const session of sessions) await window.maka.sessions.archive(session.id);
+  });
+  await expect.poll(async () =>
+    page.evaluate(async () => (await window.maka.sessions.list()).map(({ isArchived }) => isArchived)),
+  ).toEqual([true]);
+  // A cold window has no explicit new-task reload intent. Keep this test on
+  // automatic bootstrap even if retirement starts recording that intent.
+  await page.evaluate(() => sessionStorage.removeItem('maka-new-task-reload-intent-v1'));
+  await page.reload();
+  await expect(composer).toBeVisible();
+  await ensureSidebarExpanded(page);
+  await expect(page.locator('[data-session-id]')).toHaveCount(0);
+  try {
+    await expect(page.locator('.maka-titlebar-identity__segment--session')).toHaveCount(0);
+    await expect(page.locator('.maka-turn')).toHaveCount(0);
+  } finally {
+    await testInfo.attach('archived-only-startup', {
+      body: await page.screenshot({ animations: 'disabled' }),
+      contentType: 'image/png',
+    });
+  }
+
+  await composer.fill('new task after archived history');
+  await awaitSendReady(page);
+  await composer.press('Enter');
+  await expect(page.getByText(/Fake backend received: new task after archived history/))
+    .toBeVisible({ timeout: 20_000 });
+  await expect.poll(async () =>
+    page.evaluate(async () => {
+      const sessions = await window.maka.sessions.list();
+      return {
+        archived: sessions.filter((session) => session.isArchived).length,
+        active: sessions.filter((session) => !session.isArchived).length,
+      };
+    }),
+  ).toEqual({ archived: 1, active: 1 });
+});
+
 test('an explicit new task survives a renderer reload without reopening history', async ({
   window: page,
 }) => {

--- a/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
@@ -30,10 +30,10 @@ import {
   writeNewTaskReloadDraft,
 } from '../../renderer/new-task-reload-intent.js';
 
-type Summary = { id: string; lastMessageAt?: number };
+type Summary = { id: string; lastMessageAt?: number; isArchived: boolean };
 
-function session(id: string, lastMessageAt?: number): Summary {
-  return { id, lastMessageAt };
+function session(id: string, lastMessageAt?: number, isArchived = false): Summary {
+  return { id, lastMessageAt, isArchived };
 }
 
 function harness(activeId?: string) {
@@ -58,6 +58,60 @@ function harness(activeId?: string) {
 }
 
 describe('bootstrap selection lease', () => {
+  it('leaves the new-task surface selected when all history is archived', () => {
+    const state = harness();
+    state.lease.reconcile([session('archived', 2, true), session('older', 1, true)]);
+    assert.equal(state.activeId(), undefined);
+  });
+
+  it('skips archived rows when choosing the first unarchived conversation', () => {
+    const state = harness();
+    state.lease.reconcile([
+      session('archived', 3, true),
+      session('recent', 2),
+      session('older', 1),
+    ]);
+    assert.equal(state.activeId(), 'recent');
+  });
+
+  it('revalidates archive eligibility across bootstrap snapshots', () => {
+    const state = harness();
+    state.lease.reconcile([session('recent', 2), session('older', 1)]);
+    assert.equal(state.activeId(), 'recent');
+    state.lease.reconcile([session('recent', 2, true), session('older', 1)]);
+    assert.equal(state.activeId(), 'older');
+    state.lease.reconcile([session('recent', 2, true), session('older', 1, true)]);
+    assert.equal(state.activeId(), undefined);
+  });
+
+  it('does not reopen older history behind an empty unarchived task', () => {
+    const state = harness();
+    state.lease.reconcile([
+      session('archived', 2, true),
+      session('empty'),
+      session('history', 1),
+    ]);
+    assert.equal(state.activeId(), undefined);
+  });
+
+  it('preserves an eligible bootstrap selection when newer history arrives', () => {
+    const state = harness();
+    state.lease.reconcile([session('selected', 1)]);
+    state.lease.reconcile([session('newer', 2), session('selected', 1)]);
+    assert.equal(state.activeId(), 'selected');
+  });
+
+  it('does not override explicitly opened archived history', () => {
+    const state = harness();
+    state.lease.reconcile([session('active', 1)]);
+    state.select('archived');
+    assert.equal(
+      state.lease.reconcile([session('archived', 2, true), session('active', 1)]),
+      false,
+    );
+    assert.equal(state.activeId(), 'archived');
+  });
+
   it('lets snapshot A and mounted pull B reconcile while bootstrap still owns selection', () => {
     const state = harness();
     assert.equal(state.lease.reconcile([session('a', 1)]), true);

--- a/apps/desktop/src/renderer/bootstrap-selection-lease.ts
+++ b/apps/desktop/src/renderer/bootstrap-selection-lease.ts
@@ -17,12 +17,16 @@
  * under the License.
  */
 
-export interface BootstrapSelectionLease<Summary extends { id: string; lastMessageAt?: number }> {
+import type { SessionSummary } from '@maka/core/session';
+
+type BootstrapSession = Pick<SessionSummary, 'id' | 'lastMessageAt' | 'isArchived'>;
+
+export interface BootstrapSelectionLease<Summary extends BootstrapSession> {
   reconcile(sessions: readonly Summary[]): boolean;
   release(): void;
 }
 
-export function createBootstrapSelectionLease<Summary extends { id: string; lastMessageAt?: number }>(options: {
+export function createBootstrapSelectionLease<Summary extends BootstrapSession>(options: {
   readActiveId: () => string | undefined;
   readSelectionRevision: () => number;
   select: (sessionId: string | undefined) => void;
@@ -37,11 +41,13 @@ export function createBootstrapSelectionLease<Summary extends { id: string; last
         return false;
       }
 
+      // The catalog includes archived history; automatic selection must not.
+      const candidates = sessions.filter((session) => !session.isArchived);
       const current = options.readActiveId();
-      const next = current && sessions.some((session) => session.id === current)
+      const next = current && candidates.some((session) => session.id === current)
         ? current
-        : sessions[0]?.lastMessageAt
-          ? sessions[0].id
+        : candidates[0]?.lastMessageAt
+          ? candidates[0].id
           : undefined;
       if (next !== current) options.select(next);
       ownedRevision = options.readSelectionRevision();


### PR DESCRIPTION
## Summary

Fix automatic startup reopening archived history behind an empty task sidebar.

The bootstrap catalog intentionally contains archived sessions. The selector previously treated catalog membership as sufficient both when opening its first conversation and when retaining that selection across bootstrap snapshots. The normal sidebar already excludes archived sessions.

Filter archive-ineligible candidates inside the bootstrap selection owner, covering both paths without changing catalog/storage semantics. When no unarchived conversation remains, the existing new-task surface is shown. Explicit navigation (including opening archived history), explicit new-task reload intent, catalog ordering, and the existing empty-task behavior remain unchanged. No migration or data deletion is needed.

## Verification

- Unit red/green: the previous selector fails four new regressions; the corrected selector passes all 13 bootstrap tests.
- Real Electron red/green: the same archived-only scenario fails on the previous renderer with an archived title/transcript despite an empty sidebar. The corrected renderer opens the new-task surface, successfully sends a new message, and retains one archived plus one active session.
- Both `new-task-reload.spec.ts` tests pass together (27.4s), including existing draft preservation.
- Desktop dependency/build pipeline, desktop typecheck, changed-file Biome check, `git diff --check`, E2E budget (34 tests), and renderer architecture checks (101 fixtures plus baseline ratchet) pass.
- Broad desktop `test:dist`: 2329 passed and two failures in the initial parallel run. The unchanged shell-env test missed its startup PID file under load; the unchanged Vite test process required termination after its assertions finished but it did not exit. Isolated reruns pass 12/12 shell-env tests and 2/2 Vite tests. The broad command was not rerun in full.
- Initial Electron attempts also hit fixture startup timeouts. The successful focused and paired runs used the unchanged 60-second budget and zero retries.

### Before and after

Same real Electron scenario, 1280 x 900 viewport, Chinese locale, light theme, expanded sidebar, default zoom, and one archived test conversation. These use isolated synthetic data, not a personal transcript.

Before: empty sidebar, archived conversation automatically reopened.

![Before](https://raw.githubusercontent.com/hqhq1025/maka-agent/ff9e2595bf5eef3c4489df18f154e28186d622a8/archived-bootstrap-20260907/before.png)

After: empty sidebar and the existing new-task surface.

![After](https://raw.githubusercontent.com/hqhq1025/maka-agent/ff9e2595bf5eef3c4489df18f154e28186d622a8/archived-bootstrap-20260907/after.png)

## Review

Local self-review and an independent agent review found no actionable issues. The change follows the verified selection-boundary cause directly; no deeper refactor, extra runtime state, fallback, or production-code deletion is warranted. Tests cover distinct selection and ownership boundaries. A delayed-refresh/navigation interleaving is covered by separate selector/refresher tests rather than a new integrated timing fixture.

Human approval and hosted CI remain required before merge. This PR does not authorize or enable merging.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the bug, implemented the selector fix and regression tests, ran validation, captured screenshots, and prepared this PR. The commit includes a Generated-by trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

The focused checks pass; the broad-suite qualification above is why the aggregate checkbox remains unchecked.

Does this PR entail a change in behavior?

- [x] Yes, described under Summary above
- [ ] No
