### PR TITLE
fix(ci): fence nightly forward-roll baseline to proven ancestor

### DIFF
--- a/.github/workflows/asf-npm-candidate.yml
+++ b/.github/workflows/asf-npm-candidate.yml
@@ -65,3 +65,5 @@ jobs:
     uses: ./.github/workflows/cli-package-validation.yml
     with:
       source_commit: ${{ github.sha }}
+      # This workflow validates a tagged source candidate, not a forward roll.
+      fence_predecessor: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
       - id: forward-roll-baseline
         name: Resolve the published forward-roll baseline
         if: steps.plan.outputs.state_root_compat == 'true'
-        run: node scripts/release-cli-publication.mjs resolve-nightly-predecessor "$GITHUB_OUTPUT"
+        run: node scripts/release-cli-publication.mjs resolve-nightly-predecessor "$GITHUB_OUTPUT" HEAD
 
       - name: Download the forward-roll baseline
         if: steps.plan.outputs.state_root_compat == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
       - id: forward-roll-baseline
         name: Resolve the published forward-roll baseline
         if: steps.plan.outputs.state_root_compat == 'true'
-        run: node scripts/release-cli-publication.mjs resolve-nightly-predecessor "$GITHUB_OUTPUT" HEAD
+        run: node scripts/release-cli-publication.mjs resolve-nightly-predecessor "$GITHUB_OUTPUT" fence
 
       - name: Download the forward-roll baseline
         if: steps.plan.outputs.state_root_compat == 'true'

--- a/.github/workflows/cli-package-validation.yml
+++ b/.github/workflows/cli-package-validation.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: string
         default: ''
+      fence_predecessor:
+        description: Require the Nightly source commit to be an ancestor of the validation checkout
+        required: false
+        type: boolean
+        default: true
     outputs:
       release_candidate_artifact_id:
         description: Immutable artifact produced by the build job
@@ -83,6 +88,12 @@ on:
         description: Source commit proven for the npm Nightly predecessor
         value: ${{ jobs.state-root-qualification.outputs.release_predecessor_source_commit }}
   workflow_dispatch:
+    inputs:
+      fence_predecessor:
+        description: Require the Nightly source commit to precede the validation checkout
+        required: true
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -374,7 +385,7 @@ jobs:
       # is now this job's output.
       - name: Resolve the current npm Nightly as immutable evidence
         id: predecessor
-        run: node scripts/release-cli-publication.mjs resolve-nightly-predecessor "$GITHUB_OUTPUT" HEAD
+        run: node scripts/release-cli-publication.mjs resolve-nightly-predecessor "$GITHUB_OUTPUT" "${{ (github.event_name == 'pull_request' || inputs.fence_predecessor) && 'fence' || 'unfenced' }}"
       # Three runs of one script against one sandbox, not three runners. Two of
       # these transitions are between tarballs that were published and frozen,
       # so nothing in a pull request can change their outcome except the

--- a/.github/workflows/cli-package-validation.yml
+++ b/.github/workflows/cli-package-validation.yml
@@ -44,6 +44,9 @@ on:
       - 'packages/storage/src/native-file-lock.ts'
       - 'scripts/generate-runtime-host-peer-*'
       - 'scripts/release-cli-package.mjs'
+      - 'scripts/release-cli-publication.mjs'
+      - 'scripts/release-cli-publication.test.mjs'
+      - 'scripts/release-cli-workflow-policy.test.mjs'
       - 'scripts/qualify-released-cli-state-root.mjs'
       - 'scripts/qualify-released-cli-state-root.test.mjs'
       - 'scripts/released-cli-state-root-fixture.mjs'
@@ -76,6 +79,9 @@ on:
       release_predecessor_integrity:
         description: npm SHA-512 integrity of the Nightly tarball qualified against this candidate
         value: ${{ jobs.state-root-qualification.outputs.release_predecessor_integrity }}
+      release_predecessor_source_commit:
+        description: Source commit proven for the npm Nightly predecessor
+        value: ${{ jobs.state-root-qualification.outputs.release_predecessor_source_commit }}
   workflow_dispatch:
 
 permissions:
@@ -339,10 +345,12 @@ jobs:
       release_predecessor_version: ${{ steps.predecessor.outputs.version }}
       release_predecessor_tarball_url: ${{ steps.predecessor.outputs.tarball_url }}
       release_predecessor_integrity: ${{ steps.predecessor.outputs.integrity }}
+      release_predecessor_source_commit: ${{ steps.predecessor.outputs.source_commit }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.source_commit || github.sha }}
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -366,7 +374,7 @@ jobs:
       # is now this job's output.
       - name: Resolve the current npm Nightly as immutable evidence
         id: predecessor
-        run: node scripts/release-cli-publication.mjs resolve-nightly-predecessor "$GITHUB_OUTPUT"
+        run: node scripts/release-cli-publication.mjs resolve-nightly-predecessor "$GITHUB_OUTPUT" HEAD
       # Three runs of one script against one sandbox, not three runners. Two of
       # these transitions are between tarballs that were published and frozen,
       # so nothing in a pull request can change their outcome except the
@@ -379,6 +387,7 @@ jobs:
           MAKA_QUALIFICATION_BWRAP_USE_SUDO: '1'
           PREDECESSOR_TARBALL_URL: ${{ steps.predecessor.outputs.tarball_url }}
           PREDECESSOR_INTEGRITY: ${{ steps.predecessor.outputs.integrity }}
+          PREDECESSOR_SOURCE_COMMIT: ${{ steps.predecessor.outputs.source_commit }}
         run: |
           set -euo pipefail
           evidence_root="$RUNNER_TEMP/released-state-root"
@@ -458,11 +467,13 @@ jobs:
           PREDECESSOR_VERSION: ${{ steps.predecessor.outputs.version }}
           PREDECESSOR_TARBALL_URL: ${{ steps.predecessor.outputs.tarball_url }}
           PREDECESSOR_INTEGRITY: ${{ steps.predecessor.outputs.integrity }}
+          PREDECESSOR_SOURCE_COMMIT: ${{ steps.predecessor.outputs.source_commit }}
         run: |
           node scripts/release-cli-publication.mjs assert-nightly-predecessor \
             "$PREDECESSOR_VERSION" \
             "$PREDECESSOR_TARBALL_URL" \
-            "$PREDECESSOR_INTEGRITY"
+            "$PREDECESSOR_INTEGRITY" \
+            "$PREDECESSOR_SOURCE_COMMIT"
 
   eval:
     name: Validate installed CLI Eval

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -153,11 +153,13 @@ jobs:
           PREDECESSOR_VERSION: ${{ needs.cli.outputs.release_predecessor_version }}
           PREDECESSOR_TARBALL_URL: ${{ needs.cli.outputs.release_predecessor_tarball_url }}
           PREDECESSOR_INTEGRITY: ${{ needs.cli.outputs.release_predecessor_integrity }}
+          PREDECESSOR_SOURCE_COMMIT: ${{ needs.cli.outputs.release_predecessor_source_commit }}
         run: |
           node scripts/release-cli-publication.mjs assert-nightly-predecessor \
             "$PREDECESSOR_VERSION" \
             "$PREDECESSOR_TARBALL_URL" \
-            "$PREDECESSOR_INTEGRITY"
+            "$PREDECESSOR_INTEGRITY" \
+            "$PREDECESSOR_SOURCE_COMMIT"
           current="$(npm view maka-agent dist-tags.nightly --registry https://registry.npmjs.org/)"
           node scripts/product-nightly.mjs assert-channel-advance "$NIGHTLY_VERSION" "$current"
 

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -93,6 +93,7 @@ jobs:
     with:
       source_commit: ${{ needs.identity.outputs.source_commit }}
       package_version: ${{ needs.identity.outputs.version }}
+      fence_predecessor: true
 
   publish:
     name: Publish npm Nightly

--- a/.github/workflows/release-cli-stage.yml
+++ b/.github/workflows/release-cli-stage.yml
@@ -89,6 +89,9 @@ jobs:
     uses: ./.github/workflows/cli-package-validation.yml
     with:
       source_commit: ${{ needs.authorize.outputs.source_commit }}
+      # The formal candidate is a frozen tag; the live Nightly may be newer,
+      # so this lane keeps provenance identity without applying PR ancestry fencing.
+      fence_predecessor: false
 
   stage:
     name: Stage maka-agent on npm

--- a/.github/workflows/release-cli-stage.yml
+++ b/.github/workflows/release-cli-stage.yml
@@ -178,6 +178,7 @@ jobs:
           PREDECESSOR_VERSION: ${{ needs.validate.outputs.release_predecessor_version }}
           PREDECESSOR_TARBALL_URL: ${{ needs.validate.outputs.release_predecessor_tarball_url }}
           PREDECESSOR_INTEGRITY: ${{ needs.validate.outputs.release_predecessor_integrity }}
+          PREDECESSOR_SOURCE_COMMIT: ${{ needs.validate.outputs.release_predecessor_source_commit }}
           PRODUCT_SOURCE_COMMIT: ${{ needs.authorize.outputs.source_commit }}
           PRODUCT_TAG: ${{ needs.authorize.outputs.product_tag }}
           RELEASE_DIST_TAG: ${{ steps.release.outputs.dist_tag }}
@@ -186,7 +187,8 @@ jobs:
           node scripts/release-cli-publication.mjs assert-nightly-predecessor \
             "$PREDECESSOR_VERSION" \
             "$PREDECESSOR_TARBALL_URL" \
-            "$PREDECESSOR_INTEGRITY"
+            "$PREDECESSOR_INTEGRITY" \
+            "$PREDECESSOR_SOURCE_COMMIT"
 
           node scripts/product-release-authority.mjs verify-draft \
             "$PRODUCT_TAG" "$PRODUCT_SOURCE_COMMIT" "$GITHUB_REPOSITORY"

--- a/scripts/asf-npm-workflow-policy.test.mjs
+++ b/scripts/asf-npm-workflow-policy.test.mjs
@@ -41,6 +41,7 @@ test('ASF npm preflight validates the source RC package without publishing', () 
     workflow,
     /uses: \.\/\.github\/workflows\/cli-package-validation\.yml[\s\S]*?source_commit: \$\{\{ github\.sha \}\}/u,
   );
+  assert.match(workflow, /fence_predecessor: false/u);
   assert.doesNotMatch(
     workflow,
     /id-token: write|npm (?:stage )?publish|npm dist-tag|download-artifact|\.sha512|asf-candidate\.json/u,

--- a/scripts/release-cli-publication.mjs
+++ b/scripts/release-cli-publication.mjs
@@ -17,8 +17,9 @@
  * under the License.
  */
 
+import { execFileSync } from 'node:child_process';
 import { appendFileSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { basename, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createHash } from 'node:crypto';
 import { CLI_RELEASE_ARTIFACT_LIMITS } from './release-cli-artifact-policy.mjs';
@@ -30,9 +31,16 @@ import {
 
 const PACKAGE_NAME = 'maka-agent';
 const REGISTRY_ORIGIN = 'https://registry.npmjs.org';
+const REGISTRY_ATTESTATION_PATH = `${REGISTRY_ORIGIN}/-/npm/v1/attestations`;
 const REPOSITORY = 'apache/maka';
 const PUBLICATION_WORKFLOW_PATH = '.github/workflows/npm-publication.yml';
 const REGISTRY_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const SLSA_PROVENANCE_PREDICATE = 'https://slsa.dev/provenance/v1';
+const SLSA_WORKFLOW_BUILD_TYPE =
+  'https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1';
+const REPOSITORY_URL = `https://github.com/${REPOSITORY}`;
+const MAIN_REF = 'refs/heads/main';
 const RELEASE_RECORD_KEYS = [
   'schemaVersion',
   'packageName',
@@ -218,7 +226,92 @@ export async function fetchRegistryRelease({
   return { ...record, tarballPath, sha256 };
 }
 
-export async function resolveRegistryNightlyPredecessor({ fetchImpl = fetch } = {}) {
+export function assertCommitIsAncestor({
+  commit,
+  head = 'HEAD',
+  repoRoot = DEFAULT_REPO_ROOT,
+  exec = execFileSync,
+}) {
+  if (typeof commit !== 'string' || !/^[0-9a-f]{40}$/iu.test(commit)) {
+    throw new Error(`Invalid git commit SHA for ancestor check: ${commit}`);
+  }
+  try {
+    exec('git', ['merge-base', '--is-ancestor', commit, head], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+  } catch (error) {
+    if (error?.status === 1) {
+      throw new Error(
+        `Registry Nightly source commit ${commit} is not an ancestor of ${head}; forward-roll baseline must precede the change under test (#4447)`,
+      );
+    }
+    throw new Error(
+      `Unable to verify that Registry Nightly source commit ${commit} is an ancestor of ${head}; the checkout history or commit is unavailable (#4447)`,
+      { cause: error },
+    );
+  }
+}
+
+export function parseRegistryNightlySourceCommit({ version, attestations }) {
+  // Nightlies are published from tarballs, so npm leaves versionMetadata.gitHead
+  // empty. SLSA provenance is the publisher-signed source identity we can fence.
+  if (!Array.isArray(attestations)) {
+    throw new Error(`Registry Nightly ${version} has no valid provenance attestations`);
+  }
+  const expectedSubject = `pkg:npm/${PACKAGE_NAME}@${version}`;
+  const expectedSourceUri = `git+${REPOSITORY_URL}@${MAIN_REF}`;
+  const statement = attestations.map(parseProvenanceStatement).find((candidate) => {
+    const definition = candidate?.predicate?.buildDefinition;
+    const workflow = definition?.externalParameters?.workflow;
+    const dependencies = definition?.resolvedDependencies;
+    return (
+      candidate?._type === 'https://in-toto.io/Statement/v1' &&
+      candidate?.predicateType === SLSA_PROVENANCE_PREDICATE &&
+      candidate?.subject?.some((subject) => subject?.name === expectedSubject) &&
+      definition?.buildType === SLSA_WORKFLOW_BUILD_TYPE &&
+      workflow?.repository === REPOSITORY_URL &&
+      workflow?.ref === MAIN_REF &&
+      workflow?.path === PUBLICATION_WORKFLOW_PATH &&
+      ['schedule', 'workflow_dispatch'].includes(
+        definition?.internalParameters?.github?.event_name,
+      ) &&
+      Array.isArray(dependencies) &&
+      dependencies.some(
+        (dependency) =>
+          dependency?.uri === expectedSourceUri &&
+          /^[0-9a-f]{40}$/iu.test(dependency?.digest?.gitCommit ?? ''),
+      )
+    );
+  });
+  const sourceCommit = statement?.predicate?.buildDefinition?.resolvedDependencies?.find(
+    (dependency) => dependency?.uri === expectedSourceUri,
+  )?.digest?.gitCommit;
+  if (!sourceCommit) {
+    throw new Error(
+      `Registry Nightly ${version} has no valid SLSA source commit for ${REPOSITORY}@${MAIN_REF}`,
+    );
+  }
+  return sourceCommit;
+}
+
+async function fetchRegistryNightlySourceCommit({ version, fetchImpl }) {
+  const attestations = await fetchJson(
+    fetchImpl,
+    `${REGISTRY_ATTESTATION_PATH}/${PACKAGE_NAME}@${version}`,
+    'Nightly provenance attestations',
+    'application/json',
+  );
+  return parseRegistryNightlySourceCommit({ version, attestations: attestations.attestations });
+}
+
+export async function resolveRegistryNightlyPredecessor({
+  fetchImpl = fetch,
+  fencedAncestorHead,
+  includeSourceCommit = fencedAncestorHead !== undefined,
+  repoRoot = DEFAULT_REPO_ROOT,
+  exec = execFileSync,
+} = {}) {
   const packageMetadata = await fetchJson(
     fetchImpl,
     `${REGISTRY_ORIGIN}/${PACKAGE_NAME}`,
@@ -237,6 +330,19 @@ export async function resolveRegistryNightlyPredecessor({ fetchImpl = fetch } = 
     throw new Error('Registry Nightly identity does not match its dist-tag');
   }
 
+  let sourceCommit;
+  if (includeSourceCommit) {
+    sourceCommit = await fetchRegistryNightlySourceCommit({ version, fetchImpl });
+    if (fencedAncestorHead !== undefined) {
+      assertCommitIsAncestor({
+        commit: sourceCommit,
+        head: fencedAncestorHead,
+        repoRoot,
+        exec,
+      });
+    }
+  }
+
   const tarball = `${PACKAGE_NAME}-${version}.tgz`;
   const tarballUrl = parseRegistryTarballUrl(versionMetadata.dist?.tarball, tarball);
   const integrity = parseSha512Integrity(versionMetadata.dist?.integrity);
@@ -244,6 +350,7 @@ export async function resolveRegistryNightlyPredecessor({ fetchImpl = fetch } = 
     version,
     tarballUrl,
     integrity,
+    ...(sourceCommit ? { sourceCommit } : {}),
   };
 }
 
@@ -251,13 +358,18 @@ export async function assertRegistryNightlyPredecessor({
   expectedVersion,
   expectedTarballUrl,
   expectedIntegrity,
+  expectedSourceCommit,
   fetchImpl = fetch,
 }) {
-  const current = await resolveRegistryNightlyPredecessor({ fetchImpl });
+  const current = await resolveRegistryNightlyPredecessor({
+    fetchImpl,
+    includeSourceCommit: expectedSourceCommit !== undefined,
+  });
   if (
     current.version !== expectedVersion ||
     current.tarballUrl !== expectedTarballUrl ||
-    current.integrity !== expectedIntegrity
+    current.integrity !== expectedIntegrity ||
+    current.sourceCommit !== expectedSourceCommit
   ) {
     throw new Error(
       `Qualified npm Nightly predecessor ${expectedVersion} is no longer current; found ${current.version}`,
@@ -621,22 +733,24 @@ async function main() {
     });
     return;
   }
-  if (command === 'resolve-nightly-predecessor' && args.length === 1) {
-    const [output] = args;
-    const predecessor = await resolveRegistryNightlyPredecessor();
+  if (command === 'resolve-nightly-predecessor' && (args.length === 1 || args.length === 2)) {
+    const [output, fencedAncestorHead] = args;
+    const predecessor = await resolveRegistryNightlyPredecessor({ fencedAncestorHead });
     appendOutputs(output, {
       version: predecessor.version,
       tarball_url: predecessor.tarballUrl,
       integrity: predecessor.integrity,
+      ...(predecessor.sourceCommit ? { source_commit: predecessor.sourceCommit } : {}),
     });
     return;
   }
-  if (command === 'assert-nightly-predecessor' && args.length === 3) {
-    const [expectedVersion, expectedTarballUrl, expectedIntegrity] = args;
+  if (command === 'assert-nightly-predecessor' && (args.length === 3 || args.length === 4)) {
+    const [expectedVersion, expectedTarballUrl, expectedIntegrity, expectedSourceCommit] = args;
     await assertRegistryNightlyPredecessor({
       expectedVersion,
       expectedTarballUrl,
       expectedIntegrity,
+      expectedSourceCommit,
     });
     return;
   }

--- a/scripts/release-cli-publication.mjs
+++ b/scripts/release-cli-publication.mjs
@@ -285,7 +285,9 @@ export function parseRegistryNightlySourceCommit({ version, attestations }) {
     );
   });
   const sourceCommit = statement?.predicate?.buildDefinition?.resolvedDependencies?.find(
-    (dependency) => dependency?.uri === expectedSourceUri,
+    (dependency) =>
+      dependency?.uri === expectedSourceUri &&
+      /^[0-9a-f]{40}$/iu.test(dependency?.digest?.gitCommit ?? ''),
   )?.digest?.gitCommit;
   if (!sourceCommit) {
     throw new Error(
@@ -305,13 +307,23 @@ async function fetchRegistryNightlySourceCommit({ version, fetchImpl }) {
   return parseRegistryNightlySourceCommit({ version, attestations: attestations.attestations });
 }
 
+export function parseNightlyPredecessorMode(mode) {
+  if (mode === 'fence') {
+    return { fencedAncestorHead: 'HEAD', includeSourceCommit: true };
+  }
+  if (mode === 'unfenced') {
+    return { includeSourceCommit: true };
+  }
+  throw new Error('Nightly predecessor mode must be either fence or unfenced');
+}
+
 export async function resolveRegistryNightlyPredecessor({
   fetchImpl = fetch,
-  fencedAncestorHead,
-  includeSourceCommit = fencedAncestorHead !== undefined,
+  mode,
   repoRoot = DEFAULT_REPO_ROOT,
   exec = execFileSync,
 } = {}) {
+  const { fencedAncestorHead, includeSourceCommit } = parseNightlyPredecessorMode(mode);
   const packageMetadata = await fetchJson(
     fetchImpl,
     `${REGISTRY_ORIGIN}/${PACKAGE_NAME}`,
@@ -361,9 +373,12 @@ export async function assertRegistryNightlyPredecessor({
   expectedSourceCommit,
   fetchImpl = fetch,
 }) {
+  if (typeof expectedSourceCommit !== 'string' || !/^[0-9a-f]{40}$/iu.test(expectedSourceCommit)) {
+    throw new Error('Qualified npm Nightly predecessor requires a valid source commit');
+  }
   const current = await resolveRegistryNightlyPredecessor({
     fetchImpl,
-    includeSourceCommit: expectedSourceCommit !== undefined,
+    mode: 'unfenced',
   });
   if (
     current.version !== expectedVersion ||
@@ -733,9 +748,9 @@ async function main() {
     });
     return;
   }
-  if (command === 'resolve-nightly-predecessor' && (args.length === 1 || args.length === 2)) {
-    const [output, fencedAncestorHead] = args;
-    const predecessor = await resolveRegistryNightlyPredecessor({ fencedAncestorHead });
+  if (command === 'resolve-nightly-predecessor' && args.length === 2) {
+    const [output, mode] = args;
+    const predecessor = await resolveRegistryNightlyPredecessor({ mode });
     appendOutputs(output, {
       version: predecessor.version,
       tarball_url: predecessor.tarballUrl,
@@ -744,7 +759,7 @@ async function main() {
     });
     return;
   }
-  if (command === 'assert-nightly-predecessor' && (args.length === 3 || args.length === 4)) {
+  if (command === 'assert-nightly-predecessor' && args.length === 4) {
     const [expectedVersion, expectedTarballUrl, expectedIntegrity, expectedSourceCommit] = args;
     await assertRegistryNightlyPredecessor({
       expectedVersion,
@@ -763,7 +778,7 @@ async function main() {
     return;
   }
   throw new Error(
-    `Usage: release-cli-publication.mjs <prepare-stage|prepare-nightly|prepare-audit|validate-stage-run|fetch-registry|resolve-nightly-predecessor|assert-nightly-predecessor|validate-audit> ...`,
+    'Usage: release-cli-publication.mjs <prepare-stage|prepare-nightly|prepare-audit|validate-stage-run|fetch-registry|validate-audit> ... | resolve-nightly-predecessor <output> <fence|unfenced> | assert-nightly-predecessor <version> <tarball-url> <integrity> <source-commit>',
   );
 }
 

--- a/scripts/release-cli-publication.test.mjs
+++ b/scripts/release-cli-publication.test.mjs
@@ -26,6 +26,7 @@ import { join, resolve } from 'node:path';
 import test from 'node:test';
 import { CLI_RELEASE_ARTIFACT_LIMITS } from './release-cli-artifact-policy.mjs';
 import {
+  assertCommitIsAncestor,
   assertRegistryNightlyPredecessor,
   fetchRegistryRelease,
   parseCliNightlyVersion,
@@ -33,6 +34,7 @@ import {
   prepareNightlyRelease,
   prepareSignatureAuditTree,
   prepareStageRelease,
+  parseRegistryNightlySourceCommit,
   resolveRegistryNightlyPredecessor,
   validateRegistryChannels,
   validateSignatureAudit,
@@ -332,6 +334,117 @@ test('a newer Nightly invalidates previously qualified predecessor evidence', as
   );
 });
 
+test('fences the Nightly source commit from SLSA provenance (#4447)', async () => {
+  const ancestorCommit = '1'.repeat(40);
+  const futureCommit = '2'.repeat(40);
+  const fixture = {
+    ...createCandidate('0.2.0-dev.42.20260829', '0.2.0'),
+    sourceCommit: ancestorCommit,
+  };
+  const execStub = (command, args) => {
+    assert.equal(command, 'git');
+    assert.deepEqual(args.slice(0, 3), ['merge-base', '--is-ancestor', ancestorCommit]);
+  };
+
+  const predecessor = await resolveRegistryNightlyPredecessor({
+    fetchImpl: registryFetch({ fixture }),
+    fencedAncestorHead: 'HEAD',
+    exec: execStub,
+  });
+  assert.equal(predecessor.sourceCommit, ancestorCommit);
+
+  const nonAncestorFixture = {
+    ...fixture,
+    sourceCommit: futureCommit,
+  };
+  await assert.rejects(
+    resolveRegistryNightlyPredecessor({
+      fetchImpl: registryFetch({ fixture: nonAncestorFixture }),
+      fencedAncestorHead: 'HEAD',
+      exec: (command, args, options) => {
+        assert.equal(command, 'git');
+        assert.equal(args[2], futureCommit);
+        const error = new Error('not an ancestor');
+        error.status = 1;
+        throw error;
+      },
+    }),
+    /is not an ancestor of HEAD/u,
+  );
+
+  const missingProvenanceFixture = { ...fixture, sourceCommit: undefined };
+  await assert.rejects(
+    resolveRegistryNightlyPredecessor({
+      fetchImpl: registryFetch({ fixture: missingProvenanceFixture }),
+      fencedAncestorHead: 'HEAD',
+      exec: execStub,
+    }),
+    /no valid SLSA source commit/u,
+  );
+
+  assert.throws(
+    () => assertCommitIsAncestor({ commit: 'not-a-sha', exec: execStub }),
+    /Invalid git commit SHA/u,
+  );
+});
+
+test('distinguishes unavailable git history from a non-ancestor source', () => {
+  const commit = '3'.repeat(40);
+  const unavailable = new Error('unknown revision');
+  unavailable.status = 128;
+  assert.throws(
+    () =>
+      assertCommitIsAncestor({
+        commit,
+        head: 'HEAD',
+        exec: () => {
+          throw unavailable;
+        },
+      }),
+    /history or commit is unavailable/u,
+  );
+});
+
+test('revalidates the provenance source commit when predecessor evidence is reused', async () => {
+  const sourceCommit = '5'.repeat(40);
+  const fixture = { ...createCandidate('0.2.0-dev.42.20260829'), sourceCommit };
+  const current = await resolveRegistryNightlyPredecessor({
+    fetchImpl: registryFetch({ fixture }),
+    includeSourceCommit: true,
+  });
+  assert.equal(current.sourceCommit, sourceCommit);
+  await assert.doesNotReject(
+    assertRegistryNightlyPredecessor({
+      expectedVersion: current.version,
+      expectedTarballUrl: current.tarballUrl,
+      expectedIntegrity: current.integrity,
+      expectedSourceCommit: sourceCommit,
+      fetchImpl: registryFetch({ fixture }),
+    }),
+  );
+  await assert.rejects(
+    assertRegistryNightlyPredecessor({
+      expectedVersion: current.version,
+      expectedTarballUrl: current.tarballUrl,
+      expectedIntegrity: current.integrity,
+      expectedSourceCommit: '6'.repeat(40),
+      fetchImpl: registryFetch({ fixture }),
+    }),
+    /is no longer current/u,
+  );
+});
+
+test('rejects provenance that is not for the Maka main publication workflow', () => {
+  assert.throws(
+    () =>
+      parseRegistryNightlySourceCommit({
+        version: '0.2.0-dev.43.20260830',
+        attestations: [nightlyProvenanceBundle('0.2.0-dev.42.20260829', '4'.repeat(40))],
+      }),
+    /no valid SLSA source commit/u,
+  );
+});
+
 test('signature audit must contain Maka provenance for the finalized version', () => {
   const fixture = createPreparedCandidate();
   const verified = {
@@ -585,6 +698,43 @@ function provenanceBundle(mutate = () => {}) {
   };
 }
 
+function nightlyProvenanceBundle(version, sourceCommit) {
+  const statement = {
+    _type: 'https://in-toto.io/Statement/v1',
+    subject: [{ name: `pkg:npm/maka-agent@${version}`, digest: { sha512: 'a'.repeat(128) } }],
+    predicateType: 'https://slsa.dev/provenance/v1',
+    predicate: {
+      buildDefinition: {
+        buildType: 'https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1',
+        externalParameters: {
+          workflow: {
+            repository: 'https://github.com/apache/maka',
+            ref: 'refs/heads/main',
+            path: WORKFLOW_PATH,
+          },
+        },
+        resolvedDependencies: [
+          {
+            uri: 'git+https://github.com/apache/maka@refs/heads/main',
+            digest: { gitCommit: sourceCommit },
+          },
+        ],
+        internalParameters: { github: { event_name: 'schedule' } },
+      },
+      runDetails: { builder: { id: 'https://github.com/actions/runner/github-hosted' } },
+    },
+  };
+  return {
+    predicateType: 'https://slsa.dev/provenance/v1',
+    bundle: {
+      dsseEnvelope: {
+        payloadType: 'application/vnd.in-toto+json',
+        payload: Buffer.from(JSON.stringify(statement)).toString('base64'),
+      },
+    },
+  };
+}
+
 function createCandidate(version = '0.2.0', sourceVersion = version) {
   const root = mkdtempSync(join(tmpdir(), 'maka-cli-publication-'));
   const releaseDirectory = join(root, 'packages/cli/release');
@@ -616,6 +766,14 @@ function registryFetch({ fixture, bytes = fixture.bytes }) {
         name: 'maka-agent',
         version: fixture.version,
         dist: { tarball: tarballUrl, integrity, shasum },
+      });
+    }
+    if (url === `https://registry.npmjs.org/-/npm/v1/attestations/maka-agent@${fixture.version}`) {
+      assert.equal(options.headers?.accept, 'application/json');
+      return Response.json({
+        attestations: fixture.sourceCommit
+          ? [nightlyProvenanceBundle(fixture.version, fixture.sourceCommit)]
+          : [],
       });
     }
     if (url === 'https://registry.npmjs.org/maka-agent') {

--- a/scripts/release-cli-publication.test.mjs
+++ b/scripts/release-cli-publication.test.mjs
@@ -31,6 +31,7 @@ import {
   fetchRegistryRelease,
   parseCliNightlyVersion,
   parseCliReleaseVersion,
+  parseNightlyPredecessorMode,
   prepareNightlyRelease,
   prepareSignatureAuditTree,
   prepareStageRelease,
@@ -293,6 +294,7 @@ test('registry downloads stop reading as soon as the tarball exceeds its bound',
 test('release qualification binds the current Nightly tag to immutable registry bytes', async () => {
   const fixture = createCandidate('0.2.0-dev.42.20260829', '0.2.0');
   const predecessor = await resolveRegistryNightlyPredecessor({
+    mode: 'unfenced',
     fetchImpl: registryFetch({ fixture }),
   });
 
@@ -300,12 +302,14 @@ test('release qualification binds the current Nightly tag to immutable registry 
     version: fixture.version,
     tarballUrl: `https://registry.npmjs.org/maka-agent/-/${fixture.tarball}`,
     integrity: `sha512-${digest('sha512', fixture.bytes, 'base64')}`,
+    sourceCommit: fixture.sourceCommit,
   });
   await assert.doesNotReject(
     assertRegistryNightlyPredecessor({
       expectedVersion: predecessor.version,
       expectedTarballUrl: predecessor.tarballUrl,
       expectedIntegrity: predecessor.integrity,
+      expectedSourceCommit: fixture.sourceCommit,
       fetchImpl: registryFetch({ fixture }),
     }),
   );
@@ -314,6 +318,7 @@ test('release qualification binds the current Nightly tag to immutable registry 
 test('the release predecessor may come from the previous product version', async () => {
   const fixture = createCandidate('0.1.0-dev.41.20260828', '0.1.0');
   const predecessor = await resolveRegistryNightlyPredecessor({
+    mode: 'unfenced',
     fetchImpl: registryFetch({ fixture }),
   });
   assert.equal(predecessor.version, fixture.version);
@@ -328,6 +333,7 @@ test('a newer Nightly invalidates previously qualified predecessor evidence', as
       expectedVersion: previous.version,
       expectedTarballUrl: `https://registry.npmjs.org/maka-agent/-/${previous.tarball}`,
       expectedIntegrity: `sha512-${digest('sha512', previous.bytes, 'base64')}`,
+      expectedSourceCommit: previous.sourceCommit,
       fetchImpl: registryFetch({ fixture: current }),
     }),
     /is no longer current; found 0\.2\.0-dev\.43\.20260830/u,
@@ -347,8 +353,8 @@ test('fences the Nightly source commit from SLSA provenance (#4447)', async () =
   };
 
   const predecessor = await resolveRegistryNightlyPredecessor({
+    mode: 'fence',
     fetchImpl: registryFetch({ fixture }),
-    fencedAncestorHead: 'HEAD',
     exec: execStub,
   });
   assert.equal(predecessor.sourceCommit, ancestorCommit);
@@ -359,8 +365,8 @@ test('fences the Nightly source commit from SLSA provenance (#4447)', async () =
   };
   await assert.rejects(
     resolveRegistryNightlyPredecessor({
+      mode: 'fence',
       fetchImpl: registryFetch({ fixture: nonAncestorFixture }),
-      fencedAncestorHead: 'HEAD',
       exec: (command, args, options) => {
         assert.equal(command, 'git');
         assert.equal(args[2], futureCommit);
@@ -375,8 +381,8 @@ test('fences the Nightly source commit from SLSA provenance (#4447)', async () =
   const missingProvenanceFixture = { ...fixture, sourceCommit: undefined };
   await assert.rejects(
     resolveRegistryNightlyPredecessor({
+      mode: 'fence',
       fetchImpl: registryFetch({ fixture: missingProvenanceFixture }),
-      fencedAncestorHead: 'HEAD',
       exec: execStub,
     }),
     /no valid SLSA source commit/u,
@@ -409,8 +415,8 @@ test('revalidates the provenance source commit when predecessor evidence is reus
   const sourceCommit = '5'.repeat(40);
   const fixture = { ...createCandidate('0.2.0-dev.42.20260829'), sourceCommit };
   const current = await resolveRegistryNightlyPredecessor({
+    mode: 'unfenced',
     fetchImpl: registryFetch({ fixture }),
-    includeSourceCommit: true,
   });
   assert.equal(current.sourceCommit, sourceCommit);
   await assert.doesNotReject(
@@ -443,6 +449,47 @@ test('rejects provenance that is not for the Maka main publication workflow', ()
       }),
     /no valid SLSA source commit/u,
   );
+});
+
+test('requires an explicit mode for Nightly predecessor resolution', () => {
+  assert.deepEqual(parseNightlyPredecessorMode('fence'), {
+    fencedAncestorHead: 'HEAD',
+    includeSourceCommit: true,
+  });
+  assert.deepEqual(parseNightlyPredecessorMode('unfenced'), {
+    includeSourceCommit: true,
+  });
+  assert.throws(() => parseNightlyPredecessorMode(''), /mode must be either fence or unfenced/u);
+});
+
+test('rejects legacy predecessor CLI arities instead of silently skipping the fence', () => {
+  for (const args of [
+    ['resolve-nightly-predecessor', 'output.txt'],
+    ['assert-nightly-predecessor', 'version', 'tarball', 'integrity'],
+  ]) {
+    const result = spawnSync(
+      process.execPath,
+      [resolve(import.meta.dirname, 'release-cli-publication.mjs'), ...args],
+      {
+        encoding: 'utf8',
+      },
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stdout}${result.stderr}`, /Usage: release-cli-publication\.mjs/u);
+  }
+});
+
+test('extracts the same valid provenance dependency that admitted the statement', () => {
+  const version = '0.2.0-dev.42.20260829';
+  const sourceCommit = '7'.repeat(40);
+  const bundle = nightlyProvenanceBundle(version, sourceCommit);
+  const statement = JSON.parse(Buffer.from(bundle.bundle.dsseEnvelope.payload, 'base64'));
+  statement.predicate.buildDefinition.resolvedDependencies.unshift({
+    uri: 'git+https://github.com/apache/maka@refs/heads/main',
+    digest: { gitCommit: 'not-a-sha' },
+  });
+  bundle.bundle.dsseEnvelope.payload = Buffer.from(JSON.stringify(statement)).toString('base64');
+  assert.equal(parseRegistryNightlySourceCommit({ version, attestations: [bundle] }), sourceCommit);
 });
 
 test('signature audit must contain Maka provenance for the finalized version', () => {
@@ -480,6 +527,18 @@ test('signature audit must contain Maka provenance for the finalized version', (
         audit: { ...verified, invalid: [{ name: 'dependency' }] },
       }),
     /invalid or missing signatures/u,
+  );
+});
+
+test('requires a proven source commit when predecessor evidence is revalidated', async () => {
+  await assert.rejects(
+    assertRegistryNightlyPredecessor({
+      expectedVersion: '0.2.0-dev.42.20260829',
+      expectedTarballUrl: 'https://registry.npmjs.org/maka-agent/-/maka-agent.tgz',
+      expectedIntegrity: 'sha512-invalid',
+      fetchImpl: async () => new Response('{}'),
+    }),
+    /requires a valid source commit/u,
   );
 });
 
@@ -735,7 +794,7 @@ function nightlyProvenanceBundle(version, sourceCommit) {
   };
 }
 
-function createCandidate(version = '0.2.0', sourceVersion = version) {
+function createCandidate(version = '0.2.0', sourceVersion = version, sourceCommit = PUBLISHER_SHA) {
   const root = mkdtempSync(join(tmpdir(), 'maka-cli-publication-'));
   const releaseDirectory = join(root, 'packages/cli/release');
   const tarball = `maka-agent-${version}.tgz`;
@@ -751,7 +810,7 @@ function createCandidate(version = '0.2.0', sourceVersion = version) {
   writeFileSync(tarballPath, bytes);
   writeFileSync(`${tarballPath}.sha256`, `${sha256}  ${tarball}\n`);
   writeFileSync(`${tarballPath}.files.json`, '[{"path":"dist/cli.js","size":1}]\n');
-  return { root, releaseDirectory, version, tarball, tarballPath, bytes, sha256 };
+  return { root, releaseDirectory, version, tarball, tarballPath, bytes, sha256, sourceCommit };
 }
 
 function registryFetch({ fixture, bytes = fixture.bytes }) {

--- a/scripts/release-cli-workflow-policy.test.mjs
+++ b/scripts/release-cli-workflow-policy.test.mjs
@@ -65,9 +65,10 @@ test('CLI validation qualifies exact published State Roots without weakening art
     workflow,
     /release_predecessor_source_commit:[\s\S]*?jobs\.state-root-qualification\.outputs\.release_predecessor_source_commit/u,
   );
+  assert.match(workflow, /fence_predecessor:[\s\S]*?type: boolean[\s\S]*?default: true/u);
   assert.match(
     workflow,
-    /id: predecessor\n\s+run: node scripts\/release-cli-publication\.mjs resolve-nightly-predecessor "\$GITHUB_OUTPUT" HEAD/u,
+    /id: predecessor\n\s+run: node scripts\/release-cli-publication\.mjs resolve-nightly-predecessor "\$GITHUB_OUTPUT" "\$\{\{ \(github\.event_name == 'pull_request' \|\| inputs\.fence_predecessor\) && 'fence' \|\| 'unfenced' \}\}"/u,
   );
   assert.match(workflow, /state-root-qualification:\n[\s\S]*?needs: build\n/u);
   assert.doesNotMatch(workflow, /needs\.build\.outputs\.release_predecessor/u);
@@ -166,8 +167,14 @@ test('CLI validation qualifies exact published State Roots without weakening art
 
 test('forward-roll CI fences the registry predecessor to the checked-out commit', () => {
   const workflow = readWorkflow('ci.yml');
-  assert.match(workflow, /resolve-nightly-predecessor "\$GITHUB_OUTPUT" HEAD/u);
+  assert.match(workflow, /resolve-nightly-predecessor "\$GITHUB_OUTPUT" fence/u);
   assert.match(workflow, /fetch-depth: 0/u);
+});
+
+test('formal and ASF candidate workflows opt out of ancestor fencing', () => {
+  assert.match(readWorkflow('release-cli-stage.yml'), /fence_predecessor: false/u);
+  assert.match(readWorkflow('asf-npm-candidate.yml'), /fence_predecessor: false/u);
+  assert.match(readWorkflow('npm-publication.yml'), /fence_predecessor: true/u);
 });
 
 test('both supported Node versions validate the tarball even when the first fails', () => {
@@ -211,6 +218,7 @@ test('npm mutations revalidate the exact qualified Nightly predecessor', () => {
   assert.match(submit, /needs\.validate\.outputs\.release_predecessor_source_commit/u);
   assert.match(submit, /assert-nightly-predecessor/u);
   assert.ok(submit.indexOf('assert-nightly-predecessor') < submit.indexOf('npm stage publish'));
+  assert.match(stage, /fence_predecessor: false/u);
 });
 
 test('stage consumes the validated artifact and makes provenance staging the final step', () => {

--- a/scripts/release-cli-workflow-policy.test.mjs
+++ b/scripts/release-cli-workflow-policy.test.mjs
@@ -63,7 +63,11 @@ test('CLI validation qualifies exact published State Roots without weakening art
   );
   assert.match(
     workflow,
-    /id: predecessor\n\s+run: node scripts\/release-cli-publication\.mjs resolve-nightly-predecessor "\$GITHUB_OUTPUT"/u,
+    /release_predecessor_source_commit:[\s\S]*?jobs\.state-root-qualification\.outputs\.release_predecessor_source_commit/u,
+  );
+  assert.match(
+    workflow,
+    /id: predecessor\n\s+run: node scripts\/release-cli-publication\.mjs resolve-nightly-predecessor "\$GITHUB_OUTPUT" HEAD/u,
   );
   assert.match(workflow, /state-root-qualification:\n[\s\S]*?needs: build\n/u);
   assert.doesNotMatch(workflow, /needs\.build\.outputs\.release_predecessor/u);
@@ -97,8 +101,17 @@ test('CLI validation qualifies exact published State Roots without weakening art
       name,
     );
   }
+  assert.match(
+    workflow,
+    /PREDECESSOR_SOURCE_COMMIT: \$\{\{ steps\.predecessor\.outputs\.source_commit \}\}/u,
+  );
 
   const steps = workflowSteps(workflow);
+  const qualificationCheckout = workflow.slice(
+    workflow.indexOf('\n  state-root-qualification:'),
+    workflow.indexOf('\n  eval:', workflow.indexOf('\n  state-root-qualification:')),
+  );
+  assert.match(qualificationCheckout, /fetch-depth: 0/u);
   const sandbox = namedStep(steps, 'Require the account-isolation sandbox');
   assert.match(sandbox, /apt-get install --yes bubblewrap/u);
   const qualify = namedStep(steps, 'Qualify the released State Root transitions');
@@ -144,7 +157,17 @@ test('CLI validation qualifies exact published State Roots without weakening art
   const freshness = namedStep(steps, 'Require the qualified Nightly predecessor to remain current');
   assert.match(freshness, /assert-nightly-predecessor/u);
   assert.match(freshness, /steps\.predecessor\.outputs\.version/u);
+  assert.match(
+    freshness,
+    /PREDECESSOR_SOURCE_COMMIT: \$\{\{ steps\.predecessor\.outputs\.source_commit \}\}/u,
+  );
   assert.ok(steps.indexOf(freshness) > steps.indexOf(preserve));
+});
+
+test('forward-roll CI fences the registry predecessor to the checked-out commit', () => {
+  const workflow = readWorkflow('ci.yml');
+  assert.match(workflow, /resolve-nightly-predecessor "\$GITHUB_OUTPUT" HEAD/u);
+  assert.match(workflow, /fetch-depth: 0/u);
 });
 
 test('both supported Node versions validate the tarball even when the first fails', () => {
@@ -177,6 +200,7 @@ test('npm mutations revalidate the exact qualified Nightly predecessor', () => {
   );
   assert.match(nightlyFence, /needs\.cli\.outputs\.release_predecessor_version/u);
   assert.match(nightlyFence, /needs\.cli\.outputs\.release_predecessor_integrity/u);
+  assert.match(nightlyFence, /needs\.cli\.outputs\.release_predecessor_source_commit/u);
   assert.match(nightlyFence, /assert-nightly-predecessor/u);
   assert.ok(nightly.indexOf(nightlyFence) < nightly.indexOf('npm publish'));
 
@@ -184,6 +208,7 @@ test('npm mutations revalidate the exact qualified Nightly predecessor', () => {
   const submit = namedStep(workflowSteps(stage), 'Submit the candidate to npm staging');
   assert.match(submit, /needs\.validate\.outputs\.release_predecessor_version/u);
   assert.match(submit, /needs\.validate\.outputs\.release_predecessor_integrity/u);
+  assert.match(submit, /needs\.validate\.outputs\.release_predecessor_source_commit/u);
   assert.match(submit, /assert-nightly-predecessor/u);
   assert.ok(submit.indexOf('assert-nightly-predecessor') < submit.indexOf('npm stage publish'));
 });


### PR DESCRIPTION
## Summary

The forward-roll baseline was selected from the live npm `nightly` tag without proving that the published build came from a commit reachable from the checkout under test. This could make the qualification run against a future or otherwise unverifiable baseline.

This change:

- reads the Nightly source commit from npm's SLSA provenance attestation, because tarball publication leaves `gitHead` unset;
- verifies the source commit with `git merge-base --is-ancestor` for PR and Nightly forward-roll validation;
- fails closed when provenance is missing, the commit is invalid, or Git history is unavailable, while distinguishing a genuine non-ancestor result;
- makes the CLI qualification checkout full-history and adds the release script/workflow paths to the trigger list;
- carries the proven source commit through predecessor evidence and revalidates it before release mutations;
- adds an explicit `fence_predecessor` lane mode: formal release and ASF tagged-candidate validation keep provenance identity checks but do not require a live Nightly to be an ancestor of a frozen tag;
- rejects legacy CLI argument arities that could silently bypass the fence;
- adds deterministic provenance, ancestry, revalidation, mode, CLI-arity, dependency-selection, and workflow-policy coverage.

Fixes #4447

## Review focus

The earlier #4604 implementation used `gitHead`, which is `null` for current `maka-agent` Nightly tarball publications, and assumed full Git history in a validation lane that used the checkout default. This PR uses the live SLSA endpoint and explicitly sets `fetch-depth: 0` in the affected qualification job.

The formal release lane shares the reusable qualification workflow but validates a frozen product tag. Its caller now explicitly opts out of ancestor fencing while still requiring the signed Nightly source identity to remain current. PR and Nightly forward-roll callers keep the fence enabled.

## Verification

- `node --test --test-concurrency=1 scripts/release-cli-publication.test.mjs scripts/release-cli-workflow-policy.test.mjs scripts/asf-npm-workflow-policy.test.mjs` — 40 passed, 0 failed after rebase onto `upstream/main` `a49ba754`
- `npm exec biome check scripts/release-cli-publication.mjs scripts/release-cli-publication.test.mjs scripts/release-cli-workflow-policy.test.mjs scripts/asf-npm-workflow-policy.test.mjs` — passed
- `npm exec biome lint scripts/release-cli-publication.mjs scripts/release-cli-publication.test.mjs scripts/release-cli-workflow-policy.test.mjs scripts/asf-npm-workflow-policy.test.mjs` — passed
- `npm run format:check` — passed
- `npm run lint` — passed
- YAML parsing for all affected workflows — passed
- `git diff --check` — passed
- `npm --workspace @maka/runtime-host run build` after the sequential workspace build — passed
- Live resolver checks in both `fence` and `unfenced` modes — passed against the current npm Nightly; source commit `11b93d111a796f79a91635b00d6acd105ecea435` resolved correctly
- `npm run check:asf-npm`, `npm run check:product-release-identity`, and `npm run check:model-metadata` — passed

`npm run build` was attempted after the rebase. Core, Storage, MCP, Runtime, Runtime Host, Computer Use, Eval, and CLI built successfully; the repository then failed in the untouched UI workspace on existing API/type mismatches involving `settledText`, `autoScroll`, `trailingAction`, WorkHub types, and related current-main exports. The failure is outside this PR's changed files.

## Historical review

Successful related release/qualification PRs reviewed: #4313, #3481, #4131, and #3192. They bind release evidence to exact immutable identities, preserve existing release boundaries, and add deterministic policy tests.

Unsuccessful or superseded related PRs reviewed: #4604 (CLOSED, invalid `gitHead` premise and shallow-history assumption), #4418 (CLOSED, superseded by #4412), and #3241 (CLOSED, redirected to broader release-verifier work). This revision addresses #4604's metadata and formal-lane scope failures.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated #4447, implemented the provenance/ancestry fence and lane-mode correction, added tests, ran verification, and reviewed the diff. An independent review pass found and fixed the missing source-commit binding in the final revalidation step.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally; targeted lint/format/build checks pass, while the full repository build remains blocked by the unrelated UI errors described above

Does this PR entail a change in behavior?

- [x] Yes — forward-roll validation now fences the Nightly source, while formal/tagged candidate lanes explicitly retain provenance identity without applying the incompatible ancestor relation
- [ ] No
