### PR TITLE
fix(desktop): keep session skill picker stable

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-mentions.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-mentions.test.ts
@@ -116,9 +116,13 @@ function installCatalogRenderer(t: TestContext) {
       assert.ok(observation);
       return observation;
     },
-    async render(sessionId: string, skillCatalogRevision = 0) {
+    pendingRequestCount() {
+      return pending.length;
+    },
+    async render(sessionId: string, skillCatalogRevision = 0, projectPath?: string) {
       await act(() => root.render(createElement(ComposerMentionsProvider, {
         sessionId,
+        projectPath,
         skillCatalogRevision,
         children: createElement(Consumer, { sessionId }),
       })));
@@ -192,4 +196,20 @@ test('a same-context refresh keeps the settled skills visible until it resolves'
     loading: false,
     unavailable: false,
   });
+});
+
+test('resolving the project path for an existing session keeps its catalog settled', async (t) => {
+  const renderer = installCatalogRenderer(t);
+  await renderer.render('session-a');
+  await renderer.settleNext('session-a', [skillA]);
+
+  await renderer.render('session-a', 0, '/workspace/project-a');
+
+  assert.deepEqual(renderer.latest(), {
+    sessionId: 'session-a',
+    skills: [skillA],
+    loading: false,
+    unavailable: false,
+  });
+  assert.equal(renderer.pendingRequestCount(), 0);
 });

--- a/apps/desktop/src/renderer/composer-mentions.tsx
+++ b/apps/desktop/src/renderer/composer-mentions.tsx
@@ -90,6 +90,15 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
     newSessionPermissionMode,
     newTaskTarget,
   } = options;
+  // Once a session exists, Runtime resolves its Skill projection from the
+  // session identity alone. AppShell can learn the session's project path (or
+  // update the defaults for a future task) on a later render; those new-task
+  // inputs must not turn the current session into a different catalog surface.
+  const newTaskProjectPath = sessionId ? undefined : projectPath;
+  const newTaskModel = sessionId ? undefined : newSessionModel;
+  const newTaskCollaborationMode = sessionId ? undefined : newSessionCollaborationMode;
+  const newTaskPermissionMode = sessionId ? undefined : newSessionPermissionMode;
+  const activeNewTaskTarget = sessionId ? undefined : newTaskTarget;
   // One explicit representation of the Skill catalog — in flight, settled
   // empty, or settled populated — held as a single value so a refresh can
   // never tear its facets apart.
@@ -112,17 +121,19 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
   // still on screen for the new one. Deriving through the key below makes the
   // render itself fail closed the moment the context changes, without waiting
   // for the effect.
-  const contextKey = [
-    sessionId ?? '',
-    projectPath ?? '',
-    newSessionModel?.llmConnectionSlug ?? '',
-    newSessionModel?.model ?? '',
-    newSessionCollaborationMode ?? 'agent',
-    newSessionPermissionMode ?? '',
-    newTaskTarget?.profileId ?? '',
-    newTaskTarget?.hostId ?? '',
-    newTaskTarget?.projectId ?? '',
-  ].join('\u0000');
+  const contextKey = sessionId
+    ? ['session', sessionId].join('\u0000')
+    : [
+        'new-task',
+        newTaskProjectPath ?? '',
+        newTaskModel?.llmConnectionSlug ?? '',
+        newTaskModel?.model ?? '',
+        newTaskCollaborationMode ?? 'agent',
+        newTaskPermissionMode ?? '',
+        activeNewTaskTarget?.profileId ?? '',
+        activeNewTaskTarget?.hostId ?? '',
+        activeNewTaskTarget?.projectId ?? '',
+      ].join('\u0000');
   const [catalog, setCatalog] = useState<{
     contextKey: string;
     loading: boolean;
@@ -154,16 +165,16 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
             { contextKey, loading: true, settled: undefined, skills: EMPTY_SKILLS },
       );
       const context = {
-        ...(newSessionModel ?? {}),
-        collaborationMode: newSessionCollaborationMode ?? 'agent',
-        ...(newSessionPermissionMode
-          ? { permissionMode: newSessionPermissionMode }
+        ...(newTaskModel ?? {}),
+        collaborationMode: newTaskCollaborationMode ?? 'agent',
+        ...(newTaskPermissionMode
+          ? { permissionMode: newTaskPermissionMode }
           : {}),
       } as const;
       const request = sessionId
         ? window.maka.skills.listInvocable(sessionId)
-        : newTaskTarget
-          ? window.maka.newTasks.listInvocableSkills(newTaskTarget, context)
+        : activeNewTaskTarget
+          ? window.maka.newTasks.listInvocableSkills(activeNewTaskTarget, context)
           : Promise.resolve([]);
       void request.then(
         (next) => {
@@ -213,16 +224,16 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
       unsubscribeContext();
     };
   }, [
-    projectPath,
+    newTaskProjectPath,
     sessionId,
     skillCatalogRevision,
-    newSessionModel?.llmConnectionSlug,
-    newSessionModel?.model,
-    newSessionCollaborationMode,
-    newSessionPermissionMode,
-    newTaskTarget?.profileId,
-    newTaskTarget?.hostId,
-    newTaskTarget?.projectId,
+    newTaskModel?.llmConnectionSlug,
+    newTaskModel?.model,
+    newTaskCollaborationMode,
+    newTaskPermissionMode,
+    activeNewTaskTarget?.profileId,
+    activeNewTaskTarget?.hostId,
+    activeNewTaskTarget?.projectId,
   ]);
 
   const searchMentionFiles = useCallback(
@@ -230,8 +241,8 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
       try {
         const result = sessionId
           ? await window.maka.workspace.searchFiles(query, { sessionId })
-          : newTaskTarget
-            ? await window.maka.newTasks.searchFiles(newTaskTarget, query)
+          : activeNewTaskTarget
+            ? await window.maka.newTasks.searchFiles(activeNewTaskTarget, query)
             : { ok: false as const, reason: 'no_project' as const };
         return result.ok ? result.files : [];
       } catch {
@@ -242,9 +253,9 @@ function useComposerMentions(options: ComposerMentionsSurface): ComposerMentions
     },
     [
       sessionId,
-      newTaskTarget?.profileId,
-      newTaskTarget?.hostId,
-      newTaskTarget?.projectId,
+      activeNewTaskTarget?.profileId,
+      activeNewTaskTarget?.hostId,
+      activeNewTaskTarget?.projectId,
     ],
   );
 


### PR DESCRIPTION
## Summary

Keep an existing Session’s Skill catalog stable when its project metadata resolves after the Session is already active.

`skills.listInvocable(sessionId)` is session-scoped, but the provider previously treated `projectPath` and new-task defaults as part of the same catalog identity. A late `projectPath` update therefore cleared an open picker, entered loading, and started an unnecessary request; a click in that window could target an option that had just been removed from the DOM.

This change separates the two surfaces:

- an existing Session catalog is keyed only by `sessionId`;
- project path, target, model, collaboration mode, and permission mode continue to invalidate the new-task preview;
- a regression test proves that resolving a Session project path preserves the settled catalog and starts no extra request.

Fixes #5044

## Verification

- Regression test failed before the fix with `skills: []`, `loading: true`; passes after the fix.
- `composer-mentions.test`: 20 consecutive runs passed.
- `skill-draft-lifecycle.spec.ts`: 5 repetitions, 10/10 tests passed.
- Desktop `test:dist`: 2508/2508 passed.
- Desktop build, typecheck, renderer architecture check, Knip, lint, and format passed locally.
- GitHub Actions `test` passed, including build, typecheck, affected standard tests, Desktop E2E, browser smoke, and Storybook smoke.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the race, implemented the fix and regression test, and ran verification. The commit includes the required `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No