### PR TITLE
feat(cli): add searchable session picker

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -4828,6 +4828,46 @@ describe('Maka Pi TUI runner', () => {
     await run;
   });
 
+  test('searches sessions and preserves the query across Current/All scope', async () => {
+    const terminal = new FakeTerminal(160, 30);
+    const driver = new SlashCommandDriver([
+      {
+        ...fakeSessionSummary('current-session', '/repo', 'Current chat'),
+        model: 'model-a',
+        llmConnectionSlug: 'conn-a',
+      },
+      {
+        ...fakeSessionSummary('other-session', '/other/repo', 'Other chat'),
+        model: 'model-b',
+        llmConnectionSlug: 'conn-b',
+      },
+    ]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-a',
+      connectionSlug: 'conn-a',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Current chat'));
+    terminal.input('Other');
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('No matching sessions'),
+    );
+    terminal.input('\t');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Other chat'));
+    assert.match(plainTerminalOutput(terminal.screenOutput()), /\/other\/repo/);
+    terminal.input('\x1b');
+
+    exitMaka(terminal);
+    await run;
+  });
+
   test('shows localized live status badges in the Session picker', async () => {
     const terminal = new FakeTerminal(160, 30);
     const driver = new SlashCommandDriver([

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -26,7 +26,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
-import { visibleWidth } from '@earendil-works/pi-tui';
+import { TuiMainScreen, visibleWidth } from '@earendil-works/pi-tui';
 import { SHELL_RUN_UPDATE_BUFFER_MAX_ENTRIES } from '@maka/core/shell-run-result';
 import { resolveConnectionModelCatalog } from '@maka/core/model-catalog';
 import { deriveConnectionSlug } from '@maka/core/llm-connections';
@@ -66,7 +66,11 @@ import { skillInvocationBlockedMessage } from '../session-driver.js';
 import { SafeBoundaryResumeParkedError } from '../runtime-host-session-driver.js';
 import { listApiKeyOnboardableProviders } from '../onboarding-catalog.js';
 import { projectRuntimeHostModelChoices } from '../runtime-host-onboarding.js';
-import { modelChoiceConnectionLabels } from '../pi-tui-pickers.js';
+import {
+  getTuiPickerCopy,
+  modelChoiceConnectionLabels,
+  SessionSearchOverlay,
+} from '../pi-tui-pickers.js';
 import type {
   MakaOnboardingSurface,
   MakaPiTuiTurnActivitySurface,
@@ -241,6 +245,54 @@ function savedOnboardingRefreshFailed(connectionId = 'saved-connection-id'): Onb
 }
 
 describe('Maka Pi TUI runner', () => {
+  test('localizes the session search title and scope in every supported locale', () => {
+    for (const [locale, title, current, all] of [
+      ['en', 'Resume Session', 'Current', 'All'],
+      ['zh-CN', '恢复会话', '当前目录', '全部'],
+      ['zh-TW', '恢復會話', '目前目錄', '全部'],
+    ] as const) {
+      const copy = getTuiPickerCopy(locale);
+      const picker = new SessionSearchOverlay(new TuiMainScreen(new FakeTerminal()), {
+        locale,
+        choices: [],
+        scopeLabel: copy.sessionScopeCurrent,
+        onSelect() {},
+        onCancel() {},
+        onToggleScope() {},
+      });
+      assert.equal(plainTerminalOutput(picker.render(100)[0]!).trim(), `${title} ${current}`);
+      picker.updateChoices([], copy.sessionScopeAll);
+      assert.equal(plainTerminalOutput(picker.render(100)[0]!).trim(), `${title} ${all}`);
+    }
+  });
+
+  test('session names use wide viewports and keep selection across resizing', () => {
+    const name = 'Investigate runtime-host multi-account session isolation and lifecycle';
+    let selected: string | undefined;
+    const picker = new SessionSearchOverlay(new TuiMainScreen(new FakeTerminal()), {
+      locale: 'en',
+      choices: ['first', 'second'].map((value) => ({
+        item: { value, label: `${name} ${value}`, description: '/repo · model' },
+        searchText: name.toLowerCase(),
+      })),
+      scopeLabel: 'Current',
+      onSelect(item) {
+        selected = item.value;
+      },
+      onCancel() {},
+      onToggleScope() {},
+    });
+    assert.ok(plainTerminalOutput(picker.render(160).join('\n')).includes(`${name} second`));
+    picker.handleInput('\x1b[B');
+    for (const width of [40, 80, 160]) {
+      const lines = picker.render(width);
+      assert.ok(lines.every((line) => visibleWidth(line) <= width));
+    }
+    assert.ok(plainTerminalOutput(picker.render(160).join('\n')).includes(`${name} second`));
+    picker.handleInput('\r');
+    assert.equal(selected, 'second');
+  });
+
   test('/help uses the resolved locale for headings and command descriptions', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -4837,6 +4837,11 @@ describe('Maka Pi TUI runner', () => {
         llmConnectionSlug: 'conn-a',
       },
       {
+        ...fakeSessionSummary('current-second', '/repo', 'Current second'),
+        model: 'model-a',
+        llmConnectionSlug: 'conn-a',
+      },
+      {
         ...fakeSessionSummary('other-session', '/other/repo', 'Other chat'),
         model: 'model-b',
         llmConnectionSlug: 'conn-b',
@@ -4855,7 +4860,13 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session');
     terminal.input('\r');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Current chat'));
+    terminal.input('\x1b[B');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('→ Current second'));
+    terminal.input('\t');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('→ Current second'));
     terminal.input('Other');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Other chat'));
+    terminal.input('\t');
     await waitFor(() =>
       plainTerminalOutput(terminal.screenOutput()).includes('No matching sessions'),
     );
@@ -4977,6 +4988,10 @@ describe('Maka Pi TUI runner', () => {
     // The foreign row is labeled by its title and marked as a resume-from row.
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('Prior parser work'));
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('resume from Claude Code'));
+
+    // Foreign cwd participates in the advertised path search.
+    terminal.input('repo');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Prior parser work'));
 
     terminal.input('\r');
     await waitFor(() => readDigestCalls === 1);

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -23,6 +23,7 @@ import {
   Key,
   SelectList,
   decodeKittyPrintable,
+  isKeyRelease,
   isKeyRepeat,
   matchesKey,
   truncateToWidth,
@@ -70,6 +71,8 @@ interface TuiPickerCopy {
   readonly modelSearchHint: string;
   readonly searchLabel: string;
   readonly noMatchingModels: string;
+  readonly sessionSearchHint: string;
+  readonly noMatchingSessions: string;
   readonly selectPickerHint: string;
   readonly providerConfigured: string;
   readonly addAccount: string;
@@ -800,6 +803,126 @@ function matchesModelChoice(choice: ModelChoice, query: string): boolean {
   if (provider?.label.toLowerCase().includes(query)) return true;
   if (provider?.menuLabel?.toLowerCase().includes(query)) return true;
   return false;
+}
+
+export interface SessionSearchChoice {
+  item: SelectItem;
+  searchText: string;
+}
+
+export interface SessionSearchOverlayInput {
+  locale: UiLocale;
+  choices: readonly SessionSearchChoice[];
+  scopeLabel: string;
+  onSelect: (item: SelectItem) => void;
+  onCancel: () => void;
+  onToggleScope: () => void;
+}
+
+export class SessionSearchOverlay implements Component {
+  private readonly searchEditor: Editor;
+  private readonly copy: TuiPickerCopy;
+  private choices: readonly SessionSearchChoice[];
+  private filtered: readonly SessionSearchChoice[];
+  private list: SelectList;
+  private selectedValue: string | undefined;
+  private scopeLabel: string;
+
+  constructor(
+    private readonly tui: TUI,
+    private readonly input: SessionSearchOverlayInput,
+  ) {
+    this.copy = getTuiPickerCopy(input.locale);
+    this.choices = input.choices;
+    this.filtered = input.choices;
+    this.scopeLabel = input.scopeLabel;
+    this.list = this.buildList();
+    this.searchEditor = new Editor(tui, editorTheme(), { paddingX: 0 });
+    this.searchEditor.onChange = (text) => this.applyQuery(text);
+  }
+
+  updateChoices(choices: readonly SessionSearchChoice[], scopeLabel: string): void {
+    this.choices = choices;
+    this.scopeLabel = scopeLabel;
+    this.applyQuery(this.searchEditor.getText());
+  }
+
+  private buildList(): SelectList {
+    const list = new SelectList(
+      this.filtered.map(({ item }) => item),
+      10,
+      selectListTheme(),
+      {
+        minPrimaryColumnWidth: 20,
+        maxPrimaryColumnWidth: 48,
+      },
+    );
+    const selectedIndex = this.filtered.findIndex(({ item }) => item.value === this.selectedValue);
+    if (selectedIndex >= 0) list.setSelectedIndex(selectedIndex);
+    list.onSelect = (item) => {
+      this.selectedValue = item.value;
+      this.input.onSelect(item);
+    };
+    list.onCancel = () => this.input.onCancel();
+    return list;
+  }
+
+  private applyQuery(text: string): void {
+    const query = text.trim().toLocaleLowerCase();
+    this.filtered = query
+      ? this.choices.filter((choice) => choice.searchText.includes(query))
+      : this.choices;
+    this.list = this.buildList();
+  }
+
+  invalidate(): void {
+    this.searchEditor.invalidate();
+    this.list.invalidate();
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
+      this.input.onCancel();
+      return;
+    }
+    if (matchesKey(data, Key.tab) && !isKeyRelease(data) && !isKeyRepeat(data)) {
+      this.input.onToggleScope();
+      return;
+    }
+    if (matchesKey(data, Key.up) || matchesKey(data, Key.down) || matchesKey(data, Key.enter)) {
+      if (matchesKey(data, Key.enter) && isKeyRepeat(data)) return;
+      this.list.handleInput(data);
+      return;
+    }
+    this.searchEditor.handleInput(data);
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    this.searchEditor.focused = true;
+    return [
+      padLine(`Resume Session ${ansi.accent(this.scopeLabel)}`, safeWidth),
+      padLine(ansi.dim(this.copy.sessionSearchHint), safeWidth),
+      padLine('', safeWidth),
+      ...this.renderFieldRow(safeWidth),
+      padLine('', safeWidth),
+      ...(this.filtered.length === 0
+        ? [padLine(ansi.dim(this.copy.noMatchingSessions), safeWidth)]
+        : this.list.render(safeWidth).map((line) => formatPickerItemLine(line, safeWidth))),
+      padLine(ansi.accent('-'.repeat(safeWidth)), safeWidth),
+    ];
+  }
+
+  private renderFieldRow(width: number): string[] {
+    const prefix = `${this.copy.searchLabel} `;
+    const contentWidth = Math.max(1, width - visibleWidth(prefix));
+    const editorLines = this.searchEditor.render(contentWidth).slice(1, -1);
+    return editorLines.length > 0
+      ? editorLines.map((line, index) =>
+          padLine(`${index === 0 ? prefix : ' '.repeat(prefix.length)}${line}`, width),
+        )
+      : [padLine(prefix, width)];
+  }
 }
 
 export interface ModelSearchOverlayInput {

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -71,6 +71,9 @@ interface TuiPickerCopy {
   readonly modelSearchHint: string;
   readonly searchLabel: string;
   readonly noMatchingModels: string;
+  readonly resumeSessionTitle: string;
+  readonly sessionScopeCurrent: string;
+  readonly sessionScopeAll: string;
   readonly sessionSearchHint: string;
   readonly noMatchingSessions: string;
   readonly selectPickerHint: string;
@@ -820,6 +823,7 @@ export interface SessionSearchOverlayInput {
 }
 
 export class SessionSearchOverlay implements Component {
+  private renderWidth = 0;
   private readonly searchEditor: Editor;
   private readonly copy: TuiPickerCopy;
   private choices: readonly SessionSearchChoice[];
@@ -854,7 +858,7 @@ export class SessionSearchOverlay implements Component {
       selectListTheme(),
       {
         minPrimaryColumnWidth: 20,
-        maxPrimaryColumnWidth: 48,
+        maxPrimaryColumnWidth: Math.max(20, this.renderWidth - 30),
       },
     );
     const selectedIndex = this.filtered.findIndex(({ item }) => item.value === this.selectedValue);
@@ -902,9 +906,13 @@ export class SessionSearchOverlay implements Component {
 
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
+    if (safeWidth !== this.renderWidth) {
+      this.renderWidth = safeWidth;
+      this.list = this.buildList();
+    }
     this.searchEditor.focused = true;
     return [
-      padLine(`Resume Session ${ansi.accent(this.scopeLabel)}`, safeWidth),
+      padLine(`${this.copy.resumeSessionTitle} ${ansi.accent(this.scopeLabel)}`, safeWidth),
       padLine(ansi.dim(this.copy.sessionSearchHint), safeWidth),
       padLine('', safeWidth),
       ...this.renderFieldRow(safeWidth),

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -859,6 +859,9 @@ export class SessionSearchOverlay implements Component {
     );
     const selectedIndex = this.filtered.findIndex(({ item }) => item.value === this.selectedValue);
     if (selectedIndex >= 0) list.setSelectedIndex(selectedIndex);
+    list.onSelectionChange = (item) => {
+      this.selectedValue = item.value;
+    };
     list.onSelect = (item) => {
       this.selectedValue = item.value;
       this.input.onSelect(item);

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -2864,7 +2864,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         closeOverlay();
         void goToSession(item.value);
       };
-      const scopeLabel = sessionListScope === 'current' ? 'Current' : 'All';
+      const scopeLabel =
+        sessionListScope === 'current'
+          ? pickerCopy.sessionScopeCurrent
+          : pickerCopy.sessionScopeAll;
       if (sessionSearch) {
         sessionSearch.updateChoices(choices, scopeLabel);
         sessionSearch.invalidate();

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -18,7 +18,6 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { basename } from 'node:path';
 import {
   Key,
   ProcessTerminal,
@@ -167,6 +166,7 @@ import {
   MakaAutocompleteProvider,
   DirectoryPickerOverlay,
   ModelSearchOverlay,
+  SessionSearchOverlay,
   OnboardingWizard,
   PickerOverlay,
   UserQuestionOverlay,
@@ -178,6 +178,7 @@ import {
   skillPickerItems,
   thinkingLevelPickerItems,
   type MakaSlashCommand,
+  type SessionSearchChoice,
 } from './pi-tui-pickers.js';
 import { formatMakaResumeCommand } from './cli-invocation.js';
 import {
@@ -2798,21 +2799,22 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         foreignByValue.set(`foreign:${summary.source}:${summary.id}`, summary);
       }
     }
+    let overlay: OverlayHandle | undefined;
+    let sessionSearch: SessionSearchOverlay | undefined;
     const renderScope = (): void => {
       const visibleSessions =
         sessionListScope === 'current'
           ? projectedSessions.filter(({ session }) => session.cwd === cwd)
           : projectedSessions;
-      const items: SelectItem[] = visibleSessions.map(({ session, depth }) => {
+      const choices: SessionSearchChoice[] = visibleSessions.map(({ session, depth }) => {
         const state = availability.get(session.id);
         const statusBadge = sessionStatusBadge(session, locale);
         const statusDetail = statusBadge ? ` · ${statusBadge}` : '';
-        const location =
-          sessionListScope === 'all' && session.cwd ? ` ${basename(session.cwd)}` : '';
+        const location = sessionListScope === 'all' && session.cwd ? ` ${session.cwd}` : '';
         const childDetail = session.subagentRuntime
           ? ` subagent:${session.subagentRuntime.profile}`
           : '';
-        return {
+        const item = {
           value: session.id,
           label: `${depth > 0 ? `${'  '.repeat(depth - 1)}↳ ` : ''}${session.name || session.id}`,
           description:
@@ -2820,26 +2822,37 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
               ? `${shortSessionId(session.id)}${statusDetail} ${state.reason}`
               : `${shortSessionId(session.id)}${statusDetail}${location}${childDetail} ${session.llmConnectionSlug} ${session.model}`,
         };
+        return {
+          item,
+          searchText: [
+            session.name,
+            session.id,
+            session.cwd,
+            session.model,
+            session.llmConnectionSlug,
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .toLocaleLowerCase(),
+        };
       });
       // Foreign sessions are cwd-scoped; show them in both scope views (they
       // belong to this project) so a Tab toggle never makes them vanish.
       for (const [value, summary] of foreignByValue) {
-        items.push({
-          value,
-          label: summary.title,
-          description: `↩ resume from ${foreignSourceLabel(summary.source)}`,
+        choices.push({
+          item: {
+            value,
+            label: summary.title,
+            description: `↩ resume from ${foreignSourceLabel(summary.source)}`,
+          },
+          searchText: `${summary.title} ${summary.id} ${summary.source}`.toLocaleLowerCase(),
         });
       }
-      const list = new SelectList(items, 10, selectListTheme(), {
-        minPrimaryColumnWidth: 20,
-        maxPrimaryColumnWidth: Math.max(20, terminal.columns - 30),
-      });
-      let overlay: OverlayHandle | undefined;
       const closeOverlay = () => {
         sessionPickerOverlayOpen = false;
         overlay?.hide();
       };
-      list.onSelect = (item) => {
+      const onSelect = (item: SelectItem) => {
         const foreign = foreignByValue.get(item.value);
         if (foreign) {
           closeOverlay();
@@ -2850,22 +2863,25 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         closeOverlay();
         void goToSession(item.value);
       };
-      list.onCancel = () => closeOverlay();
+      const scopeLabel = sessionListScope === 'current' ? 'Current' : 'All';
+      if (sessionSearch) {
+        sessionSearch.updateChoices(choices, scopeLabel);
+        sessionSearch.invalidate();
+        return;
+      }
+      sessionSearch = new SessionSearchOverlay(tui, {
+        locale,
+        choices,
+        scopeLabel,
+        onSelect,
+        onCancel: closeOverlay,
+        onToggleScope: () => {
+          sessionListScope = sessionListScope === 'current' ? 'all' : 'current';
+          renderScope();
+        },
+      });
       sessionPickerOverlayOpen = true;
-      overlay = showBottomPicker(
-        new PickerOverlay(list, {
-          title: 'Resume Session',
-          rightLabel: sessionListScope === 'current' ? 'Current' : 'All',
-          hint: 'Tab scope · ↑↓ move · Enter select · Esc close',
-          onInput: (data) => {
-            if (!matchesKey(data, Key.tab) || isKeyRelease(data) || isKeyRepeat(data)) return false;
-            sessionListScope = sessionListScope === 'current' ? 'all' : 'current';
-            overlay?.hide();
-            renderScope();
-            return true;
-          },
-        }),
-      );
+      overlay = showBottomPicker(sessionSearch);
     };
     renderScope();
   };

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -2845,7 +2845,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
             label: summary.title,
             description: `↩ resume from ${foreignSourceLabel(summary.source)}`,
           },
-          searchText: `${summary.title} ${summary.id} ${summary.source}`.toLocaleLowerCase(),
+          searchText:
+            `${summary.title} ${summary.id} ${summary.cwd} ${summary.source}`.toLocaleLowerCase(),
         });
       }
       const closeOverlay = () => {

--- a/packages/cli/src/tui-copy-catalog.ts
+++ b/packages/cli/src/tui-copy-catalog.ts
@@ -600,6 +600,9 @@ export const TUI_COPY_RESOURCES = {
         'Search models / providers / connections · ↑↓ select · Enter confirm · Esc cancel',
       searchLabel: 'Search',
       noMatchingModels: 'No matching models',
+      resumeSessionTitle: 'Resume Session',
+      sessionScopeCurrent: 'Current',
+      sessionScopeAll: 'All',
       sessionSearchHint:
         'Search name / id / path / model / connection · Tab scope · ↑↓ select · Enter open · Esc close',
       noMatchingSessions: 'No matching sessions',
@@ -702,6 +705,9 @@ export const TUI_COPY_RESOURCES = {
       modelSearchHint: '搜索模型 / 服务商 / 连接 · ↑↓ 选择 · Enter 确认 · Esc 取消',
       searchLabel: '搜索',
       noMatchingModels: '没有匹配的模型',
+      resumeSessionTitle: '恢复会话',
+      sessionScopeCurrent: '当前目录',
+      sessionScopeAll: '全部',
       sessionSearchHint:
         '搜索名称 / ID / 路径 / 模型 / 连接 · Tab 切换范围 · ↑↓ 选择 · Enter 打开 · Esc 关闭',
       noMatchingSessions: '没有匹配的会话',
@@ -794,6 +800,9 @@ export const TUI_COPY_RESOURCES = {
       modelSearchHint: '搜尋模型 / 服務商 / 連線 · ↑↓ 選擇 · Enter 確認 · Esc 取消',
       searchLabel: '搜尋',
       noMatchingModels: '沒有符合的模型',
+      resumeSessionTitle: '恢復會話',
+      sessionScopeCurrent: '目前目錄',
+      sessionScopeAll: '全部',
       sessionSearchHint:
         '搜尋名稱 / ID / 路徑 / 模型 / 連線 · Tab 切換範圍 · ↑↓ 選取 · Enter 開啟 · Esc 關閉',
       noMatchingSessions: '沒有符合的會話',

--- a/packages/cli/src/tui-copy-catalog.ts
+++ b/packages/cli/src/tui-copy-catalog.ts
@@ -600,6 +600,9 @@ export const TUI_COPY_RESOURCES = {
         'Search models / providers / connections · ↑↓ select · Enter confirm · Esc cancel',
       searchLabel: 'Search',
       noMatchingModels: 'No matching models',
+      sessionSearchHint:
+        'Search name / id / path / model / connection · Tab scope · ↑↓ select · Enter open · Esc close',
+      noMatchingSessions: 'No matching sessions',
       selectPickerHint: '↑↓ select · Enter confirm · Esc close',
       providerConfigured: 'configured',
       addAccount: 'add account',
@@ -699,6 +702,9 @@ export const TUI_COPY_RESOURCES = {
       modelSearchHint: '搜索模型 / 服务商 / 连接 · ↑↓ 选择 · Enter 确认 · Esc 取消',
       searchLabel: '搜索',
       noMatchingModels: '没有匹配的模型',
+      sessionSearchHint:
+        '搜索名称 / ID / 路径 / 模型 / 连接 · Tab 切换范围 · ↑↓ 选择 · Enter 打开 · Esc 关闭',
+      noMatchingSessions: '没有匹配的会话',
       selectPickerHint: '↑↓ 选择 · Enter 确认 · Esc 关闭',
       providerConfigured: '已设置',
       addAccount: '添加账号',
@@ -788,6 +794,9 @@ export const TUI_COPY_RESOURCES = {
       modelSearchHint: '搜尋模型 / 服務商 / 連線 · ↑↓ 選擇 · Enter 確認 · Esc 取消',
       searchLabel: '搜尋',
       noMatchingModels: '沒有符合的模型',
+      sessionSearchHint:
+        '搜尋名稱 / ID / 路徑 / 模型 / 連線 · Tab 切換範圍 · ↑↓ 選取 · Enter 開啟 · Esc 關閉',
+      noMatchingSessions: '沒有符合的會話',
       selectPickerHint: '↑↓ 選擇 · Enter 確認 · Esc 關閉',
       providerConfigured: '已設定',
       addAccount: '新增帳號',

--- a/scripts/check-tui-copy.mjs
+++ b/scripts/check-tui-copy.mjs
@@ -101,8 +101,6 @@ export const ALLOWED_VISIBLE_LITERALS = {
     'Recap: ${…}',
     'Compacting context…',
     'Resuming from the latest safe boundary…',
-    'Resume Session',
-    'Tab scope · ↑↓ move · Enter select · Esc close',
     'Permissions: ${…}',
     'Keep Auto',
     'Turn on full access',


### PR DESCRIPTION
## Summary

Add a searchable `/session` picker with a query field, Current/All scope toggle,
search across session name, id, path, model, and connection, and the existing
Enter-to-open / foreign-session import behavior. Preserve the selected row when
the filtered list is rebuilt for a scope toggle, and include foreign-session
working directories in path search.

Refs #5016

## Verification

Against `origin/main`, the picker previously had no search field: `/session`
rendered a plain selectable list and Tab rebuilt that list. The new behavior
renders a `Search` field and keeps the query across Current/All scope changes.
Before the follow-up fix, selecting `Current second` with Down and pressing Tab
returned the highlight to the first row; after the fix the rendered row remains:
`→ Current second`.

Foreign sessions now match a cwd query (for example, `repo` matches a foreign
session whose cwd is `/repo`). Enter still closes the picker and follows the
existing session switch/import path.

Checks run:

- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm run build` — passed.
- `npm run typecheck` — passed.
- `npx knip --workspace apps/desktop` — passed.
- `npx knip --workspace packages/ui` — passed.
- `npm --workspace maka-agent run test:dist` — 864 passed, 0 failed, 3 existing platform skips (867 tests).
- `npx biome check` on changed CLI files — passed.
- `git diff --check` — passed.
- `npm run check:tui-copy` — passed (`TUI copy boundaries: ok`, 17 files).
- `node --test scripts/check-tui-copy.test.mjs` — 7 passed, 0 failed.
- `npx biome check scripts/check-tui-copy.mjs` — passed.

Not run: the full repository test suite or an interactive terminal recording. The full CLI suite was run.

Review follow-up at `dfa742da3`:

- The title and Current/All scope labels now come from the typed three-locale catalog. No new legacy allowance or checker exemption was added.
- The primary column follows the actual rendered width (`max(20, width - 30)`), including resizing; selection remains stable.
- Restoring the hardcoded English title and 48-column limit makes both new regressions fail. Restoring the fixes passes.

<details>
<summary>Actual 160-column localized component output (zh-CN)</summary>

```text
恢复会话 当前目录
→ Investigate runtime-host multi-account session isolation and lifecycle  /repo · model
```

</details>

## Review focus

- Scope toggling rebuilds the list while retaining the query and selected value.
- Foreign rows remain prefixed and continue through the existing import flow.
- All-scope rows intentionally retain full cwd text so same-named directories
  remain distinguishable; long-path description layout is not expanded here.
- Multiline search-editor rendering continues to use pi-tui's existing wrapping
  and overlay height management; no new truncation policy is introduced.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex and GPT-5.6-luna subagents reviewed the session-search lifecycle, implemented the
search picker and the two scoped fixes, and authored the regression tests.
Affected commits carry `Generated-by: Codex` trailers. Human review remains
required for correctness and merge decisions.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

<details>
<summary>中文说明</summary>

本 PR 为 `/session` 增加可搜索列表、Current/All 范围切换，并保留 Enter
直接切换或导入会话。补充修复了 Tab 重建列表时丢失高亮项，以及 foreign 会话
工作目录无法参与 path 搜索的问题。All 范围继续显示完整路径，以区分同名目录。

本轮还修复了标题与 Current/All 标签未本地化、会话名称列固定为 48 列的问题。三种语言文案统一进入 catalog；列宽随实际窗口调整，缩放保留选中项。

已通过 root lint、format、build、typecheck、两个 knip 检查，以及完整 CLI 测试（864 pass / 0 fail，3 项既有跳过）。两条新增测试均已验证旧实现会失败。完整仓库测试未运行。

</details>
