### PR TITLE
fix(runtime-host): guide Skill creation to the active workspace directory

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -3320,7 +3320,10 @@ test('one turn shares one canonical Skill inventory across prompt and lazy tools
   const skills = {
     readCanonicalModelInventory: async () => {
       inventoryReads += 1;
-      return { inventory };
+      return {
+        inventory,
+        workspaceSkillDirectory: '/maka-dev/workspaces/default/skills',
+      };
     },
   } as unknown as HostSkillCatalogCoordinator;
   const memory = {
@@ -3347,6 +3350,10 @@ test('one turn shares one canonical Skill inventory across prompt and lazy tools
   const firstPrompt = (await composition.resolveSystemPrompt(firstContext)).text;
   assert.match(firstPrompt ?? '', /^You are Maka,/);
   assert.match(firstPrompt ?? '', /OLD_DESCRIPTION/);
+  assert.match(
+    firstPrompt ?? '',
+    /authoritative install directory for a default workspace Skill is \/maka-dev\/workspaces\/default\/skills/u,
+  );
   assert.match(firstPrompt ?? '', /MEMORY_BODY/);
   assert.equal(inventoryReads, 1);
 

--- a/packages/runtime-host/src/__tests__/interactive-run-composer.test.ts
+++ b/packages/runtime-host/src/__tests__/interactive-run-composer.test.ts
@@ -35,6 +35,39 @@ test('the interactive tool surface does not expose the retired ExploreAgent tool
   );
 });
 
+test('interactive prompts name the authoritative Skill install directory with an empty catalog', async () => {
+  const workspaceSkillDirectory = '/maka-dev/workspaces/default/skills';
+  const composer = createInteractiveRunComposer({
+    runtimePolicy: { revision: 0, policy: createDefaultRuntimePolicy() },
+    skills: {
+      readCanonicalModelInventory: async () => ({
+        inventory: [],
+        workspaceSkillDirectory,
+      }),
+    } as unknown as HostSkillCatalogCoordinator,
+    memory: {
+      readPromptProjection: async () => ({
+        bundleRevision: null,
+        memoryRevision: null,
+        body: undefined,
+      }),
+    } as unknown as HostMemoryCoordinator,
+    sessionTodo: {} as SessionTodoToolStore,
+    builtinTools: {},
+  });
+
+  const prompt = await composer.resolveSystemPrompt({
+    sessionId: 'skill-creation-session',
+    turnId: 'skill-creation-turn',
+    cwd: '/maka-dev/workspaces/default',
+  });
+  assert.match(
+    prompt.text ?? '',
+    /authoritative install directory.*\/maka-dev\/workspaces\/default\/skills/u,
+  );
+  assert.match(prompt.text ?? '', /read that exact SKILL\.md back/u);
+});
+
 test('Deep Research keeps standard inspection tools and its durable workspace tools', () => {
   const tool = (name: string): MakaTool => ({
     name,

--- a/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
@@ -492,6 +492,8 @@ test('starter creation uses the shared template and reuses the lowest valid star
   const fixture = await createFixture();
   const repository = fixture.repository();
   const initial = await start(repository, fixture.project, 'governance');
+  const model = await repository.readCanonicalModelInventory({ projectRoot: fixture.project });
+  assert.equal(model.workspaceSkillDirectory, join(fixture.root, 'skills'));
   const created = await repository.mutate({
     expectedRevision: initial.revision,
     mutation: { kind: 'create_starter' },

--- a/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
@@ -21,7 +21,16 @@ import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, test } from 'node:test';
@@ -493,7 +502,7 @@ test('starter creation uses the shared template and reuses the lowest valid star
   const repository = fixture.repository();
   const initial = await start(repository, fixture.project, 'governance');
   const model = await repository.readCanonicalModelInventory({ projectRoot: fixture.project });
-  assert.equal(model.workspaceSkillDirectory, join(fixture.root, 'skills'));
+  assert.equal(model.workspaceSkillDirectory, join(await realpath(fixture.root), 'skills'));
   const created = await repository.mutate({
     expectedRevision: initial.revision,
     mutation: { kind: 'create_starter' },

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -89,6 +89,17 @@ const CHILD_INSTRUCTION_BOUNDARY = [
   'The child does not implicitly inherit local Memory or personalization context; required background must be included explicitly in the task.',
 ].join(' ');
 
+function buildSkillCreationPrompt(workspaceSkillDirectory: string | undefined): string | undefined {
+  if (!workspaceSkillDirectory) return undefined;
+  return [
+    'Local Skill creation:',
+    `- The authoritative install directory for a default workspace Skill is ${workspaceSkillDirectory}.`,
+    '- Create the Skill directly at <that directory>/<skill-id>/SKILL.md. Do not guess another Maka data directory, use a temporary directory, or create a separate lock file.',
+    '- After writing, read that exact SKILL.md back and verify the file exists and contains the intended content before reporting that the Skill was created.',
+    '- If the user explicitly requests a project-level, user-level, or managed-source Skill, follow that requested scope and its authoritative path instead.',
+  ].join('\n');
+}
+
 export interface InteractiveRunComposerInput {
   readonly runtimePolicy: RuntimePolicySnapshot;
   readonly skills: HostSkillCatalogCoordinator;
@@ -201,6 +212,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
           hostCapabilities,
           input.skillBudget,
         );
+        const skillCreation = buildSkillCreationPrompt(inventory.workspaceSkillDirectory);
         context.emitSkillCatalogTrace?.('Skill catalog selection completed', {
           policyVersion: skills.report.policyVersion,
           budgetChars: skills.report.budgetChars,
@@ -216,6 +228,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
         const text = childInstruction
           ? joinFragments([
               skills.text,
+              skillCreation,
               workspaceInstructions,
               CHILD_INSTRUCTION_BOUNDARY,
               childInstruction,
@@ -223,6 +236,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
           : assembleMainSessionSystemPrompt([
               buildPersonalizationPromptFragment(promptState.policy.personalization).text,
               skills.text,
+              skillCreation,
               workspaceInstructions,
               promptState.memory,
               input.plan?.mode === 'plan'

--- a/packages/runtime-host/src/server/skill-catalog-repository.ts
+++ b/packages/runtime-host/src/server/skill-catalog-repository.ts
@@ -157,6 +157,8 @@ export class SkillCatalogRepositoryError extends Error {
 export interface CanonicalSkillInventorySnapshot {
   readonly revision: SkillCatalogRevision;
   readonly projectRoot: string;
+  /** Host-authoritative directory where default workspace Skills are installed. */
+  readonly workspaceSkillDirectory?: string;
   readonly inventory: readonly ScannedSkill[];
   readonly diagnostics: readonly SkillScanDiagnostic[];
   readonly discoveryDiagnostics: readonly SkillDiscoveryDiagnostic[];
@@ -461,6 +463,7 @@ export class SkillCatalogRepository {
         const publicationNamespace = await readPublicationNamespace(root);
         return buildSnapshot({
           projectRoot,
+          workspaceSkillDirectory: join(root, 'skills'),
           scan,
           managedSourcesRoot: this.#managedSourcesRoot,
           publicationNamespace,
@@ -741,6 +744,7 @@ export class SkillCatalogRepository {
 
 async function buildSnapshot(input: {
   projectRoot: string;
+  workspaceSkillDirectory: string;
   scan: SkillScanResult;
   managedSourcesRoot: string;
   publicationNamespace: PublicationNamespace;
@@ -907,7 +911,13 @@ async function buildSnapshot(input: {
       effectiveMigration,
     }),
   );
-  const model = freezeModelSnapshot(revision, input.projectRoot, input.scan, effectiveMigration);
+  const model = freezeModelSnapshot(
+    revision,
+    input.projectRoot,
+    input.workspaceSkillDirectory,
+    input.scan,
+    effectiveMigration,
+  );
   return Object.freeze({
     revision,
     projectRoot: input.projectRoot,
@@ -1341,6 +1351,7 @@ function canonicalRevisionFacts(input: {
 function freezeModelSnapshot(
   revision: SkillCatalogRevision,
   projectRoot: string,
+  workspaceSkillDirectory: string,
   scan: SkillScanResult,
   migration: SkillPreferenceMigration | null,
 ): CanonicalSkillInventorySnapshot {
@@ -1372,6 +1383,7 @@ function freezeModelSnapshot(
   return Object.freeze({
     revision,
     projectRoot,
+    workspaceSkillDirectory,
     inventory: Object.freeze(inventory),
     diagnostics: Object.freeze(diagnostics),
     discoveryDiagnostics: Object.freeze(discoveryDiagnostics),


### PR DESCRIPTION
## Summary

Fixes #5012

Make local Skill creation use the active Host's installation directory in **production and development**. Packaged Desktop uses the same `SkillCatalogRepository` and interactive composer. The fix derives the directory from the Host storage-root lease, with no `isPackaged` condition or hard-coded `Maka Dev` path. On packaged Windows Desktop the usual local directory is `%APPDATA%\Maka\workspaces\default\skills`; custom or remote Hosts retain their actual root.

The observed reproduction was a development conversation writing `learn-anything/SKILL.md` into the regular Maka directory, then reporting success while the active installed list stayed empty. Production applicability follows from the shared code path; a packaged-release reproduction has not been performed.

Carry `<actual Host root>/skills` in the canonical model snapshot and include creation guidance in main/child prompts even with an empty catalog. Direct default workspace Skills to `<directory>/<skill-id>/SKILL.md`, request read-back before reporting success, and honor explicit alternate scope.

## Verification

- Full `npm run build` and `npm run typecheck`: passed.
- `npx knip --workspace apps/desktop` and `npx knip --workspace packages/ui`: passed.
- Composer and repository suites: **32 passed, 0 failed** (`node --test packages/runtime-host/dist/__tests__/interactive-run-composer.test.js packages/runtime-host/dist/__tests__/skill-catalog-repository.test.js`).
- Targeted `one turn shares one canonical Skill inventory across prompt and lazy tools`: passed.
- Biome check on all five changed files, staged ASF headers, protocol epoch guard, and staged diff check: passed.
- Root lint/format were attempted but blocked by existing nested `.codex-worktrees/*/biome.jsonc` root configurations. The Windows pre-commit launcher failed with `spawnSync biome.cmd EINVAL`; equivalent checks were run manually before committing.
- An additional runtime Skills suite reported 30 passed / 1 failed on an existing Windows/POSIX path-separator expectation. This PR does not change runtime Skills implementation files.
- No live-model or packaged Desktop end-to-end creation test was run. Tests establish repository-root propagation and guidance with an empty catalog, not guaranteed model compliance.

## Scope and boundaries

- This is Host-backed prompt guidance, not a dedicated creation tool, write redirect, or filesystem enforcement mechanism. Existing permissions and sandbox rules remain authoritative; Windows sandbox availability is a separate issue.
- No automatic migration of misplaced files, discovery-precedence change, or UI auto-refresh change. Refresh the installed list after writing. Restart the development Host to load the change; production needs a release containing the fix.
- Plain workspace Skills need no fabricated managed lock. Explicit project/user/managed-source requests retain their scope and existing installation workflow.
- The directory stays in the Host-local model snapshot, not the public catalog wire protocol. Custom/mocked snapshots omitting the optional field receive no creation guidance.
- Ablation removed an unnecessary public runtime helper/export, retaining one composer-local helper. No new tool, storage layer, lock, or UI change is needed.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with diagnosis, implementation, tests, and this submission at the contributor's request. The commit includes `Generated-by: OpenAI Codex`.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

The combined checkbox remains unchecked because of the repository-wide blockers above; changed-file checks and affected Host suites pass.

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

<details>
<summary>中文说明</summary>

## 概述

修复 #5012

使**生产版和开发版**的本地 Skill 创建使用当前 Host 的安装目录。打包版 Desktop 使用相同的 `SkillCatalogRepository` 和交互提示组装器。修复根据 Host 的存储根目录租约确定目录，没有 `isPackaged` 条件或写死的 `Maka Dev` 路径。Windows 打包版 Desktop 通常的本地目录是 `%APPDATA%\Maka\workspaces\default\skills`；自定义或远程 Host 保留其真实根目录。

实际复现是开发版对话把 `learn-anything/SKILL.md` 写入正式版 Maka 的目录，随后报告成功，而当前本地安装列表仍为空。生产版适用性由共享代码路径推得；尚未进行打包发布版复现。

在模型的规范快照中携带 `<真实 Host 根目录>/skills`，即使清单为空也在主对话和子对话提示中加入创建指引。要求默认工作区技能写入 `<directory>/<skill-id>/SKILL.md`、报告成功前回读，并尊重明确指定的其他作用域。

## 验证

- 完整 `npm run build` 和 `npm run typecheck`：通过。
- `npx knip --workspace apps/desktop` 和 `npx knip --workspace packages/ui`：通过。
- Composer 和 repository 套件：**32 项通过，0 项失败**（`node --test packages/runtime-host/dist/__tests__/interactive-run-composer.test.js packages/runtime-host/dist/__tests__/skill-catalog-repository.test.js`）。
- 定向测试 `one turn shares one canonical Skill inventory across prompt and lazy tools`：通过。
- 全部五个改动文件的 Biome 检查、暂存 ASF 头部检查、协议 epoch 检查，以及暂存差异检查：通过。
- 已尝试根目录 lint/format，但被现有嵌套 `.codex-worktrees/*/biome.jsonc` 根配置阻碍。Windows 提交前钩子启动器因 `spawnSync biome.cmd EINVAL` 失败；提交前已手动执行等价检查。
- 额外 runtime Skills 套件报告 30 项通过、1 项失败，失败项为已有的 Windows/POSIX 路径分隔符预期差异。本 PR 不修改 runtime Skills 实现文件。
- 未运行真实模型或打包版 Desktop 端到端创建测试。测试确认仓库根目录的传递和空清单时的指引，不保证模型遵从。

## 范围与边界

- 这是有 Host 依据的提示指引，不是专用创建工具、写入重定向或文件系统强制执行机制。现有权限和沙箱规则仍具有约束力；Windows 沙箱可用性是独立问题。
- 不自动迁移错放文件，不改变发现优先级或界面自动刷新。写入后刷新安装列表。重启开发 Host 加载改动；生产版需要包含此修复的发布版本。
- 普通工作区技能不需要伪造的 managed 锁。明确指定的项目级、用户级、managed-source 请求保留其作用域和现有安装流程。
- 目录保留在 Host 内部模型快照中，不进入公共目录通信协议。省略该可选字段的自定义/模拟快照不会获得创建指引。
- 消融删除了不必要的 runtime 公共 helper/export，保留一个 composer 局部 helper。无需新增工具、存储层、锁或界面改动。

## AI 使用

- [ ] 没有生成式工具作出实质贡献
- [x] 生成式工具作出了实质贡献

工具及范围：OpenAI Codex 按贡献者请求协助诊断、实现、测试和此次提交。提交包含 `Generated-by: OpenAI Codex`。

## 检查清单

- [x] 测试覆盖了改动，且没有此改动时会失败
- [ ] Lint、格式、类型检查及受影响测试套件在本地全部通过

由于上文所述全仓库阻碍，这个组合检查项保持未勾选；改动文件检查和受影响的 Host 套件通过。

此 PR 是否涉及行为变化？

- [x] 是——已在上文“概述”中描述
- [ ] 否

</details>