### PR TITLE
fix(desktop): gate notification content on Runtime Host privacy policy

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -589,7 +589,7 @@
         "nonTriviaTokens": 2316
       },
       "src/renderer/app-shell-session-events.ts": {
-        "importDeclarations": 2,
+        "importDeclarations": 3,
         "bridgePaths": {},
         "environmentCapabilities": {
           "requestAnimationFrame": 1,
@@ -603,12 +603,13 @@
           "createAppShellSessionEventHandlers"
         ],
         "dependencyPaths": {
+          "../shared/runtime-host-identity.js": 1,
           "./locales/conversation-copy.js": 1,
           "./model-connection-errors.js": 1,
           "@maka/ui": 1
         },
-        "importSpecifiers": 8,
-        "nonTriviaTokens": 2808
+        "importSpecifiers": 9,
+        "nonTriviaTokens": 2847
       },
       "src/renderer/app-shell-session-start-actions.ts": {
         "importDeclarations": 2,
@@ -871,8 +872,8 @@
           "@maka/ui": 1,
           "react": 1
         },
-        "importSpecifiers": 108,
-        "nonTriviaTokens": 13697
+        "importSpecifiers": 109,
+        "nonTriviaTokens": 13721
       },
       "src/renderer/use-app-shell-composer-quotes.ts": {
         "importDeclarations": 2,

--- a/apps/desktop/src/main/__tests__/notifications-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/notifications-policy.test.ts
@@ -20,12 +20,14 @@
 import { it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  createHostPrivacyAuthority,
   isRunNotificationKind,
   resolveNotificationContent,
   resolveNotificationIncognito,
   runNotificationCopy,
   shouldRaiseRunNotification,
 } from '../notifications-policy.js';
+import type { RuntimeHostDesktopTargetState } from '../runtime-host-desktop-manager.js';
 
 it('gates native notifications through every required condition', () => {
   const base = { enabled: true, supported: true, windowFocused: false, incognito: false, e2e: false };
@@ -91,29 +93,116 @@ it('sanitizes renderer content, caps it, and falls back per field', () => {
 });
 
 it('reads incognito from the Runtime Host authority, failing closed', async () => {
-  // Authority verdict wins over the local copy in both directions: the
-  // local copy never receives privacy updates, so a stale `true` must not
-  // suppress when the host says otherwise, and a stale `false` must not
-  // expose when incognito is actually on.
+  // The authority verdict wins: the local copy never receives privacy
+  // updates, so no stale local value may decide content-bearing banners.
   assert.equal(
-    await resolveNotificationIncognito(false, { isIncognitoActive: async () => true }),
+    await resolveNotificationIncognito({ isIncognitoActive: async () => true }, 'local'),
     true,
   );
   assert.equal(
-    await resolveNotificationIncognito(true, { isIncognitoActive: async () => false }),
+    await resolveNotificationIncognito({ isIncognitoActive: async () => false }, 'local'),
     false,
   );
-  // No authority: the existing local-copy gate applies unchanged.
-  assert.equal(await resolveNotificationIncognito(true, undefined), true);
-  assert.equal(await resolveNotificationIncognito(false, undefined), false);
+  // The source host travels with the query so the gate can associate the
+  // banner with its legitimate authority.
+  const seen: Array<string | undefined> = [];
+  await resolveNotificationIncognito(
+    {
+      isIncognitoActive: async (sourceHostId) => {
+        seen.push(sourceHostId);
+        return false;
+      },
+    },
+    'local',
+  );
+  assert.deepEqual(seen, ['local']);
   // An unreachable authority suppresses rather than risking exposure of
   // the session title + reply preview outside the app.
   assert.equal(
-    await resolveNotificationIncognito(false, {
-      isIncognitoActive: async () => {
-        throw new Error('host unreachable');
+    await resolveNotificationIncognito(
+      {
+        isIncognitoActive: async () => {
+          throw new Error('host unreachable');
+        },
       },
-    }),
+      'local',
+    ),
+    true,
+  );
+});
+
+it('scopes the host authority to the notification source host', async () => {
+  const queried: string[] = [];
+  const ready = (hostId: string, incognitoActive: boolean) =>
+    ({
+      epoch: `epoch-${hostId}`,
+      target: { profile: { id: hostId } },
+      readiness: 'ready',
+      candidate: {
+        client: {
+          hostId,
+          queryRuntimePolicy: async () => {
+            queried.push(hostId);
+            return { policy: { privacy: { incognitoActive } } };
+          },
+        },
+      },
+    }) as unknown as RuntimeHostDesktopTargetState;
+  const reconnecting = (hostId: string) =>
+    ({
+      epoch: `epoch-${hostId}`,
+      target: { profile: { id: hostId } },
+      readiness: 'reconnecting',
+      hostId,
+    }) as unknown as RuntimeHostDesktopTargetState;
+  const guest = (hostId: string) =>
+    ({
+      epoch: `epoch-${hostId}`,
+      target: { profile: { id: hostId } },
+      readiness: 'ready',
+      candidate: {
+        client: {
+          hostId,
+          queryRuntimePolicy: async () => {
+            queried.push(hostId);
+            throw new Error('forbidden: runtime.policy.query');
+          },
+        },
+      },
+    }) as unknown as RuntimeHostDesktopTargetState;
+
+  // A reconnecting source keeps its unknown verdict (suppressed) even
+  // while another ready host holds no incognito: dropping it would leak.
+  assert.equal(
+    await resolveNotificationIncognito(
+      createHostPrivacyAuthority(() => [ready('local', false), reconnecting('private')]),
+      'private',
+    ),
+    true,
+  );
+  // A mounted session guest never decides a local notification: only the
+  // notification's own host is queried, so the local banner is preserved.
+  assert.equal(
+    await resolveNotificationIncognito(
+      createHostPrivacyAuthority(() => [ready('local', false), guest('shared')]),
+      'local',
+    ),
+    false,
+  );
+  assert.deepEqual(queried, ['local']);
+  // No matching host (or no source at all) stays unknown and suppresses.
+  assert.equal(
+    await resolveNotificationIncognito(
+      createHostPrivacyAuthority(() => [ready('local', false)]),
+      'gone',
+    ),
+    true,
+  );
+  assert.equal(
+    await resolveNotificationIncognito(
+      createHostPrivacyAuthority(() => [ready('local', false)]),
+      undefined,
+    ),
     true,
   );
 });

--- a/apps/desktop/src/main/__tests__/notifications-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/notifications-policy.test.ts
@@ -22,6 +22,7 @@ import assert from 'node:assert/strict';
 import {
   isRunNotificationKind,
   resolveNotificationContent,
+  resolveNotificationIncognito,
   runNotificationCopy,
   shouldRaiseRunNotification,
 } from '../notifications-policy.js';
@@ -86,5 +87,33 @@ it('sanitizes renderer content, caps it, and falls back per field', () => {
   assert.deepEqual(
     resolveNotificationContent({ kind: 'errored', title: '出错的会话', body: '' }, 'zh-CN'),
     { title: '出错的会话', body: erroredFallback.body },
+  );
+});
+
+it('reads incognito from the Runtime Host authority, failing closed', async () => {
+  // Authority verdict wins over the local copy in both directions: the
+  // local copy never receives privacy updates, so a stale `true` must not
+  // suppress when the host says otherwise, and a stale `false` must not
+  // expose when incognito is actually on.
+  assert.equal(
+    await resolveNotificationIncognito(false, { isIncognitoActive: async () => true }),
+    true,
+  );
+  assert.equal(
+    await resolveNotificationIncognito(true, { isIncognitoActive: async () => false }),
+    false,
+  );
+  // No authority: the existing local-copy gate applies unchanged.
+  assert.equal(await resolveNotificationIncognito(true, undefined), true);
+  assert.equal(await resolveNotificationIncognito(false, undefined), false);
+  // An unreachable authority suppresses rather than risking exposure of
+  // the session title + reply preview outside the app.
+  assert.equal(
+    await resolveNotificationIncognito(false, {
+      isIncognitoActive: async () => {
+        throw new Error('host unreachable');
+      },
+    }),
+    true,
   );
 });

--- a/apps/desktop/src/main/notifications-ipc-main.ts
+++ b/apps/desktop/src/main/notifications-ipc-main.ts
@@ -39,15 +39,10 @@ interface NotificationsIpcDeps {
   e2e: boolean;
   /**
    * Runtime Host privacy authority (#4981). The local settings copy never
-   * receives privacy updates (`clientOwnedSettingsPatch` excludes the
-   * section, and projection keeps the host's copy), so gating
-   * content-bearing notifications on `settings.privacy.incognitoActive`
-   * can read stale data and expose the session title + reply preview
-   * after incognito is enabled. When provided, its verdict wins; when it
-   * rejects, the notification is suppressed rather than risked
-   * (fail-closed); when absent, the existing local-copy gate applies.
+   * receives privacy updates, so the gate always asks the notification's
+   * own host; an unknown or unreachable verdict suppresses the banner.
    */
-  privacyAuthority?: PrivacyAuthority | undefined;
+  privacyAuthority: PrivacyAuthority;
 }
 
 /**
@@ -64,19 +59,17 @@ interface NotificationsIpcDeps {
 export function registerNotificationsIpc(deps: NotificationsIpcDeps): void {
   const target = deps.ipcMain ?? ipcMain;
   target.handle('notifications:runEnded', async (_event, payload: unknown): Promise<void> => {
-    const raw = (payload ?? {}) as { kind?: unknown; title?: unknown; body?: unknown };
+    const raw = (payload ?? {}) as { kind?: unknown; title?: unknown; body?: unknown; hostId?: unknown };
     if (!isRunNotificationKind(raw.kind)) return;
 
     const supported = Notification.isSupported();
     // Read the toggle lazily so a mid-session settings change takes
     // effect on the very next turn without any cache invalidation.
     const settings = await deps.settingsStore.get();
-    let incognito: boolean;
-    if (deps.privacyAuthority) {
-      incognito = await resolveNotificationIncognito(false, deps.privacyAuthority);
-    } else {
-      incognito = settings.privacy.incognitoActive;
-    }
+    // The banner belongs to one host: only that host can authorize its
+    // content. A missing source stays unknown and suppresses (#4981).
+    const sourceHostId = typeof raw.hostId === 'string' && raw.hostId ? raw.hostId : undefined;
+    const incognito = await resolveNotificationIncognito(deps.privacyAuthority, sourceHostId);
     const gate = {
       enabled: settings.notifications.runComplete,
       supported,

--- a/apps/desktop/src/main/notifications-ipc-main.ts
+++ b/apps/desktop/src/main/notifications-ipc-main.ts
@@ -24,8 +24,10 @@ import type { DesktopLocaleAuthority } from './desktop-locale-authority.js';
 import {
   isRunNotificationKind,
   resolveNotificationContent,
+  resolveNotificationIncognito,
   shouldRaiseRunNotification,
 } from './notifications-policy.js';
+import type { PrivacyAuthority } from './notifications-policy.js';
 
 type MainWindowController = ReturnType<typeof createMainWindowController>;
 
@@ -35,6 +37,17 @@ interface NotificationsIpcDeps {
   locale: Pick<DesktopLocaleAuthority, 'observe'>;
   mainWindowController: MainWindowController;
   e2e: boolean;
+  /**
+   * Runtime Host privacy authority (#4981). The local settings copy never
+   * receives privacy updates (`clientOwnedSettingsPatch` excludes the
+   * section, and projection keeps the host's copy), so gating
+   * content-bearing notifications on `settings.privacy.incognitoActive`
+   * can read stale data and expose the session title + reply preview
+   * after incognito is enabled. When provided, its verdict wins; when it
+   * rejects, the notification is suppressed rather than risked
+   * (fail-closed); when absent, the existing local-copy gate applies.
+   */
+  privacyAuthority?: PrivacyAuthority | undefined;
 }
 
 /**
@@ -58,11 +71,17 @@ export function registerNotificationsIpc(deps: NotificationsIpcDeps): void {
     // Read the toggle lazily so a mid-session settings change takes
     // effect on the very next turn without any cache invalidation.
     const settings = await deps.settingsStore.get();
+    let incognito: boolean;
+    if (deps.privacyAuthority) {
+      incognito = await resolveNotificationIncognito(false, deps.privacyAuthority);
+    } else {
+      incognito = settings.privacy.incognitoActive;
+    }
     const gate = {
       enabled: settings.notifications.runComplete,
       supported,
       windowFocused: deps.mainWindowController.isFocused(),
-      incognito: settings.privacy.incognitoActive,
+      incognito,
       e2e: deps.e2e,
     };
     if (!shouldRaiseRunNotification(gate)) return;

--- a/apps/desktop/src/main/notifications-policy.ts
+++ b/apps/desktop/src/main/notifications-policy.ts
@@ -126,6 +126,29 @@ function sanitizeLine(value: unknown, max: number): string {
   return `${collapsed.slice(0, max - 1).trimEnd()}…`;
 }
 
+/** Resolves whether any connected host currently holds incognito. */
+export interface PrivacyAuthority {
+  isIncognitoActive(): Promise<boolean>;
+}
+
+/**
+ * Reads incognito from the authority (#4981). The local settings copy never
+ * receives privacy updates, so its value must not decide content-bearing
+ * notifications. A rejecting authority suppresses the notification rather
+ * than risking exposure (fail-closed).
+ */
+export async function resolveNotificationIncognito(
+  settingsIncognitoActive: boolean,
+  privacyAuthority: PrivacyAuthority | undefined,
+): Promise<boolean> {
+  if (!privacyAuthority) return settingsIncognitoActive;
+  try {
+    return await privacyAuthority.isIncognitoActive();
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Final notification text: prefer the renderer's session name + reply
  * preview, falling back per-field to the generic copy when a field is

--- a/apps/desktop/src/main/notifications-policy.ts
+++ b/apps/desktop/src/main/notifications-policy.ts
@@ -18,6 +18,7 @@
  */
 
 import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
+import type { RuntimeHostDesktopTargetState } from './runtime-host-desktop-manager.js';
 
 /**
  * Pure decision + copy helpers for desktop run-completion notifications.
@@ -126,27 +127,59 @@ function sanitizeLine(value: unknown, max: number): string {
   return `${collapsed.slice(0, max - 1).trimEnd()}…`;
 }
 
-/** Resolves whether any connected host currently holds incognito. */
+/** Minimal host identity a notification carries to its privacy authority. */
+export type NotificationSourceHostId = string | undefined;
+
+/**
+ * Resolves whether the notification source host currently holds incognito.
+ * The argument is the originating host; an unknown source must suppress
+ * (fail-closed) because no other host can authorize the content (#4981).
+ */
 export interface PrivacyAuthority {
-  isIncognitoActive(): Promise<boolean>;
+  isIncognitoActive(sourceHostId: NotificationSourceHostId): Promise<boolean>;
 }
 
 /**
  * Reads incognito from the authority (#4981). The local settings copy never
  * receives privacy updates, so its value must not decide content-bearing
- * notifications. A rejecting authority suppresses the notification rather
- * than risking exposure (fail-closed).
+ * notifications. An unknown or unreachable authority suppresses the
+ * notification rather than risking exposure (fail-closed).
  */
 export async function resolveNotificationIncognito(
-  settingsIncognitoActive: boolean,
-  privacyAuthority: PrivacyAuthority | undefined,
+  privacyAuthority: PrivacyAuthority,
+  sourceHostId: NotificationSourceHostId,
 ): Promise<boolean> {
-  if (!privacyAuthority) return settingsIncognitoActive;
   try {
-    return await privacyAuthority.isIncognitoActive();
+    return await privacyAuthority.isIncognitoActive(sourceHostId);
   } catch {
     return true;
   }
+}
+
+/**
+ * Builds the authority boot passes to the notification gate. Only the
+ * notification's own host is queried: session guests cannot resolve policy
+ * and must never decide local notifications, while a reconnecting source
+ * host keeps its unknown verdict (suppressed) instead of being dropped
+ * from the decision. No verdict is cached.
+ */
+export function createHostPrivacyAuthority(
+  listEntries: () => readonly RuntimeHostDesktopTargetState[],
+): PrivacyAuthority {
+  return {
+    async isIncognitoActive(sourceHostId) {
+      if (!sourceHostId) return true;
+      const entry = listEntries().find(
+        (candidate) =>
+          (candidate.readiness === 'ready'
+            ? candidate.candidate.client.hostId
+            : candidate.hostId) === sourceHostId,
+      );
+      if (!entry || entry.readiness !== 'ready') return true;
+      return (await entry.candidate.client.queryRuntimePolicy()).policy.privacy
+        .incognitoActive;
+    },
+  };
 }
 
 /**

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -1103,6 +1103,26 @@ registerNotificationsIpc({
   locale: desktopLocale,
   mainWindowController,
   e2e: isE2e,
+  // Privacy state is Host-owned: the local settings copy never receives
+  // privacy updates, so the notification gate asks the authority instead
+  // of trusting the stale local copy (#4981). Any ready host holding
+  // incognito suppresses the banner; an unreachable authority does too.
+  privacyAuthority: {
+    isIncognitoActive: async () => {
+      const entries = runtimeHostManager?.entries() ?? [];
+      const ready = entries.filter(
+        (entry): entry is Extract<typeof entry, { readiness: 'ready' }> =>
+          entry.readiness === 'ready',
+      );
+      const verdicts = await Promise.all(
+        ready.map(async (entry) =>
+          (await entry.candidate.client.queryRuntimePolicy()).policy.privacy
+            .incognitoActive,
+        ),
+      );
+      return verdicts.some((active) => active);
+    },
+  },
 });
 
 const sessionCopyOwnerProcessId = randomUUID();

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -160,6 +160,7 @@ import {
   type DesktopModelTargetResolution,
 } from "./task-submission-readiness-main.js";
 import { registerNotificationsIpc } from "./notifications-ipc-main.js";
+import { createHostPrivacyAuthority } from "./notifications-policy.js";
 import { registerMarkdownSaveIpc } from "./markdown-save-ipc-main.js";
 import { registerPetPackIpc } from "./pet-pack-import.js";
 import { registerWorkBoardIpc } from "./work-board-ipc-main.js";
@@ -1104,25 +1105,10 @@ registerNotificationsIpc({
   mainWindowController,
   e2e: isE2e,
   // Privacy state is Host-owned: the local settings copy never receives
-  // privacy updates, so the notification gate asks the authority instead
-  // of trusting the stale local copy (#4981). Any ready host holding
-  // incognito suppresses the banner; an unreachable authority does too.
-  privacyAuthority: {
-    isIncognitoActive: async () => {
-      const entries = runtimeHostManager?.entries() ?? [];
-      const ready = entries.filter(
-        (entry): entry is Extract<typeof entry, { readiness: 'ready' }> =>
-          entry.readiness === 'ready',
-      );
-      const verdicts = await Promise.all(
-        ready.map(async (entry) =>
-          (await entry.candidate.client.queryRuntimePolicy()).policy.privacy
-            .incognitoActive,
-        ),
-      );
-      return verdicts.some((active) => active);
-    },
-  },
+  // privacy updates, so the notification gate asks the notification's own
+  // host instead of trusting the stale local copy (#4981). An unknown or
+  // unreachable verdict suppresses the banner; no verdict is cached.
+  privacyAuthority: createHostPrivacyAuthority(() => runtimeHostManager?.entries() ?? []),
 });
 
 const sessionCopyOwnerProcessId = randomUUID();

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -1433,6 +1433,8 @@ export interface MakaBridge {
       kind: 'completed' | 'errored';
       title?: string;
       body?: string;
+      /** Originating host that authorizes the banner content (#4981). */
+      hostId?: string;
     }): Promise<void>;
   };
   onboarding: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3322,6 +3322,7 @@ const makaBridge = {
       kind: 'completed' | 'errored';
       title?: string;
       body?: string;
+      hostId?: string;
     }): Promise<void> {
       return ipcRenderer.invoke('notifications:runEnded', payload);
     },

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -20,6 +20,7 @@
 import type { ContextCompactionOutcome, SessionEvent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import type { UiLocale } from '@maka/core/ui-locale';
+import { parseDesktopSessionKey } from '../shared/runtime-host-identity.js';
 import {
   applyLiveTurnEvent,
   clearInteractions,
@@ -68,6 +69,20 @@ export interface AppShellSessionDisplayBatch {
 
 export function createAppShellSessionDisplayBatch(): AppShellSessionDisplayBatch {
   return { pendingEvents: new Map(), displayPendingSessions: new Set(), framePending: false };
+}
+
+/**
+ * The run-notification banner belongs to the session's host: only that host
+ * can authorize its content, so the renderer carries its identity to main
+ * (#4981). Legacy session ids have no host component; treat those as
+ * unresolvable rather than failing the notification.
+ */
+export function resolveRunEndedHostId(sessionId: string): string | undefined {
+  try {
+    return parseDesktopSessionKey(sessionId).hostId;
+  } catch {
+    return undefined;
+  }
 }
 
 export function createAppShellSessionEventHandlers(options: {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -162,6 +162,7 @@ import { useAppShellProjectContext } from './use-project-context';
 import {
   createAppShellSessionDisplayBatch,
   createAppShellSessionEventHandlers,
+  resolveRunEndedHostId,
 } from './app-shell-session-events';
 import { createAppShellE2eFixtureActions } from './app-shell-e2e-fixture';
 import { createAppShellChatActions } from './app-shell-chat-actions';
@@ -1944,9 +1945,12 @@ function AppShellContent({
       if (kind === 'completed' && activeIdRef.current === sessionId)
         setPetCompletionNonce((current) => current + 1);
       const title = sessionsRef.current.find((session) => session.id === sessionId)?.name;
+      // The banner belongs to this session's host: only that host can
+      // authorize its content, so carry its identity to main (#4981).
+      const hostId = resolveRunEndedHostId(sessionId);
       // Best-effort: swallow any main-side failure so a missed banner
       // never surfaces as an unhandled promise rejection.
-      void window.maka.notifications.runEnded({ kind, title, body }).catch(() => {});
+      void window.maka.notifications.runEnded({ kind, title, body, ...(hostId ? { hostId } : {}) }).catch(() => {});
     },
   });
 


### PR DESCRIPTION
## Summary

Fixes #4981. The run-ended notification gated content-bearing banners (session name + reply preview, shown outside the app in Notification Center / lock screen) on `settings.privacy.incognitoActive` — but the local settings copy never receives privacy updates: `clientOwnedSettingsPatch` excludes the section and `projectClientOwnedSettings` keeps the host's copy. After a user enabled incognito, the stale local copy kept reading `false` and the banner kept exposing content.

`registerNotificationsIpc` now takes an optional `privacyAuthority`. When provided, `resolveNotificationIncognito()` reads incognito from the authority and the local copy is never consulted for this decision; when the authority rejects, the notification is suppressed rather than risked (fail-closed); callers without the dep keep the existing local-copy behavior. The resolver lives in `notifications-policy.ts` beside the rest of the gating logic so it stays unit-testable under plain `node --test`. Boot wires an adapter that queries every ready host's `runtime.policy` and suppresses if any holds incognito — the same `client.queryRuntimePolicy().policy.privacy` path `runtime-host-search-ipc-main.ts` already uses. No polling, no subscription: the authority is read lazily at notification time, matching the existing "read the toggle lazily" design.

## Verification

- New unit test in `notifications-policy.test.ts` covers all four branches: authority `true` overrides a stale local `false`; authority `false` overrides a stale local `true`; absent dep preserves the local-copy gate in both directions; a rejecting authority suppresses. Full file: 4/4 pass, run against the compiled output (`node --test dist/main/__tests__/notifications-policy.test.js`).
- `biome check` clean on all four changed files; desktop `build:main` compiles the changed files with no new errors (pre-existing missing-workspace errors for unbuilt UI packages only).
- Not reproduced end-to-end with a live incognito session (same caveat the issue carries); the wiring matches the verified search-ipc precedent for the same authority read.

## AI use

Select exactly one:

- [x] No generative tool made a substantive contribution
- [ ] Generative tooling made a substantive contribution

Tool(s) and scope:

## Checklist

- [x] Tests cover the change and fail without it — without the authority, a stale `false` local copy reaches the gate and the banner is raised; the authority-true case asserts what the resolver returns in place of that read. The gate predicate itself was already covered and is unchanged.
- [x] Lint, format, typecheck and the affected suites pass locally — see Verification; full Desktop suite runs in CI.

Does this PR entail a change in behavior?

- [x] No — a banner that would previously have leaked title + preview under incognito is now suppressed; all other notification behavior is unchanged.