### PR TITLE
fix(cli): label failed text tool summaries

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -2890,12 +2890,17 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(poll?.toolUseId, 'read-bg');
     assert.equal(poll?.toolName, 'Read');
     assert.equal(toolStatus(poll), 'error');
-    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    // Assert the semantic row after stripping ANSI, as it appears with
+    // NO_COLOR; the failure label must not depend on the red disc.
+    const rendered = renderMakaPiTranscript(state, meta(), 80).map(stripAnsi).join('\n');
     assert.match(rendered, /● Read/);
-    // The error disc carries the failure state; free-text error content stays
-    // out of the compact row under #1086.
-    assert.match(rendered, /\(1 line · 32 bytes\)/);
+    // The compact row names the failure even without ANSI color; free-text
+    // error content stays out of the row and remains available when expanded.
+    assert.match(rendered, /\(error · 1 line · 32 bytes\)/);
     assert.doesNotMatch(rendered, /background task no longer exists/);
+    assert.ok(
+      visibleWidth(rendered.split('\n').find((line) => line.includes('● Read')) ?? '') <= 80,
+    );
   });
 
   test('surfaces a failed poll at the tail without rewriting scrollback', () => {

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -336,7 +336,15 @@ function compactToolSummary(entry: MakaPiToolEntry): CompactToolSummary | undefi
   ) {
     return { text: linesText(readBodyLineCount(text)), protect: true };
   }
-  return textResultSummary(text);
+  const summary = textResultSummary(text);
+  const status = makaPiToolPresentationStatus(entry);
+  // A red disc is not enough to identify a failed text result, especially
+  // under NO_COLOR. Keep the compact row bounded and secret-safe by adding
+  // only the stable presentation status; the full text remains expanded-only.
+  if (status === 'error' || status === 'failed' || status === 'aborted') {
+    return { ...summary, text: `${status} · ${summary.text}` };
+  }
+  return summary;
 }
 
 function compactTerminalSummary(


### PR DESCRIPTION
## Summary

Add a stable presentation status to compact rows for failed text tools, so `error`, `failed`, and `aborted` remain visible when terminal colors are disabled. Full error text remains available only in the expanded card, avoiding secret leakage and unbounded compact rows.

Refs #5016

## Verification

Rendered output from the affected transcript scenario:

```text
before: ● Read ... (1 line · 32 bytes)
after:  ● Read ... (error · 1 line · 32 bytes)
```

Command:

```text
node --test packages/cli/dist/__tests__/pi-transcript.test.js
ℹ tests 114
ℹ pass 111
ℹ fail 0
ℹ skipped 3
```

Also passed:

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- Affected transcript tests: 111 passed, 3 existing Windows skips

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex and GPT-5.6-luna contributed to implementation and review of the code and tests. Human review remains required before merging.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — failed text tool rows now expose their stable status in compact view
- [ ] No

<details>
<summary>中文说明</summary>

为失败的文本工具 compact 行补充稳定的 presentation status，确保无颜色终端中也能看出 `error`、`failed` 或 `aborted`。完整错误正文仍只在展开卡片中展示，避免泄漏和长行膨胀。验证结果与上方英文内容一致。

</details>

