### PR TITLE
refactor(runtime-host): extract Peer Mesh control message codecs

### DIFF
--- a/packages/runtime-host/src/__tests__/peer-mesh-control-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/peer-mesh-control-protocol.test.ts
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { createPrivateKey, sign } from 'node:crypto';
+import test from 'node:test';
+import {
+  decodeAnnounceRosterResponse,
+  decodeControlRequest,
+  decodeLeaveResponse,
+  decodeRedeemResponse,
+  decodeSyncResponse,
+} from '../peer-mesh/control-protocol.js';
+import {
+  canonicalPeerMeshMemberAdvertisement,
+  generatePeerMeshAuthorityKeyPair,
+  peerMeshId,
+  peerMeshMemberAdvertisementSigningBytes,
+  signPeerMeshRoster,
+} from '../peer-mesh/model.js';
+import {
+  canonicalPeerReachabilityLease,
+  peerReachabilityLeaseSigningBytes,
+} from '../peer-reachability/model.js';
+
+const keys = generatePeerMeshAuthorityKeyPair();
+const privateKey = createPrivateKey({
+  key: Buffer.from(keys.privateKey, 'base64url'),
+  format: 'der',
+  type: 'pkcs8',
+});
+const meshId = peerMeshId(keys.publicKey);
+const roster = signPeerMeshRoster(
+  {
+    version: 1,
+    meshId,
+    authorityPeerId: 'peer-a',
+    revision: 1,
+    members: ['peer-a'],
+    closed: false,
+  },
+  keys,
+);
+const lease = canonicalPeerReachabilityLease({
+  version: 1,
+  peerId: 'peer-a',
+  revision: 1,
+  issuedAt: 1_000,
+  expiresAt: 2_000,
+  directRoutes: ['/memory/peer-a'],
+  coordinationRoutes: [],
+});
+const reachability = {
+  lease,
+  publicKey: keys.publicKey,
+  signature: sign(null, peerReachabilityLeaseSigningBytes(lease), privateKey).toString('base64url'),
+};
+const memberAdvertisement = canonicalPeerMeshMemberAdvertisement({
+  version: 1,
+  meshId,
+  peerId: 'peer-a',
+  revision: 1,
+  offersTransit: false,
+});
+const advertisement = {
+  advertisement: memberAdvertisement,
+  publicKey: keys.publicKey,
+  signature: sign(
+    null,
+    peerMeshMemberAdvertisementSigningBytes(memberAdvertisement),
+    privateKey,
+  ).toString('base64url'),
+};
+const summary = { peerId: 'peer-a', revision: 1, digest: 'a'.repeat(64) };
+const redeem = { kind: 'redeem-invitation', meshId, secret: 'secret', reachability, advertisement };
+const sync = {
+  kind: 'sync',
+  meshId,
+  roster,
+  reachability,
+  advertisement,
+  knownReachability: [summary],
+  knownAdvertisements: [summary],
+};
+const page = { roster, reachability: [reachability], advertisements: [advertisement] };
+const wireCases: readonly {
+  decode: (value: unknown) => unknown;
+  wire: Record<string, unknown>;
+}[] = [
+  ...[
+    redeem,
+    sync,
+    { kind: 'leave', meshId, roster },
+    { kind: 'announce-roster', meshId, roster },
+  ].map((wire) => ({ decode: decodeControlRequest, wire })),
+  { decode: decodeRedeemResponse, wire: { kind: 'invitation-redeemed', ...page } },
+  ...['invalid', 'expired', 'closed', 'full'].map((reason) => ({
+    decode: decodeRedeemResponse,
+    wire: { kind: 'invitation-rejected', reason },
+  })),
+  ...[false, true].map((more) => ({
+    decode: decodeSyncResponse,
+    wire: { kind: 'sync-result', ...page, more },
+  })),
+  { decode: decodeSyncResponse, wire: { kind: 'sync-rejected', reason: 'unknown' } },
+  { decode: decodeLeaveResponse, wire: { kind: 'left', roster } },
+  { decode: decodeLeaveResponse, wire: { kind: 'leave-rejected', reason: 'unknown' } },
+  { decode: decodeAnnounceRosterResponse, wire: { kind: 'roster-observed' } },
+  { decode: decodeAnnounceRosterResponse, wire: { kind: 'roster-rejected', reason: 'unknown' } },
+];
+
+test('decodes every control request and response variant after JSON transport', () => {
+  for (const { decode, wire } of wireCases) {
+    assert.deepEqual(decode(JSON.parse(JSON.stringify(wire))), wire);
+  }
+});
+
+test('rejects extra or inherited required keys, unknown kinds, and non-object control messages', () => {
+  for (const { decode, wire } of wireCases) {
+    assert.throws(() => decode({ ...wire, unexpected: true }));
+    const { kind, ...fields } = wire;
+    const inheritedKind = Object.assign(Object.create({ kind }), fields, { unexpected: true });
+    assert.equal(Object.keys(inheritedKind).length, Object.keys(wire).length);
+    assert.throws(() => decode(inheritedKind));
+    assert.throws(() => decode({ ...wire, kind: 'future-kind' }));
+    for (const invalid of [null, [], 42]) assert.throws(() => decode(invalid));
+  }
+});
+
+test('enforces control string bounds without imposing invitation authentication', () => {
+  assert.equal(
+    decodeControlRequest({ ...redeem, meshId: 'm'.repeat(128), secret: 's'.repeat(64) }).kind,
+    'redeem-invitation',
+  );
+  for (const meshId of ['', 'm'.repeat(129), 42]) {
+    assert.throws(() => decodeControlRequest({ ...redeem, meshId }), /control value/u);
+  }
+  for (const secret of ['', 's'.repeat(65), 42]) {
+    assert.throws(() => decodeControlRequest({ ...redeem, secret }), /control value/u);
+  }
+});
+
+test('rejects unsupported response reasons and non-boolean pagination flags', () => {
+  for (const { decode, wire } of wireCases.filter(({ wire }) => 'reason' in wire)) {
+    assert.throws(() => decode({ ...wire, reason: 'future-reason' }));
+  }
+  for (const more of [undefined, 0, 'false']) {
+    assert.throws(
+      () => decodeSyncResponse({ kind: 'sync-result', ...page, more }),
+      /synchronization response/u,
+    );
+  }
+});
+
+test('validates evidence summary identities, revisions, and digests on both sync inputs', () => {
+  const invalidSummaries = [
+    { ...summary, unexpected: true },
+    ...['', 'p'.repeat(257), 42].map((peerId) => ({ ...summary, peerId })),
+    ...[0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1'].map((revision) => ({ ...summary, revision })),
+    ...['a'.repeat(63), 'a'.repeat(65), 'A'.repeat(64), 'g'.repeat(64), 42].map((digest) => ({
+      ...summary,
+      digest,
+    })),
+  ];
+  for (const field of ['knownReachability', 'knownAdvertisements'] as const) {
+    assert.doesNotThrow(() =>
+      decodeControlRequest({
+        ...sync,
+        [field]: [{ ...summary, peerId: 'p'.repeat(256), revision: Number.MAX_SAFE_INTEGER }],
+      }),
+    );
+    for (const invalid of invalidSummaries) {
+      assert.throws(() => decodeControlRequest({ ...sync, [field]: [invalid] }));
+    }
+  }
+});
+
+test('bounds sync summaries and rejects duplicate peers even when their revisions differ', () => {
+  const summaries = Array.from({ length: 64 }, (_, index) => ({
+    ...summary,
+    peerId: `peer-${index}`,
+  }));
+  for (const field of ['knownReachability', 'knownAdvertisements'] as const) {
+    assert.doesNotThrow(() => decodeControlRequest({ ...sync, [field]: summaries }));
+    assert.throws(
+      () =>
+        decodeControlRequest({
+          ...sync,
+          [field]: [...summaries, { ...summary, peerId: 'one-too-many' }],
+        }),
+      /evidence revisions/u,
+    );
+    assert.throws(
+      () => decodeControlRequest({ ...sync, [field]: [summary, { ...summary, revision: 2 }] }),
+      /Duplicate Peer Mesh evidence revision/u,
+    );
+    assert.throws(() => decodeControlRequest({ ...sync, [field]: null }), /evidence revisions/u);
+  }
+});
+
+test('keeps each evidence page and the combined response within two records', () => {
+  for (const { decode, wire } of wireCases.filter(({ wire }) => 'advertisements' in wire)) {
+    for (const field of ['reachability', 'advertisements'] as const) {
+      const other = field === 'reachability' ? 'advertisements' : 'reachability';
+      const value = field === 'reachability' ? reachability : advertisement;
+      const error =
+        field === 'reachability'
+          ? /Invalid Peer Mesh reachability page/u
+          : /Invalid Peer Mesh advertisement page/u;
+      assert.doesNotThrow(() => decode({ ...wire, [field]: [value, value], [other]: [] }));
+      assert.throws(() => decode({ ...wire, [field]: [value, value, value], [other]: [] }), error);
+      assert.throws(() => decode({ ...wire, [field]: null, [other]: [] }), error);
+      assert.throws(
+        () => decode({ ...wire, [field]: [value, value] }),
+        /evidence page exceeds its bound/u,
+      );
+    }
+  }
+});
+
+test('retains signed-record validation while decoding control envelopes', () => {
+  assert.throws(
+    () =>
+      decodeControlRequest({
+        ...sync,
+        reachability: { ...reachability, lease: { ...lease, version: 2 } },
+      }),
+    /reachability lease version/u,
+  );
+  assert.throws(
+    () =>
+      decodeControlRequest({
+        ...redeem,
+        advertisement: { ...advertisement, advertisement: { ...memberAdvertisement, version: 2 } },
+      }),
+    /advertisement version/u,
+  );
+  assert.throws(
+    () =>
+      decodeLeaveResponse({
+        kind: 'left',
+        roster: { ...roster, roster: { ...roster.roster, closed: true } },
+      }),
+    /roster signature is invalid/u,
+  );
+});
+
+test('reconstructs frozen evidence and summary collections without retaining wire objects', () => {
+  const rawRequest = JSON.parse(JSON.stringify(sync));
+  const request = decodeControlRequest(rawRequest);
+  assert.equal(request.kind, 'sync');
+  if (request.kind !== 'sync') throw new Error('Expected sync request');
+  for (const field of ['knownReachability', 'knownAdvertisements'] as const) {
+    assert.ok(Object.isFrozen(request[field]));
+    assert.ok(Object.isFrozen(request[field][0]));
+    rawRequest[field][0].digest = 'changed';
+    assert.equal(request[field][0]?.digest, summary.digest);
+  }
+  for (const { decode, wire } of wireCases.filter(({ wire }) => 'advertisements' in wire)) {
+    const rawResponse = JSON.parse(JSON.stringify(wire));
+    const result = decode(rawResponse) as typeof page;
+    assert.ok(Object.isFrozen(result.reachability));
+    assert.ok(Object.isFrozen(result.advertisements));
+    assert.ok(Object.isFrozen(result.reachability[0]));
+    assert.ok(Object.isFrozen(result.advertisements[0]));
+    rawResponse.reachability[0].lease.peerId = 'changed';
+    rawResponse.advertisements[0].advertisement.peerId = 'changed';
+    assert.equal(result.reachability[0]?.lease.peerId, 'peer-a');
+    assert.equal(result.advertisements[0]?.advertisement.peerId, 'peer-a');
+  }
+});

--- a/packages/runtime-host/src/peer-mesh/control-protocol.ts
+++ b/packages/runtime-host/src/peer-mesh/control-protocol.ts
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  decodeSignedPeerMeshMemberAdvertisement,
+  decodeSignedPeerMeshRoster,
+  PEER_MESH_MAX_MEMBERS,
+  type SignedPeerMeshMemberAdvertisementV1,
+  type SignedPeerMeshRosterV1,
+} from './model.js';
+import {
+  decodeSignedPeerReachabilityLease,
+  type SignedPeerReachabilityLeaseV1,
+} from '../peer-reachability/model.js';
+
+export const EVIDENCE_PAGE_SIZE = 2;
+
+export interface RedeemInvitationRequest {
+  readonly kind: 'redeem-invitation';
+  readonly meshId: string;
+  readonly secret: string;
+  readonly reachability: SignedPeerReachabilityLeaseV1;
+  readonly advertisement: SignedPeerMeshMemberAdvertisementV1;
+}
+
+export type RedeemInvitationResponse =
+  | {
+      readonly kind: 'invitation-redeemed';
+      readonly roster: SignedPeerMeshRosterV1;
+      readonly reachability: readonly SignedPeerReachabilityLeaseV1[];
+      readonly advertisements: readonly SignedPeerMeshMemberAdvertisementV1[];
+    }
+  | {
+      readonly kind: 'invitation-rejected';
+      readonly reason: RedeemInvitationRejectionReason;
+    };
+
+export type RedeemInvitationRejectionReason = 'invalid' | 'expired' | 'closed' | 'full';
+
+export interface PeerMeshEvidenceSummary {
+  readonly peerId: string;
+  readonly revision: number;
+  readonly digest: string;
+}
+
+export interface SyncPeerMeshRequest {
+  readonly kind: 'sync';
+  readonly meshId: string;
+  readonly roster: SignedPeerMeshRosterV1;
+  readonly reachability: SignedPeerReachabilityLeaseV1;
+  readonly advertisement: SignedPeerMeshMemberAdvertisementV1;
+  readonly knownReachability: readonly PeerMeshEvidenceSummary[];
+  readonly knownAdvertisements: readonly PeerMeshEvidenceSummary[];
+}
+
+export type SyncPeerMeshResponse =
+  | {
+      readonly kind: 'sync-result';
+      readonly roster: SignedPeerMeshRosterV1;
+      readonly reachability: readonly SignedPeerReachabilityLeaseV1[];
+      readonly advertisements: readonly SignedPeerMeshMemberAdvertisementV1[];
+      readonly more: boolean;
+    }
+  | { readonly kind: 'sync-rejected'; readonly reason: 'unknown' };
+
+export interface LeavePeerMeshRequest {
+  readonly kind: 'leave';
+  readonly meshId: string;
+  readonly roster: SignedPeerMeshRosterV1;
+}
+
+export type LeavePeerMeshResponse =
+  | { readonly kind: 'left'; readonly roster: SignedPeerMeshRosterV1 }
+  | { readonly kind: 'leave-rejected'; readonly reason: 'unknown' };
+
+export interface AnnouncePeerMeshRosterRequest {
+  readonly kind: 'announce-roster';
+  readonly meshId: string;
+  readonly roster: SignedPeerMeshRosterV1;
+}
+
+export type AnnouncePeerMeshRosterResponse =
+  | { readonly kind: 'roster-observed' }
+  | { readonly kind: 'roster-rejected'; readonly reason: 'unknown' };
+
+type PeerMeshControlRequest =
+  | RedeemInvitationRequest
+  | SyncPeerMeshRequest
+  | LeavePeerMeshRequest
+  | AnnouncePeerMeshRosterRequest;
+
+export function decodeControlRequest(value: unknown): PeerMeshControlRequest {
+  const record = recordValue(value);
+  if (
+    record.kind === 'redeem-invitation' &&
+    hasExactKeys(record, ['kind', 'meshId', 'secret', 'reachability', 'advertisement'])
+  ) {
+    return {
+      kind: 'redeem-invitation',
+      meshId: requiredString(record.meshId, 128),
+      secret: requiredString(record.secret, 64),
+      reachability: decodeSignedPeerReachabilityLease(record.reachability),
+      advertisement: decodeSignedPeerMeshMemberAdvertisement(record.advertisement),
+    };
+  }
+  if (
+    record.kind === 'sync' &&
+    hasExactKeys(record, [
+      'kind',
+      'meshId',
+      'roster',
+      'reachability',
+      'advertisement',
+      'knownReachability',
+      'knownAdvertisements',
+    ])
+  ) {
+    return {
+      kind: 'sync',
+      meshId: requiredString(record.meshId, 128),
+      roster: decodeSignedPeerMeshRoster(record.roster),
+      reachability: decodeSignedPeerReachabilityLease(record.reachability),
+      advertisement: decodeSignedPeerMeshMemberAdvertisement(record.advertisement),
+      knownReachability: decodeEvidenceSummaries(record.knownReachability),
+      knownAdvertisements: decodeEvidenceSummaries(record.knownAdvertisements),
+    };
+  }
+  if (record.kind === 'leave' && hasExactKeys(record, ['kind', 'meshId', 'roster'])) {
+    return {
+      kind: 'leave',
+      meshId: requiredString(record.meshId, 128),
+      roster: decodeSignedPeerMeshRoster(record.roster),
+    };
+  }
+  if (record.kind === 'announce-roster' && hasExactKeys(record, ['kind', 'meshId', 'roster'])) {
+    return {
+      kind: 'announce-roster',
+      meshId: requiredString(record.meshId, 128),
+      roster: decodeSignedPeerMeshRoster(record.roster),
+    };
+  }
+  throw new Error('Unsupported Peer Mesh control request');
+}
+
+export function decodeRedeemResponse(value: unknown): RedeemInvitationResponse {
+  const record = recordValue(value);
+  if (
+    record.kind === 'invitation-redeemed' &&
+    hasExactKeys(record, ['kind', 'roster', 'reachability', 'advertisements'])
+  ) {
+    const reachability = decodeReachabilityPage(record.reachability);
+    const advertisements = decodeAdvertisementPage(record.advertisements);
+    assertEvidencePageSize(reachability, advertisements);
+    return {
+      kind: 'invitation-redeemed',
+      roster: decodeSignedPeerMeshRoster(record.roster),
+      reachability,
+      advertisements,
+    };
+  }
+  if (
+    record.kind === 'invitation-rejected' &&
+    hasExactKeys(record, ['kind', 'reason']) &&
+    (record.reason === 'invalid' ||
+      record.reason === 'expired' ||
+      record.reason === 'closed' ||
+      record.reason === 'full')
+  ) {
+    return { kind: 'invitation-rejected', reason: record.reason };
+  }
+  throw new Error('Invalid Peer Mesh control response');
+}
+
+export function decodeSyncResponse(value: unknown): SyncPeerMeshResponse {
+  const record = recordValue(value);
+  if (
+    record.kind === 'sync-result' &&
+    hasExactKeys(record, ['kind', 'roster', 'reachability', 'advertisements', 'more']) &&
+    typeof record.more === 'boolean'
+  ) {
+    const reachability = decodeReachabilityPage(record.reachability);
+    const advertisements = decodeAdvertisementPage(record.advertisements);
+    assertEvidencePageSize(reachability, advertisements);
+    return {
+      kind: 'sync-result',
+      roster: decodeSignedPeerMeshRoster(record.roster),
+      reachability,
+      advertisements,
+      more: record.more,
+    };
+  }
+  if (
+    record.kind === 'sync-rejected' &&
+    hasExactKeys(record, ['kind', 'reason']) &&
+    record.reason === 'unknown'
+  ) {
+    return { kind: 'sync-rejected', reason: record.reason };
+  }
+  throw new Error('Invalid Peer Mesh synchronization response');
+}
+
+export function decodeLeaveResponse(value: unknown): LeavePeerMeshResponse {
+  const record = recordValue(value);
+  if (record.kind === 'left' && hasExactKeys(record, ['kind', 'roster'])) {
+    return { kind: 'left', roster: decodeSignedPeerMeshRoster(record.roster) };
+  }
+  if (
+    record.kind === 'leave-rejected' &&
+    hasExactKeys(record, ['kind', 'reason']) &&
+    record.reason === 'unknown'
+  ) {
+    return { kind: 'leave-rejected', reason: 'unknown' };
+  }
+  throw new Error('Invalid Peer Mesh leave response');
+}
+
+export function decodeAnnounceRosterResponse(value: unknown): AnnouncePeerMeshRosterResponse {
+  const record = recordValue(value);
+  if (record.kind === 'roster-observed' && hasExactKeys(record, ['kind'])) {
+    return { kind: 'roster-observed' };
+  }
+  if (
+    record.kind === 'roster-rejected' &&
+    hasExactKeys(record, ['kind', 'reason']) &&
+    record.reason === 'unknown'
+  ) {
+    return { kind: 'roster-rejected', reason: 'unknown' };
+  }
+  throw new Error('Invalid Peer Mesh roster announcement response');
+}
+
+function decodeReachabilityPage(value: unknown): readonly SignedPeerReachabilityLeaseV1[] {
+  if (!Array.isArray(value) || value.length > EVIDENCE_PAGE_SIZE) {
+    throw new Error('Invalid Peer Mesh reachability page');
+  }
+  return Object.freeze(value.map(decodeSignedPeerReachabilityLease));
+}
+
+function decodeAdvertisementPage(value: unknown): readonly SignedPeerMeshMemberAdvertisementV1[] {
+  if (!Array.isArray(value) || value.length > EVIDENCE_PAGE_SIZE) {
+    throw new Error('Invalid Peer Mesh advertisement page');
+  }
+  return Object.freeze(value.map(decodeSignedPeerMeshMemberAdvertisement));
+}
+
+function assertEvidencePageSize(
+  reachability: readonly SignedPeerReachabilityLeaseV1[],
+  advertisements: readonly SignedPeerMeshMemberAdvertisementV1[],
+): void {
+  if (reachability.length + advertisements.length > EVIDENCE_PAGE_SIZE) {
+    throw new Error('Peer Mesh evidence page exceeds its bound');
+  }
+}
+
+function decodeEvidenceSummaries(value: unknown): readonly PeerMeshEvidenceSummary[] {
+  if (!Array.isArray(value) || value.length > PEER_MESH_MAX_MEMBERS) {
+    throw new Error('Invalid Peer Mesh evidence revisions');
+  }
+  const revisions = value.map((entry) => {
+    const record = recordValue(entry);
+    if (!hasExactKeys(record, ['peerId', 'revision', 'digest'])) {
+      throw new Error('Invalid Peer Mesh evidence revision');
+    }
+    const revision = record.revision;
+    if (!Number.isSafeInteger(revision) || (revision as number) < 1) {
+      throw new Error('Invalid Peer Mesh evidence revision');
+    }
+    if (typeof record.digest !== 'string' || !/^[0-9a-f]{64}$/u.test(record.digest)) {
+      throw new Error('Invalid Peer Mesh evidence digest');
+    }
+    return Object.freeze({
+      peerId: requiredString(record.peerId, 256),
+      revision: revision as number,
+      digest: record.digest,
+    });
+  });
+  if (new Set(revisions.map(({ peerId }) => peerId)).size !== revisions.length) {
+    throw new Error('Duplicate Peer Mesh evidence revision');
+  }
+  return Object.freeze(revisions);
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid Peer Mesh control frame');
+  }
+  return value as Record<string, unknown>;
+}
+
+function hasExactKeys(record: Record<string, unknown>, keys: readonly string[]): boolean {
+  return (
+    Object.keys(record).length === keys.length && keys.every((key) => Object.hasOwn(record, key))
+  );
+}
+
+function requiredString(value: unknown, maxLength: number): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > maxLength) {
+    throw new Error('Invalid Peer Mesh control value');
+  }
+  return value;
+}

--- a/packages/runtime-host/src/peer-mesh/node.ts
+++ b/packages/runtime-host/src/peer-mesh/node.ts
@@ -50,6 +50,24 @@ import {
   type SignedPeerMeshRosterV1,
 } from './model.js';
 import { canonicalPeerMeshDisplayName } from './display-name.js';
+import {
+  decodeControlRequest,
+  decodeRedeemResponse,
+  decodeSyncResponse,
+  decodeLeaveResponse,
+  decodeAnnounceRosterResponse,
+  EVIDENCE_PAGE_SIZE,
+  type RedeemInvitationRequest,
+  type RedeemInvitationResponse,
+  type RedeemInvitationRejectionReason,
+  type PeerMeshEvidenceSummary,
+  type SyncPeerMeshRequest,
+  type SyncPeerMeshResponse,
+  type LeavePeerMeshRequest,
+  type LeavePeerMeshResponse,
+  type AnnouncePeerMeshRosterRequest,
+  type AnnouncePeerMeshRosterResponse,
+} from './control-protocol.js';
 import type { PeerMeshInvitationV1 } from '../protocol/peer-mesh.js';
 import {
   authenticateSignedPeerReachabilityLease,
@@ -83,84 +101,9 @@ const CONNECT_DEADLINE_MS = 30_000;
 const CONTROL_REQUEST_DEADLINE_MS = 10_000;
 const MAX_ACTIVE_CONTROL_STREAMS = 32;
 const MAX_ACTIVE_CONTROL_STREAMS_PER_PEER = 2;
-const EVIDENCE_PAGE_SIZE = 2;
 const RECONCILE_CONCURRENCY = 4;
 const RECONCILE_DEADLINE_MS = 60 * 1_000;
 const RECONCILE_INTERVAL_MS = 5 * 60 * 1_000;
-
-interface RedeemInvitationRequest {
-  readonly kind: 'redeem-invitation';
-  readonly meshId: string;
-  readonly secret: string;
-  readonly reachability: SignedPeerReachabilityLeaseV1;
-  readonly advertisement: SignedPeerMeshMemberAdvertisementV1;
-}
-
-type RedeemInvitationResponse =
-  | {
-      readonly kind: 'invitation-redeemed';
-      readonly roster: SignedPeerMeshRosterV1;
-      readonly reachability: readonly SignedPeerReachabilityLeaseV1[];
-      readonly advertisements: readonly SignedPeerMeshMemberAdvertisementV1[];
-    }
-  | {
-      readonly kind: 'invitation-rejected';
-      readonly reason: RedeemInvitationRejectionReason;
-    };
-
-type RedeemInvitationRejectionReason = 'invalid' | 'expired' | 'closed' | 'full';
-
-interface PeerMeshEvidenceSummary {
-  readonly peerId: string;
-  readonly revision: number;
-  readonly digest: string;
-}
-
-interface SyncPeerMeshRequest {
-  readonly kind: 'sync';
-  readonly meshId: string;
-  readonly roster: SignedPeerMeshRosterV1;
-  readonly reachability: SignedPeerReachabilityLeaseV1;
-  readonly advertisement: SignedPeerMeshMemberAdvertisementV1;
-  readonly knownReachability: readonly PeerMeshEvidenceSummary[];
-  readonly knownAdvertisements: readonly PeerMeshEvidenceSummary[];
-}
-
-type SyncPeerMeshResponse =
-  | {
-      readonly kind: 'sync-result';
-      readonly roster: SignedPeerMeshRosterV1;
-      readonly reachability: readonly SignedPeerReachabilityLeaseV1[];
-      readonly advertisements: readonly SignedPeerMeshMemberAdvertisementV1[];
-      readonly more: boolean;
-    }
-  | { readonly kind: 'sync-rejected'; readonly reason: 'unknown' };
-
-interface LeavePeerMeshRequest {
-  readonly kind: 'leave';
-  readonly meshId: string;
-  readonly roster: SignedPeerMeshRosterV1;
-}
-
-type LeavePeerMeshResponse =
-  | { readonly kind: 'left'; readonly roster: SignedPeerMeshRosterV1 }
-  | { readonly kind: 'leave-rejected'; readonly reason: 'unknown' };
-
-interface AnnouncePeerMeshRosterRequest {
-  readonly kind: 'announce-roster';
-  readonly meshId: string;
-  readonly roster: SignedPeerMeshRosterV1;
-}
-
-type AnnouncePeerMeshRosterResponse =
-  | { readonly kind: 'roster-observed' }
-  | { readonly kind: 'roster-rejected'; readonly reason: 'unknown' };
-
-type PeerMeshControlRequest =
-  | RedeemInvitationRequest
-  | SyncPeerMeshRequest
-  | LeavePeerMeshRequest
-  | AnnouncePeerMeshRosterRequest;
 
 interface LocalPeerMeshEvidence {
   readonly reachability: SignedPeerReachabilityLeaseV1;
@@ -2867,197 +2810,6 @@ async function exchangeControl<Request, Response>(
   }
 }
 
-function decodeControlRequest(value: unknown): PeerMeshControlRequest {
-  const record = recordValue(value);
-  if (
-    record.kind === 'redeem-invitation' &&
-    hasExactKeys(record, ['kind', 'meshId', 'secret', 'reachability', 'advertisement'])
-  ) {
-    return {
-      kind: 'redeem-invitation',
-      meshId: requiredString(record.meshId, 128),
-      secret: requiredString(record.secret, 64),
-      reachability: decodeSignedPeerReachabilityLease(record.reachability),
-      advertisement: decodeSignedPeerMeshMemberAdvertisement(record.advertisement),
-    };
-  }
-  if (
-    record.kind === 'sync' &&
-    hasExactKeys(record, [
-      'kind',
-      'meshId',
-      'roster',
-      'reachability',
-      'advertisement',
-      'knownReachability',
-      'knownAdvertisements',
-    ])
-  ) {
-    return {
-      kind: 'sync',
-      meshId: requiredString(record.meshId, 128),
-      roster: decodeSignedPeerMeshRoster(record.roster),
-      reachability: decodeSignedPeerReachabilityLease(record.reachability),
-      advertisement: decodeSignedPeerMeshMemberAdvertisement(record.advertisement),
-      knownReachability: decodeEvidenceSummaries(record.knownReachability),
-      knownAdvertisements: decodeEvidenceSummaries(record.knownAdvertisements),
-    };
-  }
-  if (record.kind === 'leave' && hasExactKeys(record, ['kind', 'meshId', 'roster'])) {
-    return {
-      kind: 'leave',
-      meshId: requiredString(record.meshId, 128),
-      roster: decodeSignedPeerMeshRoster(record.roster),
-    };
-  }
-  if (record.kind === 'announce-roster' && hasExactKeys(record, ['kind', 'meshId', 'roster'])) {
-    return {
-      kind: 'announce-roster',
-      meshId: requiredString(record.meshId, 128),
-      roster: decodeSignedPeerMeshRoster(record.roster),
-    };
-  }
-  throw new Error('Unsupported Peer Mesh control request');
-}
-
-function decodeRedeemResponse(value: unknown): RedeemInvitationResponse {
-  const record = recordValue(value);
-  if (
-    record.kind === 'invitation-redeemed' &&
-    hasExactKeys(record, ['kind', 'roster', 'reachability', 'advertisements'])
-  ) {
-    const reachability = decodeReachabilityPage(record.reachability);
-    const advertisements = decodeAdvertisementPage(record.advertisements);
-    assertEvidencePageSize(reachability, advertisements);
-    return {
-      kind: 'invitation-redeemed',
-      roster: decodeSignedPeerMeshRoster(record.roster),
-      reachability,
-      advertisements,
-    };
-  }
-  if (
-    record.kind === 'invitation-rejected' &&
-    hasExactKeys(record, ['kind', 'reason']) &&
-    (record.reason === 'invalid' ||
-      record.reason === 'expired' ||
-      record.reason === 'closed' ||
-      record.reason === 'full')
-  ) {
-    return { kind: 'invitation-rejected', reason: record.reason };
-  }
-  throw new Error('Invalid Peer Mesh control response');
-}
-
-function decodeSyncResponse(value: unknown): SyncPeerMeshResponse {
-  const record = recordValue(value);
-  if (
-    record.kind === 'sync-result' &&
-    hasExactKeys(record, ['kind', 'roster', 'reachability', 'advertisements', 'more']) &&
-    typeof record.more === 'boolean'
-  ) {
-    const reachability = decodeReachabilityPage(record.reachability);
-    const advertisements = decodeAdvertisementPage(record.advertisements);
-    assertEvidencePageSize(reachability, advertisements);
-    return {
-      kind: 'sync-result',
-      roster: decodeSignedPeerMeshRoster(record.roster),
-      reachability,
-      advertisements,
-      more: record.more,
-    };
-  }
-  if (
-    record.kind === 'sync-rejected' &&
-    hasExactKeys(record, ['kind', 'reason']) &&
-    record.reason === 'unknown'
-  ) {
-    return { kind: 'sync-rejected', reason: record.reason };
-  }
-  throw new Error('Invalid Peer Mesh synchronization response');
-}
-
-function decodeLeaveResponse(value: unknown): LeavePeerMeshResponse {
-  const record = recordValue(value);
-  if (record.kind === 'left' && hasExactKeys(record, ['kind', 'roster'])) {
-    return { kind: 'left', roster: decodeSignedPeerMeshRoster(record.roster) };
-  }
-  if (
-    record.kind === 'leave-rejected' &&
-    hasExactKeys(record, ['kind', 'reason']) &&
-    record.reason === 'unknown'
-  ) {
-    return { kind: 'leave-rejected', reason: 'unknown' };
-  }
-  throw new Error('Invalid Peer Mesh leave response');
-}
-
-function decodeAnnounceRosterResponse(value: unknown): AnnouncePeerMeshRosterResponse {
-  const record = recordValue(value);
-  if (record.kind === 'roster-observed' && hasExactKeys(record, ['kind'])) {
-    return { kind: 'roster-observed' };
-  }
-  if (
-    record.kind === 'roster-rejected' &&
-    hasExactKeys(record, ['kind', 'reason']) &&
-    record.reason === 'unknown'
-  ) {
-    return { kind: 'roster-rejected', reason: 'unknown' };
-  }
-  throw new Error('Invalid Peer Mesh roster announcement response');
-}
-
-function decodeReachabilityPage(value: unknown): readonly SignedPeerReachabilityLeaseV1[] {
-  if (!Array.isArray(value) || value.length > EVIDENCE_PAGE_SIZE) {
-    throw new Error('Invalid Peer Mesh reachability page');
-  }
-  return Object.freeze(value.map(decodeSignedPeerReachabilityLease));
-}
-
-function decodeAdvertisementPage(value: unknown): readonly SignedPeerMeshMemberAdvertisementV1[] {
-  if (!Array.isArray(value) || value.length > EVIDENCE_PAGE_SIZE) {
-    throw new Error('Invalid Peer Mesh advertisement page');
-  }
-  return Object.freeze(value.map(decodeSignedPeerMeshMemberAdvertisement));
-}
-
-function assertEvidencePageSize(
-  reachability: readonly SignedPeerReachabilityLeaseV1[],
-  advertisements: readonly SignedPeerMeshMemberAdvertisementV1[],
-): void {
-  if (reachability.length + advertisements.length > EVIDENCE_PAGE_SIZE) {
-    throw new Error('Peer Mesh evidence page exceeds its bound');
-  }
-}
-
-function decodeEvidenceSummaries(value: unknown): readonly PeerMeshEvidenceSummary[] {
-  if (!Array.isArray(value) || value.length > PEER_MESH_MAX_MEMBERS) {
-    throw new Error('Invalid Peer Mesh evidence revisions');
-  }
-  const revisions = value.map((entry) => {
-    const record = recordValue(entry);
-    if (!hasExactKeys(record, ['peerId', 'revision', 'digest'])) {
-      throw new Error('Invalid Peer Mesh evidence revision');
-    }
-    const revision = record.revision;
-    if (!Number.isSafeInteger(revision) || (revision as number) < 1) {
-      throw new Error('Invalid Peer Mesh evidence revision');
-    }
-    if (typeof record.digest !== 'string' || !/^[0-9a-f]{64}$/u.test(record.digest)) {
-      throw new Error('Invalid Peer Mesh evidence digest');
-    }
-    return Object.freeze({
-      peerId: requiredString(record.peerId, 256),
-      revision: revision as number,
-      digest: record.digest,
-    });
-  });
-  if (new Set(revisions.map(({ peerId }) => peerId)).size !== revisions.length) {
-    throw new Error('Duplicate Peer Mesh evidence revision');
-  }
-  return Object.freeze(revisions);
-}
-
 async function writeFrame(stream: RuntimeHostPeerNativeStream, value: unknown): Promise<void> {
   const bytes = Buffer.from(`${JSON.stringify(value)}\n`);
   if (bytes.length > CONTROL_FRAME_MAX_BYTES)
@@ -3080,24 +2832,4 @@ async function readFrame(stream: RuntimeHostPeerNativeStream): Promise<unknown> 
     }
     return JSON.parse(buffered.subarray(0, newline).toString('utf8')) as unknown;
   }
-}
-
-function recordValue(value: unknown): Record<string, unknown> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('Invalid Peer Mesh control frame');
-  }
-  return value as Record<string, unknown>;
-}
-
-function hasExactKeys(record: Record<string, unknown>, keys: readonly string[]): boolean {
-  return (
-    Object.keys(record).length === keys.length && keys.every((key) => Object.hasOwn(record, key))
-  );
-}
-
-function requiredString(value: unknown, maxLength: number): string {
-  if (typeof value !== 'string' || value.length === 0 || value.length > maxLength) {
-    throw new Error('Invalid Peer Mesh control value');
-  }
-  return value;
 }


### PR DESCRIPTION
## Summary

Separate Peer Mesh control-message types and object decoding from node lifecycle orchestration. The internal codec owns the five decoder entry points and their bounds, while node retains stream framing, timeouts, connection admission and state changes. Existing signed-record decoders are reused, and pagination and decoding share one evidence-page limit.

`peer-mesh/node.ts` shrinks from 3,103 to 2,835 lines. The new codec is 317 lines, so aggregate production code increases by 49 lines for module headers/imports. The result is an independently testable boundary in a large module, not a net deletion or performance improvement. Public package exports and wire formats are unchanged.

Fixes #5005

Refs #4726, A9.

## Verification

Local macOS verification with Node 24.18.0 and npm 11.19.0:

- Original Peer Mesh suite: 28/28 on baseline and candidate; existing test source unchanged. New codec tests: 9/9. All are included in the full Host result below.
- Ten deliberate mutations were detected: one for each new test group, plus an existing public node join test with a removed response-decoder implementation. Candidate compiled output was restored byte-for-byte and the focused tests passed again.
- AST equivalence: all 24 moved declarations and all retained node declarations are unchanged apart from module exports/source metadata; node.d.ts is byte-identical. No new package export or dependency cycle is introduced.
- Full Runtime Host suite: 1,818 passed, 12 skipped, 0 failed or cancelled.
- Full build, typecheck, lint, format, Desktop/UI knip, renderer architecture, staged ASF/header/protocol checks and diff checks pass. Staged checks used a temporary index containing the exact three-file patch.

Not run: other workspace test suites, a Windows execution matrix, or a multi-host native Peer Mesh deployment. The existing Peer Mesh integration tests use their original in-memory transport and real cryptographic helpers.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex inspected the existing seam, extracted the implementation, added boundary tests, ran local equivalence and regression checks, and prepared these drafts. DSH performed a separate read-only source review and ran the codec tests. Submitted with contributor approval; upstream review is pending.

## Checklist

- [x] Tests cover the change and fail without the implementation they exercise
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
