### PR TITLE
fix(desktop): preserve default connection badge typography

### DIFF
--- a/apps/desktop/src/renderer/settings/custom-pet-settings-section.tsx
+++ b/apps/desktop/src/renderer/settings/custom-pet-settings-section.tsx
@@ -209,7 +209,11 @@ export function CustomPetSettingsSection() {
             label={mutation === 'disable' ? copy.disabling : copy.disable}
           />
         ) : (
-          <Badge variant="neutral" label={copy.disabled} />
+          <Badge
+            className="settingsActionSlotBadge"
+            variant="neutral"
+            label={copy.disabled}
+          />
         )}
       />
 
@@ -233,7 +237,11 @@ export function CustomPetSettingsSection() {
             end={(
               <>
                 {isSelected ? (
-                  <Badge variant="neutral" label={copy.selected} />
+                  <Badge
+                    className="settingsActionSlotBadge"
+                    variant="neutral"
+                    label={copy.selected}
+                  />
                 ) : (
                   <Button
                     variant="secondary"

--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -292,7 +292,7 @@ export function ProjectsSettingsPage(props: {
                     <>
                       {capabilities.setLocalDefault && isDefault ? (
                         <Badge
-                          className="settingsProjectDefaultBadge"
+                          className="settingsDefaultActionBadge"
                           variant="neutral"
                           label={copy.defaultBadge}
                         />

--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -292,7 +292,7 @@ export function ProjectsSettingsPage(props: {
                     <>
                       {capabilities.setLocalDefault && isDefault ? (
                         <Badge
-                          className="settingsDefaultActionBadge"
+                          className="settingsActionSlotBadge"
                           variant="neutral"
                           label={copy.defaultBadge}
                         />

--- a/apps/desktop/src/renderer/settings/providers-panel.tsx
+++ b/apps/desktop/src/renderer/settings/providers-panel.tsx
@@ -368,7 +368,13 @@ function ProvidersPanelContent({ bridge, apiKeyOnboardingBridge, initialPage = '
             badge={isRetiredProvider(selected.providerType)
               ? null
               : selected.slug === defaultSlug
-              ? <Badge variant="neutral" label={copy.default} />
+              ? (
+                <Badge
+                  className="settingsDefaultActionBadge"
+                  variant="neutral"
+                  label={copy.default}
+                />
+              )
               : (
                 <Button
                   variant="secondary"

--- a/apps/desktop/src/renderer/settings/providers-panel.tsx
+++ b/apps/desktop/src/renderer/settings/providers-panel.tsx
@@ -370,7 +370,7 @@ function ProvidersPanelContent({ bridge, apiKeyOnboardingBridge, initialPage = '
               : selected.slug === defaultSlug
               ? (
                 <Badge
-                  className="settingsDefaultActionBadge"
+                  className="settingsActionSlotBadge"
                   variant="neutral"
                   label={copy.default}
                 />

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -147,10 +147,10 @@
   max-width: var(--settings-row-end-cap);
 }
 
-/* The default-project badge replaces the neighboring "set as default"
-   action in the same slot. Keep its label on the action type tier so the
-   settled state does not visually shrink after the user clicks the button. */
-.settingsProjectDefaultBadge {
+/* A default badge can replace a neighboring "set as default" action in the
+   same slot. Keep its label on the action type tier so the settled state does
+   not visually shrink after the user clicks the button. */
+.settingsDefaultActionBadge {
   font: var(--maka-text-label);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -147,10 +147,10 @@
   max-width: var(--settings-row-end-cap);
 }
 
-/* A default badge can replace a neighboring "set as default" action in the
-   same slot. Keep its label on the action type tier so the settled state does
-   not visually shrink after the user clicks the button. */
-.settingsDefaultActionBadge {
+/* A badge can replace a neighboring action in the same slot. Keep its label
+   on the action type tier so the settled state does not visually shrink after
+   the user clicks the button. */
+.settingsActionSlotBadge {
   font: var(--maka-text-label);
 }
 

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -957,6 +957,23 @@ const makaBridge = {
 
 const withSettingsBridge = withScopedMakaBridge(makaBridge);
 
+let typographyStoryDefaultSlug: string | null = 'zai-live';
+
+const withConnectionDefaultTypographyBridge = withScopedMakaBridge({
+  ...makaBridge,
+  connections: {
+    ...connectionsBridge,
+    getSnapshot: async () => ({
+      connections,
+      defaultConnection: typographyStoryDefaultSlug,
+      chatModelChoices: buildChatModelChoices(connections),
+    }),
+    setDefault: async (connection: Parameters<ConnectionsBridge['setDefault']>[0]) => {
+      typographyStoryDefaultSlug = connection?.slug ?? null;
+    },
+  },
+} satisfies Record<string, unknown>);
+
 /**
  * What the production App Update provider reads inside `SettingsStory`. Each
  * call goes to `window.maka.app` at call time rather than capturing the shared
@@ -1896,6 +1913,31 @@ async function openDailyReviewModelSelector(canvasElement: HTMLElement): Promise
 export const Models: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="models" />,
+};
+// Real path: 设置 → 模型 → 连接详情, comparing the action before selection
+// with the settled state after a connection is the default. Both occupy the
+// same header slot, so changing state must not shrink the label typography.
+export const ModelsDefaultBadgeTypography: Story = {
+  decorators: [withConnectionDefaultTypographyBridge],
+  render: () => {
+    typographyStoryDefaultSlug = 'zai-live';
+    return <SettingsStory section="models" />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(await canvas.findByText('OpenAI Review'));
+    const setDefaultButton = await canvas.findByRole('button', { name: '设为默认' });
+    const actionFontSize = getComputedStyle(setDefaultButton).fontSize;
+
+    await userEvent.click(setDefaultButton);
+    const detailHeader = await canvas.findByRole('toolbar', { name: 'OpenAI Review' });
+    const defaultLabel = within(detailHeader).getByText('默认');
+    const defaultBadge = defaultLabel.closest<HTMLElement>('.astryx-badge');
+    if (!defaultBadge) throw new Error('Connection default-state badge did not render');
+
+    await expect(getComputedStyle(defaultBadge).fontSize).toBe(actionFontSize);
+  },
 };
 // Real path: sidebar footer 设置 → 子 Agent, with multiple approved model routes.
 export const Subagents: Story = {

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -61,6 +61,7 @@ import type { LocalMemoryBackupInfo, LocalMemoryEntryPreview, LocalMemoryState }
 import { buildHealthSnapshot } from '@maka/core/health';
 import { createDefaultSettings, mergeSettings } from '@maka/core/settings';
 import { DEFAULT_DAILY_REVIEW_CONFIG } from '@maka/core/daily-review';
+import type { PetPackManifestV1 } from '@maka/core/pet';
 import { SettingsSurface } from '../../src/renderer/settings/settings-surface';
 import { ConnectionSettingsServicesProvider } from '../../src/renderer/features/connection-settings';
 import { RuntimeHostManagementServicesProvider } from '../../src/renderer/features/runtime-host-management';
@@ -958,6 +959,30 @@ const makaBridge = {
 const withSettingsBridge = withScopedMakaBridge(makaBridge);
 
 let typographyStoryDefaultSlug: string | null = 'zai-live';
+let typographyStorySelectedPetId: string | null = 'storybook.typography-pet';
+
+const typographyStoryPet = {
+  schema: 'maka.pet/v1',
+  id: 'storybook.typography-pet',
+  displayName: 'Typography Pet',
+  description: 'Exercises action-to-badge transitions in the custom pet rows.',
+  spriteSheet: {
+    path: 'assets/typography-pet.png',
+    format: 'png',
+    frameWidth: 32,
+    frameHeight: 32,
+    columns: 1,
+    rows: 1,
+    frameCount: 1,
+  },
+  animations: {
+    idle: { frames: [0], fps: 1, loop: true },
+    working: { frames: [0], fps: 1, loop: true },
+    'needs-input': { frames: [0], fps: 1, loop: true },
+    ready: { frames: [0], fps: 1, loop: true },
+    blocked: { frames: [0], fps: 1, loop: true },
+  },
+} satisfies PetPackManifestV1;
 
 const withConnectionDefaultTypographyBridge = withScopedMakaBridge({
   ...makaBridge,
@@ -970,6 +995,19 @@ const withConnectionDefaultTypographyBridge = withScopedMakaBridge({
     }),
     setDefault: async (connection: Parameters<ConnectionsBridge['setDefault']>[0]) => {
       typographyStoryDefaultSlug = connection?.slug ?? null;
+    },
+  },
+} satisfies Record<string, unknown>);
+
+const withPetActionBadgeTypographyBridge = withScopedMakaBridge({
+  ...makaBridge,
+  pets: {
+    ...makaBridge.pets,
+    list: async () => [typographyStoryPet],
+    getSelection: async () => typographyStorySelectedPetId,
+    select: async (petId: string | null) => {
+      typographyStorySelectedPetId = petId;
+      return { ok: true as const, selectedPetId: petId };
     },
   },
 } satisfies Record<string, unknown>);
@@ -2362,6 +2400,43 @@ export const Appearance: Story = {
     }
   },
 };
+// Real path: 设置 → 外观 → 桌宠. The selected and disabled badges each
+// replace a small action in the same row, so both settled states must retain
+// the action label's type tier.
+export const PetsActionBadgeTypography: Story = {
+  decorators: [withPetActionBadgeTypographyBridge],
+  globals: { locale: 'zh-CN' },
+  render: () => {
+    typographyStorySelectedPetId = typographyStoryPet.id;
+    return <SettingsStory section="appearance" />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const selectedLabel = await canvas.findByText('正在使用');
+    const selectedBadge = selectedLabel.closest<HTMLElement>('.astryx-badge');
+    const selectedActions = selectedBadge?.closest<HTMLElement>('.settingsRowEnd');
+    const removeButton = selectedActions
+      ? within(selectedActions).getByRole('button', { name: '删除' })
+      : null;
+    if (!selectedBadge || !removeButton) {
+      throw new Error('Selected-pet action row did not render');
+    }
+    await expect(getComputedStyle(selectedBadge).fontSize).toBe(
+      getComputedStyle(removeButton).fontSize,
+    );
+
+    const disableButton = await canvas.findByRole('button', { name: '关闭宠物' });
+    const disableActionFontSize = getComputedStyle(disableButton).fontSize;
+    await userEvent.click(disableButton);
+    const disabledLabels = await canvas.findAllByText('已关闭');
+    const disabledBadge = disabledLabels
+      .map((label) => label.closest<HTMLElement>('.astryx-badge'))
+      .find((badge): badge is HTMLElement => badge !== null);
+    if (!disabledBadge) throw new Error('Disabled-pet action badge did not render');
+    await expect(getComputedStyle(disabledBadge).fontSize).toBe(disableActionFontSize);
+  },
+};
+
 /** #1362: proxy + auth enabled so the full form-grid stack renders. */
 // Real path: 设置 → 使用统计 → 供应商统计, before any usage has been recorded.
 export const UsageEmpty: Story = {


### PR DESCRIPTION
## Summary

- Keep the connection default-state badge on the same label typography as the “Set as default” action it replaces, preventing the text from shrinking after the click.
- Reuse the action-replacement badge style for the equivalent project default state.
- Add a Storybook interaction regression that performs the real connection-detail transition and compares the computed font size before and after it.

## Before / after

<img width="2120" height="180" alt="Connection default badge typography before and after" src="https://github.com/user-attachments/assets/b4ebdcb4-d121-4ec0-89b9-545f3ad6cfd3" />


## Verification

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- Storybook `ModelsDefaultBadgeTypography` interaction regression
- Renderer production build

`npm test` was also run. The affected Runtime suite passed all 3,357 tests, and a targeted Eval lifecycle rerun passed. The full run still reported unrelated baseline failures in the Storage cross-process authority test and the Runtime Host real-model terminal timing test.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed and implemented the typography fix, added the regression coverage, ran verification, and prepared this pull request.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

