### PR TITLE
fix(cli): separate failure outcomes from output sizes

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -2896,11 +2896,78 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(rendered, /● Read/);
     // The compact row names the failure even without ANSI color; free-text
     // error content stays out of the row and remains available when expanded.
-    assert.match(rendered, /\(error · 1 line · 32 bytes\)/);
+    assert.match(rendered, /● Read.*\(failed\)/);
+    // Error-text size must not look like successfully read resource content.
+    assert.doesNotMatch(rendered, /32 bytes/);
     assert.doesNotMatch(rendered, /background task no longer exists/);
     assert.ok(
       visibleWidth(rendered.split('\n').find((line) => line.includes('● Read')) ?? '') <= 80,
     );
+  });
+
+  test('keeps generic compact text outcomes distinct by real presentation status', () => {
+    const cases = [
+      {
+        id: 'generic-success',
+        toolName: 'mcp__local__result',
+        args: {},
+        isError: false,
+        content: { kind: 'text', text: 'ok\n' } as const,
+        expected: '(1 line · 3 bytes)',
+      },
+      {
+        id: 'generic-error',
+        toolName: 'mcp__local__result',
+        args: {},
+        isError: true,
+        content: { kind: 'text', text: 'failed because of a bad input' } as const,
+        expected: '(failed)',
+      },
+      {
+        id: 'subagent-failed',
+        toolName: 'agent_spawn',
+        args: { profile: 'local_read', task: 'read' },
+        isError: true,
+        content: subagentResult({ status: 'failed', summary: 'child failed' }),
+        expected: '(failed)',
+      },
+      {
+        id: 'subagent-aborted',
+        toolName: 'agent_spawn',
+        args: { profile: 'local_read', task: 'read' },
+        isError: true,
+        content: subagentResult({ status: 'cancelled', summary: 'child stopped' }),
+        expected: '(aborted)',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const state = createMakaPiTranscriptState();
+      applyMakaSessionEventToTranscript(
+        state,
+        event({
+          type: 'tool_start',
+          toolUseId: testCase.id,
+          toolName: testCase.toolName,
+          args: testCase.args,
+        }),
+      );
+      applyMakaSessionEventToTranscript(
+        state,
+        event({
+          type: 'tool_result',
+          toolUseId: testCase.id,
+          isError: testCase.isError,
+          content: testCase.content,
+        }),
+      );
+
+      const rendered = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+      assert.match(rendered, new RegExp(`\\(${testCase.expected.slice(1, -1)}\\)`));
+      if (testCase.expected === '(failed)' || testCase.expected === '(aborted)') {
+        assert.doesNotMatch(rendered, /bytes/);
+      }
+    }
   });
 
   test('surfaces a failed poll at the tail without rewriting scrollback', () => {

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -336,15 +336,13 @@ function compactToolSummary(entry: MakaPiToolEntry): CompactToolSummary | undefi
   ) {
     return { text: linesText(readBodyLineCount(text)), protect: true };
   }
-  const summary = textResultSummary(text);
   const status = makaPiToolPresentationStatus(entry);
-  // A red disc is not enough to identify a failed text result, especially
-  // under NO_COLOR. Keep the compact row bounded and secret-safe by adding
-  // only the stable presentation status; the full text remains expanded-only.
+  // Error-text size is not a successful read's size. Show only the outcome,
+  // including under NO_COLOR; the full reason remains in expanded details.
   if (status === 'error' || status === 'failed' || status === 'aborted') {
-    return { ...summary, text: `${status} · ${summary.text}` };
+    return { text: status === 'error' ? 'failed' : status, protect: true };
   }
-  return summary;
+  return textResultSummary(text);
 }
 
 function compactTerminalSummary(


### PR DESCRIPTION
## Summary

Show a failure-only compact summary for generic text tool failures: `failed` for an errored/failed call, and `aborted` for an interrupted call. Do not present the error message's line/byte counts as though they describe successfully read content. Full error text remains in expanded details. Successful summaries and specialized terminal/shell exit-code summaries are unchanged.

Refs #5016

Follow-up to merged #5028. Its failure label was correct, but retaining the error message's line/byte counts still looked like a successful read. This PR changes only that summary presentation and its regression coverage.

## Verification

Rendered output from the affected transcript scenario:

```text
before: ● Read ... (error · 1 line · 32 bytes)
after:  ● Read ... (failed)
```

Command:

```text
node --test packages/cli/dist/__tests__/pi-transcript.test.js
ℹ tests 115
ℹ pass 112
ℹ fail 0
ℹ skipped 3
```

Also passed:

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- Affected transcript tests: 112 passed, 3 existing Windows skips; includes generic success/error and subagent failed/cancelled outcomes.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex and GPT-5.6-luna contributed to implementation and review of the code and tests. Human review remains required before merging.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — failed text tool rows now expose their stable status in compact view
- [ ] No

<details>
<summary>中文说明</summary>

根据 UX 反馈，失败时不再展示错误文本的行数、大小，避免被误认为读取成功；错误/失败调用显示 `(failed)`，中止显示 `(aborted)`。成功摘要及命令已有退出码不变，具体错误仍在展开详情中查看。先前自动审查针对旧提交，新提交需要重新审查。

</details>
