### PR TITLE
fix(desktop): stop credential warning flash

### DIFF
--- a/apps/desktop/src/main/__tests__/connection-settings-locale-render.test.ts
+++ b/apps/desktop/src/main/__tests__/connection-settings-locale-render.test.ts
@@ -28,7 +28,7 @@ import { act, createElement, type ComponentType, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { AstryxLocaleProvider, LocaleProvider, ToastProvider } from '@maka/ui';
 import type { UiLocale } from '@maka/core/ui-locale';
-import type { ProviderType } from '@maka/core/llm-connections';
+import type { ProjectedLlmConnection, ProviderType } from '@maka/core/llm-connections';
 import type { PeerMeshQueryResult } from '@maka/runtime-host/protocol';
 import type { RuntimeHostPeerConnectionPath } from '@maka/runtime-host/client';
 import type { DesktopRuntimeHostProfileSnapshot } from '../../preload/bridge-contract.js';
@@ -37,6 +37,18 @@ import type { RuntimeHostManagementServices } from '../../renderer/features/runt
 
 // Keep renderer implementations and their asset imports out of the main compilation graph.
 interface RenderModules {
+  ConnectionDetail: ComponentType<{
+    bridge: ConnectionsBridge;
+    connection: ProjectedLlmConnection;
+    isDefault: boolean;
+    onChanged(): Promise<void>;
+    onDeleted(): Promise<void>;
+  }>;
+  RuntimeHostSettingsTarget: ComponentType<{
+    host?: { profileId: string; hostId: string };
+    generation?: string;
+    children: ReactNode;
+  }>;
   AddProviderForm: ComponentType<{
     bridge: ConnectionsBridge;
     providerType: ProviderType;
@@ -85,6 +97,8 @@ before(async () => {
   await build({
     stdin: {
       contents: [
+        "export { ConnectionDetail } from './settings/provider-connection-detail';",
+        "export { RuntimeHostSettingsTarget } from './settings/runtime-host-settings-target';",
         "export { AddProviderForm } from './settings/provider-add-form';",
         "export { RuntimeHostProfilesSection } from './settings/runtime-host-profiles-section';",
         "export { RuntimeHostManagementServicesProvider, RuntimeHostPeerMeshDialog } from './features/runtime-host-management/index';",
@@ -286,8 +300,122 @@ test('zh-TW: expanded Peer Mesh members render localized route states', async ()
   }
 });
 
+test('credential probing does not flash a page-level loading warning', async () => {
+  const harness = installRenderer();
+  const credential = deferred<boolean>();
+  const bridge = connectionDetailBridge({ hasSecret: () => credential.promise });
+  const detail = createElement(components.ConnectionDetail, {
+    bridge,
+    connection: relayConnection(),
+    isDefault: true,
+    onChanged: async () => {},
+    onDeleted: async () => {},
+  });
+
+  await harness.render('zh-CN', createElement(components.RuntimeHostSettingsTarget, {
+    host: { profileId: 'local', hostId: 'host-local' },
+    children: detail,
+  }));
+
+  assert.equal(
+    harness.document.body.textContent.includes(
+      '正在读取模型凭据状态，读取完成前暂不测试连接或刷新模型。',
+    ),
+    false,
+    'an ordinary in-flight credential read must not insert a transient warning banner',
+  );
+
+  await act(async () => {
+    credential.resolve(true);
+    await credential.promise;
+  });
+});
+
+test('credential read failures still render the persistent warning', async () => {
+  const harness = installRenderer();
+  const credential = deferred<boolean>();
+  const bridge = connectionDetailBridge({ hasSecret: () => credential.promise });
+  const detail = createElement(components.ConnectionDetail, {
+    bridge,
+    connection: relayConnection(),
+    isDefault: true,
+    onChanged: async () => {},
+    onDeleted: async () => {},
+  });
+
+  await harness.render('zh-CN', createElement(components.RuntimeHostSettingsTarget, {
+    host: { profileId: 'local', hostId: 'host-local' },
+    children: detail,
+  }));
+  await act(async () => {
+    credential.reject(new Error('credential store unavailable'));
+    try {
+      await credential.promise;
+    } catch {
+      // The component owns this rejection and turns it into an error state.
+    }
+  });
+
+  assert.ok(harness.document.body.textContent.includes(
+    '模型凭据状态暂时没刷新成功，已避免把未知状态显示成未登录或未配置。',
+  ));
+});
+
 function unexpectedCall(): never {
   assert.fail('unexpected service call');
+}
+
+function deferred<T>() {
+  let resolvePromise!: (value: T) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+function relayConnection(): ProjectedLlmConnection {
+  const modelId = 'gpt-5.6-sol-joybuilder';
+  return {
+    connectionId: 'relay-connection',
+    slug: 'openai-responses-compatible-2',
+    name: '自定义中转站（OpenAI Responses）',
+    providerType: 'openai-responses-compatible',
+    baseUrl: 'https://relay.example/v1',
+    defaultModel: modelId,
+    enabledModelIds: [modelId],
+    enabled: true,
+    models: [{ id: modelId }],
+    modelSource: 'fetched',
+    createdAt: 1,
+    updatedAt: 1,
+    catalogEntries: [{
+      id: modelId,
+      canUseAsChatDefault: true,
+      isDefault: true,
+      supportsVision: false,
+      thinkingLevels: [],
+      describedByMetadata: false,
+    }],
+  };
+}
+
+function connectionDetailBridge(overrides: Partial<ConnectionsBridge>): ConnectionsBridge {
+  return {
+    oauth: {} as ConnectionsBridge['oauth'],
+    getSnapshot: unexpectedCall,
+    setDefault: unexpectedCall,
+    create: unexpectedCall,
+    update: unexpectedCall,
+    delete: unexpectedCall,
+    test: unexpectedCall,
+    fetchModels: unexpectedCall,
+    hasSecret: unexpectedCall,
+    getRequestHeaders: async () => ({ names: [] }),
+    setRequestHeaders: unexpectedCall,
+    ...overrides,
+  };
 }
 
 function managementServices(): RuntimeHostManagementServices {

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -180,7 +180,7 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
     retired,
     oauthLoginService,
     supportsRemoteDiscovery,
-    credentialProbePending,
+    credentialProbeFailed,
     hasUsableCredential,
     apiKeyStatusHint,
     hasApiKeyChange,
@@ -480,13 +480,11 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
                   : copy.oauthWaitingDetail} />
         )
       )}
-      {credentialProbePending && (
+      {credentialProbeFailed && (
         <Banner
           status="warning"
           role="alert"
-          title={hasSecret === 'loading'
-            ? copy.credentialLoadingDetail
-            : copy.credentialUnknownDetail}
+          title={copy.credentialUnknownDetail}
         />
       )}
       {/* The settled values (name, key, endpoint) are rows in the

--- a/apps/desktop/src/renderer/settings/use-connection-detail.ts
+++ b/apps/desktop/src/renderer/settings/use-connection-detail.ts
@@ -209,7 +209,12 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
   const supportsRemoteDiscovery = providerSupportsModelDiscovery(connection.providerType);
   const requiresCredential = providerAuthRequiresSecret(connection.providerType);
   const probesCredential = supportsApiKey || needsOAuth;
-  const credentialProbePending = requiresCredential && (hasSecret === 'loading' || hasSecret === 'error');
+  // `loading` is the normal first-frame state while the local credential
+  // vault answers. Rendering it as a full-width warning made every successful
+  // detail open flash the banner for one paint. Keep the durable warning for
+  // a read failure; the key row already carries the quiet loading hint and the
+  // action buttons remain gated by `hasUsableCredential` until the read lands.
+  const credentialProbeFailed = requiresCredential && hasSecret === 'error';
   const hasUsableCredential = !requiresCredential || hasSecret === true;
   const credentialTroubleshootingCopy = needsOAuth
     ? copy.oauthTroubleshooting
@@ -874,7 +879,7 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
     retired,
     oauthLoginService,
     supportsRemoteDiscovery,
-    credentialProbePending,
+    credentialProbeFailed,
     hasUsableCredential,
     apiKeyStatusHint,
     hasApiKeyChange,


### PR DESCRIPTION
## Summary

- Stop rendering the page-level credential warning during the normal initial credential probe.
- Keep the inline loading status and disable credential-dependent actions until the probe settles.
- Preserve the persistent warning when the credential read actually fails.
- Add renderer regression coverage for both pending and failed credential reads.

Fixes #5017

## Before / After

| Before | After |
| --- | --- |
| ![Before: credential-loading warning flashes while the successful probe is pending](https://raw.githubusercontent.com/liuxiaocs7/maka/pr-assets/.maka-shots/5020-before-sanitized.jpg) | ![After: the same connection opens without the page-level warning](https://raw.githubusercontent.com/liuxiaocs7/maka/pr-assets/.maka-shots/5020-after.jpg) |

## Verification

The focused regression test failed before the implementation because the loading warning was present, then passed after the fix:

```text
✔ credential probing does not flash a page-level loading warning
✔ credential read failures still render the persistent warning
```

Also passed:

- `npm --workspace @maka/desktop run typecheck`
- `npx biome check apps/desktop/src/renderer/settings/use-connection-detail.ts apps/desktop/src/renderer/settings/provider-connection-detail.tsx apps/desktop/src/main/__tests__/connection-settings-locale-render.test.ts`
- `npm --workspace @maka/desktop run check:architecture -- --base HEAD`
- `npm --workspace @maka/desktop run build:renderer`
- Full `connection-settings-locale-render` suite: 18/18 passed

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the render-state transition, implemented the UI change, and added the regression tests. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

