### PR TITLE
fix(desktop): restore right workbar scrolling

### DIFF
--- a/apps/desktop/src/renderer/styles/workbar/shell.css
+++ b/apps/desktop/src/renderer/styles/workbar/shell.css
@@ -142,9 +142,11 @@
 }
 
 .maka-session-workbar-panel[data-overlay][data-placement="right"] {
-  /* One stretched track, like the frame: the face fills the height and the
-     column can be aligned as a whole. */
+  /* One minmax track keeps the active face inside the overlay's available
+     height. An implicit auto track grows to the face's full content height,
+     leaving its own overflow scroller with nothing to scroll. */
   display: grid;
+  grid-template-rows: minmax(0, 1fr);
   padding-top: var(--maka-plate-titlebar-clearance);
 }
 

--- a/apps/desktop/stories/session-workbar.stories.tsx
+++ b/apps/desktop/stories/session-workbar.stories.tsx
@@ -301,7 +301,7 @@ const fileLineCapGitReviewSnapshot: GitReviewSnapshot = {
 // Source-level truncation: a large changeset whose file list the source capped,
 // so `truncated` is set and the panel shows its 变化过多 banner. Each file is
 // ordinary — no single file trips the per-file cap here.
-const sourceTruncatedFiles: GitReviewSnapshot['files'] = Array.from({ length: 24 }, (_, index) => {
+const sourceTruncatedFiles: GitReviewSnapshot['files'] = Array.from({ length: 40 }, (_, index) => {
   const path = `src/feature-${String(index).padStart(2, '0')}.ts`;
   return {
     path,
@@ -1162,7 +1162,22 @@ export const ChangesTruncated: Story = {
   decorators: [bridge({ review: { ok: true, snapshot: sourceTruncatedGitReviewSnapshot } })],
   render: () => <Workbar tab="review" />,
   play: async ({ canvasElement }) => {
-    await within(canvasElement).findByText('变化过多，仅显示前一部分文件');
+    const canvas = within(canvasElement);
+    await canvas.findByText('变化过多，仅显示前一部分文件');
+    await userEvent.click(await canvas.findByRole('button', { name: '再显示 20 个文件' }));
+
+    const panel = canvasElement.querySelector<HTMLElement>('.maka-session-review-panel');
+    if (!panel) throw new Error('the changes panel is missing');
+    await waitFor(() => {
+      expect(
+        canvasElement.querySelectorAll('.maka-session-review-file').length,
+      ).toBe(40);
+      expect(panel.scrollHeight).toBeGreaterThan(panel.clientHeight);
+    });
+
+    panel.scrollTop = panel.scrollHeight;
+    await waitFor(() => expect(panel.scrollTop).toBeGreaterThan(0));
+    panel.scrollTop = 0;
   },
 };
 


### PR DESCRIPTION
## Summary

- Constrain the shared right Workbar overlay to one shrinkable grid row so tall faces stay within the viewport and retain their local scroll containers.
- Add a Changes Storybook regression that reveals the second file page and proves the panel can change `scrollTop`.
- This restores scrolling for shared right-side faces such as Changes and Trace without changing their individual scroll ownership.

Fixes #4999

## Verification

- Regression Story reproduced before the fix: `clientHeight=1305`, `scrollHeight=1305`, `scrollTop=0`.
- After the fix, Changes measured `clientHeight=868`, `scrollHeight=1289`, and scrolled 421px; Trace measured `clientHeight=868`, `scrollHeight=1416`, and scrolled 548px.
- `npm run build-storybook -w @maka/desktop`
- `npm run smoke:storybook -w @maka/desktop` — 326 stories, 353 theme renders
- `npm run typecheck:stories -w @maka/desktop`
- `npm run check:architecture -w @maka/desktop`
- `npm run build:renderer -w @maka/desktop`
- `npx biome check apps/desktop/stories/session-workbar.stories.tsx apps/desktop/src/renderer/styles/workbar/shell.css`
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Codex diagnosed the shared Grid sizing regression, implemented the CSS fix and Storybook regression, ran verification, and prepared the issue, commit, and PR description.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No