### PR TITLE
perf(desktop): cache workspace file search

### DIFF
--- a/apps/desktop/src/main/__tests__/workspace-file-search.test.ts
+++ b/apps/desktop/src/main/__tests__/workspace-file-search.test.ts
@@ -20,10 +20,13 @@
 import { strict as assert } from 'node:assert';
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { ExecFileException } from 'node:child_process';
-import { searchWorkspaceFiles } from '../workspace-file-search.js';
+import {
+  createWorkspaceFileSearcher,
+  searchWorkspaceFiles,
+} from '../workspace-file-search.js';
 
 type ExecFileCallback = (
   file: string,
@@ -61,6 +64,332 @@ async function withPlainDir(run: (root: string) => Promise<void>): Promise<void>
 }
 
 describe('searchWorkspaceFiles', () => {
+  it('reuses one workspace enumeration across consecutive queries', async () => {
+    await withGitRepo(async (root) => {
+      let enumerations = 0;
+      const hundredThousandFiles = `${Array.from(
+        { length: 100_000 },
+        (_value, index) => `src/generated/file-${String(index).padStart(5, '0')}.ts`,
+      ).join('\0')}\0`;
+      const listed = fakeGit(hundredThousandFiles);
+      const searcher = createWorkspaceFileSearcher({
+        execFileImpl(file, args, options, callback) {
+          enumerations += 1;
+          listed(file, args, options, callback);
+        },
+      });
+
+      for (const query of Array.from(
+        { length: 20 },
+        (_value, index) => `file-${String(index).padStart(5, '0')}`,
+      )) {
+        const result = await searcher.search(root, { query });
+        assert.ok(result.ok);
+        assert.equal(result.ok ? result.files.length : 0, 1);
+      }
+
+      assert.equal(enumerations, 1);
+    });
+  });
+
+  it('shares an in-flight enumeration between concurrent queries', async () => {
+    await withGitRepo(async (root) => {
+      let enumerations = 0;
+      let finishEnumeration!: () => void;
+      const enumerationReady = new Promise<void>((resolve) => {
+        finishEnumeration = resolve;
+      });
+      const searcher = createWorkspaceFileSearcher({
+        canonicalizeRoot: async (projectRoot) => projectRoot,
+        execFileImpl(_file, _args, _options, callback) {
+          enumerations += 1;
+          void enumerationReady.then(() => callback(null, 'src/app.tsx\0docs/readme.md\0', ''));
+        },
+      });
+
+      const sourceSearch = searcher.search(root, { query: 'src' });
+      const docsSearch = searcher.search(root, { query: 'docs' });
+      while (enumerations === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      assert.equal(enumerations, 1);
+
+      finishEnumeration();
+      const [sourceResult, docsResult] = await Promise.all([sourceSearch, docsSearch]);
+      assert.deepEqual(sourceResult, {
+        ok: true,
+        files: [{ relativePath: 'src/app.tsx' }],
+      });
+      assert.deepEqual(docsResult, {
+        ok: true,
+        files: [{ relativePath: 'docs/readme.md' }],
+      });
+    });
+  });
+
+  it('refreshes the workspace after the cache TTL expires', async () => {
+    await withGitRepo(async (root) => {
+      let now = 1_000;
+      let enumerations = 0;
+      const searcher = createWorkspaceFileSearcher({
+        now: () => now,
+        ttlMs: 100,
+        execFileImpl(_file, _args, _options, callback) {
+          enumerations += 1;
+          const files = enumerations === 1
+            ? 'src/app.tsx\0'
+            : 'src/app.tsx\0src/new-file.ts\0';
+          callback(null, files, '');
+        },
+      });
+
+      assert.deepEqual(await searcher.search(root, { query: 'new-file' }), {
+        ok: true,
+        files: [],
+      });
+      now += 99;
+      assert.deepEqual(await searcher.search(root, { query: 'new-file' }), {
+        ok: true,
+        files: [],
+      });
+      assert.equal(enumerations, 1);
+
+      now += 1;
+      assert.deepEqual(await searcher.search(root, { query: 'new-file' }), {
+        ok: true,
+        files: [{ relativePath: 'src/new-file.ts' }],
+      });
+      assert.equal(enumerations, 2);
+    });
+  });
+
+  it('refreshes a non-git directory after the cache TTL expires', async () => {
+    await withPlainDir(async (root) => {
+      let now = 1_000;
+      await writeFile(join(root, 'existing.ts'), '', 'utf8');
+      const searcher = createWorkspaceFileSearcher({ now: () => now, ttlMs: 100 });
+
+      await searcher.search(root);
+      await writeFile(join(root, 'new-file.ts'), '', 'utf8');
+      assert.deepEqual(await searcher.search(root, { query: 'new-file' }), {
+        ok: true,
+        files: [],
+      });
+
+      now += 100;
+      assert.deepEqual(await searcher.search(root, { query: 'new-file' }), {
+        ok: true,
+        files: [{ relativePath: 'new-file.ts' }],
+      });
+    });
+  });
+
+  it('does not cache a fallback result after git enumeration fails', async () => {
+    await withGitRepo(async (root) => {
+      await writeFile(join(root, 'walked.ts'), '', 'utf8');
+      let enumerations = 0;
+      const searcher = createWorkspaceFileSearcher({
+        execFileImpl(_file, _args, _options, callback) {
+          enumerations += 1;
+          if (enumerations === 1) {
+            callback(new Error('temporary failure') as ExecFileException, '', 'fatal');
+            return;
+          }
+          callback(null, 'from-git.ts\0', '');
+        },
+      });
+
+      assert.deepEqual(await searcher.search(root, { query: 'walked' }), {
+        ok: true,
+        files: [{ relativePath: 'walked.ts' }],
+      });
+      assert.deepEqual(await searcher.search(root, { query: 'from-git' }), {
+        ok: true,
+        files: [{ relativePath: 'from-git.ts' }],
+      });
+      assert.equal(enumerations, 2);
+    });
+  });
+
+  it('keeps cached file lists isolated by canonical project root', async () => {
+    await withGitRepo(async (firstRoot) => {
+      await withGitRepo(async (secondRoot) => {
+        const enumerations = new Map<string, number>();
+        const searcher = createWorkspaceFileSearcher({
+          canonicalizeRoot: async (projectRoot) => projectRoot,
+          execFileImpl(_file, _args, options, callback) {
+            enumerations.set(options.cwd, (enumerations.get(options.cwd) ?? 0) + 1);
+            callback(
+              null,
+              options.cwd === firstRoot ? 'first-only.ts\0' : 'second-only.ts\0',
+              '',
+            );
+          },
+        });
+
+        assert.deepEqual(await searcher.search(firstRoot, { query: 'first' }), {
+          ok: true,
+          files: [{ relativePath: 'first-only.ts' }],
+        });
+        assert.deepEqual(await searcher.search(secondRoot, { query: 'second' }), {
+          ok: true,
+          files: [{ relativePath: 'second-only.ts' }],
+        });
+        assert.deepEqual(await searcher.search(firstRoot, { query: 'second' }), {
+          ok: true,
+          files: [],
+        });
+        assert.equal(enumerations.get(firstRoot), 1);
+        assert.equal(enumerations.get(secondRoot), 1);
+      });
+    });
+  });
+
+  it('shares a cache entry for equivalent project-root paths', async () => {
+    await withGitRepo(async (root) => {
+      let enumerations = 0;
+      let canonicalizations = 0;
+      const searcher = createWorkspaceFileSearcher({
+        async canonicalizeRoot(projectRoot) {
+          canonicalizations += 1;
+          return projectRoot;
+        },
+        execFileImpl(_file, _args, _options, callback) {
+          enumerations += 1;
+          callback(null, 'src/app.tsx\0', '');
+        },
+      });
+
+      await searcher.search(root);
+      await searcher.search(join(root, '.'));
+      await searcher.search(join(root, 'src', '..'));
+
+      assert.equal(resolve(join(root, 'src', '..')), root);
+      assert.equal(canonicalizations, 1);
+      assert.equal(enumerations, 1);
+    });
+  });
+
+  it('shares an in-flight canonical-root lookup', async () => {
+    await withGitRepo(async (root) => {
+      let canonicalizations = 0;
+      let finishCanonicalization!: () => void;
+      const canonicalizationReady = new Promise<void>((resolve) => {
+        finishCanonicalization = resolve;
+      });
+      const searcher = createWorkspaceFileSearcher({
+        async canonicalizeRoot(projectRoot) {
+          canonicalizations += 1;
+          await canonicalizationReady;
+          return projectRoot;
+        },
+        execFileImpl: fakeGit('src/app.tsx\0'),
+      });
+
+      const firstSearch = searcher.search(root);
+      const secondSearch = searcher.search(root);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(canonicalizations, 1);
+
+      finishCanonicalization();
+      await Promise.all([firstSearch, secondSearch]);
+    });
+  });
+
+  it('refreshes the canonical-root mapping after the cache TTL expires', async () => {
+    await withGitRepo(async (root) => {
+      let now = 1_000;
+      let canonicalizations = 0;
+      const searcher = createWorkspaceFileSearcher({
+        now: () => now,
+        ttlMs: 100,
+        async canonicalizeRoot(projectRoot) {
+          canonicalizations += 1;
+          return projectRoot;
+        },
+        execFileImpl: fakeGit('src/app.tsx\0'),
+      });
+
+      await searcher.search(root);
+      now += 99;
+      await searcher.search(root);
+      assert.equal(canonicalizations, 1);
+
+      now += 1;
+      await searcher.search(root);
+      assert.equal(canonicalizations, 2);
+    });
+  });
+
+  it('keeps caches isolated between workspace searcher instances', async () => {
+    await withGitRepo(async (root) => {
+      let enumerations = 0;
+      const createSearcher = () => createWorkspaceFileSearcher({
+        execFileImpl(_file, _args, _options, callback) {
+          enumerations += 1;
+          callback(null, 'shared-path.ts\0', '');
+        },
+      });
+
+      await createSearcher().search(root);
+      await createSearcher().search(root);
+
+      assert.equal(enumerations, 2);
+    });
+  });
+
+  it('evicts the least recently used ready workspace', async () => {
+    await withGitRepo(async (firstRoot) => {
+      await withGitRepo(async (secondRoot) => {
+        await withGitRepo(async (thirdRoot) => {
+          const enumerations = new Map<string, number>();
+          const searcher = createWorkspaceFileSearcher({
+            maxEntries: 2,
+            canonicalizeRoot: async (projectRoot) => projectRoot,
+            execFileImpl(_file, _args, options, callback) {
+              enumerations.set(options.cwd, (enumerations.get(options.cwd) ?? 0) + 1);
+              callback(null, `${options.cwd}.ts\0`, '');
+            },
+          });
+
+          await searcher.search(firstRoot);
+          await searcher.search(secondRoot);
+          await searcher.search(firstRoot);
+          await searcher.search(thirdRoot);
+          await searcher.search(secondRoot);
+
+          assert.equal(enumerations.get(firstRoot), 1);
+          assert.equal(enumerations.get(secondRoot), 2);
+          assert.equal(enumerations.get(thirdRoot), 1);
+        });
+      });
+    });
+  });
+
+  it('evicts ready workspaces when the cached path-byte budget is exceeded', async () => {
+    await withGitRepo(async (firstRoot) => {
+      await withGitRepo(async (secondRoot) => {
+        const enumerations = new Map<string, number>();
+        const searcher = createWorkspaceFileSearcher({
+          maxEntries: 10,
+          maxPathBytes: 30,
+          canonicalizeRoot: async (projectRoot) => projectRoot,
+          execFileImpl(_file, _args, options, callback) {
+            enumerations.set(options.cwd, (enumerations.get(options.cwd) ?? 0) + 1);
+            callback(null, '1234567890.ts\0', '');
+          },
+        });
+
+        await searcher.search(firstRoot);
+        await searcher.search(secondRoot);
+        await searcher.search(firstRoot);
+
+        assert.equal(enumerations.get(firstRoot), 2);
+        assert.equal(enumerations.get(secondRoot), 1);
+      });
+    });
+  });
+
   it('filters with AND-of-substring tokens, case-insensitively', async () => {
     await withGitRepo(async (root) => {
       const execFileImpl = fakeGit('src/app.tsx\0src/main.tsx\0docs/app.md\0');

--- a/apps/desktop/src/main/workspace-file-search.ts
+++ b/apps/desktop/src/main/workspace-file-search.ts
@@ -18,8 +18,8 @@
  */
 
 import { execFile, type ExecFileException } from 'node:child_process';
-import { readdir } from 'node:fs/promises';
-import { join, relative, sep } from 'node:path';
+import { readdir, realpath } from 'node:fs/promises';
+import { join, relative, resolve, sep } from 'node:path';
 import { resolveProjectGitInfo } from '@maka/runtime/system-prompt/project-context';
 
 /**
@@ -28,7 +28,9 @@ import { resolveProjectGitInfo } from '@maka/runtime/system-prompt/project-conte
  * when
  * the project root is a git repo (so .gitignore + untracked files are honored
  * exactly as the user expects) and fall back to a bounded recursive readdir
- * walk otherwise. `execFileImpl` is injectable so unit tests can fake git.
+ * walk otherwise. A searcher owns a short-lived, bounded LRU so repeated
+ * keystrokes reuse one sorted enumeration, including while its first load is
+ * still in flight. `execFileImpl` is injectable so unit tests can fake git.
  *
  * Returned `relativePath`s are always POSIX-style (forward slashes) and always
  * inside the project root — the git path list is repo-relative by construction,
@@ -41,6 +43,12 @@ export type WorkspaceFileSearchResult =
 
 const LS_TIMEOUT_MS = 3_000;
 const DEFAULT_LIMIT = 50;
+/** Short enough for newly-created files and branch switches to appear quickly. */
+const DEFAULT_CACHE_TTL_MS = 5_000;
+/** Host-scoped bound: project switches cannot grow the cache indefinitely. */
+const DEFAULT_CACHE_MAX_ENTRIES = 8;
+/** Keep cached path strings bounded even when several very large repos are open. */
+const DEFAULT_CACHE_MAX_PATH_BYTES = 64 * 1024 * 1024;
 /** Cap the fallback walk so a huge non-git tree can't stall the popup. */
 const MAX_WALK_ENTRIES = 5_000;
 const SKIP_DIRS = new Set(['.git', 'node_modules']);
@@ -52,6 +60,38 @@ type ExecFileCallback = (
   cb: (error: ExecFileException | null, stdout: string, stderr: string) => void,
 ) => void;
 
+export interface WorkspaceFileSearcher {
+  search(
+    projectRoot: string,
+    input?: { query?: unknown; limit?: unknown },
+  ): Promise<WorkspaceFileSearchResult>;
+}
+
+export interface WorkspaceFileSearcherOptions {
+  /** Test seam for the Git process boundary. */
+  execFileImpl?: ExecFileCallback;
+  /** Test seam for canonical path resolution. */
+  canonicalizeRoot?: (projectRoot: string) => Promise<string>;
+  /** Test seam for TTL expiry. */
+  now?: () => number;
+  ttlMs?: number;
+  maxEntries?: number;
+  maxPathBytes?: number;
+}
+
+type WorkspaceFileCacheEntry =
+  | { state: 'loading'; promise: Promise<readonly string[]> }
+  | {
+    state: 'ready';
+    sortedPaths: readonly string[];
+    pathBytes: number;
+    expiresAt: number;
+  };
+
+type CanonicalRootCacheEntry =
+  | { state: 'loading'; promise: Promise<string> }
+  | { state: 'ready'; canonicalRoot: string; expiresAt: number };
+
 /** AND-of-substring token match, case-insensitive — the same rule the composer
  *  uses client-side (kept local so the main process doesn't import @maka/ui). */
 function matchesAllTokens(tokens: readonly string[], text: string): boolean {
@@ -61,6 +101,17 @@ function matchesAllTokens(tokens: readonly string[], text: string): boolean {
 
 function toPosix(path: string): string {
   return sep === '/' ? path : path.split(sep).join('/');
+}
+
+function compareWorkspacePaths(left: string, right: string): number {
+  return left.length - right.length || left.localeCompare(right);
+}
+
+function estimatePathBytes(paths: readonly string[]): number {
+  // JavaScript strings can occupy up to two bytes per UTF-16 code unit. The
+  // estimate intentionally ignores array/object overhead; the entry limit is
+  // the secondary bound for that fixed per-path cost.
+  return paths.reduce((total, path) => total + path.length * 2, 0);
 }
 
 function runGitLsFiles(
@@ -87,14 +138,16 @@ function runGitLsFiles(
 /** Bounded recursive walk. Skips node_modules/.git, never recurses into
  *  symlinked directories (dirent.isDirectory() is false for a symlink), and
  *  stops once MAX_WALK_ENTRIES files are collected. */
-async function walkFiles(root: string): Promise<string[]> {
+async function walkFiles(root: string): Promise<{ files: string[]; rootReadable: boolean }> {
   const out: string[] = [];
   const stack: string[] = [root];
+  let rootReadable = false;
   while (stack.length > 0 && out.length < MAX_WALK_ENTRIES) {
     const dir = stack.pop()!;
     let entries;
     try {
       entries = await readdir(dir, { withFileTypes: true });
+      if (dir === root) rootReadable = true;
     } catch {
       continue; // unreadable dir — skip rather than fail the whole walk
     }
@@ -109,39 +162,216 @@ async function walkFiles(root: string): Promise<string[]> {
       // Symlinks (isDirectory()/isFile() both false) are intentionally ignored.
     }
   }
-  return out;
+  return { files: out, rootReadable };
+}
+
+async function enumerateWorkspaceFiles(
+  projectRoot: string,
+  execFileImpl: ExecFileCallback,
+): Promise<{ sortedPaths: readonly string[]; cacheable: boolean }> {
+  const info = await resolveProjectGitInfo(projectRoot);
+  if (info.isGitRepo) {
+    const listed = await runGitLsFiles(projectRoot, execFileImpl);
+    if (listed.ok) {
+      return { sortedPaths: listed.files.sort(compareWorkspacePaths), cacheable: true };
+    }
+    const walked = await walkFiles(projectRoot);
+    return { sortedPaths: walked.files.sort(compareWorkspacePaths), cacheable: false };
+  }
+
+  const walked = await walkFiles(projectRoot);
+  return {
+    sortedPaths: walked.files.sort(compareWorkspacePaths),
+    cacheable: walked.rootReadable,
+  };
+}
+
+/** The cache is already globally ranked, so a warm query can stop at `limit`. */
+function filterSortedPaths(
+  sortedPaths: readonly string[],
+  query: string,
+  limit: number,
+): Array<{ relativePath: string }> {
+  if (limit < 1) return [];
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+  const files: Array<{ relativePath: string }> = [];
+  for (const relativePath of sortedPaths) {
+    if (tokens.length > 0 && !matchesAllTokens(tokens, relativePath)) continue;
+    files.push({ relativePath });
+    if (files.length >= limit) break;
+  }
+  return files;
+}
+
+export function createWorkspaceFileSearcher(
+  options: WorkspaceFileSearcherOptions = {},
+): WorkspaceFileSearcher {
+  const execFileImpl = options.execFileImpl ?? (execFile as unknown as ExecFileCallback);
+  const canonicalizeRoot = options.canonicalizeRoot
+    ?? (async (projectRoot: string) => realpath(projectRoot).catch(() => projectRoot));
+  const now = options.now ?? Date.now;
+  const ttlMs = typeof options.ttlMs === 'number' && options.ttlMs > 0
+    ? options.ttlMs
+    : DEFAULT_CACHE_TTL_MS;
+  const maxEntries = typeof options.maxEntries === 'number' && options.maxEntries > 0
+    ? Math.floor(options.maxEntries)
+    : DEFAULT_CACHE_MAX_ENTRIES;
+  const maxPathBytes = typeof options.maxPathBytes === 'number' && options.maxPathBytes > 0
+    ? Math.floor(options.maxPathBytes)
+    : DEFAULT_CACHE_MAX_PATH_BYTES;
+  const cache = new Map<string, WorkspaceFileCacheEntry>();
+  const canonicalRoots = new Map<string, CanonicalRootCacheEntry>();
+  let cachedPathBytes = 0;
+
+  const touch = (key: string, entry: WorkspaceFileCacheEntry): void => {
+    cache.delete(key);
+    cache.set(key, entry);
+  };
+
+  const evictLeastRecentlyUsed = (): void => {
+    while (cache.size > maxEntries || cachedPathBytes > maxPathBytes) {
+      // In-flight loads stay deduplicated even during a burst across projects;
+      // completed entries are the only safe eviction candidates.
+      let oldestReady: [string, Extract<WorkspaceFileCacheEntry, { state: 'ready' }>]
+        | undefined;
+      for (const [key, entry] of cache) {
+        if (entry.state === 'ready') {
+          oldestReady = [key, entry];
+          break;
+        }
+      }
+      if (!oldestReady) break;
+      cache.delete(oldestReady[0]);
+      cachedPathBytes -= oldestReady[1].pathBytes;
+    }
+  };
+
+  const removeCacheEntry = (key: string, entry: WorkspaceFileCacheEntry): void => {
+    cache.delete(key);
+    if (entry.state === 'ready') cachedPathBytes -= entry.pathBytes;
+  };
+
+  const evictCanonicalRoots = (): void => {
+    while (canonicalRoots.size > maxEntries) {
+      const oldestReady = Array.from(canonicalRoots).find(
+        ([, entry]) => entry.state === 'ready',
+      );
+      if (!oldestReady) break;
+      canonicalRoots.delete(oldestReady[0]);
+    }
+  };
+
+  const canonicalRootFor = (projectRoot: string): Promise<string> => {
+    const lexicalRoot = resolve(projectRoot);
+    const cached = canonicalRoots.get(lexicalRoot);
+    if (cached?.state === 'loading') return cached.promise;
+    if (cached?.state === 'ready' && now() < cached.expiresAt) {
+      canonicalRoots.delete(lexicalRoot);
+      canonicalRoots.set(lexicalRoot, cached);
+      return Promise.resolve(cached.canonicalRoot);
+    }
+    canonicalRoots.delete(lexicalRoot);
+
+    const promise = canonicalizeRoot(lexicalRoot).then(
+      (canonicalRoot) => {
+        const current = canonicalRoots.get(lexicalRoot);
+        if (current?.state === 'loading' && current.promise === promise) {
+          canonicalRoots.delete(lexicalRoot);
+          canonicalRoots.set(lexicalRoot, {
+            state: 'ready',
+            canonicalRoot,
+            expiresAt: now() + ttlMs,
+          });
+          evictCanonicalRoots();
+        }
+        return canonicalRoot;
+      },
+      (error: unknown) => {
+        const current = canonicalRoots.get(lexicalRoot);
+        if (current?.state === 'loading' && current.promise === promise) {
+          canonicalRoots.delete(lexicalRoot);
+        }
+        throw error;
+      },
+    );
+    canonicalRoots.set(lexicalRoot, { state: 'loading', promise });
+    return promise;
+  };
+
+  const load = (canonicalRoot: string): Promise<readonly string[]> => {
+    const promise = enumerateWorkspaceFiles(canonicalRoot, execFileImpl).then(
+      ({ sortedPaths, cacheable }) => {
+        const current = cache.get(canonicalRoot);
+        if (current?.state === 'loading' && current.promise === promise) {
+          if (cacheable) {
+            const pathBytes = estimatePathBytes(sortedPaths);
+            touch(canonicalRoot, {
+              state: 'ready',
+              sortedPaths,
+              pathBytes,
+              expiresAt: now() + ttlMs,
+            });
+            cachedPathBytes += pathBytes;
+            evictLeastRecentlyUsed();
+          } else {
+            removeCacheEntry(canonicalRoot, current);
+          }
+        }
+        return sortedPaths;
+      },
+      (error: unknown) => {
+        const current = cache.get(canonicalRoot);
+        if (current?.state === 'loading' && current.promise === promise) {
+          removeCacheEntry(canonicalRoot, current);
+        }
+        throw error;
+      },
+    );
+    touch(canonicalRoot, { state: 'loading', promise });
+    evictLeastRecentlyUsed();
+    return promise;
+  };
+
+  const candidatesFor = async (canonicalRoot: string): Promise<readonly string[]> => {
+    const cached = cache.get(canonicalRoot);
+    if (cached?.state === 'loading') {
+      touch(canonicalRoot, cached);
+      return cached.promise;
+    }
+    if (cached?.state === 'ready') {
+      if (now() < cached.expiresAt) {
+        touch(canonicalRoot, cached);
+        return cached.sortedPaths;
+      }
+      removeCacheEntry(canonicalRoot, cached);
+    }
+    return load(canonicalRoot);
+  };
+
+  return {
+    async search(projectRoot, input = {}) {
+      if (typeof projectRoot !== 'string' || !projectRoot) {
+        return { ok: false, reason: 'no_project' };
+      }
+      const query = typeof input.query === 'string' ? input.query : '';
+      const limit = typeof input.limit === 'number' && input.limit > 0
+        ? Math.floor(input.limit)
+        : DEFAULT_LIMIT;
+
+      try {
+        const canonicalRoot = await canonicalRootFor(projectRoot);
+        const sortedPaths = await candidatesFor(canonicalRoot);
+        return { ok: true, files: filterSortedPaths(sortedPaths, query, limit) };
+      } catch {
+        return { ok: false, reason: 'search_failed' };
+      }
+    },
+  };
 }
 
 export async function searchWorkspaceFiles(
   projectRoot: string,
   input: { query?: unknown; limit?: unknown; execFileImpl?: ExecFileCallback } = {},
 ): Promise<WorkspaceFileSearchResult> {
-  if (typeof projectRoot !== 'string' || !projectRoot) {
-    return { ok: false, reason: 'no_project' };
-  }
-  const query = typeof input.query === 'string' ? input.query : '';
-  const limit = typeof input.limit === 'number' && input.limit > 0 ? Math.floor(input.limit) : DEFAULT_LIMIT;
-  const execFileImpl = input.execFileImpl ?? (execFile as unknown as ExecFileCallback);
-
-  try {
-    let candidates: string[];
-    const info = await resolveProjectGitInfo(projectRoot);
-    if (info.isGitRepo) {
-      const listed = await runGitLsFiles(projectRoot, execFileImpl);
-      candidates = listed.ok ? listed.files : await walkFiles(projectRoot);
-    } else {
-      candidates = await walkFiles(projectRoot);
-    }
-
-    const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
-    const filtered = tokens.length === 0
-      ? candidates
-      : candidates.filter((path) => matchesAllTokens(tokens, path));
-    // Rank shorter paths first (usually the closest / most relevant match),
-    // then lexicographically for a stable order.
-    filtered.sort((a, b) => a.length - b.length || a.localeCompare(b));
-    return { ok: true, files: filtered.slice(0, limit).map((relativePath) => ({ relativePath })) };
-  } catch {
-    return { ok: false, reason: 'search_failed' };
-  }
+  return createWorkspaceFileSearcher({ execFileImpl: input.execFileImpl }).search(projectRoot, input);
 }

--- a/apps/desktop/src/main/workspace-search-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-search-ipc-main.ts
@@ -18,7 +18,7 @@
  */
 
 import { ipcMain as electronIpcMain } from 'electron';
-import { searchWorkspaceFiles } from './workspace-file-search.js';
+import { createWorkspaceFileSearcher } from './workspace-file-search.js';
 import {
   handleReconnectableRead,
   type ReconnectableReadIpcMain,
@@ -32,6 +32,7 @@ export interface WorkspaceSearchIpcDeps {
 
 export function registerWorkspaceSearchIpc(deps: WorkspaceSearchIpcDeps): void {
   const ipcMain = deps.ipcMain ?? electronIpcMain;
+  const searcher = createWorkspaceFileSearcher();
   // Composer `@` mention popup: active sessions resolve from their persisted
   // cwd; the new-task surface resolves from the app project root. Git repos
   // honor .gitignore + untracked via `git ls-files`; other trees fall back to
@@ -45,6 +46,6 @@ export function registerWorkspaceSearchIpc(deps: WorkspaceSearchIpcDeps): void {
       projectId?: unknown;
     };
     const projectPath = await deps.getProjectRoot(request.sessionId, request.projectId);
-    return searchWorkspaceFiles(projectPath, { query: request.query, limit: request.limit });
+    return searcher.search(projectPath, { query: request.query, limit: request.limit });
   });
 }


### PR DESCRIPTION
## Summary

Cache the workspace file enumeration used by composer `@` mentions so consecutive queries reuse the same sorted path list instead of spawning and parsing `git ls-files` for every keystroke.

- key entries by canonical project root and scope each cache to its Runtime Host IPC registration
- coalesce concurrent misses, sort once, and stop filtering after the requested limit
- expire entries after 5 seconds and bound them by LRU project count plus an estimated 64 MiB path-string budget
- avoid caching degraded Git-fallback results so transient failures can recover immediately

Fixes #5039

## Benchmark

Measured against a real local Apache HBase checkout (`~/Development/Code/Github/hbase`, 3.8 GB, 6,631 candidates from `git ls-files -z --cached --others --exclude-standard`). Each round issued the same 20 progressive queries from `h` through `hbase-client/src/main/j` with a result limit of 50.

The benchmark used 3 warm-up rounds followed by 25 measured rounds, alternating `origin/main` and this PR to reduce ordering bias. Each PR round created a fresh searcher, so its first query was application-cache cold and the remaining 19 were warm. OS filesystem caches were not flushed. Every baseline/PR result was asserted equal.

| Metric | `origin/main` | This PR | Change |
| --- | ---: | ---: | ---: |
| 20-query burst, median | 1,309.5 ms | 66.8 ms | 19.6x faster (-94.9%) |
| 20-query burst, p95 | 1,664.7 ms | 79.5 ms | 20.9x faster (-95.2%) |
| Git subprocesses per burst | 20 | 1 | -95% |
| Application-cold first query, median | — | 65.5 ms | comparable to one baseline query |
| Warm query, median | 63.05 ms baseline/query | 0.092 ms | 685x faster |
| Warm query, p95 | — | 0.108 ms | — |

Environment: macOS arm64 (`Mac16,7`), Node 24.14.0, Git 2.52.0. This measures warm-OS-cache interactive behavior, not a machine-reboot cold start.

## Verification

- `node --test --test-force-exit "apps/desktop/dist/main/__tests__/workspace-file-search.test.js"` — 19/19 passed, including a 100k-file fixture with 20 queries and one enumeration
- `npm --workspace @maka/desktop run test:dist` — 2519/2519 passed
- `npm --workspace @maka/desktop run typecheck` — passed
- `npx biome lint apps/desktop/src/main/workspace-file-search.ts apps/desktop/src/main/workspace-search-ipc-main.ts apps/desktop/src/main/__tests__/workspace-file-search.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed
- Desktop sources are intentionally excluded from the repository Biome formatter per `biome.jsonc`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the cache, tests, validation, benchmark, and review support. The commit includes the required `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format policy, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No