### PR TITLE
style(ui): present context compaction as a transcript checkpoint

### DIFF
--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -3343,9 +3343,11 @@ export const NarrowWorkbarClearsTitlebarReserve: Story = {
 // Real path (#3587): an explicit compaction runs as its own host Turn. The
 // transcript shows a live "正在压缩上下文…" row driven by the live Turn snapshot
 // (rootExecutionKind: 'context_compact'), with no assistant content of its own.
-export const ContextCompactionRunning: Story = {
-  render: () => (
+function CompactionRunningScene(props: { motionEnabled?: boolean }) {
+  const [startedAt] = useState(() => props.motionEnabled ? Date.now() - 25_000 : NOW - 2_000);
+  return (
     <ComposedShell
+      motionEnabled={props.motionEnabled}
       session={{ status: 'running', streaming: true }}
       chat={{
         runningStatus: true,
@@ -3353,19 +3355,22 @@ export const ContextCompactionRunning: Story = {
           user('msg-c-1', 'turn-c1', 6, '继续把上下文压缩那个功能实现完。'),
           assistant('msg-c-2', 'turn-c1', 5, '好的，我先梳理一下现有实现，再动手。'),
           { type: 'turn_state', id: 'state-c1', turnId: 'turn-c1', ts: NOW - 300_000, status: 'completed' },
-          { type: 'turn_state', id: 'state-compact', turnId: 'turn-compact', ts: NOW - 2_000, status: 'running' },
+          { type: 'turn_state', id: 'state-compact', turnId: 'turn-compact', ts: startedAt, status: 'running' },
         ],
         liveTurn: {
           turnId: 'turn-compact',
           phase: 'waiting',
           steps: [],
           rootExecutionKind: 'context_compact',
-          startedAt: NOW - 2_000,
+          startedAt,
         },
       }}
     />
-  ),
-};
+  );
+}
+
+export const ContextCompactionRunning: Story = { render: () => <CompactionRunningScene /> };
+export const ContextCompactionLive: Story = { render: () => <CompactionRunningScene motionEnabled /> };
 
 // Real path (#3587): the compaction Turn ends. The live row settles into the
 // durable `context_compacted` system note, rendered in transcript order.
@@ -3379,6 +3384,21 @@ export const ContextCompactionCompacted: Story = {
           { type: 'turn_state', id: 'state-c1', turnId: 'turn-c1', ts: NOW - 300_000, status: 'completed' },
           { type: 'system_note', id: 'note-compact', turnId: 'turn-compact', ts: NOW - 1_000, kind: 'context_compacted' },
           { type: 'turn_state', id: 'state-compact', turnId: 'turn-compact', ts: NOW - 1_000, status: 'completed' },
+        ],
+      }}
+    />
+  ),
+};
+
+export const ContextCompactionFailed: Story = {
+  render: () => (
+    <ComposedShell
+      chat={{
+        messages: [
+          user('msg-c-1', 'turn-c1', 6, '继续把上下文压缩那个功能实现完。'),
+          assistant('msg-c-2', 'turn-c1', 5, '好的，我先梳理一下现有实现，再动手。'),
+          { type: 'system_note', id: 'note-compact', turnId: 'turn-c1', ts: NOW - 1_000, kind: 'context_compaction_failed_open' },
+          { type: 'turn_state', id: 'state-c1', turnId: 'turn-c1', ts: NOW - 1_000, status: 'completed' },
         ],
       }}
     />

--- a/packages/ui/src/__tests__/chat-view-empty-compaction.test.tsx
+++ b/packages/ui/src/__tests__/chat-view-empty-compaction.test.tsx
@@ -19,11 +19,6 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { act } from 'react';
-import { createRoot } from 'react-dom/client';
-import { parseHTML } from 'linkedom';
-import { TurnView } from '../chat-turn.js';
-import { materializeTurns, overlayLiveTurn } from '../materialize.js';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { SessionSummary } from '@maka/core/session';
 import { ChatSurfaceLayout } from '../chat-surface-layout.js';
@@ -66,121 +61,10 @@ test('renders the live compaction row in a session with no settled messages', ()
   // Before the fix, showEmptyState hid this overlaid row behind the empty hero
   // because it keyed off chat.length (0) and never saw the synthesized turn.
   assert.match(markup, /Compacting context/);
-  const { document } = parseHTML(markup);
-  const row = document.querySelector('[data-compaction-state="running"]');
-  assert.equal(row?.getAttribute('data-variant'), 'divider');
-  assert.equal(row?.querySelector('.astryx-spinner')?.getAttribute('aria-hidden'), 'true');
 });
 
 test('renders the empty hero when an empty session has no live compaction row', () => {
   const markup = renderChat(undefined);
 
   assert.doesNotMatch(markup, /Compacting context/);
-});
-
-for (const [kind, state, variant] of [
-  ['context_compacted', 'compacted', 'divider'],
-  ['context_compaction_failed_open', 'failed', 'default'],
-] as const) {
-  test(`durable ${kind} renders the appropriate compaction state`, () => {
-    const [turn] = materializeTurns(
-      [{ type: 'system_note', id: 'note', turnId: 'compact', ts: 1000, kind }],
-      'en',
-    );
-    const { document } = parseHTML(
-      renderToStaticMarkup(
-        <LocaleProvider locale="en">
-          <TurnView turn={turn!} />
-        </LocaleProvider>,
-      ),
-    );
-    const row = document.querySelector('[data-compaction-state]');
-    assert.equal(row?.getAttribute('data-compaction-state'), state);
-    assert.equal(row?.getAttribute('data-variant'), variant);
-    assert.equal(row?.querySelector('.astryx-spinner'), null);
-  });
-}
-
-test('compaction clock uses the recorded Turn start and disappears when the durable note takes over', async () => {
-  const previous = { window: globalThis.window, document: globalThis.document };
-  const actGlobals = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
-  const previousAct = actGlobals.IS_REACT_ACT_ENVIRONMENT;
-  const { window, document } = parseHTML('<div id="root"></div>');
-  Object.assign(globalThis, { window, document, IS_REACT_ACT_ENVIRONMENT: true });
-  const container = document.querySelector('#root')!;
-  const root = createRoot(container);
-  try {
-    const [turn] = overlayLiveTurn(
-      materializeTurns(
-        [
-          {
-            type: 'turn_state',
-            id: 'running',
-            turnId: 'compact',
-            ts: Date.now() - 25_000,
-            status: 'running',
-            partialOutputRetained: false,
-          },
-        ],
-        'en',
-      ),
-      {
-        turnId: 'compact',
-        phase: 'waiting',
-        steps: [],
-        rootExecutionKind: 'context_compact',
-        startedAt: Date.now() - 10_000,
-      },
-      'en',
-    );
-    await act(() =>
-      root.render(
-        <LocaleProvider locale="en">
-          <TurnView turn={turn!} />
-        </LocaleProvider>,
-      ),
-    );
-    const clock = container.querySelector('.maka-turn-elapsed')!;
-    assert.equal(clock.textContent, '25s');
-    assert.equal(clock.getAttribute('aria-hidden'), 'true');
-    await act(() => new Promise((resolve) => setTimeout(resolve, 1100)));
-    assert.equal(clock.textContent, '26s');
-    const [done] = materializeTurns(
-      [
-        {
-          type: 'system_note',
-          id: 'done',
-          turnId: 'compact',
-          ts: Date.now(),
-          kind: 'context_compacted',
-        },
-      ],
-      'en',
-    );
-    await act(() =>
-      root.render(
-        <LocaleProvider locale="en">
-          <TurnView turn={done!} />
-        </LocaleProvider>,
-      ),
-    );
-    assert.equal(container.querySelector('.maka-turn-elapsed'), null);
-    assert.equal(container.querySelector('.astryx-spinner'), null);
-    assert.equal(
-      container.querySelector('[data-compaction-state]')?.getAttribute('data-variant'),
-      'divider',
-    );
-    container.setAttribute('data-maka-e2e-fixture', 'true');
-    await act(() =>
-      root.render(
-        <LocaleProvider locale="en">
-          <TurnView turn={turn!} />
-        </LocaleProvider>,
-      ),
-    );
-    assert.equal(container.querySelector('.maka-turn-elapsed')?.textContent, '');
-  } finally {
-    await act(() => root.unmount());
-    Object.assign(globalThis, previous, { IS_REACT_ACT_ENVIRONMENT: previousAct });
-  }
 });

--- a/packages/ui/src/__tests__/chat-view-empty-compaction.test.tsx
+++ b/packages/ui/src/__tests__/chat-view-empty-compaction.test.tsx
@@ -19,6 +19,11 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { parseHTML } from 'linkedom';
+import { TurnView } from '../chat-turn.js';
+import { materializeTurns, overlayLiveTurn } from '../materialize.js';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { SessionSummary } from '@maka/core/session';
 import { ChatSurfaceLayout } from '../chat-surface-layout.js';
@@ -61,10 +66,121 @@ test('renders the live compaction row in a session with no settled messages', ()
   // Before the fix, showEmptyState hid this overlaid row behind the empty hero
   // because it keyed off chat.length (0) and never saw the synthesized turn.
   assert.match(markup, /Compacting context/);
+  const { document } = parseHTML(markup);
+  const row = document.querySelector('[data-compaction-state="running"]');
+  assert.equal(row?.getAttribute('data-variant'), 'divider');
+  assert.equal(row?.querySelector('.astryx-spinner')?.getAttribute('aria-hidden'), 'true');
 });
 
 test('renders the empty hero when an empty session has no live compaction row', () => {
   const markup = renderChat(undefined);
 
   assert.doesNotMatch(markup, /Compacting context/);
+});
+
+for (const [kind, state, variant] of [
+  ['context_compacted', 'compacted', 'divider'],
+  ['context_compaction_failed_open', 'failed', 'default'],
+] as const) {
+  test(`durable ${kind} renders the appropriate compaction state`, () => {
+    const [turn] = materializeTurns(
+      [{ type: 'system_note', id: 'note', turnId: 'compact', ts: 1000, kind }],
+      'en',
+    );
+    const { document } = parseHTML(
+      renderToStaticMarkup(
+        <LocaleProvider locale="en">
+          <TurnView turn={turn!} />
+        </LocaleProvider>,
+      ),
+    );
+    const row = document.querySelector('[data-compaction-state]');
+    assert.equal(row?.getAttribute('data-compaction-state'), state);
+    assert.equal(row?.getAttribute('data-variant'), variant);
+    assert.equal(row?.querySelector('.astryx-spinner'), null);
+  });
+}
+
+test('compaction clock uses the live Host start and disappears when the durable note takes over', async () => {
+  const previous = { window: globalThis.window, document: globalThis.document };
+  const actGlobals = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+  const previousAct = actGlobals.IS_REACT_ACT_ENVIRONMENT;
+  const { window, document } = parseHTML('<div id="root"></div>');
+  Object.assign(globalThis, { window, document, IS_REACT_ACT_ENVIRONMENT: true });
+  const container = document.querySelector('#root')!;
+  const root = createRoot(container);
+  try {
+    const [turn] = overlayLiveTurn(
+      materializeTurns(
+        [
+          {
+            type: 'turn_state',
+            id: 'running',
+            turnId: 'compact',
+            ts: Date.now() - 60_000,
+            status: 'running',
+            partialOutputRetained: false,
+          },
+        ],
+        'en',
+      ),
+      {
+        turnId: 'compact',
+        phase: 'waiting',
+        steps: [],
+        rootExecutionKind: 'context_compact',
+        startedAt: Date.now() - 25_000,
+      },
+      'en',
+    );
+    await act(() =>
+      root.render(
+        <LocaleProvider locale="en">
+          <TurnView turn={turn!} />
+        </LocaleProvider>,
+      ),
+    );
+    const clock = container.querySelector('.maka-turn-elapsed')!;
+    assert.equal(clock.textContent, '25s');
+    assert.equal(clock.getAttribute('aria-hidden'), 'true');
+    await act(() => new Promise((resolve) => setTimeout(resolve, 1100)));
+    assert.equal(clock.textContent, '26s');
+    const [done] = materializeTurns(
+      [
+        {
+          type: 'system_note',
+          id: 'done',
+          turnId: 'compact',
+          ts: Date.now(),
+          kind: 'context_compacted',
+        },
+      ],
+      'en',
+    );
+    await act(() =>
+      root.render(
+        <LocaleProvider locale="en">
+          <TurnView turn={done!} />
+        </LocaleProvider>,
+      ),
+    );
+    assert.equal(container.querySelector('.maka-turn-elapsed'), null);
+    assert.equal(container.querySelector('.astryx-spinner'), null);
+    assert.equal(
+      container.querySelector('[data-compaction-state]')?.getAttribute('data-variant'),
+      'divider',
+    );
+    container.setAttribute('data-maka-e2e-fixture', 'true');
+    await act(() =>
+      root.render(
+        <LocaleProvider locale="en">
+          <TurnView turn={turn!} />
+        </LocaleProvider>,
+      ),
+    );
+    assert.equal(container.querySelector('.maka-turn-elapsed')?.textContent, '');
+  } finally {
+    await act(() => root.unmount());
+    Object.assign(globalThis, previous, { IS_REACT_ACT_ENVIRONMENT: previousAct });
+  }
 });

--- a/packages/ui/src/__tests__/chat-view-empty-compaction.test.tsx
+++ b/packages/ui/src/__tests__/chat-view-empty-compaction.test.tsx
@@ -101,7 +101,7 @@ for (const [kind, state, variant] of [
   });
 }
 
-test('compaction clock uses the live Host start and disappears when the durable note takes over', async () => {
+test('compaction clock uses the recorded Turn start and disappears when the durable note takes over', async () => {
   const previous = { window: globalThis.window, document: globalThis.document };
   const actGlobals = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
   const previousAct = actGlobals.IS_REACT_ACT_ENVIRONMENT;
@@ -117,7 +117,7 @@ test('compaction clock uses the live Host start and disappears when the durable 
             type: 'turn_state',
             id: 'running',
             turnId: 'compact',
-            ts: Date.now() - 60_000,
+            ts: Date.now() - 25_000,
             status: 'running',
             partialOutputRetained: false,
           },
@@ -129,7 +129,7 @@ test('compaction clock uses the live Host start and disappears when the durable 
         phase: 'waiting',
         steps: [],
         rootExecutionKind: 'context_compact',
-        startedAt: Date.now() - 25_000,
+        startedAt: Date.now() - 10_000,
       },
       'en',
     );

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -204,15 +204,15 @@ describe("materializeChat message metadata", () => {
 
     assert.equal(
       materializeChat(messages, "en")[0]?.text,
-      "Context compacted to keep this session within the model window.",
+      "Earlier context compacted.",
     );
     assert.equal(
       materializeChat(messages, "zh-CN")[0]?.text,
-      "已压缩较早的对话内容，以适应模型上下文窗口。",
+      "已压缩较早的上下文。",
     );
     assert.equal(
       materializeTurns(messages, "zh-CN")[0]?.notes[0]?.text,
-      "已压缩较早的对话内容，以适应模型上下文窗口。",
+      "已压缩较早的上下文。",
     );
   });
 

--- a/packages/ui/src/__tests__/transcript-projection.test.ts
+++ b/packages/ui/src/__tests__/transcript-projection.test.ts
@@ -91,11 +91,11 @@ describe('incremental transcript projection', () => {
 
     assert.equal(
       english[0]?.notes[0]?.text,
-      'Context compacted to keep this session within the model window.',
+      'Earlier context compacted.',
     );
     assert.equal(
       chinese[0]?.notes[0]?.text,
-      '已压缩较早的对话内容，以适应模型上下文窗口。',
+      '已压缩较早的上下文。',
     );
     assert.notStrictEqual(chinese, english);
   });

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -608,9 +608,17 @@ export const TurnView = memo(function TurnView(props: {
         <ChatSystemMessage
           key={note.id}
           className="maka-chat-system-message"
-          aria-label={copy.systemAriaLabel}
+          variant={note.compactionState === "running" || note.compactionState === "compacted" ? "divider" : "default"}
+          data-compaction-state={note.compactionState}
+          aria-label={note.compactionState === "running" ? note.text : copy.systemAriaLabel}
         >
-          {note.text}
+          {note.compactionState ? (
+            <span className="maka-compaction-status">
+              {note.compactionState === "running" && <Spinner size="sm" shade="subtle" aria-hidden="true" />}
+              <span>{note.text}</span>
+              {note.compactionState === "running" && <TurnElapsedTime startedAt={note.ts} />}
+            </span>
+          ) : note.text}
         </ChatSystemMessage>
       ))}
       {conversationSegments.map((segment, segmentIndex) => {
@@ -992,8 +1000,30 @@ export function TurnRunningStatus(props: {
   activityLabel?: string;
 }) {
   const copy = getConversationCopy(useUiLocale()).messages;
+
+  return (
+    <div
+      className="maka-turn-processing"
+      role="status"
+      aria-label={props.activityLabel ?? copy.awaitingModelOutput}
+    >
+      {props.showSpinner !== false && (
+        <Spinner size="md" shade="subtle" aria-hidden="true" />
+      )}
+      {/* Name the activity once; the clock must not announce each second. */}
+      <span className="maka-turn-indicator-text" aria-hidden="true">
+        <span className="maka-turn-status-label">
+          {props.activityLabel ?? copy.awaitingModelOutput}
+        </span>
+        <TurnElapsedTime startedAt={props.startedAt} separator />
+      </span>
+    </div>
+  );
+}
+
+function TurnElapsedTime(props: { startedAt?: number; separator?: boolean }) {
   const { startedAt } = props;
-  const rootRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLSpanElement>(null);
   // Undefined until an effect measures it, which is also what keeps a static
   // render deterministic: the clock is a client-only value, so server markup
   // and the first paint carry the phrase alone.
@@ -1013,30 +1043,12 @@ export function TurnRunningStatus(props: {
   }, [startedAt]);
 
   return (
-    <div
-      className="maka-turn-processing"
-      role="status"
-      aria-label={props.activityLabel ?? copy.awaitingModelOutput}
-      ref={rootRef}
-    >
-      {props.showSpinner !== false && (
-        <Spinner size="md" shade="subtle" aria-hidden="true" />
-      )}
-      {/* Every visible token here moves on the clock. Announcing either would
-          talk over the answer being streamed beside it, so the row's label is
-          its whole accessible name and the text is decoration. */}
-      <span className="maka-turn-indicator-text" aria-hidden="true">
-        <span className="maka-turn-status-label">
-          {props.activityLabel ?? copy.awaitingModelOutput}
-        </span>
-        {elapsedMs !== undefined && (
-          <>
-            <span className="maka-turn-status-separator">·</span>
-            <span className="maka-turn-elapsed">{formatTurnDuration(elapsedMs)}</span>
-          </>
-        )}
-      </span>
-    </div>
+    <span className="maka-turn-elapsed" aria-hidden="true" ref={rootRef}>
+      {elapsedMs !== undefined && <>
+        {props.separator && <span className="maka-turn-status-separator">·</span>}
+        {formatTurnDuration(elapsedMs)}
+      </>}
+    </span>
   );
 }
 

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -616,7 +616,7 @@ export const TurnView = memo(function TurnView(props: {
             <span className="maka-compaction-status">
               {note.compactionState === "running" && <Spinner size="sm" shade="subtle" aria-hidden="true" />}
               <span>{note.text}</span>
-              {note.compactionState === "running" && <TurnElapsedTime startedAt={note.ts} />}
+              {note.compactionState === "running" && <TurnElapsedTime startedAt={turn.startedAt} />}
             </span>
           ) : note.text}
         </ChatSystemMessage>

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -553,8 +553,8 @@ const CONVERSATION_COPY = {
       thinkingTruncatedTitle: '部分 reasoning 已截断；显示的是最近的内容', outputTruncatedTitle: '助手输出已超过单次回合上限，超出部分未渲染。如需完整内容请重新生成或查看持久化的任务日志。', removeAttachmentAriaLabel: (name) => `移除 ${name}`, quoteLabel: '引用', quoteExpandAriaLabel: '展开引用全文', quoteCollapseAriaLabel: '收起引用', removeQuoteAriaLabel: '移除引用', aborted: '已中断', abortedByStop: '已中断 · 由停止按钮触发',
       systemNotes: {
         contextCompacting: '正在压缩上下文…',
-        contextCompacted: '已压缩较早的对话内容，以适应模型上下文窗口。',
-        contextCompactionFailedOpen: '上下文摘要失败；本轮已在未生成新摘要的情况下继续。',
+        contextCompacted: '已压缩较早的上下文。',
+        contextCompactionFailedOpen: '上下文压缩失败；会话已继续，未生成新摘要。',
         contextProviderDropping: (used, prior) =>
           `供应商在丢弃或改写上下文：追加了内容，它报告的输入却是 ${used.toLocaleString('zh-CN')} tokens，与之前的 ${prior.toLocaleString('zh-CN')} 相比没有增长。在连接设置里为该模型声明上下文窗口，让 Maka 先行压缩。`,
         contextWindowSuggestion: (tokens, declared) =>
@@ -712,8 +712,8 @@ const CONVERSATION_COPY = {
       thinkingTruncatedTitle: '部分 reasoning 已截斷；顯示的是最近的內容', outputTruncatedTitle: '助手輸出已超過單次回合上限，超出部分未渲染。如需完整內容請重新生成或檢視持久化的任務記錄。', removeAttachmentAriaLabel: (name) => `移除 ${name}`, quoteLabel: '引用', quoteExpandAriaLabel: '展開引用全文', quoteCollapseAriaLabel: '收起引用', removeQuoteAriaLabel: '移除引用', aborted: '(已中斷)', abortedByStop: '(已中斷 · 由停止按鈕觸發)',
       systemNotes: {
         contextCompacting: '正在壓縮上下文…',
-        contextCompacted: '已壓縮較早的對話內容，以適應模型上下文視窗。',
-        contextCompactionFailedOpen: '上下文摘要失敗；本輪已在未生成新摘要的情況下繼續。',
+        contextCompacted: '已壓縮較早的上下文。',
+        contextCompactionFailedOpen: '上下文壓縮失敗；會話已繼續，未產生新摘要。',
         contextProviderDropping: (used, prior) =>
           `供應商在丟棄或改寫上下文：追加了內容，它報告的輸入卻是 ${used.toLocaleString('zh-TW')} tokens，與之前的 ${prior.toLocaleString('zh-TW')} 相比沒有成長。在連線設定裡為該模型宣告上下文視窗，讓 Maka 先行壓縮。`,
         contextWindowSuggestion: (tokens, declared) =>
@@ -897,8 +897,8 @@ const CONVERSATION_COPY = {
       thinkingTruncatedTitle: 'Some reasoning was truncated; showing the most recent content', outputTruncatedTitle: 'The assistant output exceeded the per-turn limit. Regenerate it or inspect the persisted task log for the complete content.', removeAttachmentAriaLabel: (name) => `Remove ${name}`, quoteLabel: 'Quote', quoteExpandAriaLabel: 'Show the full quoted excerpt', quoteCollapseAriaLabel: 'Collapse the quoted excerpt', removeQuoteAriaLabel: 'Remove quote', aborted: 'Interrupted', abortedByStop: 'Interrupted · Stop button',
       systemNotes: {
         contextCompacting: 'Compacting context…',
-        contextCompacted: 'Context compacted to keep this session within the model window.',
-        contextCompactionFailedOpen: 'Context summary failed; the session continued without a new summary.',
+        contextCompacted: 'Earlier context compacted.',
+        contextCompactionFailedOpen: 'Context compaction failed; the session continued without a new summary.',
         contextProviderDropping: (used, prior) =>
           `The provider is dropping or rewriting context: content was appended, and it counted ${used.toLocaleString('en-US')} input tokens against ${prior.toLocaleString('en-US')} before, which is no growth. Declare a context window for this model in the connection settings so Maka compacts first.`,
         contextWindowSuggestion: (tokens, declared) =>

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -554,7 +554,7 @@ const CONVERSATION_COPY = {
       systemNotes: {
         contextCompacting: '正在压缩上下文…',
         contextCompacted: '已压缩较早的上下文。',
-        contextCompactionFailedOpen: '上下文压缩失败；会话已继续，未生成新摘要。',
+        contextCompactionFailedOpen: '上下文压缩失败，Maka 已继续处理你的请求。',
         contextProviderDropping: (used, prior) =>
           `供应商在丢弃或改写上下文：追加了内容，它报告的输入却是 ${used.toLocaleString('zh-CN')} tokens，与之前的 ${prior.toLocaleString('zh-CN')} 相比没有增长。在连接设置里为该模型声明上下文窗口，让 Maka 先行压缩。`,
         contextWindowSuggestion: (tokens, declared) =>
@@ -713,7 +713,7 @@ const CONVERSATION_COPY = {
       systemNotes: {
         contextCompacting: '正在壓縮上下文…',
         contextCompacted: '已壓縮較早的上下文。',
-        contextCompactionFailedOpen: '上下文壓縮失敗；會話已繼續，未產生新摘要。',
+        contextCompactionFailedOpen: '上下文壓縮失敗，Maka 已繼續處理你的請求。',
         contextProviderDropping: (used, prior) =>
           `供應商在丟棄或改寫上下文：追加了內容，它報告的輸入卻是 ${used.toLocaleString('zh-TW')} tokens，與之前的 ${prior.toLocaleString('zh-TW')} 相比沒有成長。在連線設定裡為該模型宣告上下文視窗，讓 Maka 先行壓縮。`,
         contextWindowSuggestion: (tokens, declared) =>
@@ -898,7 +898,7 @@ const CONVERSATION_COPY = {
       systemNotes: {
         contextCompacting: 'Compacting context…',
         contextCompacted: 'Earlier context compacted.',
-        contextCompactionFailedOpen: 'Context compaction failed; the session continued without a new summary.',
+        contextCompactionFailedOpen: 'Context compaction failed. Maka continued with your request.',
         contextProviderDropping: (used, prior) =>
           `The provider is dropping or rewriting context: content was appended, and it counted ${used.toLocaleString('en-US')} input tokens against ${prior.toLocaleString('en-US')} before, which is no growth. Declare a context window for this model in the connection settings so Maka compacts first.`,
         contextWindowSuggestion: (tokens, declared) =>

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -554,7 +554,7 @@ const CONVERSATION_COPY = {
       systemNotes: {
         contextCompacting: '正在压缩上下文…',
         contextCompacted: '已压缩较早的上下文。',
-        contextCompactionFailedOpen: '上下文压缩失败，Maka 已继续处理你的请求。',
+        contextCompactionFailedOpen: '上下文压缩失败。',
         contextProviderDropping: (used, prior) =>
           `供应商在丢弃或改写上下文：追加了内容，它报告的输入却是 ${used.toLocaleString('zh-CN')} tokens，与之前的 ${prior.toLocaleString('zh-CN')} 相比没有增长。在连接设置里为该模型声明上下文窗口，让 Maka 先行压缩。`,
         contextWindowSuggestion: (tokens, declared) =>
@@ -713,7 +713,7 @@ const CONVERSATION_COPY = {
       systemNotes: {
         contextCompacting: '正在壓縮上下文…',
         contextCompacted: '已壓縮較早的上下文。',
-        contextCompactionFailedOpen: '上下文壓縮失敗，Maka 已繼續處理你的請求。',
+        contextCompactionFailedOpen: '上下文壓縮失敗。',
         contextProviderDropping: (used, prior) =>
           `供應商在丟棄或改寫上下文：追加了內容，它報告的輸入卻是 ${used.toLocaleString('zh-TW')} tokens，與之前的 ${prior.toLocaleString('zh-TW')} 相比沒有成長。在連線設定裡為該模型宣告上下文視窗，讓 Maka 先行壓縮。`,
         contextWindowSuggestion: (tokens, declared) =>
@@ -898,7 +898,7 @@ const CONVERSATION_COPY = {
       systemNotes: {
         contextCompacting: 'Compacting context…',
         contextCompacted: 'Earlier context compacted.',
-        contextCompactionFailedOpen: 'Context compaction failed. Maka continued with your request.',
+        contextCompactionFailedOpen: 'Context compaction failed.',
         contextProviderDropping: (used, prior) =>
           `The provider is dropping or rewriting context: content was appended, and it counted ${used.toLocaleString('en-US')} input tokens against ${prior.toLocaleString('en-US')} before, which is no growth. Declare a context window for this model in the connection settings so Maka compacts first.`,
         contextWindowSuggestion: (tokens, declared) =>

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -49,6 +49,7 @@ import { getConversationCopy } from "./conversation-copy.js";
 export { isCancelledToolResultContent, isInFlightToolStatus, toolResultActivityStatus } from '@maka/core/tool-result-status';
 
 export interface ChatItem {
+  compactionState?: "running" | "compacted" | "failed";
   id: string;
   role: "user" | "assistant" | "system";
   text: string;
@@ -227,6 +228,7 @@ export function materializeChat(
         id: message.id,
         role: "system",
         text: systemNoteLabel(message.kind, message.data, locale),
+        compactionState: message.kind === "context_compacted" ? "compacted" : message.kind === "context_compaction_failed_open" ? "failed" : undefined,
         ts: message.ts,
       });
     }
@@ -478,7 +480,8 @@ export function overlayLiveTurn(
         id: noteId,
         role: "system",
         text: getConversationCopy(locale).messages.systemNotes.contextCompacting,
-        ts: existing.startedAt,
+        compactionState: "running",
+        ts: liveTurn.startedAt ?? existing.startedAt,
       };
       return turns.map((turn, index) =>
         index === targetIndex ? { ...turn, notes: [...turn.notes, note] } : turn,
@@ -496,7 +499,8 @@ export function overlayLiveTurn(
             id: noteId,
             role: "system",
             text: getConversationCopy(locale).messages.systemNotes.contextCompacting,
-            ts: startedAt,
+            compactionState: "running",
+            ts: liveTurn.startedAt,
           },
         ],
         timeline: [],
@@ -855,6 +859,7 @@ export function materializeTurns(
         id: message.id,
         role: "system",
         text: systemNoteLabel(message.kind, message.data, locale),
+        compactionState: message.kind === "context_compacted" ? "compacted" : message.kind === "context_compaction_failed_open" ? "failed" : undefined,
         ts: message.ts,
       });
     } else if (message.type === "token_usage") {

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -481,7 +481,7 @@ export function overlayLiveTurn(
         role: "system",
         text: getConversationCopy(locale).messages.systemNotes.contextCompacting,
         compactionState: "running",
-        ts: liveTurn.startedAt ?? existing.startedAt,
+        ts: existing.startedAt,
       };
       return turns.map((turn, index) =>
         index === targetIndex ? { ...turn, notes: [...turn.notes, note] } : turn,
@@ -500,7 +500,7 @@ export function overlayLiveTurn(
             role: "system",
             text: getConversationCopy(locale).messages.systemNotes.contextCompacting,
             compactionState: "running",
-            ts: liveTurn.startedAt,
+            ts: startedAt,
           },
         ],
         timeline: [],

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -243,7 +243,9 @@
 .maka-turn-status-label { font-weight: var(--font-weight-medium); }
 .maka-turn-status-separator { color: var(--foreground-alpha-16); }
 /* Tabular figures so a ticking clock changes glyphs without changing width. */
-.maka-turn-elapsed { font-variant-numeric: tabular-nums; }
+.maka-turn-elapsed { display: inline-flex; align-items: center; gap: 6px; font-variant-numeric: tabular-nums; }
+.maka-turn-elapsed:empty { display: none; }
+.maka-compaction-status { display: inline-flex; align-items: center; gap: 8px; font: var(--maka-text-body); vertical-align: top; }
 /* #1879: an Astryx `Badge variant="yellow"` now — the warning tone it used to
    draw by hand (hairline + 5% wash) is a variant, and the box comes with it.
    Product CSS keeps only what is layout: it is a block-level note under the


### PR DESCRIPTION
## Summary

When context compaction starts, its transcript notice now uses body text (14px/20px), an Astryx Spinner, and elapsed time derived from the existing Turn start. Running and completed notices share an Astryx divider, keeping the context boundary visible through the state change without a fade or height shift. Failure notices use the same body typography and retain their inline status presentation, without claiming that the request continued.

The elapsed display is extracted from `TurnRunningStatus` and reused, including its deterministic-fixture gate. Spinner and clock are hidden from assistive technology so ticking does not repeatedly announce the status. This changes presentation only; there is no storage migration or new execution state.

Refs #3651. Toast terminal handling (#4854) and missing durable notes (#4974) remain separate follow-ups.

## Verification

- UI build, Storybook story typecheck, format, and lint passed.
- All 412 UI workspace tests passed, including the existing persisted-turn timestamp regression. The persisted-turn timestamp regression was reproduced before its fix. Visual states and live timing are verified in Storybook; no additional DOM lifecycle or variant tests are introduced.
- Built BEFORE from main `c58c48182` and AFTER from this branch. Chromium checks covered running/completed/failed, light/dark, and 1440px/900px English, Simplified Chinese, and Traditional Chinese layouts: body typography, equal 20px running/completed rows, no overflow or page errors.
- Live Storybook clock advanced from 25s to 26s. Deterministic fixtures suppress the clock; the screenshots below use those fixtures.
- Real Desktop Runtime compaction/restart acceptance was not run.

### Running

![Running light](https://github.com/user-attachments/assets/40018a0b-6764-423c-92e8-ca2769e22eba)
![Running dark](https://github.com/user-attachments/assets/c4473662-de7c-428d-b3f2-36733417b844)

### Completed

![Completed light](https://github.com/user-attachments/assets/200a1254-b726-4702-b5ca-634701c6d302)
![Completed dark](https://github.com/user-attachments/assets/e76244c3-d754-4f54-8da8-67c5a1400866)

<details>
<summary>中文说明</summary>

压缩状态统一为 14px/20px。运行中显示 Spinner 和来自 Host 开始时间的已耗时，运行与完成始终保留两侧细线，不加淡入淡出；失败保持普通状态提示。计时复用普通 Turn 运行状态的实现，不新增执行权威。截图为相同视口的真实 Storybook 对比，静态 fixture 按已有规则隐藏秒数。

</details>

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex — implementation, targeted tests, and visual verification following user-approved design comparisons. Gemini 3.8 Flash (via Antigravity) — localized transcript copy polishing, reviewed and applied by Codex.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No




