### PR TITLE
fix(runtime-host): align local CLI recovery and handoff UX

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
@@ -29,6 +29,7 @@ import {
   RuntimeHostRemoteCompatibilityError,
   RuntimeHostStartupError,
   HostHandoffRequiredError,
+  HostHandoffCancelledError,
   type RuntimeHostConnection,
   type RuntimeHostProfileCatalog,
   type RemoteRuntimeHostProfile,
@@ -826,3 +827,193 @@ test('activated managed Host incompatibility stays operator-owned', async () => 
     },
   );
 });
+
+for (const action of ['cancel', 'interrupt', 'retry'] as const) {
+  test(`source CLI observed-process recovery requires explicit interruption: ${action}`, async () => {
+    let stopped = 0;
+    let attention = 0;
+    const registration = hostRegistration({ compatibilityEpoch: 121 });
+    const processIdentity = { startIdentity: 'linux:42:123' };
+    const connection = {
+      rootId: registration.rootId,
+      hostEpoch: 'new-host',
+      connectionId: 'new-connection',
+      selectedProtocol: 0,
+      closed: new Promise<void>(() => {}),
+      status: async () => ({ state: 'ready' }),
+      subscribeConfigurationChanges: () => () => {},
+      subscribeConnectionCatalogChanges: () => () => {},
+      subscribeProjectCatalogChanges: () => () => {},
+      subscribeSessionCatalogChanges: () => () => {},
+      subscribeScheduledTaskChanges: () => () => {},
+      close: async () => {},
+    } as unknown as RuntimeHostConnection;
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(new Error('handoff did not settle')), 3000);
+    try {
+      const running = connectRuntimeHostCliConnection(
+        {
+          rootPath: '/source-root',
+          signal: abort.signal,
+          handoffSurface: (submit) => ({
+            update(view) {
+              if (view.state !== 'attention') return;
+              assert.equal(view.reason, 'activity_unknown');
+              assert.deepEqual(view.actions, ['cancel', 'retry', 'interrupt']);
+              assert.equal(stopped, 0);
+              submit(view.revision, attention++ === 0 ? action : 'cancel');
+            },
+            close() {},
+          }),
+        },
+        {
+          isTemporaryNpxInstallation: async () => false,
+          resolveManagedAuthority: async () => undefined,
+          readDeploymentRecord: async () => undefined,
+          resolveInstallation: async () => {
+            throw new Error('development checkout');
+          },
+          connectOrSpawn: async () =>
+            stopped
+              ? connectedHostResult(connection)
+              : {
+                  kind: 'incompatible',
+                  registration,
+                  processIdentity,
+                  handshake: incompatibleRemoteHandshake({ hostEpoch: registration.hostEpoch }),
+                },
+          terminateObservedHost: async (observed, authority) => {
+            assert.equal(observed.registration, registration);
+            assert.equal(authority.processIdentity, processIdentity);
+            assert.equal(authority.isCurrent(), true);
+            stopped++;
+            return true;
+          },
+        },
+      );
+      if (action === 'interrupt') {
+        const context = await running;
+        await context.close();
+        assert.equal(stopped, 1);
+      } else {
+        // Retry preserves the same view; cancellation is a separate user action.
+        if (action === 'retry') setTimeout(() => abort.abort(new HostHandoffCancelledError()), 30);
+        await assert.rejects(running, HostHandoffCancelledError);
+        assert.equal(stopped, 0);
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+}
+
+for (const blocker of ['managed', 'owner', 'temporary', 'identity'] as const) {
+  test(`CLI never offers unowned process recovery for ${blocker}`, async () => {
+    await assert.rejects(
+      connectRuntimeHostCliConnection(
+        { rootPath: '/source-root' },
+        {
+          isTemporaryNpxInstallation: async () => blocker === 'temporary',
+          resolveManagedAuthority: async () =>
+            blocker === 'managed' ? ({ record: {} } as never) : undefined,
+          readDeploymentRecord: async () =>
+            blocker === 'owner'
+              ? ({
+                  state: { kind: 'owned', owner: { kind: 'desktop', installationId: 'other' } },
+                } as never)
+              : undefined,
+          resolveInstallation: async () => {
+            throw new Error('development checkout');
+          },
+          connectOrSpawn: async () => ({
+            kind: 'incompatible',
+            registration: hostRegistration(),
+            ...(blocker === 'identity' ? {} : { processIdentity: { startIdentity: 'observed' } }),
+            handshake: incompatibleRemoteHandshake(),
+          }),
+          terminateObservedHost: async () => {
+            throw new Error('must not terminate');
+          },
+        },
+      ),
+      (error: unknown) => {
+        assert.ok(error instanceof HostHandoffRequiredError);
+        assert.deepEqual(error.view.actions, ['cancel', 'retry']);
+        assert.equal(
+          error.view.recoveryBlocker,
+          blocker === 'temporary' ? 'installation' : blocker,
+        );
+        return true;
+      },
+    );
+  });
+}
+
+for (const changed of ['managed', 'owner'] as const) {
+  test(`CLI rechecks ${changed} authority after interruption consent`, async () => {
+    let inspections = 0;
+    let attention = 0;
+    let terminated = false;
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(new Error('handoff did not settle')), 3000);
+    try {
+      await assert.rejects(
+        connectRuntimeHostCliConnection(
+          {
+            rootPath: '/source-root',
+            signal: abort.signal,
+            handoffSurface: (submit) => ({
+              update(view) {
+                if (view.state !== 'attention') return;
+                if (attention++ === 0) {
+                  assert.ok(view.actions.includes('interrupt'));
+                  submit(view.revision, 'interrupt');
+                } else {
+                  assert.equal(view.reason, 'operator_required');
+                  assert.ok(!view.actions.includes('interrupt'));
+                  submit(view.revision, 'cancel');
+                }
+              },
+              close() {},
+            }),
+          },
+          {
+            isTemporaryNpxInstallation: async () => false,
+            resolveInstallation: async () => {
+              throw new Error('source installation');
+            },
+            resolveManagedAuthority: async () => {
+              inspections++;
+              return changed === 'managed' && inspections >= 3
+                ? ({ record: {} } as never)
+                : undefined;
+            },
+            readDeploymentRecord: async () =>
+              changed === 'owner' && inspections >= 3
+                ? ({
+                    state: {
+                      kind: 'owned',
+                      owner: { kind: 'desktop', installationId: 'new-owner' },
+                    },
+                  } as never)
+                : undefined,
+            connectOrSpawn: async () => ({
+              kind: 'incompatible',
+              registration: hostRegistration(),
+              processIdentity: { startIdentity: 'observed-process' },
+              handshake: incompatibleRemoteHandshake(),
+            }),
+            terminateObservedHost: async () => {
+              terminated = true;
+              return true;
+            },
+          },
+        ),
+        HostHandoffCancelledError,
+      );
+      assert.equal(terminated, false);
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+}

--- a/packages/cli/src/__tests__/runtime-host-handoff-surface.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-handoff-surface.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { PassThrough, Writable } from 'node:stream';
+import { stripVTControlCharacters } from 'node:util';
+import test from 'node:test';
+import type { HostHandoffView } from '@maka/runtime-host/client';
+import { createCliHostHandoffSurface } from '../runtime-host-handoff-surface.js';
+
+test('handoff explains the blocker before prompting and clears stale consent on redraw', () => {
+  const input = new PassThrough();
+  let text = '';
+  const output = Object.assign(
+    new Writable({
+      write(chunk, _encoding, done) {
+        text += chunk.toString();
+        done();
+      },
+    }),
+    { isTTY: true, columns: 120 },
+  );
+  const actions: string[] = [];
+  const surface = createCliHostHandoffSurface(
+    'zh-CN',
+    input,
+    output,
+  )((revision, action) => {
+    actions.push(`${revision}:${action}`);
+  });
+  const view: HostHandoffView = {
+    revision: 'first',
+    state: 'attention',
+    reason: 'activity_unknown',
+    target: { name: 'Local', location: 'local' },
+    mayExitNaturally: false,
+    actions: ['cancel', 'retry', 'interrupt'],
+    defaultAction: 'cancel',
+  };
+  surface.update(view);
+  const rendered = stripVTControlCharacters(text);
+  assert.ok(rendered.trimStart().startsWith('需要确认是否停止后台服务'));
+  assert.ok(rendered.indexOf('可能中断') < rendered.indexOf('Enter:'));
+  assert.equal((rendered.match(/> /g) ?? []).length, 1);
+  assert.doesNotMatch(rendered, /常驻服务|没有替换此服务的权限/);
+  input.write('sto');
+  text = '';
+  surface.update({ ...view, revision: 'second' });
+  assert.ok(stripVTControlCharacters(text).trimStart().startsWith('需要确认是否停止后台服务'));
+  input.write('p\n');
+  assert.deepEqual(actions, []);
+  input.write('\n');
+  assert.deepEqual(actions, ['second:cancel']);
+  surface.close();
+  input.end();
+  output.end();
+});
+
+for (const [locale, title, action] of [
+  ['en', 'Confirm before stopping the service', 'Stop and continue'],
+  ['zh-CN', '需要确认是否停止后台服务', '停止并继续'],
+  ['zh-TW', '需要確認是否停止背景服務', '停止並繼續'],
+] as const) {
+  test(`handoff honors ${locale} before the TUI starts`, () => {
+    const input = new PassThrough();
+    let text = '';
+    const output = new Writable({
+      write(chunk, _encoding, done) {
+        text += chunk.toString();
+        done();
+      },
+    });
+    const surface = createCliHostHandoffSurface(locale, input, output)(() => {});
+    surface.update({
+      revision: 'locale',
+      state: 'attention',
+      reason: 'activity_unknown',
+      target: { name: 'Local', location: 'local' },
+      mayExitNaturally: false,
+      actions: ['cancel', 'retry', 'interrupt'],
+      defaultAction: 'cancel',
+    });
+    assert.ok(text.trimStart().startsWith(title));
+    assert.ok(text.includes(action));
+    if (locale === 'en') assert.doesNotMatch(text, /[\u3400-\u9fff]/u);
+    surface.close();
+    input.end();
+    output.end();
+  });
+}
+
+test('handoff keeps cancellation live during progress and disposes input without submitting', () => {
+  const input = new PassThrough();
+  const output = new Writable({
+    write(_chunk, _encoding, done) {
+      done();
+    },
+  });
+  const actions: string[] = [];
+  const surface = createCliHostHandoffSurface(
+    'en',
+    input,
+    output,
+  )((revision, action) => {
+    actions.push(`${revision}:${action}`);
+  });
+  const view: HostHandoffView = {
+    revision: 'attention',
+    state: 'attention',
+    reason: 'activity_unknown',
+    target: { name: 'Local', location: 'local' },
+    mayExitNaturally: false,
+    actions: ['cancel', 'retry', 'interrupt'],
+    defaultAction: 'cancel',
+  };
+  surface.update(view);
+  surface.update({
+    ...view,
+    revision: 'progress',
+    state: 'progress',
+    phase: 'retiring',
+    actions: ['cancel'],
+  });
+  assert.deepEqual(actions, []);
+  input.write('\n');
+  assert.deepEqual(actions, ['progress:cancel']);
+  surface.update({ ...view, revision: 'settling', state: 'progress', actions: [] });
+  surface.close();
+  input.end();
+  output.end();
+  assert.deepEqual(actions, ['progress:cancel']);
+});

--- a/packages/cli/src/__tests__/runtime-host-local-handoff.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-local-handoff.test.ts
@@ -1105,3 +1105,72 @@ function incompatibleHost(registration: HostRegistration) {
     },
   };
 }
+
+for (const mode of ['explicit', 'safe', 'identity_changed'] as const) {
+  test(`legacy npm restart preserves staged deployment authority during ${mode} recovery`, async (t) => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-legacy-process-recovery-'));
+    t.after(() => rm(base, { recursive: true, force: true }));
+    const sourcePackageRoot = await selfContainedPackage(base, TARGET.version);
+    const authorityRoot = join(base, 'authority');
+    const registration = hostRegistration();
+    const processIdentity = { startIdentity: 'observed-process-start' };
+    const events: string[] = [];
+    const result = await restartRuntimeHostNpmGlobalDeployment(
+      {
+        rootPath: join(base, 'root'),
+        registration,
+        processIdentity,
+        activeWorkPolicy: mode === 'safe' ? 'refuse_active_work' : 'interrupt_active_work',
+        deploymentPathOptions: { platform: 'linux', homeDir: join(base, 'home') },
+      },
+      { authorityRoot },
+      {
+        resolveManagedAuthority: async () => undefined,
+        resolveInstallation: async () => ({
+          owner: CLI_OWNER,
+          observedRelease: {
+            version: TARGET.version,
+            packageRoot: sourcePackageRoot,
+            cliPath: join(sourcePackageRoot, 'dist', 'cli.js'),
+          },
+        }),
+        resolveCandidate: async () => TARGET,
+        withPackage: async (_candidate, use) => {
+          events.push('stage');
+          return use(sourcePackageRoot);
+        },
+        prepareDeployment: prepareRuntimeHostPackageDeployment,
+        connectExisting: async () => incompatibleHost(registration),
+        terminateObservedHost: async (observed, authority) => {
+          assert.equal(observed.registration, registration);
+          assert.equal(authority.processIdentity, processIdentity);
+          assert.equal(authority.isCurrent(), true);
+          events.push('stop');
+          return mode !== 'identity_changed';
+        },
+        activateTarget: async () => {
+          events.push('activate');
+          return mode === 'safe'
+            ? { kind: 'active_work', settle: async () => {} }
+            : { kind: 'ready', settle: async () => {} };
+        },
+      },
+    );
+    if (mode === 'explicit') {
+      assert.equal(result.kind, 'completed');
+      assert.deepEqual(events, ['stage', 'stop', 'activate']);
+      assert.deepEqual((await readLocalHostDeploymentRecord(ROOT_ID, { authorityRoot }))?.state, {
+        kind: 'owned',
+        owner: CLI_OWNER,
+        selected: TARGET,
+      });
+    } else if (mode === 'safe') {
+      assert.equal(result.kind, 'active_work');
+      assert.deepEqual(events, ['stage', 'activate']);
+      assert.equal(await readLocalHostDeploymentRecord(ROOT_ID, { authorityRoot }), undefined);
+    } else {
+      assert.equal(result.kind, 'recovery_required');
+      assert.deepEqual(events, ['stage', 'stop']);
+    }
+  });
+}

--- a/packages/cli/src/runtime-host-cli-context.ts
+++ b/packages/cli/src/runtime-host-cli-context.ts
@@ -28,6 +28,7 @@ import type {
 import type { ChatDefaultPermissionMode } from '@maka/core/settings';
 import {
   connectOrSpawnRuntimeHost,
+  forceTerminateObservedRegisteredRuntimeHost,
   connectRuntimeHost,
   connectRuntimeHostProfile,
   createClientRuntimeHostProfileCatalog,
@@ -52,6 +53,7 @@ import {
 import {
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
   RUNTIME_HOST_PROTOCOL_VERSION,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
 } from '@maka/runtime-host/protocol';
 import {
   readLocalHostDeploymentRecord,
@@ -137,6 +139,7 @@ interface RuntimeHostCliContextDeps {
   readonly profileCatalog?: RuntimeHostProfileCatalog;
   readonly resolveInstallation: typeof resolveRuntimeHostNpmGlobalInstallation;
   readonly isTemporaryNpxInstallation: typeof isTemporaryNpxInstallation;
+  readonly terminateObservedHost: typeof forceTerminateObservedRegisteredRuntimeHost;
   readonly restartDeployment: typeof restartRuntimeHostNpmGlobalDeployment;
   readonly sourceRetirementAvailable: typeof runtimeHostNpmGlobalSourceRetirementAvailable;
 }
@@ -178,6 +181,7 @@ export async function connectRuntimeHostCliConnection(
     createPeerClient: createRuntimeHostPeerClientFromEnvironment,
     resolveInstallation: resolveRuntimeHostNpmGlobalInstallation,
     isTemporaryNpxInstallation,
+    terminateObservedHost: forceTerminateObservedRegisteredRuntimeHost,
     restartDeployment: restartRuntimeHostNpmGlobalDeployment,
     sourceRetirementAvailable: runtimeHostNpmGlobalSourceRetirementAvailable,
     ...overrides,
@@ -272,14 +276,15 @@ export async function connectRuntimeHostCliConnection(
           : await deps.readDeploymentRecord(connected.registration.rootId);
         let replacement: HostHandoffReplacement | undefined;
         let installation;
+        let installationFailure: string | undefined;
         // On-demand managed Hosts are also ephemeral processes. Their durable
         // operator authority, not the process lifetime label, decides who may
         // replace them (including when the Host was already running).
         if (!managed && connected.registration.lifecycleMode === 'ephemeral') {
           try {
             installation = await deps.resolveInstallation();
-          } catch {
-            /* No persistent installation authority. */
+          } catch (error) {
+            installationFailure = error instanceof Error ? error.message : String(error);
           }
           const owner = record?.state.kind === 'handoff' ? record.state.from : record?.state.owner;
           if (
@@ -289,15 +294,17 @@ export async function connectRuntimeHostCliConnection(
                 owner.installationId === installation.owner.installationId))
           ) {
             const expectedInstallation = installation;
-            const canInterrupt = record
-              ? await deps
-                  .sourceRetirementAvailable({
-                    rootId: connected.registration.rootId,
-                    owner: installation.owner,
-                    source: record.state.selected,
-                  })
-                  .catch(() => false)
-              : false;
+            const canInterrupt =
+              connected.processIdentity !== undefined ||
+              (record
+                ? await deps
+                    .sourceRetirementAvailable({
+                      rootId: connected.registration.rootId,
+                      owner: installation.owner,
+                      source: record.state.selected,
+                    })
+                    .catch(() => false)
+                : false);
             replacement = {
               kind: record?.state.kind === 'handoff' ? 'repair' : 'replace',
               canReplaceIdle: true,
@@ -306,6 +313,9 @@ export async function connectRuntimeHostCliConnection(
                 const result = await deps.restartDeployment({
                   rootPath: input.rootPath,
                   registration: connected.registration,
+                  ...(connected.processIdentity
+                    ? { processIdentity: connected.processIdentity }
+                    : {}),
                   activeWorkPolicy,
                   expectedInstallation,
                   ...(attemptSignal ? { signal: attemptSignal } : {}),
@@ -326,11 +336,51 @@ export async function connectRuntimeHostCliConnection(
             };
           }
         }
+        // The same observed-process recovery used by Desktop is available to
+        // persistent local invocations without a deployment owner. This is an
+        // explicit interruption, never an idle inference or an installation claim.
+        const processIdentity = connected.processIdentity;
+        if (
+          !replacement &&
+          !managed &&
+          !record &&
+          !invocationOwned &&
+          connected.registration.lifecycleMode === 'ephemeral' &&
+          processIdentity
+        ) {
+          const registration = connected.registration;
+          replacement = {
+            kind: 'replace',
+            canReplaceIdle: false,
+            canInterrupt: true,
+            execute: async (policy, progress, consent, attemptSignal) => {
+              if (policy !== 'interrupt_active_work' || consent !== 'explicit') {
+                return { kind: 'active_work' };
+              }
+              attemptSignal?.throwIfAborted();
+              if (
+                (await deps.resolveManagedAuthority(registration.rootId)) ||
+                (await deps.readDeploymentRecord(registration.rootId))
+              )
+                return { kind: 'changed' };
+              attemptSignal?.throwIfAborted();
+              progress('retiring');
+              const stopped = await deps.terminateObservedHost(
+                { rootPath: input.rootPath, registration },
+                { processIdentity, isCurrent: () => !signal?.aborted && !attemptSignal?.aborted },
+              );
+              if (!stopped) return { kind: 'changed' };
+              progress('verifying');
+              return { kind: 'completed' };
+            },
+          };
+        }
         return {
           kind: 'blocked',
           blocker: {
             identity: JSON.stringify([
               connected.registration,
+              processIdentity,
               managed?.record,
               record,
               installation,
@@ -342,6 +392,24 @@ export async function connectRuntimeHostCliConnection(
               hostEpoch: connected.registration.hostEpoch,
             },
             reason: record?.state.kind === 'handoff' ? 'repair' : 'upgrade',
+            ...(!replacement
+              ? {
+                  recoveryBlocker:
+                    managed || connected.registration.lifecycleMode === 'service'
+                      ? ('managed' as const)
+                      : record
+                        ? ('owner' as const)
+                        : invocationOwned
+                          ? ('installation' as const)
+                          : ('identity' as const),
+                  diagnostic: [
+                    `Host compatibility: ${connected.registration.compatibilityEpoch}; client: ${RUNTIME_HOST_COMPATIBILITY_EPOCH}.`,
+                    installationFailure,
+                  ]
+                    .filter(Boolean)
+                    .join('\n'),
+                }
+              : {}),
             ...(connected.handshake?.activity ? { activity: connected.handshake.activity } : {}),
             mayExitNaturally:
               !managed &&

--- a/packages/cli/src/runtime-host-handoff-surface.ts
+++ b/packages/cli/src/runtime-host-handoff-surface.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { createInterface } from 'node:readline';
+import { clearLine, createInterface, cursorTo, type Interface } from 'node:readline';
 import { stripVTControlCharacters } from 'node:util';
 import type { Readable, Writable } from 'node:stream';
 import type { UiLocale } from '@maka/core/ui-locale';
@@ -27,35 +27,25 @@ import {
   type OpenHostHandoffSurface,
 } from '@maka/runtime-host/client';
 
-/** One readline lifetime renders the shared decision; it never selects replacement policy. */
+/** The surface owns terminal input; replacement policy stays in the shared handoff. */
 export function createCliHostHandoffSurface(
   locale: UiLocale,
   input: Readable = process.stdin,
   output: Writable & { isTTY?: boolean } = process.stderr,
 ): OpenHostHandoffSurface {
   return (submit) => {
-    const readline = createInterface({ input, output, terminal: output.isTTY === true });
+    let readline: Interface | undefined;
     let current: HostHandoffView | undefined;
     let closed = false;
     let ended = false;
+    const releaseReader = () => {
+      const previous = readline;
+      readline = undefined;
+      previous?.close();
+    };
     const cancel = () => {
       if (current) submit(current.revision, 'cancel');
     };
-    readline.on('SIGINT', cancel);
-    readline.on('close', () => {
-      ended = true;
-      if (!closed) cancel();
-    });
-    readline.on('line', (line) => {
-      if (!current) return;
-      const answer = line.trim().toLowerCase();
-      const action = answer === 'r' ? 'retry' : answer === 'stop' ? 'interrupt' : 'cancel';
-      if (!current.actions.includes(action)) {
-        readline.prompt();
-        return;
-      }
-      submit(current.revision, action);
-    });
     return {
       update(view) {
         if (closed || current?.revision === view.revision) return;
@@ -64,8 +54,13 @@ export function createCliHostHandoffSurface(
           cancel();
           return;
         }
-        // Discard partially typed consent when the observed target/consequences change.
-        if (output.isTTY) readline.write(null, { ctrl: true, name: 'u' });
+        // A new observation gets a new input buffer. Ctrl+U leaves text after
+        // the cursor intact and is ignored by readline in TERM=dumb.
+        releaseReader();
+        if (output.isTTY) {
+          clearLine(output, 0);
+          cursorTo(output, 0);
+        }
         const copy = formatHostHandoff(view, locale);
         const text = [copy.title, copy.description, copy.detail, view.diagnostic]
           .filter(Boolean)
@@ -82,12 +77,43 @@ export function createCliHostHandoffSurface(
           ({ action, label }) =>
             `${action === 'interrupt' ? 'stop' : action === 'retry' ? 'r' : 'Enter'}: ${label}`,
         );
-        readline.setPrompt(options.join(' · ') + ' > ');
-        readline.prompt();
+        // Create the reader only after the explanation is visible, with the
+        // final action prompt already installed. Never draw readline's default >.
+        const reader = createInterface({
+          input,
+          output,
+          terminal: output.isTTY === true,
+          prompt: options.join(' · ') + ' > ',
+        });
+        readline = reader;
+        reader.on('SIGINT', cancel);
+        reader.on('close', () => {
+          if (readline !== reader) return;
+          ended = true;
+          if (!closed) cancel();
+        });
+        reader.on('line', (line) => {
+          if (readline !== reader || current?.revision !== view.revision) return;
+          const answer = line.trim().toLowerCase();
+          const action =
+            answer === 'r'
+              ? 'retry'
+              : answer === 'stop'
+                ? 'interrupt'
+                : answer === ''
+                  ? 'cancel'
+                  : undefined;
+          if (!action || !view.actions.includes(action)) {
+            reader.prompt();
+            return;
+          }
+          submit(view.revision, action);
+        });
+        reader.prompt();
       },
       close() {
         closed = true;
-        readline.close();
+        releaseReader();
       },
     };
   };

--- a/packages/cli/src/runtime-host-local-handoff.ts
+++ b/packages/cli/src/runtime-host-local-handoff.ts
@@ -35,7 +35,11 @@ import {
   type RuntimeHostInstallationOwner,
 } from '@maka/runtime-host/operator';
 import { compareProductReleaseVersions } from '@maka/runtime-host/operator/update-package-evidence';
-import { connectExistingRuntimeHost } from '@maka/runtime-host/client';
+import {
+  connectExistingRuntimeHost,
+  forceTerminateObservedRegisteredRuntimeHost,
+  type RuntimeHostProcessIdentity,
+} from '@maka/runtime-host/client';
 import {
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
   RUNTIME_HOST_PROTOCOL_VERSION,
@@ -116,6 +120,7 @@ interface RuntimeHostLocalRestartDeps extends RuntimeHostLocalHandoffDeps {
     input: RuntimeHostTargetActivationInput,
   ) => Promise<RuntimeHostTargetActivation>;
   readonly retireSource: typeof launchRuntimeHostLocalSourceRetirement;
+  readonly terminateObservedHost: typeof forceTerminateObservedRegisteredRuntimeHost;
 }
 
 export type RuntimeHostLocalProcessLifecycleAdapter = Omit<
@@ -155,6 +160,7 @@ export async function restartRuntimeHostNpmGlobalDeployment(
   input: {
     readonly rootPath: string;
     readonly registration: HostRegistration;
+    readonly processIdentity?: RuntimeHostProcessIdentity;
     readonly installationOptions?: Parameters<typeof resolveRuntimeHostNpmGlobalInstallation>[0];
     readonly deploymentPathOptions?: RuntimeHostLocalDeploymentPathOptions;
     readonly activeWorkPolicy?: 'refuse_active_work' | 'interrupt_active_work';
@@ -183,6 +189,7 @@ export async function restartRuntimeHostNpmGlobalDeployment(
     connectExisting: connectExistingRuntimeHost,
     activateTarget: launchRuntimeHostTargetActivator,
     retireSource: launchRuntimeHostLocalSourceRetirement,
+    terminateObservedHost: forceTerminateObservedRegisteredRuntimeHost,
     ...overrides,
   };
   if (await deps.resolveManagedAuthority(input.registration.rootId)) {
@@ -361,6 +368,18 @@ export async function restartRuntimeHostNpmGlobalDeployment(
         throw new Error('The exact target did not activate after source retirement began');
       }
       return { kind: 'target_present' };
+    }
+    // Older source packages cannot negotiate retirement. Explicit consent may
+    // use Desktop's exact-process recovery, inside this existing deployment
+    // transaction and only after staging the verified successor.
+    if (activeWorkPolicy === 'interrupt_active_work' && input.processIdentity) {
+      input.signal?.throwIfAborted();
+      const stopped = await deps.terminateObservedHost(
+        { rootPath: input.rootPath, registration: input.registration },
+        { processIdentity: input.processIdentity, isCurrent: () => !input.signal?.aborted },
+      );
+      if (!stopped)
+        throw new Error('The observed Runtime Host changed before it could be stopped safely');
     }
     const activated = await activateExactTarget(
       rootId,

--- a/packages/runtime-host/src/client/host-handoff-copy.ts
+++ b/packages/runtime-host/src/client/host-handoff-copy.ts
@@ -36,7 +36,7 @@ export function formatHostHandoff(
     ? {
         busy: '背景服務仍在使用中',
         activity_unknown: '需要確認是否停止背景服務',
-        operator_required: '需要在服務所在位置處理',
+        operator_required: '背景服務需要手動更新',
         repair_required: '背景服務需要修復',
         retry_required: '暫時無法完成交接',
       }
@@ -44,14 +44,14 @@ export function formatHostHandoff(
       ? {
           busy: '后台服务仍在使用中',
           activity_unknown: '需要确认是否停止后台服务',
-          operator_required: '需要在服务所在位置处理',
+          operator_required: '后台服务需要手动更新',
           repair_required: '后台服务需要修复',
           retry_required: '暂时无法完成交接',
         }
       : {
           busy: 'Your background service is still in use',
           activity_unknown: 'Confirm before stopping the service',
-          operator_required: 'Action is needed where the service runs',
+          operator_required: 'The background service needs a manual update',
           repair_required: 'Your background service needs repair',
           retry_required: 'The handoff could not finish yet',
         };
@@ -59,8 +59,8 @@ export function formatHostHandoff(
     ? {
         busy: '其他連線或正在執行的工作阻止了自動交接。停止並繼續可能中斷這些工作。',
         activity_unknown:
-          '這個版本無法提供足夠的活動資訊。停止服務可能中斷其他視窗或裝置上的工作。',
-        operator_required: `目前的用戶端沒有替換此服務的權限。請在 ${view.target.name} 上，由管理該服務的使用者更新或停止服務。`,
+          '背景服務與目前用戶端不相容，且無法確認有哪些工作仍在執行。停止並繼續會重新啟動服務，可能中斷其他視窗或裝置上的工作。',
+        operator_required: `目前無法從這裡更新背景服務。請透過 ${view.target.name} 上管理此服務的應用程式或命令更新，再重試。`,
         repair_required: '上次啟動或交接未能完成。可以安全重試；若仍失敗，請複製診斷資訊。',
         retry_required: '服務狀態發生了變化，或交接尚未完成。可以安全重試，不會預設中斷工作。',
       }
@@ -68,21 +68,53 @@ export function formatHostHandoff(
       ? {
           busy: '其它连接或正在执行的工作阻止了自动交接。停止并继续可能中断这些工作。',
           activity_unknown:
-            '这个版本无法提供足够的活动信息。停止服务可能中断其它窗口或设备上的工作。',
-          operator_required: `当前客户端没有替换此服务的权限。请在 ${view.target.name} 上，由管理该服务的用户更新或停止服务。`,
+            '后台服务与当前客户端不兼容，且无法确认有哪些工作仍在运行。停止并继续会重新启动服务，可能中断其他窗口或设备上的工作。',
+          operator_required: `目前无法从这里更新后台服务。请通过 ${view.target.name} 上管理此服务的应用或命令更新，然后重试。`,
           repair_required: '上次启动或交接未能完成。可以安全重试；若仍失败，请复制诊断信息。',
           retry_required: '服务状态发生了变化，或交接尚未完成。可以安全重试，不会默认中断工作。',
         }
       : {
           busy: 'Other connections or work in progress prevent an automatic handoff. Stopping the service may interrupt that work.',
           activity_unknown:
-            'This version cannot provide enough activity information. Stopping it may interrupt work in other windows or on other devices.',
-          operator_required: `This client cannot replace the service. Ask its operator to update or stop it on ${view.target.name}.`,
+            'The background service is incompatible with this client, and its active work is unknown. Stop and continue restarts it and may interrupt work in other windows or devices.',
+          operator_required: `This client cannot update the background service here. Use its managing app or operator command on ${view.target.name}, then retry.`,
           repair_required:
             'The last startup or handoff did not finish. Retry safely, or copy diagnostics if it still fails.',
           retry_required:
             'The service changed or the handoff has not finished. A safe retry will not interrupt work by default.',
         };
+  if (view.recoveryBlocker && view.reason === 'operator_required') {
+    const guidance = zh
+      ? tw
+        ? {
+            managed:
+              '此背景服務由已安裝的管理程式維護。請在服務的管理應用程式中更新，再回到這裡重試。',
+            owner: '此背景服務屬於另一個 Maka 安裝。請使用管理它的 Maka 安裝更新，再重試。',
+            installation:
+              '這次啟動使用暫存安裝，無法接管現有背景服務。請使用已安裝的 Maka 更新服務，再重試。',
+            identity:
+              '無法確認舊背景服務的處理程序身分，因此不能安全停止它。請關閉啟動它的 Maka 或透過其管理程式停止服務，再重試。',
+          }
+        : {
+            managed: '此后台服务由已安装的管理程序维护。请在服务的管理应用中更新，再回到这里重试。',
+            owner: '此后台服务属于另一个 Maka 安装。请使用管理它的 Maka 安装更新，然后重试。',
+            installation:
+              '本次启动使用临时安装，无法接管现有后台服务。请使用已安装的 Maka 更新服务，然后重试。',
+            identity:
+              '无法确认旧后台服务的进程身份，因此不能安全停止它。请关闭启动它的 Maka 或通过其管理程序停止服务，然后重试。',
+          }
+      : {
+          managed:
+            'An installed operator manages this background service. Update it through its managing app, then return here and retry.',
+          owner:
+            'Another Maka installation owns this background service. Update it using that installation, then retry.',
+          installation:
+            'This temporary installation cannot take over the existing background service. Update it using an installed Maka, then retry.',
+          identity:
+            'The old background process could not be identified safely. Close the Maka instance that started it or stop it through its operator, then retry.',
+        };
+    descriptions.operator_required = guidance[view.recoveryBlocker];
+  }
   const activity = view.activity;
   const facts = activity
     ? tw
@@ -98,10 +130,10 @@ export function formatHostHandoff(
         ? 'Maka 会持续检查，并在可以安全继续时自动继续。'
         : 'Maka keeps checking and continues automatically when it is safe.'
     : tw
-      ? 'Maka 會持續檢查。常駐服務不會僅因等待而結束，可能需要你採取操作。'
+      ? 'Maka 會持續檢查。若狀態沒有改變，等待或重試不會解決此問題。'
       : zh
-        ? 'Maka 会持续检查。常驻服务不会仅因等待而退出，可能需要你采取操作。'
-        : 'Maka keeps checking. A persistent service will not exit just because you wait; action may be needed.';
+        ? 'Maka 会持续检查。若状态没有变化，等待或重试不会解决此问题。'
+        : 'Maka keeps checking. Waiting or retrying will not resolve this unless the service state changes.';
   const repairNotice =
     view.operation === 'repair'
       ? tw

--- a/packages/runtime-host/src/client/host-handoff.ts
+++ b/packages/runtime-host/src/client/host-handoff.ts
@@ -60,6 +60,8 @@ export type HostHandoffReplacementResult =
   | { readonly kind: 'completed' | 'active_work' | 'changed' }
   | { readonly kind: 'recovery_required'; readonly diagnostic: string };
 
+export type HostHandoffRecoveryBlocker = 'managed' | 'owner' | 'installation' | 'identity';
+
 export interface HostHandoffBlocker {
   /** Includes all authority evidence that invalidates consent when it changes. */
   readonly identity: string;
@@ -68,6 +70,7 @@ export interface HostHandoffBlocker {
   readonly activity?: HostActivitySnapshot;
   readonly mayExitNaturally: boolean;
   readonly replacement?: HostHandoffReplacement;
+  readonly recoveryBlocker?: HostHandoffRecoveryBlocker;
   readonly operatorStep?: string;
   readonly diagnostic?: string;
 }
@@ -93,6 +96,7 @@ export interface HostHandoffView {
   readonly phase?: HostHandoffPhase;
   readonly actions: readonly HostHandoffAction[];
   readonly defaultAction: 'cancel';
+  readonly recoveryBlocker?: HostHandoffRecoveryBlocker;
   readonly operatorStep?: string;
   readonly diagnostic?: string;
 }
@@ -337,6 +341,7 @@ function projectBlocker(
     ...(replacement ? { operation: replacement.kind } : {}),
     actions: replacement?.canInterrupt ? ['cancel', 'retry', 'interrupt'] : ['cancel', 'retry'],
     defaultAction: 'cancel',
+    ...(blocker.recoveryBlocker ? { recoveryBlocker: blocker.recoveryBlocker } : {}),
     ...(blocker.operatorStep ? { operatorStep: blocker.operatorStep } : {}),
     ...((recovery ?? blocker.diagnostic)
       ? { diagnostic: redactSecrets((recovery ?? blocker.diagnostic)!).slice(0, 8_192) }
@@ -356,6 +361,7 @@ function blockerSignature(blocker: HostHandoffBlocker): string {
     blocker.replacement?.canReplaceIdle,
     blocker.replacement?.canInterrupt,
     blocker.operatorStep,
+    blocker.recoveryBlocker,
     blocker.diagnostic,
   ]);
 }


### PR DESCRIPTION
## Summary

Source-linked CLI/TUI startup can get stuck telling the local user to find a service operator when an older, same-account ephemeral Host is incompatible. CLI now offers the same identity-checked, explicit stop used by Desktop for unmanaged Hosts. Legacy npm updates can use that recovery inside the existing staged deployment transaction; managed ownership and safe-only retries remain enforced.

Startup explains the blocker before displaying actions, distinguishes recovery blockers instead of calling every failure a permission problem, and no longer labels every blocked Host a persistent service. Each changed confirmation gets a fresh input buffer, including in `TERM=dumb`; invalid input simply prompts again. English, Simplified Chinese and Traditional Chinese follow the selected locale.

Fixes #5026

## Verification

- 135 tests passed across CLI context, terminal handoff, locale, local deployment handoff, shared handoff, process termination, Desktop manager and compatibility handshake suites.
- Runtime Host and CLI TypeScript builds passed; UI and Desktop test builds passed.
- Changed-file Biome lint/format, TUI copy boundaries, locale hygiene, ASF headers, Windows skip inventory and `git diff --check` passed.
- Read-only observation of the affected live Host confirmed the new stop capability. The test selected Cancel; the live Host was not stopped. Actual interruption and transaction outcomes are covered by controlled tests.
- Full repository test suite and Windows execution were not run locally.

Terminal evidence (Chinese locale selected):

Before:
```text
>
需要在服务所在位置处理
当前客户端没有替换此服务的权限。请在 Local 上，由管理该服务的用户更新或停止服务。
Maka 会持续检查。常驻服务不会仅因等待而退出，可能需要你采取操作。
Enter: 取消 · r: 安全重试 >
```

After, for the affected unmanaged Host:
```text
需要确认是否停止后台服务
后台服务与当前客户端不兼容，且无法确认有哪些工作仍在运行。停止并继续会重新启动服务，可能中断其他窗口或设备上的工作。
Maka 会持续检查。若状态没有变化，等待或重试不会解决此问题。
Enter: 取消 · r: 安全重试 · stop: 停止并继续 >
```

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the recovery and terminal changes, added tests, ran validation, and prepared this PR. The commit includes a `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
