### PR TITLE
fix(runtime): abort pending TLS connections on transport close

### DIFF
--- a/packages/runtime/src/bots/proxied-fetch.ts
+++ b/packages/runtime/src/bots/proxied-fetch.ts
@@ -40,14 +40,14 @@ export async function proxiedFetch(
   const url =
     typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
   const proxy = resolveActiveProxy();
-  let dispatcher: Dispatcher | undefined;
-  if (proxy && !matchesBypassList(new URL(url).hostname, proxy.bypassList)) {
-    dispatcher = buildProxyDispatcher(proxy) as Dispatcher;
-  }
   const { timeoutMs = DEFAULT_TIMEOUT_MS, signal, ...fetchInit } = init;
-  const timeoutEnabled = timeoutMs > 0;
   const controller = new AbortController();
   const requestSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal;
+  let dispatcher: Dispatcher | undefined;
+  if (proxy && !matchesBypassList(new URL(url).hostname, proxy.bypassList)) {
+    dispatcher = buildProxyDispatcher(proxy, requestSignal) as Dispatcher;
+  }
+  const timeoutEnabled = timeoutMs > 0;
   let timedOut = false;
 
   const disposeDispatcher = async (force = false) => {
@@ -95,6 +95,7 @@ export async function proxiedFetch(
       : ((await request) as unknown as Response);
   } catch (error) {
     if (timer) clearTimeout(timer);
+    controller.abort(error);
     await disposeDispatcher(timedOut);
     throw error;
   }

--- a/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
+++ b/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
@@ -20,6 +20,7 @@
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import net from 'node:net';
+import { withTimeout } from '@maka/core/test-only/async-primitives';
 import { describe, test } from 'node:test';
 import { PROXY_DEFAULTS, type ProxySettings } from '@maka/core/settings/network-settings';
 import {
@@ -31,8 +32,178 @@ import {
 import { runConnectionModelDiscoveryEffect } from '../../model-fetcher.js';
 import { runConnectionTestEffect, testConnection } from '../../test-connection.js';
 import { createConnectionEffectFetchTransport } from '../scoped-fetch-transport.js';
+import { testProxyConnection } from '../proxy-test.js';
+import { proxiedFetch } from '../../bots/proxied-fetch.js';
+import { setActiveProxy } from '../active-proxy-state.js';
 
 describe('connection effect network transport', () => {
+  for (const authenticated of [false, true]) {
+    test(`SOCKS preserves remote DNS and successful HTTP responses (auth: ${authenticated})`, async () => {
+      const proxy = await startStalledProxy(authenticated ? 'socks-auth-http' : 'socks-http');
+      const transport = createConnectionEffectFetchTransport({
+        ...PROXY_DEFAULTS,
+        enabled: true,
+        type: 'socks5',
+        host: '127.0.0.1',
+        port: proxy.port,
+        username: authenticated ? 'proxy-user' : '',
+        password: authenticated ? 'proxy-password' : '',
+        bypassList: [],
+      });
+      try {
+        const response = await withTimeout(
+          transport.fetch('http://provider.invalid/models'),
+          2_000,
+          'SOCKS request did not finish',
+        );
+        assert.equal(response.status, 200);
+        assert.equal(await response.text(), 'proxy-ok');
+      } finally {
+        await transport.close();
+        await proxy.close();
+      }
+    });
+  }
+
+  for (const type of ['http', 'https', 'socks5'] as const) {
+    test(`immediate close rejects pending and subsequent requests (${type})`, async () => {
+      const transport = createConnectionEffectFetchTransport({
+        ...PROXY_DEFAULTS,
+        enabled: true,
+        type,
+        host: '127.0.0.1',
+        port: 1,
+        bypassList: [],
+      });
+      const request = assert.rejects(transport.fetch('https://provider.invalid/models'));
+      const closed = transport.close();
+      assert.equal(transport.close(), closed);
+      await withTimeout(Promise.all([request, closed]), 2_000, 'immediate close did not finish');
+      await assert.rejects(
+        transport.fetch('https://provider.invalid/models'),
+        /transport is closed/,
+      );
+    });
+  }
+
+  test('proxy connection probe timeout releases its pending TLS tunnel', async () => {
+    const proxy = await startStalledProxy('http-tls');
+    const settings = {
+      ...PROXY_DEFAULTS,
+      enabled: true,
+      type: 'http' as const,
+      host: '127.0.0.1',
+      port: proxy.port,
+      bypassList: [],
+    };
+    const request = testProxyConnection({
+      proxy: settings,
+      url: 'https://provider.invalid/models',
+      timeoutMs: 500,
+    });
+    try {
+      await withTimeout(proxy.started, 2_000, 'probe did not start TLS');
+      const closed = waitForSocketClose([...proxy.sockets][0]!);
+      const result = await withTimeout(request, 2_000, 'probe did not time out');
+      assert.equal(result.ok, false);
+      assert.match(result.error ?? '', /timeout/i);
+      await withTimeout(closed, 1_000, 'probe TLS socket survived timeout');
+    } finally {
+      await proxy.close();
+      await request;
+    }
+  });
+
+  for (const abortRequest of [false, true]) {
+    test(`bot proxy fetch releases pending TLS (caller abort: ${abortRequest})`, async () => {
+      const proxy = await startStalledProxy('http-tls');
+      setActiveProxy({
+        ...PROXY_DEFAULTS,
+        enabled: true,
+        type: 'http',
+        host: '127.0.0.1',
+        port: proxy.port,
+        bypassList: [],
+      });
+      const abort = new AbortController();
+      const request = proxiedFetch('https://provider.invalid/models', {
+        signal: abort.signal,
+        timeoutMs: abortRequest ? 0 : 500,
+      }).catch((error: unknown) => error);
+      try {
+        await withTimeout(proxy.started, 2_000, 'bot fetch did not start TLS');
+        const closed = waitForSocketClose([...proxy.sockets][0]!);
+        if (abortRequest) abort.abort();
+        assert.ok(
+          (await withTimeout(request, 2_000, 'bot fetch did not terminate')) instanceof Error,
+        );
+        await withTimeout(closed, 1_000, 'bot TLS socket survived cancellation');
+      } finally {
+        abort.abort();
+        await proxy.close();
+        await request;
+        setActiveProxy(null);
+      }
+    });
+  }
+
+  for (const stage of [
+    'http-connect',
+    'http-tls',
+    'https-proxy-tls',
+    'socks-greeting',
+    'socks-connect',
+    'socks-tls',
+  ] as const) {
+    for (const abortRequest of [false, true]) {
+      test(`close releases pending ${stage} (request aborted: ${abortRequest})`, {
+        timeout: 5_000,
+      }, async () => {
+        const proxy = await startStalledProxy(stage);
+        const transport = createConnectionEffectFetchTransport({
+          ...PROXY_DEFAULTS,
+          enabled: true,
+          type: stage.startsWith('socks')
+            ? 'socks5'
+            : stage === 'https-proxy-tls'
+              ? 'https'
+              : 'http',
+          host: '127.0.0.1',
+          port: proxy.port,
+          bypassList: [],
+        });
+        const abort = new AbortController();
+        const request = transport
+          .fetch('https://provider.invalid/models', { signal: abort.signal })
+          .catch(() => undefined);
+        let deadline: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await withTimeout(proxy.started, 2_000, `${stage} did not start`);
+          const socket = [...proxy.sockets][0]!;
+          const closed = waitForSocketClose(socket);
+          if (abortRequest) abort.abort();
+          await transport.close();
+          await Promise.race([
+            closed,
+            new Promise<never>((_resolve, reject) => {
+              deadline = setTimeout(
+                () => reject(new Error(`${stage} socket survived transport.close()`)),
+                1_000,
+              );
+            }),
+          ]);
+          await request;
+        } finally {
+          clearTimeout(deadline);
+          abort.abort();
+          await transport.close();
+          await proxy.close();
+          await request;
+        }
+      });
+    }
+  }
+
   for (const abortRequest of [false, true]) {
     test(`close releases a pending TLS handshake (request aborted: ${abortRequest})`, async () => {
       const sockets = new Set<net.Socket>();
@@ -448,6 +619,89 @@ describe('connection effect network transport', () => {
     }
   });
 });
+
+async function startStalledProxy(stage: string) {
+  const sockets = new Set<net.Socket>();
+  let started!: () => void;
+  const reachedStage = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    socket.on('error', () => {});
+    let phase = stage.startsWith('socks')
+      ? 'greeting'
+      : stage === 'https-proxy-tls'
+        ? 'tls'
+        : 'http';
+    let buffer = Buffer.alloc(0);
+    socket.on('data', (chunk) => {
+      buffer = Buffer.concat([buffer, Buffer.from(chunk)]);
+      if (phase === 'tls') {
+        assert.equal(buffer[0], 22, 'expected a TLS handshake record');
+        phase = 'stalled';
+        started();
+      } else if (phase === 'http' && buffer.includes('\r\n\r\n')) {
+        assert.match(buffer.toString('latin1'), /^CONNECT provider\.invalid:443 /);
+        buffer = Buffer.alloc(0);
+        if (stage === 'http-connect') {
+          phase = 'stalled';
+          started();
+        } else {
+          phase = 'tls';
+          socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        }
+      } else if (phase === 'response' && buffer.includes('\r\n\r\n')) {
+        assert.match(buffer.toString('latin1'), /^GET \/models /);
+        phase = 'done';
+        socket.end(jsonResponse(200, 'proxy-ok'));
+      } else if (phase === 'greeting' && buffer.length >= 2 + buffer[1]!) {
+        assert.equal(buffer[0], 5);
+        if (stage === 'socks-auth-http') assert.ok(buffer.subarray(2).includes(2));
+        buffer = Buffer.alloc(0);
+        if (stage === 'socks-greeting') {
+          phase = 'stalled';
+          started();
+        } else {
+          phase = stage === 'socks-auth-http' ? 'auth' : 'socks-connect';
+          socket.write(Buffer.from([5, stage === 'socks-auth-http' ? 2 : 0]));
+        }
+      } else if (phase === 'auth' && buffer.length >= 3 + buffer[1]!) {
+        const nameLength = buffer[1]!;
+        const passwordLength = buffer[2 + nameLength]!;
+        if (buffer.length < 3 + nameLength + passwordLength) return;
+        assert.equal(buffer[0], 1);
+        assert.equal(buffer.subarray(2, 2 + nameLength).toString(), 'proxy-user');
+        assert.equal(buffer.subarray(3 + nameLength).toString(), 'proxy-password');
+        buffer = Buffer.alloc(0);
+        phase = 'socks-connect';
+        socket.write(Buffer.from([1, 0]));
+      } else if (phase === 'socks-connect' && buffer.length >= 5) {
+        assert.equal(buffer[3], 3, 'the destination hostname must be resolved by the proxy');
+        if (buffer.length < 7 + buffer[4]!) return;
+        assert.equal(buffer.subarray(5, 5 + buffer[4]!).toString(), 'provider.invalid');
+        buffer = Buffer.alloc(0);
+        if (stage === 'socks-connect') {
+          phase = 'stalled';
+          started();
+        } else {
+          phase = stage.endsWith('-http') ? 'response' : 'tls';
+          socket.write(Buffer.from([5, 0, 0, 1, 127, 0, 0, 1, 0, 80]));
+        }
+      }
+    });
+  });
+  return {
+    port: await listen(server),
+    sockets,
+    started: reachedStage,
+    async close() {
+      for (const socket of sockets) socket.destroy();
+      await closeServer(server);
+    },
+  };
+}
 
 function openAiConnection(slug: string) {
   return {

--- a/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
+++ b/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
@@ -33,6 +33,59 @@ import { runConnectionTestEffect, testConnection } from '../../test-connection.j
 import { createConnectionEffectFetchTransport } from '../scoped-fetch-transport.js';
 
 describe('connection effect network transport', () => {
+  for (const abortRequest of [false, true]) {
+    test(`close releases a pending TLS handshake (request aborted: ${abortRequest})`, async () => {
+      const sockets = new Set<net.Socket>();
+      let handshakeStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        handshakeStarted = resolve;
+      });
+      const server = net.createServer((socket) => {
+        sockets.add(socket);
+        socket.once('close', () => sockets.delete(socket));
+        // Read the ClientHello but never answer it. No external networking or
+        // certificate configuration is needed to hold the connector in flight.
+        socket.once('data', handshakeStarted);
+        socket.resume();
+      });
+      const port = await listen(server);
+      const transport = createConnectionEffectFetchTransport(null);
+      const abort = new AbortController();
+      const request = transport
+        .fetch(`https://127.0.0.1:${port}/models`, {
+          signal: abort.signal,
+        })
+        .catch(() => undefined);
+      let deadline: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await started;
+        const socket = [...sockets][0]!;
+        const closed = waitForSocketClose(socket);
+        if (abortRequest) abort.abort();
+        await transport.close();
+        // Observe peer closure before the connector's own 10 s timeout could
+        // hide an unowned socket. This is a failure bound, not a fixed sleep.
+        await Promise.race([
+          closed,
+          new Promise<never>((_resolve, reject) => {
+            deadline = setTimeout(
+              () => reject(new Error('TLS socket survived transport.close()')),
+              1_000,
+            );
+          }),
+        ]);
+        await request;
+      } finally {
+        clearTimeout(deadline);
+        abort.abort();
+        await transport.close();
+        for (const socket of sockets) socket.destroy();
+        await closeServer(server);
+        await request;
+      }
+    });
+  }
+
   test('concurrent discovery uses immutable per-effect proxy snapshots', async () => {
     const firstProxy = await startConnectProxy(() =>
       jsonResponse(200, modelPayload('first-model')),

--- a/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
+++ b/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
@@ -20,7 +20,9 @@
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import net from 'node:net';
-import { withTimeout } from '@maka/core/test-only/async-primitives';
+import { getEventListeners } from 'node:events';
+import { Agent, fetch as undiciFetch } from 'undici';
+import { waitFor, withTimeout } from '@maka/core/test-only/async-primitives';
 import { describe, test } from 'node:test';
 import { PROXY_DEFAULTS, type ProxySettings } from '@maka/core/settings/network-settings';
 import {
@@ -35,8 +37,142 @@ import { createConnectionEffectFetchTransport } from '../scoped-fetch-transport.
 import { testProxyConnection } from '../proxy-test.js';
 import { proxiedFetch } from '../../bots/proxied-fetch.js';
 import { setActiveProxy } from '../active-proxy-state.js';
+import { buildProxyDispatcher } from '../proxy-dispatcher.js';
+import { buildAbortableConnector } from '../abortable-connector.js';
 
 describe('connection effect network transport', () => {
+  for (const type of ['direct', 'http', 'socks5'] as const) {
+    test(`closed successful connections do not accumulate abort listeners (${type})`, async () => {
+      const server = createServer((_request, response) => {
+        response.writeHead(200, { connection: 'close' });
+        response.end('proxy-ok');
+      });
+      const port = await listen(server);
+      const socks = type === 'socks5' ? await startStalledProxy('socks-http') : undefined;
+      const controller = new AbortController();
+      const dispatcher =
+        type === 'direct'
+          ? new Agent({ connect: buildAbortableConnector(controller.signal) })
+          : buildProxyDispatcher(
+              {
+                ...PROXY_DEFAULTS,
+                enabled: true,
+                type,
+                host: '127.0.0.1',
+                port: socks?.port ?? port,
+                bypassList: [],
+              },
+              controller.signal,
+            );
+      try {
+        for (let index = 0; index < 25; index++) {
+          const response = await undiciFetch(
+            type === 'direct'
+              ? `http://127.0.0.1:${port}/models`
+              : 'http://provider.invalid/models',
+            { dispatcher },
+          );
+          assert.equal(await response.text(), 'proxy-ok');
+          // Socket close is delivered after the body. Wait for I/O, not GC.
+          await waitFor(() => getEventListeners(controller.signal, 'abort').length === 0, {
+            timeoutMs: 1_000,
+            message: 'closed socket retained an abort listener',
+          });
+        }
+      } finally {
+        controller.abort();
+        await dispatcher.destroy();
+        await socks?.close();
+        await closeServer(server);
+      }
+    });
+  }
+
+  for (const stage of [
+    'direct',
+    'http-tls',
+    'https-proxy-tls',
+    'https-proxy-tls-forward',
+    'socks-tls',
+  ] as const) {
+    test(`failed TLS connections do not accumulate abort listeners (${stage})`, async () => {
+      const proxy = await startStalledProxy(stage === 'direct' ? 'https-proxy-tls' : stage, true);
+      const controller = new AbortController();
+      const dispatcher =
+        stage === 'direct'
+          ? new Agent({ connect: buildAbortableConnector(controller.signal) })
+          : buildProxyDispatcher(
+              {
+                ...PROXY_DEFAULTS,
+                enabled: true,
+                type:
+                  stage === 'socks-tls'
+                    ? 'socks5'
+                    : stage.startsWith('https-proxy-tls')
+                      ? 'https'
+                      : 'http',
+                host: '127.0.0.1',
+                port: proxy.port,
+                bypassList: [],
+              },
+              controller.signal,
+            );
+      try {
+        for (let index = 0; index < 25; index++) {
+          await assert.rejects(
+            undiciFetch(
+              stage === 'direct'
+                ? `https://127.0.0.1:${proxy.port}/models`
+                : `${stage.endsWith('-forward') ? 'http' : 'https'}://provider.invalid/models`,
+              { dispatcher },
+            ),
+          );
+          await waitFor(() => getEventListeners(controller.signal, 'abort').length === 0, {
+            timeoutMs: 1_000,
+            message: 'failed TLS socket retained an abort listener',
+          });
+        }
+      } finally {
+        controller.abort();
+        await dispatcher.destroy();
+        await proxy.close();
+      }
+    });
+  }
+
+  test('SOCKS leaves the negotiation deadline to SocksClient after TCP connects', async (t) => {
+    const proxy = await startStalledProxy('socks-greeting');
+    const sockets = new Set<net.Socket>();
+    const original = net.Socket.prototype.setTimeout;
+    t.mock.method(
+      net.Socket.prototype,
+      'setTimeout',
+      function (this: net.Socket, ...args: Parameters<typeof original>) {
+        sockets.add(this);
+        return original.apply(this, args);
+      },
+    );
+    const transport = createConnectionEffectFetchTransport({
+      ...PROXY_DEFAULTS,
+      enabled: true,
+      type: 'socks5',
+      host: '127.0.0.1',
+      port: proxy.port,
+      bypassList: [],
+    });
+    const request = transport.fetch('https://provider.invalid/models').catch(() => undefined);
+    try {
+      await withTimeout(proxy.started, 2_000, 'SOCKS greeting did not start');
+      const socket = [...sockets].find((entry) => entry.remotePort === proxy.port);
+      assert.ok(socket);
+      assert.equal(socket.timeout, 0, 'TCP timeout must be cleared before SOCKS negotiation');
+    } finally {
+      await transport.close();
+      await proxy.close();
+      await request;
+    }
+  });
+
   for (const authenticated of [false, true]) {
     test(`SOCKS preserves remote DNS and successful HTTP responses (auth: ${authenticated})`, async () => {
       const proxy = await startStalledProxy(authenticated ? 'socks-auth-http' : 'socks-http');
@@ -67,22 +203,34 @@ describe('connection effect network transport', () => {
 
   for (const type of ['http', 'https', 'socks5'] as const) {
     test(`immediate close rejects pending and subsequent requests (${type})`, async () => {
+      const proxy = await startStalledProxy(
+        type === 'socks5'
+          ? 'socks-greeting'
+          : type === 'https'
+            ? 'https-proxy-tls'
+            : 'http-connect',
+      );
       const transport = createConnectionEffectFetchTransport({
         ...PROXY_DEFAULTS,
         enabled: true,
         type,
         host: '127.0.0.1',
-        port: 1,
+        port: proxy.port,
         bypassList: [],
       });
-      const request = assert.rejects(transport.fetch('https://provider.invalid/models'));
-      const closed = transport.close();
-      assert.equal(transport.close(), closed);
-      await withTimeout(Promise.all([request, closed]), 2_000, 'immediate close did not finish');
-      await assert.rejects(
-        transport.fetch('https://provider.invalid/models'),
-        /transport is closed/,
-      );
+      try {
+        const request = assert.rejects(transport.fetch('https://provider.invalid/models'));
+        const closed = transport.close();
+        assert.equal(transport.close(), closed);
+        await withTimeout(Promise.all([request, closed]), 2_000, 'immediate close did not finish');
+        await assert.rejects(
+          transport.fetch('https://provider.invalid/models'),
+          /transport is closed/,
+        );
+      } finally {
+        await transport.close();
+        await proxy.close();
+      }
     });
   }
 
@@ -151,6 +299,7 @@ describe('connection effect network transport', () => {
     'http-connect',
     'http-tls',
     'https-proxy-tls',
+    'https-proxy-tls-forward',
     'socks-greeting',
     'socks-connect',
     'socks-tls',
@@ -165,7 +314,7 @@ describe('connection effect network transport', () => {
           enabled: true,
           type: stage.startsWith('socks')
             ? 'socks5'
-            : stage === 'https-proxy-tls'
+            : stage.startsWith('https-proxy-tls')
               ? 'https'
               : 'http',
           host: '127.0.0.1',
@@ -173,9 +322,11 @@ describe('connection effect network transport', () => {
           bypassList: [],
         });
         const abort = new AbortController();
-        const request = transport
-          .fetch('https://provider.invalid/models', { signal: abort.signal })
-          .catch(() => undefined);
+        const request = fetchForConnectionEffect(
+          transport.fetch,
+          `${stage.endsWith('-forward') ? 'http' : 'https'}://provider.invalid/models`,
+          { signal: abort.signal, timeoutMs: 0 },
+        ).catch((error: unknown) => error);
         let deadline: ReturnType<typeof setTimeout> | undefined;
         try {
           await withTimeout(proxy.started, 2_000, `${stage} did not start`);
@@ -192,7 +343,9 @@ describe('connection effect network transport', () => {
               );
             }),
           ]);
-          await request;
+          const outcome = await request;
+          assert.ok(outcome instanceof ConnectionEffectFetchError);
+          assert.equal(outcome.kind, 'network');
         } finally {
           clearTimeout(deadline);
           abort.abort();
@@ -222,11 +375,14 @@ describe('connection effect network transport', () => {
       const port = await listen(server);
       const transport = createConnectionEffectFetchTransport(null);
       const abort = new AbortController();
-      const request = transport
-        .fetch(`https://127.0.0.1:${port}/models`, {
+      const request = fetchForConnectionEffect(
+        transport.fetch,
+        `https://127.0.0.1:${port}/models`,
+        {
           signal: abort.signal,
-        })
-        .catch(() => undefined);
+          timeoutMs: 0,
+        },
+      ).catch((error: unknown) => error);
       let deadline: ReturnType<typeof setTimeout> | undefined;
       try {
         await started;
@@ -245,7 +401,9 @@ describe('connection effect network transport', () => {
             );
           }),
         ]);
-        await request;
+        const outcome = await request;
+        assert.ok(outcome instanceof ConnectionEffectFetchError);
+        assert.equal(outcome.kind, 'network');
       } finally {
         clearTimeout(deadline);
         abort.abort();
@@ -620,7 +778,7 @@ describe('connection effect network transport', () => {
   });
 });
 
-async function startStalledProxy(stage: string) {
+async function startStalledProxy(stage: string, rejectTls = false) {
   const sockets = new Set<net.Socket>();
   let started!: () => void;
   const reachedStage = new Promise<void>((resolve) => {
@@ -632,7 +790,7 @@ async function startStalledProxy(stage: string) {
     socket.on('error', () => {});
     let phase = stage.startsWith('socks')
       ? 'greeting'
-      : stage === 'https-proxy-tls'
+      : stage.startsWith('https-proxy-tls')
         ? 'tls'
         : 'http';
     let buffer = Buffer.alloc(0);
@@ -642,6 +800,7 @@ async function startStalledProxy(stage: string) {
         assert.equal(buffer[0], 22, 'expected a TLS handshake record');
         phase = 'stalled';
         started();
+        if (rejectTls) socket.destroy();
       } else if (phase === 'http' && buffer.includes('\r\n\r\n')) {
         assert.match(buffer.toString('latin1'), /^CONNECT provider\.invalid:443 /);
         buffer = Buffer.alloc(0);

--- a/packages/runtime/src/network/abortable-connector.ts
+++ b/packages/runtime/src/network/abortable-connector.ts
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { buildConnector } from 'undici';
+import type { Duplex } from 'node:stream';
+import { Socket } from 'node:net';
+
+/** Unlike Node's socket signal option, release the listener on socket close. */
+export function abortSocket(signal: AbortSignal, socket: Duplex): () => void {
+  const abort = () =>
+    socket.destroy(
+      Object.assign(new Error('The operation was aborted', { cause: signal.reason }), {
+        name: 'AbortError',
+        code: 'ABORT_ERR',
+      }),
+    );
+  const dispose = () => {
+    signal.removeEventListener('abort', abort);
+    socket.off('close', dispose);
+  };
+  socket.once('close', dispose);
+  signal.addEventListener('abort', abort, { once: true });
+  if (signal.aborted) abort();
+  return dispose;
+}
+
+/** Keep Undici's timeout and TLS session cache; own only the pending socket. */
+export function buildAbortableConnector(
+  signal: AbortSignal,
+  options: buildConnector.BuildOptions = {},
+): buildConnector.connector {
+  return withSocketCancellation(buildConnector(options), signal);
+}
+
+export function withSocketCancellation(
+  connect: buildConnector.connector,
+  signal: AbortSignal,
+): buildConnector.connector {
+  return (options, callback) => {
+    let dispose = () => {};
+    // Undici returns the socket immediately, although its TS signature is void.
+    // Regression coverage exercises this boundary with real TCP/TLS sockets.
+    const socket = connect(options, (...args) => {
+      dispose();
+      callback(...args);
+    }) as unknown;
+    // ProxyAgent's outer CONNECT connector is async; its upgraded tunnel is
+    // owned separately by the proxy pool's upgrade handler.
+    if (socket instanceof Socket) dispose = abortSocket(signal, socket);
+  };
+}

--- a/packages/runtime/src/network/proxy-dispatcher.ts
+++ b/packages/runtime/src/network/proxy-dispatcher.ts
@@ -19,19 +19,26 @@
 
 import { Agent, ProxyAgent, buildConnector } from 'undici';
 import { SocksClient } from 'socks';
-import { isIP } from 'node:net';
-import { connect as tlsConnect } from 'node:tls';
+import { Socket } from 'node:net';
+import { once } from 'node:events';
 import { buildProxyUrl } from './proxy-parser.js';
 import type { ProxySettings } from '@maka/core/settings/network-settings';
 
-export function buildProxyDispatcher(proxy: ProxySettings): Agent | ProxyAgent {
-  if (proxy.type === 'socks5') return buildSocks5Dispatcher(proxy);
-  return new ProxyAgent(buildProxyUrl(proxy));
+export function buildProxyDispatcher(
+  proxy: ProxySettings,
+  signal: AbortSignal,
+): Agent | ProxyAgent {
+  if (proxy.type === 'socks5') return buildSocks5Dispatcher(proxy, signal);
+  const connectOptions = { signal } as buildConnector.BuildOptions;
+  return new ProxyAgent({
+    uri: buildProxyUrl(proxy),
+    proxyTls: connectOptions,
+    requestTls: connectOptions,
+  });
 }
 
-function buildSocks5Dispatcher(proxy: ProxySettings): Agent {
-  const connector = buildConnector({ allowH2: false });
-  void connector;
+function buildSocks5Dispatcher(proxy: ProxySettings, signal: AbortSignal): Agent {
+  const connector = buildConnector({ allowH2: false, signal });
 
   return new Agent({
     connect: (opts, callback) => {
@@ -53,36 +60,13 @@ function buildSocks5Dispatcher(proxy: ProxySettings): Agent {
           ? connectionOptions.port
           : Number(connectionOptions.port) || (connectionOptions.protocol === 'https:' ? 443 : 80);
 
-      SocksClient.createConnection({
-        proxy: {
-          host: proxy.host,
-          port: proxy.port,
-          type: 5,
-          userId: proxy.username,
-          password: proxy.password,
-        },
-        command: 'connect',
-        destination: { host, port },
-      })
-        .then(({ socket }) => {
+      connectSocksProxy(proxy, host, port, signal)
+        .then((socket) => {
           socket.setKeepAlive(true, 60_000);
           if (connectionOptions.protocol === 'https:') {
-            const servername = connectionOptions.servername ?? (isIP(host) ? undefined : host);
-            const tlsSocket = tlsConnect({
-              ...(opts as object),
-              servername,
-              host,
-              port,
-              socket,
-            });
-            tlsSocket.once('error', (error) => {
-              socket.destroy();
-              callback(error, null);
-            });
-            tlsSocket.once('secureConnect', () => {
-              tlsSocket.setKeepAlive(true, 60_000);
-              callback(null, tlsSocket);
-            });
+            // Use Undici's bounded, single-callback TLS connector for the
+            // tunnel too, rather than leaving a custom handshake unowned.
+            connector({ ...opts, httpSocket: socket }, callback);
             return;
           }
           callback(null, socket);
@@ -92,4 +76,40 @@ function buildSocks5Dispatcher(proxy: ProxySettings): Agent {
         );
     },
   });
+}
+
+async function connectSocksProxy(
+  proxy: ProxySettings,
+  host: string,
+  port: number,
+  signal: AbortSignal,
+): Promise<Socket> {
+  // SOCKS creates an unabortable Socket internally. Supply our own connected
+  // socket so close can interrupt TCP setup, SOCKS negotiation and the tunnel.
+  const socket = new Socket({ signal });
+  const onTimeout = () => socket.destroy(new Error('SOCKS proxy connection timed out'));
+  socket.setTimeout(30_000, onTimeout);
+  try {
+    socket.connect({ host: proxy.host, port: proxy.port });
+    await once(socket, 'connect');
+    await SocksClient.createConnection({
+      proxy: {
+        host: proxy.host,
+        port: proxy.port,
+        type: 5,
+        userId: proxy.username,
+        password: proxy.password,
+      },
+      command: 'connect',
+      destination: { host, port },
+      existing_socket: socket,
+    });
+    return socket;
+  } catch (error) {
+    socket.destroy();
+    throw error;
+  } finally {
+    socket.setTimeout(0);
+    socket.off('timeout', onTimeout);
+  }
 }

--- a/packages/runtime/src/network/proxy-dispatcher.ts
+++ b/packages/runtime/src/network/proxy-dispatcher.ts
@@ -17,28 +17,52 @@
  * under the License.
  */
 
-import { Agent, ProxyAgent, buildConnector } from 'undici';
+import { Agent, Pool, ProxyAgent } from 'undici';
 import { SocksClient } from 'socks';
 import { Socket } from 'node:net';
 import { once } from 'node:events';
 import { buildProxyUrl } from './proxy-parser.js';
 import type { ProxySettings } from '@maka/core/settings/network-settings';
+import {
+  abortSocket,
+  buildAbortableConnector,
+  withSocketCancellation,
+} from './abortable-connector.js';
 
 export function buildProxyDispatcher(
   proxy: ProxySettings,
   signal: AbortSignal,
 ): Agent | ProxyAgent {
   if (proxy.type === 'socks5') return buildSocks5Dispatcher(proxy, signal);
-  const connectOptions = { signal } as buildConnector.BuildOptions;
+  const factory: NonNullable<Agent.Options['factory']> = (origin, options) => {
+    const poolOptions = options as Pool.Options;
+    return new Pool(origin, {
+      ...poolOptions,
+      connect:
+        typeof poolOptions.connect === 'function'
+          ? withSocketCancellation(poolOptions.connect, signal)
+          : buildAbortableConnector(signal, poolOptions.connect ?? {}),
+    });
+  };
   return new ProxyAgent({
     uri: buildProxyUrl(proxy),
-    proxyTls: connectOptions,
-    requestTls: connectOptions,
+    factory,
+    clientFactory: (origin, options) =>
+      factory(origin, options).compose((dispatch) => (options, handler) => {
+        const onUpgrade = handler.onRequestUpgrade;
+        // CONNECT transfers the tunnel out of the proxy pool before target TLS
+        // settles. Keep that socket cancellable, but never retain a closed one.
+        handler.onRequestUpgrade = (controller, status, headers, socket) => {
+          abortSocket(signal, socket);
+          onUpgrade?.call(handler, controller, status, headers, socket);
+        };
+        return dispatch(options, handler);
+      }),
   });
 }
 
 function buildSocks5Dispatcher(proxy: ProxySettings, signal: AbortSignal): Agent {
-  const connector = buildConnector({ allowH2: false, signal });
+  const connector = buildAbortableConnector(signal, { allowH2: false });
 
   return new Agent({
     connect: (opts, callback) => {
@@ -86,12 +110,16 @@ async function connectSocksProxy(
 ): Promise<Socket> {
   // SOCKS creates an unabortable Socket internally. Supply our own connected
   // socket so close can interrupt TCP setup, SOCKS negotiation and the tunnel.
-  const socket = new Socket({ signal });
+  const socket = new Socket();
   const onTimeout = () => socket.destroy(new Error('SOCKS proxy connection timed out'));
+  // Bound only TCP setup; SocksClient owns the negotiation deadline.
   socket.setTimeout(30_000, onTimeout);
   try {
     socket.connect({ host: proxy.host, port: proxy.port });
+    abortSocket(signal, socket);
     await once(socket, 'connect');
+    socket.setTimeout(0);
+    socket.off('timeout', onTimeout);
     await SocksClient.createConnection({
       proxy: {
         host: proxy.host,

--- a/packages/runtime/src/network/proxy-test.ts
+++ b/packages/runtime/src/network/proxy-test.ts
@@ -41,8 +41,8 @@ export async function testProxyConnection(
   if (!proxy.host || !proxy.port)
     return { ok: false, latencyMs: 0, error: 'Proxy host/port required' };
 
-  const dispatcher = buildProxyDispatcher(proxy);
   const controller = new AbortController();
+  const dispatcher = buildProxyDispatcher(proxy, controller.signal);
   let timedOut = false;
   const disposeDispatcher = async (force = false) => {
     const disposable = dispatcher as {

--- a/packages/runtime/src/network/scoped-fetch-transport.ts
+++ b/packages/runtime/src/network/scoped-fetch-transport.ts
@@ -69,10 +69,10 @@ export function createProxiedFetchTransport(
   const proxySnapshot: ProxySettings | null = proxy?.enabled
     ? { ...proxy, bypassList: [...proxy.bypassList] }
     : null;
-  // The direct dispatcher does not own sockets until their connector calls
-  // back. Abort the connector too, including a still-pending TLS handshake.
-  const directConnections = new AbortController();
-  const directDispatcher = new Agent({ connect: { signal: directConnections.signal } });
+  // Dispatchers do not own sockets until their connectors call back. Abort
+  // direct and proxy connection establishment too, including TLS handshakes.
+  const connections = new AbortController();
+  const directDispatcher = new Agent({ connect: { signal: connections.signal } });
   let proxyDispatcher: Dispatcher | undefined;
   let closePromise: Promise<void> | undefined;
   let closed = false;
@@ -84,7 +84,8 @@ export function createProxiedFetchTransport(
       typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     const useProxy =
       proxySnapshot !== null && !matchesBypassList(new URL(url).hostname, proxySnapshot.bypassList);
-    if (useProxy) proxyDispatcher ??= buildProxyDispatcher(proxySnapshot) as Dispatcher;
+    if (useProxy)
+      proxyDispatcher ??= buildProxyDispatcher(proxySnapshot, connections.signal) as Dispatcher;
 
     return (await undiciFetch(
       input as Parameters<typeof undiciFetch>[0],
@@ -102,7 +103,7 @@ export function createProxiedFetchTransport(
   const close = (): Promise<void> => {
     if (closePromise) return closePromise;
     closed = true;
-    directConnections.abort(new Error('Connection effect fetch transport closed'));
+    connections.abort(new Error('Connection effect fetch transport closed'));
     closePromise = Promise.all([
       directDispatcher
         .destroy(new Error('Connection effect fetch transport closed'))

--- a/packages/runtime/src/network/scoped-fetch-transport.ts
+++ b/packages/runtime/src/network/scoped-fetch-transport.ts
@@ -69,7 +69,10 @@ export function createProxiedFetchTransport(
   const proxySnapshot: ProxySettings | null = proxy?.enabled
     ? { ...proxy, bypassList: [...proxy.bypassList] }
     : null;
-  const directDispatcher = new Agent();
+  // The direct dispatcher does not own sockets until their connector calls
+  // back. Abort the connector too, including a still-pending TLS handshake.
+  const directConnections = new AbortController();
+  const directDispatcher = new Agent({ connect: { signal: directConnections.signal } });
   let proxyDispatcher: Dispatcher | undefined;
   let closePromise: Promise<void> | undefined;
   let closed = false;
@@ -99,6 +102,7 @@ export function createProxiedFetchTransport(
   const close = (): Promise<void> => {
     if (closePromise) return closePromise;
     closed = true;
+    directConnections.abort(new Error('Connection effect fetch transport closed'));
     closePromise = Promise.all([
       directDispatcher
         .destroy(new Error('Connection effect fetch transport closed'))

--- a/packages/runtime/src/network/scoped-fetch-transport.ts
+++ b/packages/runtime/src/network/scoped-fetch-transport.ts
@@ -22,6 +22,7 @@ import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
 import type { ConnectionEffectFetch } from '../connection-effect-fetch.js';
 import { matchesBypassList } from './bypass-matcher.js';
 import { buildProxyDispatcher } from './proxy-dispatcher.js';
+import { buildAbortableConnector } from './abortable-connector.js';
 
 export const FETCH_PROXY_SNAPSHOT = Symbol.for('maka.fetch.proxy-snapshot');
 
@@ -72,7 +73,7 @@ export function createProxiedFetchTransport(
   // Dispatchers do not own sockets until their connectors call back. Abort
   // direct and proxy connection establishment too, including TLS handshakes.
   const connections = new AbortController();
-  const directDispatcher = new Agent({ connect: { signal: connections.signal } });
+  const directDispatcher = new Agent({ connect: buildAbortableConnector(connections.signal) });
   let proxyDispatcher: Dispatcher | undefined;
   let closePromise: Promise<void> | undefined;
   let closed = false;


### PR DESCRIPTION
## Summary

Abort pending direct and proxied connections when a connection-effect transport closes, preventing sockets from surviving teardown and delaying Host exit. Refs #5009.

Undici dispatchers cannot destroy sockets that their connectors have not handed over yet. The transport now cancels pending direct TLS, HTTP CONNECT target TLS, HTTPS proxy TLS (including HTTP forwarding), and SOCKS setup/target TLS before destroying its dispatchers. Proxy probes and bot fetches use the same cancellation path.

Follow-up: explicitly release cancellation listeners when connection attempts settle or sockets close, avoiding retention of every closed socket by a backend-lifetime signal. Keep Undici's TLS cache, connection timeout and existing ALPN defaults. The SOCKS socket timeout now bounds TCP setup only; SocksClient owns the negotiation deadline.

## Verification

Real loopback TCP/TLS and proxy fixtures cover pending stages, prior request cancellation, listener cleanup, normal SOCKS responses/authentication/remote DNS, and network error classification.

- Focused suites: **50/50** passed — scoped transport **42**, proxy probe **3**, bot proxy fetch **5**.
- Negative controls: reverting production code produced eight expected failures; removing listener cleanup failed all seven selected retention cases; removing CONNECT tunnel cancellation failed both selected stalled-TLS cases. All mutations were restored before final validation.
- Complete test build and production build, lint, format, workspace typechecks, Desktop/UI Knip, architecture, source headers and diff checks pass.
- Release contract tests: **196/196** passed.
- CLI local non-publishable packaging and installed-package smoke pass: empty-cache offline installation, native modules, Eval, interactive TUI, a controlled model turn, npx lifecycle, schedule recovery after cache removal, and managed Runtime Host lifecycle. Focused tests pass **50/50** again after the packaging rebuild. Nothing was uploaded to a registry.

| Suite | Passed | Skipped | Failed |
| --- | ---: | ---: | ---: |
| Runtime | 3377 | 13 | 0 |
| Runtime Host | 1809 | 12 | 0 |
| Desktop | 2507 | 0 | 0 |
| CLI | 886 | 3 | 0 |
| Eval Node | 82 | 1 | 0 |
| Eval Python | 70 | 12 | 0 |
| Computer Use | 117 | 0 | 0 |

Local validation uses macOS arm64, Node 24.19.0 and npm 11.19.0. Linux sandbox validation is left to CI because Docker/Podman is unavailable locally. External proxy services, native Windows behavior and full Desktop E2E were not exercised. The connector wrapper relies on current Undici 8.10.1 returning a Socket at runtime; real-socket regressions protect that dependency boundary.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with diagnosis, code changes, regression tests, local validation, and this PR description. Codex submitted this PR on the user's behalf; the human contributor is responsible for reviewing and deciding to submit the contribution and remains accountable for its contents. Automated checks do not replace independent human review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
