### PR TITLE
fix(desktop): unblock sends after a failed local message

### DIFF
--- a/apps/desktop/src/main/__tests__/session-local.test.ts
+++ b/apps/desktop/src/main/__tests__/session-local.test.ts
@@ -303,6 +303,101 @@ test('offline intents are dispatched only after connectivity returns', async (t)
   assert.equal(calls[0]!.content.attachments?.length, 1);
 });
 
+for (const refusal of ['operation-error', 'blocked-skill'] as const) {
+  test(`a retained ${refusal} local message does not block later sends`, async (t) => {
+    const { store, beforeClose } = await database(t);
+    const calls: string[] = [];
+    const target: DesktopSessionLocalTarget = {
+      partition: 'authority',
+      profileId: 'profile',
+      scope: { hostId: 'root', targetEpoch: 'target' },
+      client: client('epoch'),
+      submit: async (input) => {
+        calls.push(input.messageId);
+        if (input.messageId === 'message-1') {
+          if (refusal === 'blocked-skill')
+            return { disposition: 'blocked', skillInvocation: accepted.skillInvocation };
+          throw new RuntimeHostOperationError('turn.message.submit', 'session_busy', 'busy');
+        }
+        return accepted;
+      },
+    };
+    const service = new DesktopSessionLocalService(store, {
+      targets: () => [target],
+      changed() {},
+      onError: (error) => assert.fail(String(error)),
+    });
+    beforeClose.push(() => service.close());
+    store.enqueue('authority', intent());
+    service.wake();
+    await waitFor(() => store.get('authority', 'message-1')?.state === 'failed');
+    const failed = store.get('authority', 'message-1');
+
+    store.enqueue('authority', intent('message-2'));
+    store.enqueue('authority', intent('message-3'));
+    service.wake();
+    await waitFor(() => store.get('authority', 'message-3')?.state === 'accepted');
+
+    assert.deepEqual(calls, ['message-1', 'message-2', 'message-3']);
+    assert.equal(store.get('authority', 'message-2')?.state, 'accepted');
+    assert.deepEqual(store.get('authority', 'message-1'), failed);
+    const retained = service.listMessages(target, 'session-1')[0]!;
+    assert.equal(retained.state, 'failed');
+    assert.equal(retained.text, 'hello');
+    assert.equal(retained.canCancel, true);
+    assert.ok(retained.error);
+  });
+}
+
+test('an unknown Host outcome blocks later local sends until the original message is reconciled', async (t) => {
+  const { store, beforeClose } = await database(t);
+  const calls: string[] = [];
+  const originalAck = deferred<TurnMessageSubmitResult>();
+  let reconcile = false;
+  const target: DesktopSessionLocalTarget = {
+    partition: 'authority',
+    profileId: 'profile',
+    scope: { hostId: 'root', targetEpoch: 'target' },
+    client: client('epoch'),
+    submit: async (input) => {
+      calls.push(input.messageId);
+      if (input.messageId === 'message-1') {
+        if (reconcile) return originalAck.promise;
+        throw new RuntimeHostRequestInterruptedError(
+          'turn.message.submit',
+          'command',
+          'dispatched',
+          'connection_lost',
+        );
+      }
+      return accepted;
+    },
+  };
+  const service = new DesktopSessionLocalService(store, {
+    targets: () => [target],
+    changed() {},
+    onError: (error) => assert.fail(String(error)),
+  });
+  beforeClose.push(() => service.close());
+  store.enqueue('authority', intent());
+  service.wake();
+  await waitFor(() => store.get('authority', 'message-1')?.state === 'unknown');
+  store.enqueue('authority', intent('message-2'));
+  store.enqueue('authority', intent('other-session', 'session-2'));
+  service.wake();
+  await waitFor(() => store.get('authority', 'other-session')?.state === 'accepted');
+  assert.deepEqual(calls, ['message-1', 'other-session']);
+  assert.equal(store.get('authority', 'message-2')?.state, 'saved');
+
+  reconcile = true;
+  service.reconcile(target, 'session-1', 'message-1');
+  await waitFor(() => calls.length === 3);
+  assert.equal(store.get('authority', 'message-2')?.state, 'saved');
+  originalAck.resolve(accepted);
+  await waitFor(() => store.get('authority', 'message-2')?.state === 'accepted');
+  assert.deepEqual(calls, ['message-1', 'other-session', 'message-1', 'message-2']);
+});
+
 test('lost ACK recovery never changes epoch or ID and does not block another Session', async (t) => {
   const { store, beforeClose } = await database(t);
   const calls: TurnMessageSubmitInput[] = [];

--- a/apps/desktop/src/main/session-local-service.ts
+++ b/apps/desktop/src/main/session-local-service.ts
@@ -162,10 +162,11 @@ export class DesktopSessionLocalService {
         if (!target.client || !target.submit || this.#running.has(target.partition)) continue;
         const blockedSessions = new Set<string>();
         const record = this.store.list(target.partition).find((record) => {
-          if (record.state === 'accepted') return false;
+          // Settled messages retain their local copy without reserving delivery order.
+          // Unresolved Host outcomes must still hold later messages behind them.
+          if (record.state === 'accepted' || record.state === 'failed') return false;
           if (blockedSessions.has(record.sessionId)) return false;
           blockedSessions.add(record.sessionId);
-          if (record.state === 'failed') return false;
           return this.#probed.get(`${target.partition}:${record.messageId}`) !== target.client;
         });
         if (!record) continue;


### PR DESCRIPTION
## Summary

Fixes #5007

After a local message is definitively refused, later messages in the same Session now send without requiring the user to delete the failed copy. The failed text and removal action remain available. Unknown Host outcomes still block subsequent delivery until reconciled, preserving admission order.

Skip settled failures before reserving the Session's delivery position. Regression coverage exercises both an operation refusal and a blocked Skill result, plus unknown-outcome reconciliation using the real local SQLite store.

## Verification

- Before the fix: both refusal regression cases fail because subsequent messages remain local; the unknown-outcome control passes.
- After the fix: local-message suite passes (23 tests); full Desktop `test:dist` passes (2,479 tests, zero failures/skips).
- `npm run build`, `npm run lint`, `npm run format:check`, `npm run typecheck`: passed.
- `npx knip --workspace apps/desktop` and `npx knip --workspace packages/ui`: passed.

Behavior evidence from the regression assertions:

```text
Before: A=failed; B and C remain saved; submit calls=[A]
After:  A=failed and retained; B and C accepted; submit calls=[A,B,C]
Unknown outcome: later same-Session send waits until A is reconciled
```

No renderer layout or copy changes. The original Stop-to-first-refusal trigger is not established by this fix; the reproduction injects the initial Host refusal. Delivery wording and recovery affordances remain separate UX follow-up scope.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the reproduction, authored the patch and tests, ran validation, and prepared this PR on behalf of @me2seeks.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
