### PR TITLE
feat(ui): copy rendered Mermaid diagrams to clipboard as PNG

### DIFF
--- a/packages/ui/src/__tests__/mermaid-png-clipboard.test.tsx
+++ b/packages/ui/src/__tests__/mermaid-png-clipboard.test.tsx
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { LocaleProvider } from '../locale-context.js';
+import { MermaidDiagram } from '../mermaid-diagram.js';
+import { installDom, settleEffects } from './mermaid-test-dom.js';
+
+const BACKGROUND = 'rgb(24, 32, 48)';
+
+for (const expanded of [false, true]) {
+  for (const failure of ['none', 'decode', 'toBlob-null', 'toBlob-throw', 'write'] as const) {
+    test(`copies PNG from ${expanded ? 'fullscreen' : 'inline'} toolbar: ${failure}`, async (t) => {
+      const dom = installDom();
+      t.after(() => dom.restore());
+      const createElement = dom.document.createElement.bind(dom.document);
+      t.mock.method(dom.document, 'createElement', (name: string, options?: ElementCreationOptions) => {
+        const element = createElement(name, options);
+        if (name === 'dialog') {
+          Object.assign(element, {
+            showModal() { element.setAttribute('open', ''); },
+            close() { element.removeAttribute('open'); },
+          });
+        }
+        return element;
+      });
+      const mermaid = (await import('mermaid')).default;
+      t.mock.method(mermaid, 'initialize', () => {});
+      t.mock.method(mermaid, 'render', async (id: string) => ({
+        diagramType: 'flowchart-v2',
+        svg: `<svg id="${id}" viewBox="0 0 123 45" width="100%" style="max-width:123px"><rect width="10" height="10" /></svg>`,
+      }));
+
+      const calls: string[] = [];
+      const images: TestImage[] = [];
+      class TestImage {
+        src = '';
+        constructor() { images.push(this); }
+        async decode() {
+          calls.push('decode');
+          if (failure === 'decode') throw new Error('decode rejected');
+        }
+      }
+      class TestClipboardItem {
+        constructor(readonly data: Record<string, Blob>) {}
+      }
+      for (const [key, value] of Object.entries({ Image: TestImage, ClipboardItem: TestClipboardItem })) {
+        const original = Object.getOwnPropertyDescriptor(globalThis, key);
+        Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+        t.after(() => {
+          if (original) Object.defineProperty(globalThis, key, original);
+          else Reflect.deleteProperty(globalThis, key);
+        });
+      }
+
+      const originalComputedStyle = globalThis.getComputedStyle;
+      t.mock.method(globalThis, 'getComputedStyle', (element: Element) => ({
+        ...originalComputedStyle(element),
+        backgroundColor: element.tagName === 'FIGURE' ? BACKGROUND : 'transparent',
+      }));
+      const blob = new Blob(['test PNG bytes'], { type: 'image/png' });
+      const writes: TestClipboardItem[][] = [];
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        value: {
+          clipboard: {
+            async write(items: TestClipboardItem[]) {
+              calls.push('write');
+              writes.push(items);
+              if (failure === 'write') throw new Error('clipboard rejected');
+            },
+          },
+        },
+      });
+      const canvases: HTMLCanvasElement[] = [];
+      const paints: unknown[][] = [];
+      const context = {
+        fillStyle: '',
+        fillRect(...args: number[]) {
+          calls.push('fill');
+          paints.push([this.fillStyle, ...args]);
+        },
+        drawImage(...args: unknown[]) {
+          calls.push('draw');
+          paints.push(args);
+        },
+      };
+      t.mock.method(dom.document.defaultView!.HTMLCanvasElement.prototype, 'getContext', function (this: HTMLCanvasElement, kind: string) {
+        assert.equal(kind, '2d');
+        canvases.push(this);
+        return context;
+      });
+      // linkedom does not provide toBlob, so install and restore the descriptor.
+      const canvasPrototype = dom.document.defaultView!.HTMLCanvasElement.prototype;
+      const originalToBlob = Object.getOwnPropertyDescriptor(canvasPrototype, 'toBlob');
+      Object.defineProperty(canvasPrototype, 'toBlob', {
+        configurable: true,
+        value(callback: BlobCallback, mime: string) {
+          calls.push('toBlob');
+          assert.equal(mime, 'image/png');
+          if (failure === 'toBlob-throw') throw new Error('canvas export rejected');
+          callback(failure === 'toBlob-null' ? null : blob);
+        },
+      });
+      t.after(() => {
+        if (originalToBlob) Object.defineProperty(canvasPrototype, 'toBlob', originalToBlob);
+        else Reflect.deleteProperty(canvasPrototype, 'toBlob');
+      });
+
+      const root = createRoot(dom.document.querySelector('#root')!);
+      try {
+        await act(async () => root.render(
+          <LocaleProvider locale="en">
+            <MermaidDiagram code={`flowchart LR\n${expanded}_${failure} --> b`} density="default" />
+          </LocaleProvider>,
+        ));
+        await settleEffects();
+        const click = async (selector: string) => {
+          const button = dom.document.querySelector<HTMLButtonElement>(selector);
+          assert.ok(button, `expected rendered button: ${selector}`);
+          await act(async () => button.click());
+          await settleEffects();
+        };
+        if (expanded) await click('button[aria-label="View diagram fullscreen"]');
+        const figure = expanded ? 'figure.maka-mermaid-diagram-expanded' : 'figure:not(.maka-mermaid-diagram-expanded)';
+        await click(`${figure} button[aria-label="Copy diagram"]`);
+
+        assert.equal(images.length, 1);
+        assert.match(images[0]!.src, /^data:image\/svg\+xml;charset=utf-8,/);
+        const svg = decodeURIComponent(images[0]!.src.split(',')[1]!);
+        assert.match(svg, /^<svg width="123" height="45"/);
+        assert.doesNotMatch(svg, /width="100%"/);
+        if (failure === 'decode') {
+          assert.deepEqual(calls, ['decode']);
+          assert.equal(canvases.length, 0);
+        } else {
+          assert.equal(canvases.length, 1);
+          assert.equal(canvases[0]!.width, 246);
+          assert.equal(canvases[0]!.height, 90);
+          assert.deepEqual(paints, [[BACKGROUND, 0, 0, 246, 90], [images[0], 0, 0, 246, 90]]);
+          assert.deepEqual(calls, ['decode', 'fill', 'draw', 'toBlob', ...(['none', 'write'].includes(failure) ? ['write'] : [])]);
+        }
+        if (failure === 'none' || failure === 'write') {
+          assert.equal(writes.length, 1);
+          assert.equal(writes[0]!.length, 1);
+          const item = writes[0]![0]!;
+          assert.ok(item instanceof TestClipboardItem);
+          assert.deepEqual(Object.keys(item.data), ['image/png']);
+          assert.equal(item.data['image/png'], blob);
+          assert.equal(item.data['image/png']!.type, 'image/png');
+        } else {
+          assert.equal(writes.length, 0);
+        }
+        if (failure === 'none') {
+          assert.ok(dom.document.querySelector(`${figure} button[aria-label="Copy diagram"] .lucide-check`));
+          assert.equal(dom.document.querySelector('button[aria-label="Copy diagram failed"]'), null);
+        } else {
+          assert.ok(dom.document.querySelector(`${figure} button[aria-label="Copy diagram failed"]`));
+          assert.equal(dom.document.querySelector(`${figure} .lucide-check`), null);
+        }
+      } finally {
+        await act(async () => root.unmount());
+        t.mock.restoreAll();
+      }
+    });
+  }
+}

--- a/packages/ui/src/__tests__/mermaid-png-clipboard.test.tsx
+++ b/packages/ui/src/__tests__/mermaid-png-clipboard.test.tsx
@@ -22,14 +22,31 @@ import { test } from 'node:test';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { LocaleProvider } from '../locale-context.js';
-import { MermaidDiagram } from '../mermaid-diagram.js';
+import {
+  MERMAID_EXPORT_MAX_EDGE_PX,
+  MERMAID_EXPORT_MAX_PIXELS,
+  MERMAID_EXPORT_PIXEL_RATIO,
+  MermaidDiagram,
+} from '../mermaid-diagram.js';
 import { installDom, settleEffects } from './mermaid-test-dom.js';
 
 const BACKGROUND = 'rgb(24, 32, 48)';
+const cases = [
+  ...(['none', 'decode', 'toBlob-null', 'toBlob-throw', 'write'] as const).map((failure) => ({
+    name: failure,
+    failure,
+    width: 123,
+    height: 45,
+    exportWidth: 123 * MERMAID_EXPORT_PIXEL_RATIO,
+    exportHeight: 45 * MERMAID_EXPORT_PIXEL_RATIO,
+  })),
+  { name: 'area cap', failure: 'none', width: 10_000, height: 10_000, exportWidth: 8192, exportHeight: 8192 },
+  { name: 'edge cap', failure: 'none', width: 40_000, height: 100, exportWidth: 32767, exportHeight: 81 },
+];
 
 for (const expanded of [false, true]) {
-  for (const failure of ['none', 'decode', 'toBlob-null', 'toBlob-throw', 'write'] as const) {
-    test(`copies PNG from ${expanded ? 'fullscreen' : 'inline'} toolbar: ${failure}`, async (t) => {
+  for (const { name, failure, width, height, exportWidth, exportHeight } of cases) {
+    test(`copies PNG from ${expanded ? 'fullscreen' : 'inline'} toolbar: ${name}`, async (t) => {
       const dom = installDom();
       t.after(() => dom.restore());
       const createElement = dom.document.createElement.bind(dom.document);
@@ -47,16 +64,15 @@ for (const expanded of [false, true]) {
       t.mock.method(mermaid, 'initialize', () => {});
       t.mock.method(mermaid, 'render', async (id: string) => ({
         diagramType: 'flowchart-v2',
-        svg: `<svg id="${id}" viewBox="0 0 123 45" width="100%" style="max-width:123px"><rect width="10" height="10" /></svg>`,
+        svg: `<svg id="${id}" viewBox="0 0 ${width} ${height}" width="100%" style="max-width:${width}px"><rect width="10" height="10" /></svg>`,
       }));
 
-      const calls: string[] = [];
+      const paintOrder: string[] = [];
       const images: TestImage[] = [];
       class TestImage {
         src = '';
         constructor() { images.push(this); }
         async decode() {
-          calls.push('decode');
           if (failure === 'decode') throw new Error('decode rejected');
         }
       }
@@ -84,7 +100,6 @@ for (const expanded of [false, true]) {
         value: {
           clipboard: {
             async write(items: TestClipboardItem[]) {
-              calls.push('write');
               writes.push(items);
               if (failure === 'write') throw new Error('clipboard rejected');
             },
@@ -92,16 +107,17 @@ for (const expanded of [false, true]) {
         },
       });
       const canvases: HTMLCanvasElement[] = [];
-      const paints: unknown[][] = [];
+      const fills: { color: string; bounds: number[] }[] = [];
+      const draws: unknown[][] = [];
       const context = {
         fillStyle: '',
         fillRect(...args: number[]) {
-          calls.push('fill');
-          paints.push([this.fillStyle, ...args]);
+          paintOrder.push('fill');
+          fills.push({ color: this.fillStyle, bounds: args });
         },
         drawImage(...args: unknown[]) {
-          calls.push('draw');
-          paints.push(args);
+          paintOrder.push('draw');
+          draws.push(args);
         },
       };
       t.mock.method(dom.document.defaultView!.HTMLCanvasElement.prototype, 'getContext', function (this: HTMLCanvasElement, kind: string) {
@@ -115,7 +131,6 @@ for (const expanded of [false, true]) {
       Object.defineProperty(canvasPrototype, 'toBlob', {
         configurable: true,
         value(callback: BlobCallback, mime: string) {
-          calls.push('toBlob');
           assert.equal(mime, 'image/png');
           if (failure === 'toBlob-throw') throw new Error('canvas export rejected');
           callback(failure === 'toBlob-null' ? null : blob);
@@ -130,7 +145,7 @@ for (const expanded of [false, true]) {
       try {
         await act(async () => root.render(
           <LocaleProvider locale="en">
-            <MermaidDiagram code={`flowchart LR\n${expanded}_${failure} --> b`} density="default" />
+            <MermaidDiagram code={`flowchart LR\n${expanded}_${failure}_${width}_${height} --> b`} density="default" />
           </LocaleProvider>,
         ));
         await settleEffects();
@@ -147,17 +162,27 @@ for (const expanded of [false, true]) {
         assert.equal(images.length, 1);
         assert.match(images[0]!.src, /^data:image\/svg\+xml;charset=utf-8,/);
         const svg = decodeURIComponent(images[0]!.src.split(',')[1]!);
-        assert.match(svg, /^<svg width="123" height="45"/);
-        assert.doesNotMatch(svg, /width="100%"/);
+        const svgRoot = new DOMParser().parseFromString(svg, 'image/svg+xml').documentElement;
+        assert.equal(Number(svgRoot.getAttribute('width')), exportWidth);
+        assert.equal(Number(svgRoot.getAttribute('height')), exportHeight);
+        assert.equal(svgRoot.getAttribute('viewBox'), `0 0 ${width} ${height}`);
         if (failure === 'decode') {
-          assert.deepEqual(calls, ['decode']);
           assert.equal(canvases.length, 0);
         } else {
           assert.equal(canvases.length, 1);
-          assert.equal(canvases[0]!.width, 246);
-          assert.equal(canvases[0]!.height, 90);
-          assert.deepEqual(paints, [[BACKGROUND, 0, 0, 246, 90], [images[0], 0, 0, 246, 90]]);
-          assert.deepEqual(calls, ['decode', 'fill', 'draw', 'toBlob', ...(['none', 'write'].includes(failure) ? ['write'] : [])]);
+          assert.equal(canvases[0]!.width, exportWidth);
+          assert.equal(canvases[0]!.height, exportHeight);
+          const canvas = canvases[0]!;
+          assert.ok(canvas.width > 0 && canvas.width <= MERMAID_EXPORT_MAX_EDGE_PX);
+          assert.ok(canvas.height > 0 && canvas.height <= MERMAID_EXPORT_MAX_EDGE_PX);
+          assert.ok(canvas.width * canvas.height <= MERMAID_EXPORT_MAX_PIXELS);
+          assert.ok(fills.some(({ color, bounds }) => color === BACKGROUND
+            && bounds[0] === 0 && bounds[1] === 0
+            && bounds[2] === canvas.width && bounds[3] === canvas.height),
+          'fills the full canvas with the theme background');
+          assert.ok(draws.some(([image]) => image === images[0]), 'draws the decoded diagram');
+          assert.ok(paintOrder.lastIndexOf('fill') < paintOrder.indexOf('draw'),
+            'fills the background before drawing, without painting over the diagram');
         }
         if (failure === 'none' || failure === 'write') {
           assert.equal(writes.length, 1);

--- a/packages/ui/src/__tests__/mermaid-render-cache.test.tsx
+++ b/packages/ui/src/__tests__/mermaid-render-cache.test.tsx
@@ -21,128 +21,12 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { parseHTML } from 'linkedom';
+import { installDom, settleEffects } from './mermaid-test-dom.js';
 import { LocaleProvider } from '../locale-context.js';
 import {
   MERMAID_RENDER_CACHE_LIMIT,
   MermaidDiagram,
 } from '../mermaid-diagram.js';
-
-const GLOBAL_KEYS = [
-  'CSS',
-  'CSSStyleSheet',
-  'DOMParser',
-  'Element',
-  'HTMLElement',
-  'IS_REACT_ACT_ENVIRONMENT',
-  'MutationObserver',
-  'Node',
-  'ResizeObserver',
-  'SVGElement',
-  'XMLSerializer',
-  'cancelAnimationFrame',
-  'document',
-  'getComputedStyle',
-  'navigator',
-  'requestAnimationFrame',
-  'window',
-] as const;
-
-function installDom() {
-  const originals = new Map<PropertyKey, PropertyDescriptor | undefined>(
-    GLOBAL_KEYS.map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]),
-  );
-  const { document, window } = parseHTML('<html><body><div id="root"></div></body></html>');
-  Object.defineProperty(window, 'location', {
-    configurable: true,
-    value: new URL('http://localhost/'),
-  });
-
-  class InertResizeObserver {
-    observe(): void {}
-    unobserve(): void {}
-    disconnect(): void {}
-  }
-  class TestXmlSerializer {
-    serializeToString(node: Node): string {
-      return String(node);
-    }
-  }
-  Object.defineProperties(window.SVGElement.prototype, {
-    getBBox: {
-      configurable: true,
-      value() {
-        return { x: 0, y: 0, width: Math.max(1, (this.textContent ?? '').length * 8), height: 16 };
-      },
-    },
-    getComputedTextLength: {
-      configurable: true,
-      value() {
-        return Math.max(1, (this.textContent ?? '').length * 8);
-      },
-    },
-  });
-  const CSSStyleSheet = document.createElement('style').sheet!.constructor;
-  const globals = {
-    CSS: { escape: String, supports: () => false },
-    CSSStyleSheet,
-    DOMParser: window.DOMParser,
-    Element: window.Element,
-    HTMLElement: window.HTMLElement,
-    IS_REACT_ACT_ENVIRONMENT: true,
-    MutationObserver: window.MutationObserver,
-    Node: window.Node,
-    ResizeObserver: InertResizeObserver,
-    SVGElement: window.SVGElement,
-    XMLSerializer: TestXmlSerializer,
-    cancelAnimationFrame: () => {},
-    document,
-    getComputedStyle: () => ({
-      paddingBottom: '0',
-      paddingLeft: '0',
-      paddingRight: '0',
-      paddingTop: '0',
-    }),
-    navigator: window.navigator ?? { userAgent: 'node' },
-    requestAnimationFrame: (callback: FrameRequestCallback) => {
-      queueMicrotask(() => callback(0));
-      return 1;
-    },
-    window,
-  };
-  for (const [key, value] of Object.entries(globals)) {
-    Object.defineProperty(globalThis, key, {
-      configurable: true,
-      value,
-      writable: true,
-    });
-  }
-  Object.assign(window, {
-    CSS: globals.CSS,
-    CSSStyleSheet,
-    cancelAnimationFrame: globals.cancelAnimationFrame,
-    getComputedStyle: globals.getComputedStyle,
-    innerHeight: 800,
-    requestAnimationFrame: globals.requestAnimationFrame,
-  });
-
-  return {
-    document,
-    restore() {
-      for (const key of GLOBAL_KEYS) {
-        const descriptor = originals.get(key);
-        if (descriptor) Object.defineProperty(globalThis, key, descriptor);
-        else Reflect.deleteProperty(globalThis, key);
-      }
-    },
-  };
-}
-
-async function settleEffects(): Promise<void> {
-  for (let index = 0; index < 8; index += 1) {
-    await act(async () => Promise.resolve());
-  }
-}
 
 function diagram(code: string) {
   return (

--- a/packages/ui/src/__tests__/mermaid-svg-data-url.test.ts
+++ b/packages/ui/src/__tests__/mermaid-svg-data-url.test.ts
@@ -19,7 +19,13 @@
 
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { mermaidSvgToDataUrl } from '../mermaid-diagram.js';
+import {
+  MERMAID_EXPORT_MAX_EDGE_PX,
+  MERMAID_EXPORT_MAX_PIXELS,
+  MERMAID_EXPORT_PIXEL_RATIO,
+  mermaidExportScale,
+  mermaidSvgToDataUrl,
+} from '../mermaid-diagram.js';
 
 describe('mermaidSvgToDataUrl', () => {
   test('injects explicit pixel dimensions and strips responsive sizing from the root tag', () => {
@@ -38,5 +44,45 @@ describe('mermaidSvgToDataUrl', () => {
     const decoded = decodeURIComponent(mermaidSvgToDataUrl(svg, 10, 10).split(',')[1]);
     assert.ok(decoded.includes('<rect x="1" y="1" width="2" height="2"/>'));
     assert.match(decoded, /^<svg width="10" height="10"/);
+  });
+});
+
+describe('mermaidExportScale', () => {
+  function bitmap(width: number, height: number) {
+    const scale = mermaidExportScale(width, height);
+    return { width: Math.floor(width * scale), height: Math.floor(height * scale) };
+  }
+  function withinBudget({ width, height }: { width: number; height: number }) {
+    assert.ok(width <= MERMAID_EXPORT_MAX_EDGE_PX, `${width} exceeds the edge budget`);
+    assert.ok(height <= MERMAID_EXPORT_MAX_EDGE_PX, `${height} exceeds the edge budget`);
+    assert.ok(width * height <= MERMAID_EXPORT_MAX_PIXELS, `${width}x${height} exceeds the pixel budget`);
+  }
+
+  test('keeps the full pixel ratio for diagrams that fit the budget', () => {
+    assert.equal(mermaidExportScale(123, 45), MERMAID_EXPORT_PIXEL_RATIO);
+    assert.deepEqual(bitmap(123, 45), {
+      width: 123 * MERMAID_EXPORT_PIXEL_RATIO,
+      height: 45 * MERMAID_EXPORT_PIXEL_RATIO,
+    });
+  });
+
+  test('clamps the report case below the ratio that would exceed the canvas limits', () => {
+    // 30_000x4_000 at 2x used to become a 60_000x8_000 canvas.
+    assert.ok(mermaidExportScale(30_000, 4_000) < MERMAID_EXPORT_PIXEL_RATIO);
+    withinBudget(bitmap(30_000, 4_000));
+  });
+
+  test('clamps a near-square viewBox by area before the edge budget applies', () => {
+    const size = bitmap(10_000, 10_000);
+    withinBudget(size);
+    assert.ok(size.width < MERMAID_EXPORT_MAX_EDGE_PX);
+  });
+
+  test('scales below 1x for elongated diagrams rather than rejecting them', () => {
+    // Wider than the edge budget, so only the edge clamp can resolve it.
+    const scale = mermaidExportScale(40_000, 100);
+    assert.ok(scale > 0 && scale < 1);
+    assert.ok(Math.abs(40_000 * scale - MERMAID_EXPORT_MAX_EDGE_PX) <= 1);
+    withinBudget(bitmap(40_000, 100));
   });
 });

--- a/packages/ui/src/__tests__/mermaid-svg-data-url.test.ts
+++ b/packages/ui/src/__tests__/mermaid-svg-data-url.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { mermaidSvgToDataUrl } from '../mermaid-diagram.js';
+
+describe('mermaidSvgToDataUrl', () => {
+  test('injects explicit pixel dimensions and strips responsive sizing from the root tag', () => {
+    const svg = '<svg viewBox="0 0 1200 675" width="100%" style="max-width: 1200px;"><g/></svg>';
+    const url = mermaidSvgToDataUrl(svg, 1200, 675);
+    assert.match(url, /^data:image\/svg\+xml;charset=utf-8,/);
+    const decoded = decodeURIComponent(url.slice(url.indexOf(',') + 1));
+    assert.match(decoded, /^<svg width="1200" height="675"/);
+    assert.doesNotMatch(decoded, /width="100%"/);
+    assert.doesNotMatch(decoded, /style="/);
+    assert.ok(decoded.includes('<g/>'));
+  });
+
+  test('does not touch width/height attributes inside the svg body', () => {
+    const svg = '<svg viewBox="0 0 10 10"><rect x="1" y="1" width="2" height="2"/></svg>';
+    const decoded = decodeURIComponent(mermaidSvgToDataUrl(svg, 10, 10).split(',')[1]);
+    assert.ok(decoded.includes('<rect x="1" y="1" width="2" height="2"/>'));
+    assert.match(decoded, /^<svg width="10" height="10"/);
+  });
+});

--- a/packages/ui/src/__tests__/mermaid-test-dom.ts
+++ b/packages/ui/src/__tests__/mermaid-test-dom.ts
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { act } from 'react';
+import { parseHTML } from 'linkedom';
+
+const GLOBAL_KEYS = [
+  'CSS',
+  'CSSStyleSheet',
+  'DOMParser',
+  'Element',
+  'HTMLElement',
+  'IS_REACT_ACT_ENVIRONMENT',
+  'MutationObserver',
+  'Node',
+  'ResizeObserver',
+  'SVGElement',
+  'XMLSerializer',
+  'cancelAnimationFrame',
+  'document',
+  'getComputedStyle',
+  'navigator',
+  'requestAnimationFrame',
+  'scrollTo',
+  'window',
+] as const;
+
+export function installDom() {
+  const originals = new Map<PropertyKey, PropertyDescriptor | undefined>(
+    GLOBAL_KEYS.map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]),
+  );
+  const { document, window } = parseHTML('<html><body><div id="root"></div></body></html>');
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: new URL('http://localhost/'),
+  });
+
+  class InertResizeObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  class TestXmlSerializer {
+    serializeToString(node: Node): string {
+      return String(node);
+    }
+  }
+  Object.defineProperties(window.SVGElement.prototype, {
+    getBBox: {
+      configurable: true,
+      value() {
+        return { x: 0, y: 0, width: Math.max(1, (this.textContent ?? '').length * 8), height: 16 };
+      },
+    },
+    getComputedTextLength: {
+      configurable: true,
+      value() {
+        return Math.max(1, (this.textContent ?? '').length * 8);
+      },
+    },
+  });
+  const CSSStyleSheet = document.createElement('style').sheet!.constructor;
+  const globals = {
+    CSS: { escape: String, supports: () => false },
+    CSSStyleSheet,
+    DOMParser: window.DOMParser,
+    Element: window.Element,
+    HTMLElement: window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    MutationObserver: window.MutationObserver,
+    Node: window.Node,
+    ResizeObserver: InertResizeObserver,
+    SVGElement: window.SVGElement,
+    XMLSerializer: TestXmlSerializer,
+    cancelAnimationFrame: () => {},
+    document,
+    getComputedStyle: () => ({
+      paddingBottom: '0',
+      paddingLeft: '0',
+      paddingRight: '0',
+      paddingTop: '0',
+    }),
+    navigator: window.navigator ?? { userAgent: 'node' },
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      queueMicrotask(() => callback(0));
+      return 1;
+    },
+    scrollTo: () => {},
+    window,
+  };
+  for (const [key, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  }
+  Object.assign(window, {
+    CSS: globals.CSS,
+    CSSStyleSheet,
+    cancelAnimationFrame: globals.cancelAnimationFrame,
+    getComputedStyle: globals.getComputedStyle,
+    innerHeight: 800,
+    requestAnimationFrame: globals.requestAnimationFrame,
+    scrollTo: globals.scrollTo,
+  });
+
+  return {
+    document,
+    restore() {
+      for (const key of GLOBAL_KEYS) {
+        const descriptor = originals.get(key);
+        if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+        else Reflect.deleteProperty(globalThis, key);
+      }
+    },
+  };
+}
+
+export async function settleEffects(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) {
+    await act(async () => Promise.resolve());
+  }
+}

--- a/packages/ui/src/mermaid-diagram.tsx
+++ b/packages/ui/src/mermaid-diagram.tsx
@@ -22,12 +22,13 @@ import { CodeBlock } from '@astryxdesign/core/CodeBlock';
 import { Collapsible } from '@astryxdesign/core/Collapsible';
 import { Dialog } from '@astryxdesign/core/Dialog';
 import { Toolbar } from '@astryxdesign/core/Toolbar';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
 import type { MermaidConfig } from 'mermaid';
 import mermaidPackage from 'mermaid/package.json' with { type: 'json' };
-import { ICON_SIZE, Maximize2, Minimize2, Scan, ZoomIn, ZoomOut } from './icons.js';
+import { ICON_SIZE, Check, Copy, Maximize2, Minimize2, Scan, ZoomIn, ZoomOut } from './icons.js';
 import { useUiLocale } from './locale-context.js';
 import { getSharedUiCopy } from './shared-ui-copy.js';
+import { useClipboardCopyFeedback } from './clipboard-feedback.js';
 
 export const MAX_MERMAID_SOURCE_LENGTH = 20_000;
 export const MAX_MERMAID_EDGES = 500;
@@ -36,6 +37,10 @@ export const MERMAID_RENDER_CACHE_MAX_CHARS = 4 * 1024 * 1024;
 export const MIN_MERMAID_ZOOM = 0.5;
 export const MAX_MERMAID_ZOOM = 3;
 export const MERMAID_ZOOM_STEP = 0.25;
+/** 导出剪贴板 PNG 的像素比：2× 在清晰度与 clipboard.write 体积之间取平衡。 */
+export const MERMAID_EXPORT_PIXEL_RATIO = 2;
+/** useClipboardCopyFeedback 的 attempt key，区分于其他文本复制入口。 */
+const MERMAID_IMAGE_COPY_KEY = 'mermaid-image';
 const MIN_MERMAID_VIEWPORT_HEIGHT = 112;
 const MAX_MERMAID_VIEWPORT_HEIGHT = 480;
 const MAX_MERMAID_VIEWPORT_HEIGHT_RATIO = 0.55;
@@ -333,6 +338,45 @@ function clampMermaidZoom(value: number): number {
   return Math.min(MAX_MERMAID_ZOOM, Math.max(MIN_MERMAID_ZOOM, value));
 }
 
+/**
+ * 纯函数：给 SVG 根节点注入显式像素尺寸并编码为 data URL。
+ * 剥掉根节点的 width/height/style（mermaid 默认输出 width="100%" + max-width），
+ * 否则 Image 解码时百分比尺寸会退化为默认视口，导出画布比例失真。
+ */
+export function mermaidSvgToDataUrl(svg: string, width: number, height: number): string {
+  const rootTag = /<svg\b[^>]*>/i.exec(svg)?.[0] ?? '';
+  const sizedRootTag = rootTag
+    .replace(/\s(?:width|height|style)="[^"]*"/gi, '')
+    .replace(/^<svg\b/i, `<svg width="${width}" height="${height}"`);
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(sizedRootTag + svg.slice(rootTag.length))}`;
+}
+
+/**
+ * 把渲染好的 Mermaid SVG 字符串栅格化为 PNG Blob（仅浏览器环境）。
+ * 输入是 state 里的净化 SVG 字符串而非 DOM，不受 pan/zoom 交互态影响。
+ */
+async function mermaidSvgToPngBlob(
+  svg: string,
+  width: number,
+  height: number,
+  background: string,
+): Promise<Blob> {
+  const image = new Image();
+  image.src = mermaidSvgToDataUrl(svg, width, height);
+  await image.decode();
+  const canvas = document.createElement('canvas');
+  canvas.width = width * MERMAID_EXPORT_PIXEL_RATIO;
+  canvas.height = height * MERMAID_EXPORT_PIXEL_RATIO;
+  const context = canvas.getContext('2d');
+  if (!context) throw new Error('Canvas 2D context unavailable');
+  context.fillStyle = background;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  context.drawImage(image, 0, 0, canvas.width, canvas.height);
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'));
+  if (!blob) throw new Error('Canvas toBlob returned no PNG blob');
+  return blob;
+}
+
 export function calculateMermaidFitScale(options: {
   availableWidth: number;
   availableHeight: number;
@@ -383,6 +427,7 @@ export function MermaidDiagram(props: {
   const [panning, setPanning] = useState(false);
   const [pannableAxis, setPannableAxis] = useState<'none' | 'horizontal' | 'vertical' | 'both'>('none');
   const [viewportLayout, setViewportLayout] = useState<MermaidViewportLayout | null>(null);
+  const copyFeedback = useClipboardCopyFeedback();
   const viewportRef = useRef<HTMLDivElement>(null);
   const panRef = useRef<{
     pointerId: number;
@@ -539,6 +584,23 @@ export function MermaidDiagram(props: {
   const className = `maka-markdown-code maka-markdown-code-${props.density}`;
   if (state.status === 'rendered') {
     const zoomPercent = Math.round(zoom * 100);
+    const diagramCopyPhase = copyFeedback.phaseFor(MERMAID_IMAGE_COPY_KEY);
+    async function copyDiagramToClipboard(event: ReactMouseEvent<HTMLButtonElement>) {
+      if (state.status !== 'rendered') return;
+      // 背景色取 figure 实际解析值（styles.css 里 .maka-mermaid-diagram 绑定 --background），
+      // 深色主题导出的 PNG 不会是透明底或误用浅色底。
+      const figure = event.currentTarget.closest('figure');
+      const background = figure ? getComputedStyle(figure).backgroundColor : '';
+      await copyFeedback.attempt(MERMAID_IMAGE_COPY_KEY, async () => {
+        const blob = await mermaidSvgToPngBlob(
+          state.svg,
+          state.naturalWidth,
+          state.naturalHeight,
+          background || '#ffffff',
+        );
+        await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+      });
+    }
     const canvasWidth = viewportLayout
       ? `${viewportLayout.fitWidth * zoom}px`
       : `min(${state.naturalWidth * zoom}px, ${zoomPercent}%)`;
@@ -589,6 +651,15 @@ export function MermaidDiagram(props: {
                   icon={<Scan size={ICON_SIZE.chrome} aria-hidden="true" />}
                 />
               </div>
+              <IconButton
+                variant="ghost"
+                label={diagramCopyPhase === 'failed' ? copy.mermaidCopyImageFailed : copy.mermaidCopyImage}
+                tooltip={diagramCopyPhase === 'failed' ? copy.mermaidCopyImageFailed : copy.mermaidCopyImage}
+                onClick={copyDiagramToClipboard}
+                icon={diagramCopyPhase === 'copied'
+                  ? <Check size={ICON_SIZE.chrome} aria-hidden="true" />
+                  : <Copy size={ICON_SIZE.chrome} aria-hidden="true" />}
+              />
               <IconButton
                 variant="ghost"
                 label={isExpanded ? copy.mermaidCollapseView : copy.mermaidExpandView}

--- a/packages/ui/src/mermaid-diagram.tsx
+++ b/packages/ui/src/mermaid-diagram.tsx
@@ -37,9 +37,21 @@ export const MERMAID_RENDER_CACHE_MAX_CHARS = 4 * 1024 * 1024;
 export const MIN_MERMAID_ZOOM = 0.5;
 export const MAX_MERMAID_ZOOM = 3;
 export const MERMAID_ZOOM_STEP = 0.25;
-/** 导出剪贴板 PNG 的像素比：2× 在清晰度与 clipboard.write 体积之间取平衡。 */
+/** Export clipboard PNG pixel ratio: 2x balances sharpness against clipboard.write size. */
 export const MERMAID_EXPORT_PIXEL_RATIO = 2;
-/** useClipboardCopyFeedback 的 attempt key，区分于其他文本复制入口。 */
+/**
+ * Export canvas edge cap, in pixels. Chromium's own limit is 65535 (kMaxSkiaDim); 32767 is
+ * Firefox's edge limit and leaves a 2x margin under Chromium's, at the cost of downscaling
+ * wider diagrams.
+ */
+export const MERMAID_EXPORT_MAX_EDGE_PX = 32_767;
+/**
+ * Export canvas area cap: 64 megapixels, at worst 256MB of RGBA. Chromium's limit is
+ * 32768 * 8192 = 268435456 CSS px (kMaxCanvasArea); stay 4x under it to keep the bitmap
+ * desktop-sized.
+ */
+export const MERMAID_EXPORT_MAX_PIXELS = 64 * 1024 * 1024;
+/** useClipboardCopyFeedback attempt key, distinct from the other text-copy entry points. */
 const MERMAID_IMAGE_COPY_KEY = 'mermaid-image';
 const MIN_MERMAID_VIEWPORT_HEIGHT = 112;
 const MAX_MERMAID_VIEWPORT_HEIGHT = 480;
@@ -339,9 +351,10 @@ function clampMermaidZoom(value: number): number {
 }
 
 /**
- * 纯函数：给 SVG 根节点注入显式像素尺寸并编码为 data URL。
- * 剥掉根节点的 width/height/style（mermaid 默认输出 width="100%" + max-width），
- * 否则 Image 解码时百分比尺寸会退化为默认视口，导出画布比例失真。
+ * Pure function: inject explicit pixel dimensions into the SVG root and encode it as a data URL.
+ * Strips width/height/style from the root tag (mermaid emits width="100%" + max-width by
+ * default); otherwise the percentage sizing degrades to the default viewport when the Image
+ * decodes and the export canvas ratio is distorted.
  */
 export function mermaidSvgToDataUrl(svg: string, width: number, height: number): string {
   const rootTag = /<svg\b[^>]*>/i.exec(svg)?.[0] ?? '';
@@ -352,8 +365,25 @@ export function mermaidSvgToDataUrl(svg: string, width: number, height: number):
 }
 
 /**
- * 把渲染好的 Mermaid SVG 字符串栅格化为 PNG Blob（仅浏览器环境）。
- * 输入是 state 里的净化 SVG 字符串而非 DOM，不受 pan/zoom 交互态影响。
+ * Pure function: the export canvas scale relative to the SVG's natural size.
+ * Diagrams live in viewBox coordinates (tens of thousands of pixels); scaling that by 2x with no
+ * cap crosses Chromium's canvas limits (32768 * 8192 CSS px area, 65535 per side). There the 2D
+ * context is lost and toBlob yields null, so the copy fails; just under the limit it instead
+ * allocates the RGBA bitmap (up to 1GB at 2^28 px). So clamp against both an edge and an area
+ * budget; elongated diagrams may drop below 1x and still produce a complete, usable image.
+ */
+export function mermaidExportScale(width: number, height: number): number {
+  return Math.min(
+    MERMAID_EXPORT_PIXEL_RATIO,
+    MERMAID_EXPORT_MAX_EDGE_PX / Math.max(width, height),
+    Math.sqrt(MERMAID_EXPORT_MAX_PIXELS / (width * height)),
+  );
+}
+
+/**
+ * Rasterizes a rendered Mermaid SVG string into a PNG Blob (browser only).
+ * Takes the sanitized SVG string from state rather than from the DOM, so pan/zoom interaction
+ * state does not affect it.
  */
 async function mermaidSvgToPngBlob(
   svg: string,
@@ -361,12 +391,20 @@ async function mermaidSvgToPngBlob(
   height: number,
   background: string,
 ): Promise<Blob> {
+  const scale = mermaidExportScale(width, height);
+  // floor makes the area cap a hard guarantee; a side below 1px afterwards means the aspect
+  // ratio is too extreme to export — fail through the existing feedback rather than silently
+  // copying a 1px image.
+  const canvasWidth = Math.floor(width * scale);
+  const canvasHeight = Math.floor(height * scale);
+  if (canvasWidth < 1 || canvasHeight < 1) throw new Error('Mermaid diagram too large to export');
+  // Bound the SVG image viewport as well as the canvas; preserve its original viewBox.
   const image = new Image();
-  image.src = mermaidSvgToDataUrl(svg, width, height);
+  image.src = mermaidSvgToDataUrl(svg, canvasWidth, canvasHeight);
   await image.decode();
   const canvas = document.createElement('canvas');
-  canvas.width = width * MERMAID_EXPORT_PIXEL_RATIO;
-  canvas.height = height * MERMAID_EXPORT_PIXEL_RATIO;
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
   const context = canvas.getContext('2d');
   if (!context) throw new Error('Canvas 2D context unavailable');
   context.fillStyle = background;
@@ -587,16 +625,17 @@ export function MermaidDiagram(props: {
     const diagramCopyPhase = copyFeedback.phaseFor(MERMAID_IMAGE_COPY_KEY);
     async function copyDiagramToClipboard(event: ReactMouseEvent<HTMLButtonElement>) {
       if (state.status !== 'rendered') return;
-      // 背景色取 figure 实际解析值（styles.css 里 .maka-mermaid-diagram 绑定 --background），
-      // 深色主题导出的 PNG 不会是透明底或误用浅色底。
+      // Background color comes from the figure's resolved value (styles.css binds --background on
+      // .maka-mermaid-diagram), so a dark-theme export is neither transparent nor wrongly light.
       const figure = event.currentTarget.closest('figure');
-      const background = figure ? getComputedStyle(figure).backgroundColor : '';
+      if (!figure) return;
+      const background = getComputedStyle(figure).backgroundColor;
       await copyFeedback.attempt(MERMAID_IMAGE_COPY_KEY, async () => {
         const blob = await mermaidSvgToPngBlob(
           state.svg,
           state.naturalWidth,
           state.naturalHeight,
-          background || '#ffffff',
+          background,
         );
         await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
       });

--- a/packages/ui/src/shared-ui-copy.ts
+++ b/packages/ui/src/shared-ui-copy.ts
@@ -52,6 +52,8 @@ export interface SharedUiCopy {
     mermaidExpandView: string;
     mermaidCollapseView: string;
     mermaidZoomLevel: (percent: number) => string;
+    mermaidCopyImage: string;
+    mermaidCopyImageFailed: string;
   };
   formControls: {
     selectPlaceholder: string;
@@ -146,6 +148,8 @@ const SHARED_UI_COPY = {
       mermaidExpandView: '全屏查看图表',
       mermaidCollapseView: '退出全屏图表',
       mermaidZoomLevel: (percent) => `缩放比例 ${percent}%`,
+      mermaidCopyImage: '复制图表',
+      mermaidCopyImageFailed: '复制图表失败',
     },
     formControls: {
       selectPlaceholder: '选择…',
@@ -223,6 +227,8 @@ const SHARED_UI_COPY = {
       mermaidExpandView: '全屏檢視圖表',
       mermaidCollapseView: '退出全屏圖表',
       mermaidZoomLevel: (percent) => `縮放比例 ${percent}%`,
+      mermaidCopyImage: '複製圖表',
+      mermaidCopyImageFailed: '複製圖表失敗',
     },
     formControls: {
       selectPlaceholder: '選擇…',
@@ -300,6 +306,8 @@ const SHARED_UI_COPY = {
       mermaidExpandView: 'View diagram fullscreen',
       mermaidCollapseView: 'Exit diagram fullscreen',
       mermaidZoomLevel: (percent) => `Zoom level ${percent}%`,
+      mermaidCopyImage: 'Copy diagram',
+      mermaidCopyImageFailed: 'Copy diagram failed',
     },
     formControls: {
       selectPlaceholder: 'Select…',


### PR DESCRIPTION
## Summary

Closes #5034

Add a "Copy diagram" button to the Mermaid toolbar (inline + fullscreen views) that copies the rendered diagram to the clipboard as a PNG image.

## Implementation

- `packages/ui/src/mermaid-diagram.tsx`
  - New pure helper `mermaidSvgToDataUrl`: injects explicit pixel dimensions and strips responsive sizing (`width="100%"`, `max-width` style) from the root tag, then encodes the sanitized SVG string as a data URL.
  - Canvas pipeline (`Image.decode -> canvas -> toBlob`) rasterizes at **2x** the natural size; the input is the state-held sanitized SVG string, so exports are unaffected by pan/zoom state.
  - Writes via `navigator.clipboard.write(new ClipboardItem({ 'image/png': blob }))`; feedback reuses the existing `useClipboardCopyFeedback` tri-state (Copy -> Check icon, brief failure label).
  - Background color resolves the figure's computed theme background so dark-mode exports stay readable.
- `packages/ui/src/shared-ui-copy.ts`: `mermaidCopyImage` / `mermaidCopyImageFailed` for zh-CN / zh-TW / en.
- `packages/ui/src/__tests__/mermaid-svg-data-url.test.ts`: node tests for the pure helper.

No new dependencies (kwaipilot's `html-to-image` approach is unnecessary here since the sanitized SVG string is already self-contained).

## Test plan

- [x] `npm run typecheck` (packages/ui)
- [x] `npm run build` (packages/ui)
- [x] `node --test dist/__tests__/mermaid-svg-data-url.test.js` — 2 pass
- [x] Existing `mermaid-render-cache` tests still pass
- [ ] Manual: copy in light/dark themes, paste into a document / IM
