### PR TITLE
feat(cli): add current Todo indicator and read-only view

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-client.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client.test.ts
@@ -147,6 +147,7 @@ function subscription(
 ): RuntimeHostSessionSubscription {
   return {
     subscribePtyData: () => () => undefined,
+    subscribeSessionDomainChanges: () => () => undefined,
     hostEpoch: 'host-1',
     subscriptionId: `subscription-${sessionId}`,
     activeAssistantStreams: [],

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -3608,6 +3608,128 @@ describe('Maka Pi TUI runner', () => {
     await run;
   });
 
+  test('shows unavailable rather than empty when a driver lacks Todo queries', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new (class extends SlashCommandDriver {
+      override getSessionId(): null {
+        return null;
+      }
+    })();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'm',
+      connectionSlug: 'c',
+      permissionMode: 'bypass',
+      terminal,
+    });
+    terminal.input('/todo');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Todo unavailable'));
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('No Todo items'), false);
+    terminal.input('\x1b');
+    terminal.input('/exit');
+    terminal.input('\r');
+    await run;
+  });
+
+  test('refreshes Todo on domain invalidation and clears the old session after /new', async () => {
+    const terminal = new FakeTerminal();
+    let changed: ((sessionId: string) => void) | undefined;
+    let content = 'First current item';
+    let unsubscribed = false;
+    const driver = Object.assign(new SlashCommandDriver(), {
+      async queryTodo(sessionId: string) {
+        return {
+          sessionId,
+          items: sessionId === 'session-new' ? [] : [{ content, status: 'in_progress' as const }],
+        };
+      },
+      subscribeTodoChanges(listener: (sessionId: string) => void) {
+        changed = listener;
+        return () => {
+          unsubscribed = true;
+        };
+      },
+    });
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'm',
+      connectionSlug: 'c',
+      permissionMode: 'bypass',
+      terminal,
+    });
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes(content));
+    content = 'Updated current item';
+    changed?.(driver.getSessionId()!);
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes(content));
+    terminal.input('/new');
+    terminal.input('\r');
+    await waitFor(() => driver.startNewSessionCalls === 1);
+    await waitForTuiPaint(terminal);
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes(content), false);
+    terminal.input('/todo');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('No Todo items'));
+    terminal.input('\x1b');
+    terminal.input('/exit');
+    terminal.input('\r');
+    await run;
+    assert.equal(unsubscribed, true);
+  });
+
+  test('opens current Todo during a turn without steering and returns Escape to the composer', async () => {
+    const terminal = new FakeTerminal();
+    const driver = Object.assign(new SteeringTurnDriver(), {
+      async queryTodo(sessionId: string) {
+        return {
+          sessionId,
+          items: [
+            { content: 'Verify current Todo', status: 'in_progress' as const },
+            { content: 'Already marked', status: 'completed' as const },
+          ],
+        };
+      },
+    });
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'm',
+      connectionSlug: 'c',
+      permissionMode: 'bypass',
+      terminal,
+    });
+    terminal.input('start the work');
+    terminal.input('\r');
+    await waitFor(() => terminal.progressStates.at(-1) === true);
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Verify current Todo'),
+    );
+    terminal.input('/todo');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Already marked'));
+    assert.deepEqual(driver.steered, []);
+    terminal.input('\x1b');
+    await waitForTuiPaint(terminal);
+    assert.equal(terminal.progressStates.at(-1), true);
+    terminal.input('draft after closing');
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('draft after closing'),
+    );
+    terminal.input('\x03');
+    terminal.input('\x1b');
+    terminal.input('\x1b');
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+    terminal.input('\x03');
+    terminal.input('/exit');
+    terminal.input('\r');
+    await run;
+  });
+
   test('opens /transcript during a running turn instead of steering it', async () => {
     const terminal = new FakeTerminal();
     const driver = new SteeringTurnDriver();

--- a/packages/cli/src/__tests__/pi-tui-todo-layout.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-todo-layout.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createMakaPiTranscriptState } from '../pi-transcript.js';
+import {
+  MakaPiLayoutComponent,
+  MakaTranscriptComponent,
+  MakaActivityStripComponent,
+  MakaPendingQueueComponent,
+} from '../pi-tui-layout.js';
+import { FakeTerminal } from './tui-terminal-mock.js';
+
+test('current Todo reserves one chrome row and yields to the minimum composer on short screens', () => {
+  const terminal = new FakeTerminal();
+  const state = createMakaPiTranscriptState();
+  const metadata = () => ({
+    title: 'Maka',
+    cwd: '/repo',
+    model: 'm',
+    connectionSlug: 'c',
+    permissionMode: 'bypass',
+  });
+  let viewport = 0;
+  const editor = {
+    invalidate() {},
+    render: () => ['EDITOR'],
+    setViewportRows(rows: number) {
+      viewport = rows;
+    },
+    isShowingAutocomplete: () => false,
+    minimumViewportRows: () => 3,
+  };
+  const layout = new MakaPiLayoutComponent(
+    state,
+    new MakaTranscriptComponent(state, metadata),
+    new MakaActivityStripComponent(metadata),
+    new MakaPendingQueueComponent(state, 'en'),
+    editor,
+    { invalidate() {}, render: () => ['STATUS'] },
+    terminal,
+    { invalidate() {}, render: () => ['TODO', 'MUST NOT RENDER'] },
+  );
+  terminal.rows = 10;
+  const lines = layout.render(80);
+  assert.deepEqual(lines.slice(-3), ['TODO', 'EDITOR', 'STATUS']);
+  assert.equal(lines.includes('MUST NOT RENDER'), false);
+  assert.equal(viewport, 7);
+  terminal.rows = 5;
+  assert.equal(layout.render(80).includes('TODO'), false);
+  assert.equal(viewport, 3);
+});

--- a/packages/cli/src/__tests__/pi-tui-todo.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-todo.test.ts
@@ -20,13 +20,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { stripAnsi } from '../tui-ansi.js';
-import {
-  CurrentTodoStore,
-  TodoOverlay,
-  TodoQueryState,
-  renderTodoIndicator,
-  type SessionTodoReader,
-} from '../pi-tui-todo.js';
+import { CurrentTodoStore, TodoOverlay, renderTodoIndicator } from '../pi-tui-todo.js';
 
 const snapshot = (
   items: Array<{ content: string; status: 'pending' | 'in_progress' | 'completed' }>,
@@ -34,37 +28,26 @@ const snapshot = (
   items,
 });
 
-test('TodoQueryState distinguishes loading, empty, ready, and failure', async () => {
-  const state = new TodoQueryState();
+test('CurrentTodoStore distinguishes loading, empty, ready, and failure', async () => {
   const pending = deferred<ReturnType<typeof snapshot>>();
-  const reader: SessionTodoReader = { read: async () => pending.promise };
-  const load = state.load('session-1', reader);
-  assert.equal(state.getSnapshot().status, 'loading');
-  pending.resolve(snapshot([]));
-  assert.equal(await load, true);
-  assert.equal(state.getSnapshot().status, 'empty');
-
-  const failing = await state.load('session-1', {
+  let fail = false;
+  const state = new CurrentTodoStore({
     read: async () => {
-      throw new Error('unavailable');
+      if (fail) throw new Error('unavailable');
+      return pending.promise;
     },
   });
-  assert.equal(failing, true);
-  assert.equal(state.getSnapshot().status, 'error');
-});
-
-test('TodoQueryState ignores a late response from an older session', async () => {
-  const state = new TodoQueryState();
-  const first = deferred<ReturnType<typeof snapshot>>();
-  const second = deferred<ReturnType<typeof snapshot>>();
-  const firstLoad = state.load('old', { read: async () => first.promise });
-  const secondLoad = state.load('new', { read: async () => second.promise });
-  second.resolve(snapshot([{ content: 'new item', status: 'in_progress' }]));
-  assert.equal(await secondLoad, true);
-  first.resolve(snapshot([{ content: 'stale item', status: 'completed' }]));
-  assert.equal(await firstLoad, false);
-  assert.equal(state.getSnapshot().sessionId, 'new');
-  assert.equal(state.getSnapshot().items[0]?.content, 'new item');
+  state.setSession('session-1');
+  const load = state.refresh();
+  assert.equal(state.getState().status, 'loading');
+  pending.resolve(snapshot([]));
+  assert.equal(await load, true);
+  assert.equal(state.getState().status, 'empty');
+  fail = true;
+  await state.refresh();
+  // Refreshes requested during a query are coalesced into one trailing query.
+  await state.refresh();
+  assert.equal(state.getState().status, 'error');
 });
 
 test('CurrentTodoStore exposes one current session and invalidates on dispose', async () => {
@@ -86,6 +69,7 @@ test('CurrentTodoStore starts the new session while an old refresh is pending', 
     read: async (sessionId) => (sessionId === 'old' ? old.promise : next.promise),
   });
   store.setSession('old');
+  const oldLoad = store.refresh();
   store.setSession('new');
   assert.equal(store.getState().sessionId, 'new');
   assert.equal(store.getState().status, 'loading');
@@ -93,11 +77,37 @@ test('CurrentTodoStore starts the new session while an old refresh is pending', 
   assert.equal(await store.refresh(), true);
   assert.equal(store.getState().items[0]?.content, 'new');
   old.resolve(snapshot([{ content: 'old', status: 'completed' }]));
+  assert.equal(await oldLoad, false);
+  assert.equal(store.getState().items[0]?.content, 'new');
+});
+
+test('refresh bursts coalesce without clearing the visible current list', async () => {
+  const queued = deferred<ReturnType<typeof snapshot>>();
+  let reads = 0;
+  const store = new CurrentTodoStore({
+    read: async () => {
+      reads++;
+      return reads === 1 ? snapshot([{ content: 'visible', status: 'pending' }]) : queued.promise;
+    },
+  });
+  store.setSession('s');
+  await store.refresh();
+  assert.equal(reads, 2);
+  const pending = store.refresh();
+  assert.equal(store.refresh(), pending);
+  store.setSession('s');
+  assert.equal(reads, 2);
+  assert.equal(store.getState().status, 'ready');
+  assert.equal(store.getState().items[0]?.content, 'visible');
+  queued.resolve(snapshot([]));
+  await pending;
+  assert.equal(reads, 3);
+  assert.equal(store.getState().status, 'empty');
+  store.dispose();
 });
 
 test('renders a bounded indicator and hides empty state', async () => {
-  const state = new TodoQueryState();
-  await state.load('s', {
+  const state = new CurrentTodoStore({
     read: async () =>
       snapshot([
         { content: 'Implement the current Todo preview', status: 'in_progress' },
@@ -105,13 +115,15 @@ test('renders a bounded indicator and hides empty state', async () => {
         { content: 'Next', status: 'pending' },
       ]),
   });
-  const indicator = renderTodoIndicator(state.getSnapshot(), { locale: 'en', width: 40 });
+  state.setSession('s');
+  await state.refresh();
+  const indicator = renderTodoIndicator(state.getState(), { locale: 'en', width: 40 });
   const plainIndicator = stripAnsi(indicator ?? '');
   assert.ok(plainIndicator.length <= 40);
   assert.match(plainIndicator, /Todo 1\/3 · \/todo to view$/);
 
-  await state.load('s', { read: async () => snapshot([]) });
-  assert.equal(renderTodoIndicator(state.getSnapshot(), { locale: 'zh-CN', width: 80 }), undefined);
+  state.setSession(undefined);
+  assert.equal(renderTodoIndicator(state.getState(), { locale: 'zh-CN', width: 80 }), undefined);
 });
 
 test('CurrentTodoStore does not coalesce across A -> undefined -> A', async () => {
@@ -134,8 +146,7 @@ test('CurrentTodoStore does not coalesce across A -> undefined -> A', async () =
 });
 
 test('TodoOverlay renders status symbols, failure, and scrolls safely', async () => {
-  const state = new TodoQueryState();
-  await state.load('s', {
+  const state = new CurrentTodoStore({
     read: async () =>
       snapshot([
         { content: 'pending item', status: 'pending' },
@@ -143,10 +154,12 @@ test('TodoOverlay renders status symbols, failure, and scrolls safely', async ()
         { content: 'done item', status: 'completed' },
       ]),
   });
+  state.setSession('s');
+  await state.refresh();
   let closed = false;
   const overlay = new TodoOverlay({
     locale: 'zh-CN',
-    getState: () => state.getSnapshot(),
+    getState: () => state.getState(),
     viewportRows: () => 4,
     onClose: () => {
       closed = true;
@@ -161,14 +174,15 @@ test('TodoOverlay renders status symbols, failure, and scrolls safely', async ()
 });
 
 test('TodoOverlay wraps grapheme-safe content and supports Home/End', async () => {
-  const state = new TodoQueryState();
-  await state.load('s', {
+  const state = new CurrentTodoStore({
     read: async () => snapshot([{ content: '👩‍💻 中文内容很长', status: 'pending' }]),
   });
+  state.setSession('s');
+  await state.refresh();
   let changes = 0;
   const overlay = new TodoOverlay({
     locale: 'en',
-    getState: () => state.getSnapshot(),
+    getState: () => state.getState(),
     viewportRows: () => 4,
     onClose: () => undefined,
     onChange: () => changes++,
@@ -181,14 +195,15 @@ test('TodoOverlay wraps grapheme-safe content and supports Home/End', async () =
 });
 
 test('error state renders unavailable instead of exposing query errors', async () => {
-  const state = new TodoQueryState();
-  await state.load('s', {
+  const state = new CurrentTodoStore({
     read: async () => {
       throw new Error('secret-token');
     },
   });
+  state.setSession('s');
+  await state.refresh();
   const indicator = stripAnsi(
-    renderTodoIndicator(state.getSnapshot(), { locale: 'en', width: 80 }) ?? '',
+    renderTodoIndicator(state.getState(), { locale: 'en', width: 80 }) ?? '',
   );
   assert.equal(indicator, 'Todo unavailable · /todo to view');
 });

--- a/packages/cli/src/__tests__/pi-tui-todo.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-todo.test.ts
@@ -173,6 +173,36 @@ test('TodoOverlay renders status symbols, failure, and scrolls safely', async ()
   assert.equal(closed, true);
 });
 
+test('TodoOverlay permits Kitty scrolling repeats but ignores closing repeats and releases', () => {
+  let closes = 0;
+  const overlay = new TodoOverlay({
+    locale: 'en',
+    getState: () => ({
+      status: 'ready',
+      items: Array.from({ length: 12 }, (_, i) => ({ content: `item-${i}`, status: 'pending' })),
+    }),
+    viewportRows: () => 4,
+    onClose: () => closes++,
+  });
+  const firstRow = () => stripAnsi(overlay.render(80)[1] ?? '').trim();
+  assert.equal(firstRow(), '○ item-0');
+  overlay.handleInput('\x1b[1;1:2B');
+  assert.equal(firstRow(), '○ item-1');
+  overlay.handleInput('\x1b[6;1:2~');
+  assert.equal(firstRow(), '○ item-3');
+  overlay.handleInput('\x1b[1;1:3B');
+  assert.equal(firstRow(), '○ item-3');
+  overlay.handleInput('\x1b[B');
+  assert.equal(firstRow(), '○ item-4');
+  for (const key of ['\x1b[27;1:2u', '\x1b[99;5:2u', '\x1b[27;1:3u']) {
+    overlay.handleInput(key);
+  }
+  assert.equal(closes, 0);
+  overlay.handleInput('\x1b');
+  overlay.handleInput('\x03');
+  assert.equal(closes, 2);
+});
+
 test('TodoOverlay wraps grapheme-safe content and supports Home/End', async () => {
   const state = new CurrentTodoStore({
     read: async () => snapshot([{ content: '👩‍💻 中文内容很长', status: 'pending' }]),

--- a/packages/cli/src/__tests__/pi-tui-todo.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-todo.test.ts
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { stripAnsi } from '../tui-ansi.js';
+import {
+  CurrentTodoStore,
+  TodoOverlay,
+  TodoQueryState,
+  renderTodoIndicator,
+  type SessionTodoReader,
+} from '../pi-tui-todo.js';
+
+const snapshot = (
+  items: Array<{ content: string; status: 'pending' | 'in_progress' | 'completed' }>,
+) => ({
+  items,
+});
+
+test('TodoQueryState distinguishes loading, empty, ready, and failure', async () => {
+  const state = new TodoQueryState();
+  const pending = deferred<ReturnType<typeof snapshot>>();
+  const reader: SessionTodoReader = { read: async () => pending.promise };
+  const load = state.load('session-1', reader);
+  assert.equal(state.getSnapshot().status, 'loading');
+  pending.resolve(snapshot([]));
+  assert.equal(await load, true);
+  assert.equal(state.getSnapshot().status, 'empty');
+
+  const failing = await state.load('session-1', {
+    read: async () => {
+      throw new Error('unavailable');
+    },
+  });
+  assert.equal(failing, true);
+  assert.equal(state.getSnapshot().status, 'error');
+});
+
+test('TodoQueryState ignores a late response from an older session', async () => {
+  const state = new TodoQueryState();
+  const first = deferred<ReturnType<typeof snapshot>>();
+  const second = deferred<ReturnType<typeof snapshot>>();
+  const firstLoad = state.load('old', { read: async () => first.promise });
+  const secondLoad = state.load('new', { read: async () => second.promise });
+  second.resolve(snapshot([{ content: 'new item', status: 'in_progress' }]));
+  assert.equal(await secondLoad, true);
+  first.resolve(snapshot([{ content: 'stale item', status: 'completed' }]));
+  assert.equal(await firstLoad, false);
+  assert.equal(state.getSnapshot().sessionId, 'new');
+  assert.equal(state.getSnapshot().items[0]?.content, 'new item');
+});
+
+test('CurrentTodoStore exposes one current session and invalidates on dispose', async () => {
+  const pending = deferred<ReturnType<typeof snapshot>>();
+  const store = new CurrentTodoStore({ read: async () => pending.promise });
+  store.setSession('session-1');
+  assert.equal(store.getState().status, 'loading');
+  store.dispose();
+  pending.resolve(snapshot([{ content: 'late', status: 'in_progress' }]));
+  await Promise.resolve();
+  assert.equal(store.getState().status, 'idle');
+  assert.equal(await store.refresh(), false);
+});
+
+test('CurrentTodoStore starts the new session while an old refresh is pending', async () => {
+  const old = deferred<ReturnType<typeof snapshot>>();
+  const next = deferred<ReturnType<typeof snapshot>>();
+  const store = new CurrentTodoStore({
+    read: async (sessionId) => (sessionId === 'old' ? old.promise : next.promise),
+  });
+  store.setSession('old');
+  store.setSession('new');
+  assert.equal(store.getState().sessionId, 'new');
+  assert.equal(store.getState().status, 'loading');
+  next.resolve(snapshot([{ content: 'new', status: 'in_progress' }]));
+  assert.equal(await store.refresh(), true);
+  assert.equal(store.getState().items[0]?.content, 'new');
+  old.resolve(snapshot([{ content: 'old', status: 'completed' }]));
+});
+
+test('renders a bounded indicator and hides empty state', async () => {
+  const state = new TodoQueryState();
+  await state.load('s', {
+    read: async () =>
+      snapshot([
+        { content: 'Implement the current Todo preview', status: 'in_progress' },
+        { content: 'Done', status: 'completed' },
+        { content: 'Next', status: 'pending' },
+      ]),
+  });
+  const indicator = renderTodoIndicator(state.getSnapshot(), { locale: 'en', width: 40 });
+  const plainIndicator = stripAnsi(indicator ?? '');
+  assert.ok(plainIndicator.length <= 40);
+  assert.match(plainIndicator, /Todo 1\/3 · \/todo to view$/);
+
+  await state.load('s', { read: async () => snapshot([]) });
+  assert.equal(renderTodoIndicator(state.getSnapshot(), { locale: 'zh-CN', width: 80 }), undefined);
+});
+
+test('CurrentTodoStore does not coalesce across A -> undefined -> A', async () => {
+  const first = deferred<ReturnType<typeof snapshot>>();
+  const second = deferred<ReturnType<typeof snapshot>>();
+  let reads = 0;
+  const store = new CurrentTodoStore({
+    read: async () => (reads++ === 0 ? first.promise : second.promise),
+  });
+  store.setSession('A');
+  store.setSession(undefined);
+  store.setSession('A');
+  assert.equal(reads, 2);
+  second.resolve(snapshot([{ content: 'fresh', status: 'in_progress' }]));
+  assert.equal(await store.refresh(), true);
+  assert.equal(store.getState().items[0]?.content, 'fresh');
+  first.resolve(snapshot([{ content: 'stale', status: 'completed' }]));
+  await Promise.resolve();
+  assert.equal(store.getState().items[0]?.content, 'fresh');
+});
+
+test('TodoOverlay renders status symbols, failure, and scrolls safely', async () => {
+  const state = new TodoQueryState();
+  await state.load('s', {
+    read: async () =>
+      snapshot([
+        { content: 'pending item', status: 'pending' },
+        { content: 'active item', status: 'in_progress' },
+        { content: 'done item', status: 'completed' },
+      ]),
+  });
+  let closed = false;
+  const overlay = new TodoOverlay({
+    locale: 'zh-CN',
+    getState: () => state.getSnapshot(),
+    viewportRows: () => 4,
+    onClose: () => {
+      closed = true;
+    },
+  });
+  assert.match(stripAnsi(overlay.render(24).join('\n')), /待办/);
+  assert.match(overlay.render(24).join('\n'), /○|●|✓/);
+  overlay.handleInput('\x1b[B');
+  assert.match(stripAnsi(overlay.render(24).join('\n')), /active item/);
+  overlay.handleInput('\x1b');
+  assert.equal(closed, true);
+});
+
+test('TodoOverlay wraps grapheme-safe content and supports Home/End', async () => {
+  const state = new TodoQueryState();
+  await state.load('s', {
+    read: async () => snapshot([{ content: '👩‍💻 中文内容很长', status: 'pending' }]),
+  });
+  let changes = 0;
+  const overlay = new TodoOverlay({
+    locale: 'en',
+    getState: () => state.getSnapshot(),
+    viewportRows: () => 4,
+    onClose: () => undefined,
+    onChange: () => changes++,
+  });
+  // The existing display projection removes zero-width format characters.
+  assert.match(stripAnsi(overlay.render(8).join('\n')), /👩💻/);
+  overlay.handleInput('\x1b[H');
+  overlay.handleInput('\x1b[F');
+  assert.equal(changes, 2);
+});
+
+test('error state renders unavailable instead of exposing query errors', async () => {
+  const state = new TodoQueryState();
+  await state.load('s', {
+    read: async () => {
+      throw new Error('secret-token');
+    },
+  });
+  const indicator = stripAnsi(
+    renderTodoIndicator(state.getSnapshot(), { locale: 'en', width: 80 }) ?? '',
+  );
+  assert.equal(indicator, 'Todo unavailable · /todo to view');
+});
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -87,6 +87,100 @@ describe('Runtime Host Maka Session driver', () => {
     );
   });
 
+  test('queries the attached Session Todo projection without storing history', async () => {
+    const subscription = new FakeSubscription(continuitySnapshot(), Promise.resolve([]));
+    const connection = new FakeConnection([subscription]);
+    connection.todoQuery = {
+      sessionId: 'session-id',
+      items: [
+        { content: 'keep sk-1234567890abcdef <session-todo> visible', status: 'in_progress' },
+      ],
+    };
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/repo',
+      llmConnectionId: 'connection-1',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      newId: () => 'session-id',
+    });
+
+    await driver.createSession({
+      cwd: '/repo',
+      llmConnectionId: 'connection-1',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+
+    const queried = await driver.queryTodo!('session-id');
+    assert.deepEqual(queried, {
+      sessionId: 'session-id',
+      items: [{ content: 'keep <redacted>  visible', status: 'in_progress' }],
+    });
+    assert.deepEqual(
+      connection.requests.filter(({ operation }) => operation === 'session.todo.query'),
+      [{ operation: 'session.todo.query', input: { sessionId: 'session-id' } }],
+    );
+    await assert.rejects(driver.queryTodo!('other-session'), /non-current Session/);
+
+    connection.todoQuery = { sessionId: 'other-session', items: [] };
+    await assert.rejects(driver.queryTodo!('session-id'), /unexpected Session/);
+  });
+
+  test('publishes only Todo domain invalidations and supports unsubscribe', async () => {
+    const subscription = new FakeSubscription(continuitySnapshot(), Promise.resolve([]));
+    const connection = new FakeConnection([subscription]);
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/repo',
+      llmConnectionId: 'connection-1',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      newId: () => 'session-id',
+    });
+    await driver.createSession({
+      cwd: '/repo',
+      llmConnectionId: 'connection-1',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+
+    const changes: string[] = [];
+    const unsubscribe = driver.subscribeTodoChanges!((sessionId) => changes.push(sessionId));
+    subscription.push({
+      kind: 'subscription.session_domain_changed',
+      hostEpoch: 'host-1',
+      subscriptionId: 'subscription-1',
+      sequence: 1,
+      sessionId: 'session-id',
+      domain: 'usage',
+    });
+    subscription.push({
+      kind: 'subscription.session_domain_changed',
+      hostEpoch: 'host-1',
+      subscriptionId: 'subscription-1',
+      sequence: 2,
+      sessionId: 'session-id',
+      domain: 'todo',
+    });
+    await waitFor(() => changes.length === 1);
+    assert.deepEqual(changes, ['session-id']);
+
+    unsubscribe();
+    subscription.push({
+      kind: 'subscription.session_domain_changed',
+      hostEpoch: 'host-1',
+      subscriptionId: 'subscription-1',
+      sequence: 3,
+      sessionId: 'session-id',
+      domain: 'todo',
+    });
+    await delay(0);
+    assert.deepEqual(changes, ['session-id']);
+  });
+
   test('keeps remote Session paths out of Client filesystem policy', async () => {
     const driver = createRuntimeHostMakaSessionDriver({
       connection: new FakeConnection([]).value,
@@ -2652,6 +2746,7 @@ class FakeConnection {
   openedSubscriptions = 0;
   interactionQuery: unknown;
   runtimeResourceQuery: unknown;
+  todoQuery: OperationOutput<'session.todo.query'> | undefined;
   onRuntimeResourceStart: (() => Promise<void>) | undefined;
   executionBoundary: unknown = { kind: 'managed', access: 'read_write', revision: 1 };
   skillStartBlocked = false;
@@ -2804,6 +2899,10 @@ class FakeConnection {
       }
       return this.runtimeResourceQuery as OperationOutput<K>;
     }
+    if (operation === 'session.todo.query') {
+      if (this.todoQuery === undefined) throw new Error('Unexpected Session Todo query');
+      return this.todoQuery as OperationOutput<K>;
+    }
     if (operation === 'turn.stop') {
       return {} as OperationOutput<K>;
     }
@@ -2904,6 +3003,17 @@ class FakeSubscription implements RuntimeHostSessionSubscription, AsyncIterator<
   subscribePtyData(): () => void {
     return () => undefined;
   }
+  readonly #sessionDomainListeners = new Set<
+    (frame: Extract<SubscriptionFrame, { kind: 'subscription.session_domain_changed' }>) => void
+  >();
+  subscribeSessionDomainChanges(
+    listener: (
+      frame: Extract<SubscriptionFrame, { kind: 'subscription.session_domain_changed' }>,
+    ) => void,
+  ): () => void {
+    this.#sessionDomainListeners.add(listener);
+    return () => this.#sessionDomainListeners.delete(listener);
+  }
   readonly hostEpoch = 'host-1';
   readonly activeAssistantStreams = [];
   readonly transcriptBootstrap = null;
@@ -2939,6 +3049,9 @@ class FakeSubscription implements RuntimeHostSessionSubscription, AsyncIterator<
   }
 
   push(frame: SubscriptionFrame): void {
+    if (frame.kind === 'subscription.session_domain_changed') {
+      for (const listener of this.#sessionDomainListeners) listener(frame);
+    }
     const waiter = this.#waiters.shift();
     if (waiter) waiter.resolve({ done: false, value: frame });
     else this.#frames.push(frame);

--- a/packages/cli/src/__tests__/tui-copy-catalog.test.ts
+++ b/packages/cli/src/__tests__/tui-copy-catalog.test.ts
@@ -131,6 +131,12 @@ describe('TUI copy resources', () => {
     );
   });
 
+  test('localizes current Todo indicator and overlay copy', () => {
+    assert.equal(TUI_COPY_RESOURCES.todo.en.open, '/todo to view');
+    assert.equal(TUI_COPY_RESOURCES.todo['zh-CN'].open, '/todo 查看');
+    assert.equal(TUI_COPY_RESOURCES.todo['zh-TW'].unavailable, '待辦不可用');
+  });
+
   test('localizes stable onboarding failure codes at the TUI boundary', () => {
     assert.equal(
       onboardingFailureMessage({ kind: 'rejected', reason: 'connection_not_found' }, 'en'),

--- a/packages/cli/src/__tests__/tui-primary-guidance.test.ts
+++ b/packages/cli/src/__tests__/tui-primary-guidance.test.ts
@@ -33,6 +33,12 @@ describe('TUI primary guidance catalog', () => {
     }
   });
 
+  test('describes /todo as the current session Todo list in every primary locale', () => {
+    assert.equal(getTuiPrimaryGuidance('en').commands.todo, 'Show the current session Todo list');
+    assert.equal(getTuiPrimaryGuidance('zh-CN').commands.todo, '查看当前会话待办清单');
+    assert.equal(getTuiPrimaryGuidance('zh-TW').commands.todo, '檢視目前會話待辦清單');
+  });
+
   test('keeps keybinding tokens identical across locales', () => {
     const tokens = (locale: 'zh-CN' | 'en') =>
       getTuiPrimaryGuidance(locale).help.keybindings.flatMap((line) => {

--- a/packages/cli/src/pi-tui-layout.ts
+++ b/packages/cli/src/pi-tui-layout.ts
@@ -168,11 +168,13 @@ export class MakaPiLayoutComponent extends Container {
     private readonly editor: ViewportAwareEditor,
     private readonly statusLine: Component,
     private readonly terminal: Terminal,
+    private readonly todoIndicator?: Component,
   ) {
     super();
     this.addChild(transcript);
     this.addChild(activityStrip);
     this.addChild(pendingQueue);
+    if (todoIndicator) this.addChild(todoIndicator);
     this.addChild(editor);
     this.addChild(statusLine);
   }
@@ -182,18 +184,32 @@ export class MakaPiLayoutComponent extends Container {
     const activityLines = this.activityStrip.render(width);
     const allPendingLines = this.pendingQueue.render(width);
     const statusLines = this.statusLine.render(width);
+    // Supplementary information must not steal the composer's minimum space.
+    const todoLines =
+      this.terminal.rows >
+      activityLines.length +
+        allPendingLines.length +
+        statusLines.length +
+        this.editor.minimumViewportRows()
+        ? (this.todoIndicator?.render(width) ?? []).slice(0, 1)
+        : [];
     const pendingRowsAvailable = this.editor.isShowingAutocomplete()
       ? Math.max(
           0,
           this.terminal.rows -
             activityLines.length -
             statusLines.length -
+            todoLines.length -
             this.editor.minimumViewportRows(),
         )
       : allPendingLines.length;
     const pendingLines = fitPendingQueueLines(allPendingLines, pendingRowsAvailable);
     this.editor.setViewportRows(
-      this.terminal.rows - activityLines.length - pendingLines.length - statusLines.length,
+      this.terminal.rows -
+        activityLines.length -
+        pendingLines.length -
+        statusLines.length -
+        todoLines.length,
     );
     const editorLines = this.editor.render(width);
     // #1064: when the activity strip is showing (a turn is running), separate
@@ -207,7 +223,11 @@ export class MakaPiLayoutComponent extends Container {
       activityActive && lastTranscriptLine !== undefined && lastTranscriptLine.length > 0;
     const paddedTranscript = needGap ? [...transcriptLines, ''] : transcriptLines;
     const chromeRows =
-      activityLines.length + pendingLines.length + editorLines.length + statusLines.length;
+      activityLines.length +
+      pendingLines.length +
+      todoLines.length +
+      editorLines.length +
+      statusLines.length;
     const viewportRows = Math.max(0, this.terminal.rows - chromeRows);
     const paddingRows = Math.max(0, viewportRows - paddedTranscript.length);
     const lines = [
@@ -215,6 +235,7 @@ export class MakaPiLayoutComponent extends Container {
       ...Array.from({ length: paddingRows }, () => ''),
       ...activityLines,
       ...pendingLines,
+      ...todoLines,
       ...editorLines,
       ...statusLines,
     ];

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -32,6 +32,7 @@ import {
   type Terminal,
 } from '@earendil-works/pi-tui';
 import type { PermissionMode } from '@maka/core/permission';
+import { CurrentTodoStore, TodoOverlay, renderTodoIndicator } from './pi-tui-todo.js';
 import { isThinkingLevel, type ThinkingLevel } from '@maka/core/model-thinking';
 import {
   deriveConnectionSlug,
@@ -565,6 +566,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // overlay, not arm the double-Escape interrupt for the running Turn (#3380).
   let sessionPickerOverlayOpen = false;
   let transcriptOverlay: OverlayHandle | undefined;
+  let todoOverlay: OverlayHandle | undefined;
+  const closeTodoOverlay = (): void => {
+    todoOverlay?.hide();
+    todoOverlay = undefined;
+  };
   let transcriptViewer: TranscriptViewerOverlay | undefined;
   let transcriptViewerSessionId: string | undefined;
   const resetTranscriptViewer = (): void => {
@@ -687,6 +693,33 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const activityStrip = new MakaActivityStripComponent(metadata);
   const pendingQueue = new MakaPendingQueueComponent(state, locale);
   const statusLine = new MakaStatusLineComponent(metadata);
+  const currentTodo = new CurrentTodoStore(
+    {
+      read: async (sessionId) => {
+        if (!input.driver.queryTodo) throw new Error('Todo query unavailable');
+        return input.driver.queryTodo(sessionId);
+      },
+    },
+    () => {
+      if (!closed) tui.requestRender();
+    },
+  );
+  const syncTodoSession = (): void => {
+    currentTodo.setSession(input.driver.getSessionId() ?? undefined);
+  };
+  const unsubscribeTodoChanges = input.driver.subscribeTodoChanges?.((sessionId) => {
+    if (sessionId !== input.driver.getSessionId()) return;
+    syncTodoSession();
+    void currentTodo.refresh();
+  });
+  const todoIndicator: Component = {
+    invalidate() {},
+    render(width) {
+      if (!input.driver.queryTodo) return [];
+      const line = renderTodoIndicator(currentTodo.getState(), { locale, width });
+      return line === undefined ? [] : [line];
+    },
+  };
   // Use the vendor editor's full 20-item autocomplete capacity. Larger command
   // catalogs remain scrollable and keep an exact position/total counter.
   const editor = new MakaSkillHighlightEditor(tui, editorTheme(), {
@@ -703,6 +736,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     editorSurface,
     statusLine,
     terminal,
+    todoIndicator,
   );
   const attention = new AttentionController(terminal, {
     baseTitle: input.title,
@@ -1012,6 +1046,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     unsubscribeModelCatalogChanges?.();
     unsubscribeSessionTitleChanges();
     unsubscribeGoalChanges?.();
+    unsubscribeTodoChanges?.();
+    currentTodo.dispose();
+    closeTodoOverlay();
     void sideConversation?.stopParentObserver?.();
     unsubscribeStartedTurns();
     unsubscribeResolvedInteractions();
@@ -1643,6 +1680,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   }
 
   const adoptSessionMetadata = (summary: SessionSummary, announceIdentity = true) => {
+    syncTodoSession();
     cwd = summary.cwd ?? cwd;
     setSessionTitle(summary.name);
     model = summary.model;
@@ -1750,6 +1788,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     activeTurn,
   }: MakaSessionSwitchResult): Promise<void> => {
     resetTranscriptViewer();
+    closeTodoOverlay();
     adoptSessionMetadata(summary, false);
     replaceTranscript(messages);
     syncInteractionOverlays();
@@ -2331,6 +2370,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const syncInteractionOverlays = (): void => {
     if (state.pendingInteraction) {
+      closeTodoOverlay();
       transcriptOverlay?.hide();
       transcriptOverlay = undefined;
     }
@@ -2965,6 +3005,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return false;
     }
     resetTranscriptViewer();
+    closeTodoOverlay();
+    syncTodoSession();
     // A fresh session is not bound by the previous one's boundary. Falling back
     // to the *current* label would keep the previous Session's mode, including
     // Auto while a changed Host default creates with full access; the launch
@@ -3064,6 +3106,26 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       width: '100%',
       maxHeight: '100%',
     });
+  };
+
+  const showTodo = (): void => {
+    if (state.pendingInteraction) return;
+    syncTodoSession();
+    void currentTodo.refresh();
+    closeTodoOverlay();
+    todoOverlay = tui.showOverlay(
+      new TodoOverlay({
+        locale,
+        getState: () =>
+          input.driver.queryTodo
+            ? currentTodo.getState()
+            : { status: 'error', generation: 0, items: [] },
+        viewportRows: () => terminal.rows,
+        onClose: closeTodoOverlay,
+        onChange: () => tui.requestRender(),
+      }),
+      { anchor: 'top-left', width: '100%', maxHeight: '100%' },
+    );
   };
 
   const showMcpStatus = (): void => {
@@ -3934,6 +3996,22 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         showTranscriptViewer();
       },
     },
+    todo: {
+      description: primaryGuidance.commands.todo,
+      midTurn: 'local',
+      run: (parts: string[]) => {
+        if (parts.length !== 1) {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: TUI_COPY_RESOURCES.todo[locale].usage,
+          });
+          requestRender();
+          return;
+        }
+        showTodo();
+      },
+    },
     permissions: {
       description: primaryGuidance.commands.permissions,
       midTurn: 'refuse',
@@ -4400,6 +4478,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     });
   }
 
+  syncTodoSession();
   return closedPromise;
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -3117,9 +3117,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       new TodoOverlay({
         locale,
         getState: () =>
-          input.driver.queryTodo
-            ? currentTodo.getState()
-            : { status: 'error', generation: 0, items: [] },
+          input.driver.queryTodo ? currentTodo.getState() : { status: 'error', items: [] },
         viewportRows: () => terminal.rows,
         onClose: closeTodoOverlay,
         onChange: () => tui.requestRender(),

--- a/packages/cli/src/pi-tui-todo.ts
+++ b/packages/cli/src/pi-tui-todo.ts
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Key,
+  isKeyRelease,
+  isKeyRepeat,
+  matchesKey,
+  truncateToWidth,
+  visibleWidth,
+  type Component,
+} from '@earendil-works/pi-tui';
+import {
+  projectSessionTodoItemsForDisplay,
+  type SessionTodoItem,
+  type SessionTodoSnapshot,
+} from '@maka/core/session-todo';
+import type { UiLocale } from '@maka/core/ui-locale';
+import { ansi } from './tui-ansi.js';
+import { TUI_COPY_RESOURCES } from './tui-copy-catalog.js';
+
+export interface SessionTodoReader {
+  read(sessionId: string): Promise<SessionTodoSnapshot>;
+}
+
+export type TodoQueryStatus = 'idle' | 'loading' | 'ready' | 'empty' | 'error';
+
+export interface TodoQuerySnapshot {
+  status: TodoQueryStatus;
+  sessionId?: string;
+  generation: number;
+  items: readonly SessionTodoItem[];
+  refreshing?: boolean;
+}
+
+export type TodoQueryListener = (snapshot: TodoQuerySnapshot) => void;
+
+/**
+ * Current Todo projection for one session. A load is accepted only when both
+ * its generation and session identity still match, so a late response from a
+ * previous session cannot overwrite the visible current state.
+ */
+export class TodoQueryState {
+  private snapshot: TodoQuerySnapshot = { status: 'idle', generation: 0, items: [] };
+  private readonly listeners = new Set<TodoQueryListener>();
+
+  getSnapshot(): TodoQuerySnapshot {
+    return this.snapshot;
+  }
+
+  subscribe(listener: TodoQueryListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async load(sessionId: string, reader: SessionTodoReader): Promise<boolean> {
+    const generation = this.snapshot.generation + 1;
+    const previous = this.snapshot;
+    const hasCurrentData =
+      previous.sessionId === sessionId &&
+      (previous.status === 'ready' || previous.status === 'empty');
+    this.publish({
+      status: hasCurrentData ? previous.status : 'loading',
+      sessionId,
+      generation,
+      items: hasCurrentData ? previous.items : [],
+      refreshing: hasCurrentData,
+    });
+    try {
+      const result = await reader.read(sessionId);
+      if (!this.isCurrent(sessionId, generation)) return false;
+      const items = projectSessionTodoItemsForDisplay(result.items);
+      this.publish({
+        status: items.length === 0 ? 'empty' : 'ready',
+        sessionId,
+        generation,
+        items,
+        refreshing: false,
+      });
+      return true;
+    } catch {
+      if (!this.isCurrent(sessionId, generation)) return false;
+      this.publish({ status: 'error', sessionId, generation, items: [] });
+      return true;
+    }
+  }
+
+  reset(): void {
+    this.publish({ status: 'idle', generation: this.snapshot.generation + 1, items: [] });
+  }
+
+  private isCurrent(sessionId: string, generation: number): boolean {
+    return this.snapshot.sessionId === sessionId && this.snapshot.generation === generation;
+  }
+
+  private publish(snapshot: TodoQuerySnapshot): void {
+    this.snapshot = snapshot;
+    for (const listener of this.listeners) listener(snapshot);
+  }
+}
+
+/** Runner-facing owner for the one current-session Todo query. */
+export class CurrentTodoStore {
+  private readonly query = new TodoQueryState();
+  private readonly unsubscribe: () => void;
+  private sessionId: string | undefined;
+  private disposed = false;
+  private refreshRecord: { sessionId: string; promise: Promise<boolean> } | undefined;
+  private refreshAgain = false;
+
+  constructor(
+    private readonly reader: SessionTodoReader,
+    onChange?: TodoQueryListener,
+  ) {
+    this.unsubscribe = onChange ? this.query.subscribe(onChange) : () => undefined;
+  }
+
+  getState(): TodoQuerySnapshot {
+    return this.query.getSnapshot();
+  }
+
+  setSession(sessionId: string | undefined): void {
+    if (this.disposed || this.sessionId === sessionId) return;
+    this.sessionId = sessionId;
+    this.refreshAgain = false;
+    this.refreshRecord = undefined;
+    this.query.reset();
+    if (sessionId) void this.refresh();
+  }
+
+  refresh(): Promise<boolean> {
+    if (this.disposed || !this.sessionId) return Promise.resolve(false);
+    const current = this.refreshRecord;
+    if (current?.sessionId === this.sessionId) {
+      this.refreshAgain = true;
+      return current.promise;
+    }
+    const sessionId = this.sessionId;
+    const promise = this.query.load(sessionId, this.reader).finally(() => {
+      if (this.refreshRecord?.promise !== promise) return;
+      this.refreshRecord = undefined;
+      if (this.refreshAgain) {
+        this.refreshAgain = false;
+        if (!this.disposed && this.sessionId === sessionId) void this.refresh();
+      }
+    });
+    this.refreshRecord = { sessionId, promise };
+    return promise;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.sessionId = undefined;
+    this.refreshRecord = undefined;
+    this.unsubscribe();
+    this.query.reset();
+  }
+}
+
+export interface TodoIndicatorInput {
+  locale: UiLocale;
+  width: number;
+}
+
+/** Render the one-line current Todo indicator. Empty and initial states stay hidden. */
+export function renderTodoIndicator(
+  snapshot: TodoQuerySnapshot,
+  input: TodoIndicatorInput,
+): string | undefined {
+  const copy = TUI_COPY_RESOURCES.todo[input.locale];
+  if (snapshot.status === 'idle' || snapshot.status === 'loading' || snapshot.status === 'empty') {
+    return undefined;
+  }
+  if (snapshot.status === 'error')
+    return fitLine(`${copy.unavailable} · ${copy.open}`, input.width);
+  const current = snapshot.items.find((item) => item.status === 'in_progress');
+  const completed = snapshot.items.filter((item) => item.status === 'completed').length;
+  const suffix = `${copy.progress} ${completed}/${snapshot.items.length} · ${copy.open}`;
+  const prefix = current ? `${ansi.accent('◐')} ` : '';
+  const available = input.width - visibleWidth(prefix) - visibleWidth(suffix) - (current ? 3 : 1);
+  if (!current) return fitLine(suffix, input.width);
+  if (available < 1) return fitLine(suffix, input.width);
+  const content = truncateToWidth(current.content, Math.max(1, available), '…');
+  return fitLine(`${prefix}${content} · ${suffix}`, input.width);
+}
+
+export interface TodoOverlayInput {
+  locale: UiLocale;
+  getState: () => TodoQuerySnapshot;
+  viewportRows: () => number;
+  onClose: () => void;
+  onChange?: () => void;
+}
+
+/** Read-only, scrollable view of the current Todo projection. */
+export class TodoOverlay implements Component {
+  private top = 0;
+  private bodyRows = 1;
+  private width = 80;
+
+  constructor(private readonly input: TodoOverlayInput) {}
+
+  invalidate(): void {}
+
+  handleInput(data: string): void {
+    if (isKeyRelease(data)) return;
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
+      this.input.onClose();
+      return;
+    }
+    if (isKeyRepeat(data)) return;
+    if (matchesKey(data, Key.up)) this.scrollBy(-1);
+    else if (matchesKey(data, Key.down)) this.scrollBy(1);
+    else if (matchesKey(data, Key.pageUp)) this.scrollBy(-this.bodyRows);
+    else if (matchesKey(data, Key.pageDown)) this.scrollBy(this.bodyRows);
+    else if (matchesKey(data, Key.home)) {
+      this.scrollTo(0);
+      this.input.onChange?.();
+    } else if (matchesKey(data, Key.end)) {
+      this.scrollTo(Number.MAX_SAFE_INTEGER);
+      this.input.onChange?.();
+    }
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    this.width = safeWidth;
+    const copy = TUI_COPY_RESOURCES.todo[this.input.locale];
+    const viewport = Math.max(1, Math.floor(this.input.viewportRows()));
+    const showFooter = viewport > 2;
+    this.bodyRows = Math.max(0, viewport - (showFooter ? 2 : 1));
+    const snapshot = this.input.getState();
+    const rows = this.rows(snapshot, safeWidth);
+    const maxTop = Math.max(0, rows.length - this.bodyRows);
+    this.top = Math.min(this.top, maxTop);
+    const visible = rows.slice(this.top, this.top + this.bodyRows);
+    const completed = snapshot.items.filter((item) => item.status === 'completed').length;
+    const summary =
+      snapshot.status === 'ready'
+        ? ` · ${completed}/${snapshot.items.length} ${copy.markedComplete}`
+        : '';
+    const position =
+      rows.length > this.bodyRows && this.bodyRows > 0
+        ? ` · ${this.top + 1}-${this.top + visible.length}/${rows.length}`
+        : '';
+    const header = padLine(`${ansi.bold(copy.title)}${summary}${ansi.dim(position)}`, safeWidth);
+    const body = [
+      ...visible,
+      ...Array.from({ length: this.bodyRows - visible.length }, () => ' '.repeat(safeWidth)),
+    ];
+    if (!showFooter) return [header, ...body];
+    const footer = padLine(ansi.dim(copy.hint), safeWidth);
+    return [header, ...body, footer];
+  }
+
+  private rows(snapshot: TodoQuerySnapshot, width: number): string[] {
+    const copy = TUI_COPY_RESOURCES.todo[this.input.locale];
+    if (snapshot.status === 'loading') return [padLine(copy.loading, width)];
+    if (snapshot.status === 'error') return [padLine(copy.unavailable, width)];
+    if (snapshot.status === 'idle' || snapshot.status === 'empty')
+      return [padLine(copy.empty, width)];
+    return snapshot.items.flatMap((item) => {
+      const symbol =
+        item.status === 'completed'
+          ? ansi.green('✓')
+          : item.status === 'in_progress'
+            ? ansi.accent('●')
+            : ansi.muted('○');
+      return wrapTodoItem(`${symbol} `, item.content, width);
+    });
+  }
+
+  private scrollBy(delta: number): void {
+    this.scrollTo(this.top + delta);
+    this.input.onChange?.();
+  }
+
+  private scrollTo(top: number): void {
+    const rows = this.rows(this.input.getState(), this.width);
+    this.top = Math.max(0, Math.min(top, Math.max(0, rows.length - this.bodyRows)));
+  }
+}
+
+function wrapTodoItem(prefix: string, content: string, width: number): string[] {
+  const safeWidth = Math.max(1, width);
+  const firstWidth = Math.max(1, safeWidth - visibleWidth(prefix));
+  const lines: string[] = [];
+  let remaining = content;
+  let first = true;
+  while (remaining.length > 0 || lines.length === 0) {
+    const available = first ? firstWidth : safeWidth - 2;
+    let take = '';
+    for (const character of graphemes(remaining)) {
+      if (visibleWidth(`${take}${character}`) > Math.max(1, available)) break;
+      take += character;
+    }
+    if (!take) take = graphemes(remaining)[0] ?? '';
+    remaining = remaining.slice(take.length);
+    lines.push(padLine(`${first ? prefix : '  '}${take}`, safeWidth));
+    first = false;
+  }
+  return lines;
+}
+
+function graphemes(value: string): string[] {
+  if (typeof Intl.Segmenter === 'function') {
+    return [...new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(value)].map(
+      (part) => part.segment,
+    );
+  }
+  return Array.from(value);
+}
+
+function fitLine(text: string, width: number): string {
+  return truncateToWidth(text, Math.max(1, width), '…');
+}
+
+function padLine(text: string, width: number): string {
+  const safeWidth = Math.max(1, width);
+  const trimmed = fitLine(text, safeWidth);
+  return `${trimmed}${' '.repeat(Math.max(0, safeWidth - visibleWidth(trimmed)))}`;
+}

--- a/packages/cli/src/pi-tui-todo.ts
+++ b/packages/cli/src/pi-tui-todo.ts
@@ -24,6 +24,7 @@ import {
   matchesKey,
   truncateToWidth,
   visibleWidth,
+  wrapTextWithAnsi,
   type Component,
 } from '@earendil-works/pi-tui';
 import {
@@ -35,142 +36,85 @@ import type { UiLocale } from '@maka/core/ui-locale';
 import { ansi } from './tui-ansi.js';
 import { TUI_COPY_RESOURCES } from './tui-copy-catalog.js';
 
-export interface SessionTodoReader {
-  read(sessionId: string): Promise<SessionTodoSnapshot>;
-}
-
-export type TodoQueryStatus = 'idle' | 'loading' | 'ready' | 'empty' | 'error';
-
 export interface TodoQuerySnapshot {
-  status: TodoQueryStatus;
+  status: 'idle' | 'loading' | 'ready' | 'empty' | 'error';
   sessionId?: string;
-  generation: number;
   items: readonly SessionTodoItem[];
-  refreshing?: boolean;
 }
 
-export type TodoQueryListener = (snapshot: TodoQuerySnapshot) => void;
-
-/**
- * Current Todo projection for one session. A load is accepted only when both
- * its generation and session identity still match, so a late response from a
- * previous session cannot overwrite the visible current state.
- */
-export class TodoQueryState {
-  private snapshot: TodoQuerySnapshot = { status: 'idle', generation: 0, items: [] };
-  private readonly listeners = new Set<TodoQueryListener>();
-
-  getSnapshot(): TodoQuerySnapshot {
-    return this.snapshot;
-  }
-
-  subscribe(listener: TodoQueryListener): () => void {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
-  }
-
-  async load(sessionId: string, reader: SessionTodoReader): Promise<boolean> {
-    const generation = this.snapshot.generation + 1;
-    const previous = this.snapshot;
-    const hasCurrentData =
-      previous.sessionId === sessionId &&
-      (previous.status === 'ready' || previous.status === 'empty');
-    this.publish({
-      status: hasCurrentData ? previous.status : 'loading',
-      sessionId,
-      generation,
-      items: hasCurrentData ? previous.items : [],
-      refreshing: hasCurrentData,
-    });
-    try {
-      const result = await reader.read(sessionId);
-      if (!this.isCurrent(sessionId, generation)) return false;
-      const items = projectSessionTodoItemsForDisplay(result.items);
-      this.publish({
-        status: items.length === 0 ? 'empty' : 'ready',
-        sessionId,
-        generation,
-        items,
-        refreshing: false,
-      });
-      return true;
-    } catch {
-      if (!this.isCurrent(sessionId, generation)) return false;
-      this.publish({ status: 'error', sessionId, generation, items: [] });
-      return true;
-    }
-  }
-
-  reset(): void {
-    this.publish({ status: 'idle', generation: this.snapshot.generation + 1, items: [] });
-  }
-
-  private isCurrent(sessionId: string, generation: number): boolean {
-    return this.snapshot.sessionId === sessionId && this.snapshot.generation === generation;
-  }
-
-  private publish(snapshot: TodoQuerySnapshot): void {
-    this.snapshot = snapshot;
-    for (const listener of this.listeners) listener(snapshot);
-  }
-}
-
-/** Runner-facing owner for the one current-session Todo query. */
+/** Owns only the current session; late queries cannot cross session changes or disposal. */
 export class CurrentTodoStore {
-  private readonly query = new TodoQueryState();
-  private readonly unsubscribe: () => void;
-  private sessionId: string | undefined;
+  private snapshot: TodoQuerySnapshot = { status: 'idle', items: [] };
+  private generation = 0;
   private disposed = false;
-  private refreshRecord: { sessionId: string; promise: Promise<boolean> } | undefined;
+  private pending: Promise<boolean> | undefined;
   private refreshAgain = false;
 
   constructor(
-    private readonly reader: SessionTodoReader,
-    onChange?: TodoQueryListener,
-  ) {
-    this.unsubscribe = onChange ? this.query.subscribe(onChange) : () => undefined;
-  }
+    private readonly reader: { read(sessionId: string): Promise<SessionTodoSnapshot> },
+    private readonly onChange: () => void = () => undefined,
+  ) {}
 
   getState(): TodoQuerySnapshot {
-    return this.query.getSnapshot();
+    return this.snapshot;
   }
 
   setSession(sessionId: string | undefined): void {
-    if (this.disposed || this.sessionId === sessionId) return;
-    this.sessionId = sessionId;
+    if (this.disposed || this.snapshot.sessionId === sessionId) return;
+    this.generation++;
+    this.pending = undefined;
     this.refreshAgain = false;
-    this.refreshRecord = undefined;
-    this.query.reset();
+    this.publish({ status: 'idle', ...(sessionId ? { sessionId } : {}), items: [] });
     if (sessionId) void this.refresh();
   }
 
   refresh(): Promise<boolean> {
-    if (this.disposed || !this.sessionId) return Promise.resolve(false);
-    const current = this.refreshRecord;
-    if (current?.sessionId === this.sessionId) {
+    const { sessionId } = this.snapshot;
+    if (this.disposed || !sessionId) return Promise.resolve(false);
+    if (this.pending) {
       this.refreshAgain = true;
-      return current.promise;
+      return this.pending;
     }
-    const sessionId = this.sessionId;
-    const promise = this.query.load(sessionId, this.reader).finally(() => {
-      if (this.refreshRecord?.promise !== promise) return;
-      this.refreshRecord = undefined;
+    const pending = this.load(sessionId, this.generation).finally(() => {
+      if (this.pending !== pending) return;
+      this.pending = undefined;
       if (this.refreshAgain) {
         this.refreshAgain = false;
-        if (!this.disposed && this.sessionId === sessionId) void this.refresh();
+        void this.refresh();
       }
     });
-    this.refreshRecord = { sessionId, promise };
-    return promise;
+    this.pending = pending;
+    return pending;
   }
 
   dispose(): void {
-    if (this.disposed) return;
     this.disposed = true;
-    this.sessionId = undefined;
-    this.refreshRecord = undefined;
-    this.unsubscribe();
-    this.query.reset();
+    this.generation++;
+    this.pending = undefined;
+    this.refreshAgain = false;
+    this.snapshot = { status: 'idle', items: [] };
+  }
+
+  private async load(sessionId: string, generation: number): Promise<boolean> {
+    // Keep current data visible during background refreshes, without a second cache.
+    if (this.snapshot.status !== 'ready' && this.snapshot.status !== 'empty') {
+      this.publish({ status: 'loading', sessionId, items: [] });
+    }
+    try {
+      const result = await this.reader.read(sessionId);
+      if (generation !== this.generation) return false;
+      const items = projectSessionTodoItemsForDisplay(result.items);
+      this.publish({ status: items.length ? 'ready' : 'empty', sessionId, items });
+    } catch {
+      if (generation !== this.generation) return false;
+      this.publish({ status: 'error', sessionId, items: [] });
+    }
+    return true;
+  }
+
+  private publish(snapshot: TodoQuerySnapshot): void {
+    this.snapshot = snapshot;
+    this.onChange();
   }
 }
 
@@ -299,33 +243,10 @@ export class TodoOverlay implements Component {
 }
 
 function wrapTodoItem(prefix: string, content: string, width: number): string[] {
-  const safeWidth = Math.max(1, width);
-  const firstWidth = Math.max(1, safeWidth - visibleWidth(prefix));
-  const lines: string[] = [];
-  let remaining = content;
-  let first = true;
-  while (remaining.length > 0 || lines.length === 0) {
-    const available = first ? firstWidth : safeWidth - 2;
-    let take = '';
-    for (const character of graphemes(remaining)) {
-      if (visibleWidth(`${take}${character}`) > Math.max(1, available)) break;
-      take += character;
-    }
-    if (!take) take = graphemes(remaining)[0] ?? '';
-    remaining = remaining.slice(take.length);
-    lines.push(padLine(`${first ? prefix : '  '}${take}`, safeWidth));
-    first = false;
-  }
-  return lines;
-}
-
-function graphemes(value: string): string[] {
-  if (typeof Intl.Segmenter === 'function') {
-    return [...new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(value)].map(
-      (part) => part.segment,
-    );
-  }
-  return Array.from(value);
+  const lines = wrapTextWithAnsi(content, Math.max(1, width - 2));
+  return (lines.length ? lines : ['']).map((line, index) =>
+    padLine(`${index === 0 ? prefix : '  '}${line}`, width),
+  );
 }
 
 function fitLine(text: string, width: number): string {

--- a/packages/cli/src/pi-tui-todo.ts
+++ b/packages/cli/src/pi-tui-todo.ts
@@ -166,10 +166,9 @@ export class TodoOverlay implements Component {
   handleInput(data: string): void {
     if (isKeyRelease(data)) return;
     if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
-      this.input.onClose();
+      if (!isKeyRepeat(data)) this.input.onClose();
       return;
     }
-    if (isKeyRepeat(data)) return;
     if (matchesKey(data, Key.up)) this.scrollBy(-1);
     else if (matchesKey(data, Key.down)) this.scrollBy(1);
     else if (matchesKey(data, Key.pageUp)) this.scrollBy(-this.bodyRows);

--- a/packages/cli/src/runtime-host-session-channel.ts
+++ b/packages/cli/src/runtime-host-session-channel.ts
@@ -43,6 +43,7 @@ import {
   InteractionPendingSnapshot,
   SESSION_TRANSCRIPT_BOOTSTRAP_MAX_BYTES,
   SessionContinuitySnapshot,
+  SessionDomainChangedFrame,
   SubscriptionFrame,
   type GoalProjection,
 } from '@maka/runtime-host/protocol';
@@ -71,6 +72,7 @@ export interface RuntimeHostSessionChannelOptions {
   now: () => number;
   onTurnStarted: (turn: MakaPreparedSessionTurn) => void;
   onRuntimeResourceChanged: (sourceSessionId: string, ref: string) => void;
+  onSessionDomainChanged?: (frame: SessionDomainChangedFrame) => void;
   onInteractionPending: (pending: InteractionPendingSnapshot) => void;
   onInteractionResolved: (pending: InteractionPendingSnapshot) => void;
   onTranscriptSettlement: (turnId: string) => void;
@@ -96,6 +98,7 @@ export class RuntimeHostSessionChannel {
   readonly #now: () => number;
   readonly #onTurnStarted: (turn: MakaPreparedSessionTurn) => void;
   readonly #onRuntimeResourceChanged: (sourceSessionId: string, ref: string) => void;
+  readonly #onSessionDomainChanged: ((frame: SessionDomainChangedFrame) => void) | undefined;
   readonly #onInteractionPending: (pending: InteractionPendingSnapshot) => void;
   readonly #onInteractionResolved: (pending: InteractionPendingSnapshot) => void;
   readonly #onTranscriptSettlement: (turnId: string) => void;
@@ -136,6 +139,7 @@ export class RuntimeHostSessionChannel {
     this.#now = options.now;
     this.#onTurnStarted = options.onTurnStarted;
     this.#onRuntimeResourceChanged = options.onRuntimeResourceChanged;
+    this.#onSessionDomainChanged = options.onSessionDomainChanged;
     this.#onInteractionPending = options.onInteractionPending;
     this.#onInteractionResolved = options.onInteractionResolved;
     this.#onTranscriptSettlement = options.onTranscriptSettlement;
@@ -144,6 +148,16 @@ export class RuntimeHostSessionChannel {
     this.#onSnapshotChanged = options.onSnapshotChanged;
     this.#onFailed = options.onFailed;
     this.#onRecovered = options.onRecovered;
+    this.#subscribeSessionDomainChanges(subscription);
+  }
+
+  #subscribeSessionDomainChanges(subscription: RuntimeHostSessionSubscription): void {
+    if (!this.#onSessionDomainChanged) return;
+    subscription.subscribeSessionDomainChanges((frame) => {
+      if (!this.#closing && this.#subscription === subscription) {
+        this.#onSessionDomainChanged?.(frame);
+      }
+    });
   }
 
   static async open(
@@ -408,6 +422,7 @@ export class RuntimeHostSessionChannel {
         return;
       }
       this.#subscription = replacement;
+      this.#subscribeSessionDomainChanges(replacement);
       this.#ready = false;
       this.#pendingFrames.length = 0;
       void this.#pump(replacement);

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -28,6 +28,7 @@ import {
   type SessionSummary,
   type StoredMessage,
 } from '@maka/core/session';
+import { projectSessionTodoItemsForDisplay, type SessionTodoItem } from '@maka/core/session-todo';
 import { markPersisted } from '@maka/core/persisted-value';
 import {
   type ActiveInteractionRequestEvent,
@@ -74,6 +75,7 @@ import {
   type GoalControlAction,
   type GoalProjection,
   type SessionContinuitySnapshot,
+  type SessionDomainChangedFrame,
   type TurnResumeParkReason,
 } from '@maka/runtime-host/protocol';
 import { RuntimeHostSessionChannel } from './runtime-host-session-channel.js';
@@ -230,6 +232,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   #transcriptRefreshSequence = 0;
   readonly #startedTurnListeners = new Set<(turn: MakaAttachedSessionTurn) => void>();
   readonly #goalListeners = new Set<(goal: GoalProjection | null) => void>();
+  readonly #todoChangeListeners = new Set<(sessionId: string) => void>();
   readonly #pendingInteractionListeners = new Set<(pending: InteractionPendingSnapshot) => void>();
   readonly #claimedTurnIds = new Set<string>();
   readonly #shellRunListeners = new Set<(update: ShellRunUpdate) => void>();
@@ -560,6 +563,23 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   ): Promise<OperationOutput<'turn.message.query'>> {
     const sessionId = await this.#ensureSession();
     return this.#request('turn.message.query', { sessionId, messageIds });
+  }
+
+  async queryTodo(sessionId: string): Promise<{ sessionId: string; items: SessionTodoItem[] }> {
+    const currentSessionId = this.#requireSession('query Todo');
+    if (sessionId !== currentSessionId) {
+      throw new Error(`Cannot query Todo for a non-current Session: ${sessionId}`);
+    }
+    const sessionGeneration = this.#sessionGeneration;
+    const result = await this.#request('session.todo.query', { sessionId });
+    this.#assertCurrentSession(sessionId, sessionGeneration);
+    if (result.sessionId !== sessionId) {
+      throw new Error(`Runtime Host returned Todo for an unexpected Session: ${result.sessionId}`);
+    }
+    return {
+      sessionId,
+      items: projectSessionTodoItemsForDisplay(result.items),
+    };
   }
 
   async retractQueued(): Promise<MakaRetractedMessages> {
@@ -1103,6 +1123,11 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     return () => this.#goalListeners.delete(listener);
   }
 
+  subscribeTodoChanges(listener: (sessionId: string) => void): () => void {
+    this.#todoChangeListeners.add(listener);
+    return () => this.#todoChangeListeners.delete(listener);
+  }
+
   async controlGoal(action: GoalControlAction): Promise<GoalProjection | null> {
     const sessionId = this.#sessionId;
     if (!sessionId) return null;
@@ -1538,6 +1563,8 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       onTurnStarted: (turn) => this.#publishStartedTurn(turn, sessionGeneration),
       onRuntimeResourceChanged: (sourceSessionId, ref) =>
         this.#publishRuntimeResource(sourceSessionId, ref),
+      onSessionDomainChanged: (frame) =>
+        this.#publishSessionDomainChanged(frame, sessionId, sessionGeneration),
       onInteractionPending: (pending) => {
         for (const listener of this.#pendingInteractionListeners) listener(pending);
       },
@@ -1558,8 +1585,32 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
         if (this.#sessionId !== sessionId || this.#sessionGeneration !== sessionGeneration) return;
         for (const listener of this.#goalListeners) listener(goal);
       },
-      onRecovered: () => this.#refreshRuntimeResources(sessionId),
+      onRecovered: () => {
+        this.#refreshRuntimeResources(sessionId);
+        this.#publishTodoChanged(sessionId, sessionGeneration);
+      },
     });
+  }
+
+  #publishSessionDomainChanged(
+    frame: SessionDomainChangedFrame,
+    sessionId: string,
+    sessionGeneration: number,
+  ): void {
+    if (
+      frame.domain !== 'todo' ||
+      frame.sessionId !== sessionId ||
+      this.#sessionId !== sessionId ||
+      this.#sessionGeneration !== sessionGeneration
+    ) {
+      return;
+    }
+    this.#publishTodoChanged(sessionId, sessionGeneration);
+  }
+
+  #publishTodoChanged(sessionId: string, sessionGeneration: number): void {
+    if (this.#sessionId !== sessionId || this.#sessionGeneration !== sessionGeneration) return;
+    for (const listener of this.#todoChangeListeners) listener(sessionId);
   }
 
   #publishRuntimeResource(sourceSessionId: string, ref: string): void {

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -23,6 +23,7 @@ import type { OrchestrationMode } from '@maka/core/orchestration';
 import type { PermissionMode } from '@maka/core/permission';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type { SessionSummary, StoredMessage } from '@maka/core/session';
+import type { SessionTodoItem } from '@maka/core/session-todo';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { CreateSessionInput, TurnOrchestration } from '@maka/core/runtime-inputs';
 import type { UserQuestionResponse } from '@maka/core/user-question';
@@ -143,6 +144,8 @@ export interface MakaUserCommand {
 
 export interface MakaSessionDriver {
   listSessions(): Promise<SessionSummary[]>;
+  /** Reads the current committed Todo projection for the attached Session. */
+  queryTodo?(sessionId: string): Promise<{ sessionId: string; items: SessionTodoItem[] }>;
   getSessionResumeAvailability?(session: SessionSummary): Promise<SessionResumeAvailability>;
   preparePrompt(
     prompt: string,
@@ -221,6 +224,8 @@ export interface MakaSessionDriver {
    * resumed, cleared, or when the attached session changes.
    */
   subscribeGoalChanges?(listener: (goal: GoalProjection | null) => void): () => void;
+  /** Fires when the attached Session's committed Todo projection is invalidated. */
+  subscribeTodoChanges?(listener: (sessionId: string) => void): () => void;
   /**
    * Applies a goal control action (pause/resume/clear) with optimistic
    * revision retry, mirroring the desktop client. Resolves with the resulting

--- a/packages/cli/src/tui-copy-catalog.ts
+++ b/packages/cli/src/tui-copy-catalog.ts
@@ -18,6 +18,41 @@
  */
 
 export const TUI_COPY_RESOURCES = {
+  todo: {
+    en: {
+      title: 'Current Todo',
+      markedComplete: 'marked complete',
+      open: '/todo to view',
+      usage: 'Usage: /todo',
+      progress: 'Todo',
+      unavailable: 'Todo unavailable',
+      empty: 'No Todo items',
+      loading: 'Loading Todo…',
+      hint: '↑↓/PgUp/PgDn scroll · Home/End · Esc close',
+    },
+    'zh-CN': {
+      title: '当前待办',
+      markedComplete: '标记完成',
+      open: '/todo 查看',
+      usage: '用法：/todo',
+      progress: '待办',
+      unavailable: '待办不可用',
+      empty: '暂无待办',
+      loading: '正在加载待办…',
+      hint: '↑↓/PgUp/PgDn 滚动 · Home/End · Esc 关闭',
+    },
+    'zh-TW': {
+      title: '目前待辦',
+      markedComplete: '標記完成',
+      open: '/todo 查看',
+      usage: '用法：/todo',
+      progress: '待辦',
+      unavailable: '待辦不可用',
+      empty: '沒有待辦',
+      loading: '正在載入待辦…',
+      hint: '↑↓/PgUp/PgDn 捲動 · Home/End · Esc 關閉',
+    },
+  },
   'transcript-reader': {
     en: {
       title: 'DETAILED TRANSCRIPT',
@@ -947,6 +982,7 @@ export const TUI_COPY_RESOURCES = {
         skill: 'Invoke a skill (or type /skill:<name> inline)',
         swarm: 'Show, enable, disable, or run one Swarm turn',
         thinking: 'Set thinking level',
+        todo: 'Show the current session Todo list',
         transcript: 'Browse the full transcript inside Maka',
       },
       help: {
@@ -1000,6 +1036,7 @@ export const TUI_COPY_RESOURCES = {
         skill: '调用 Skill（也可直接输入 /skill:<name>）',
         swarm: '查看、启用、停用 Swarm 模式，或执行一次 Swarm 任务',
         thinking: '设置思考级别',
+        todo: '查看当前会话待办清单',
         transcript: '在 Maka 内浏览完整对话记录',
       },
       help: {
@@ -1053,6 +1090,7 @@ export const TUI_COPY_RESOURCES = {
         skill: '呼叫 Skill（也可直接輸入 /skill:<name>）',
         swarm: '檢視、啟用、停用 Swarm 模式，或執行一次 Swarm 任務',
         thinking: '設定思考級別',
+        todo: '檢視目前會話待辦清單',
         transcript: '在 Maka 內瀏覽完整對話記錄',
       },
       help: {

--- a/packages/core/src/__tests__/slash-command-catalog.test.ts
+++ b/packages/core/src/__tests__/slash-command-catalog.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { slashCommandsForSurface } from '../slash-command-catalog.js';
+
+describe('slash command catalog', () => {
+  test('/todo is a TUI-only read of the current session Todo projection', () => {
+    const todo = slashCommandsForSurface('tui').find((command) => command.id === 'todo');
+
+    assert.deepEqual(todo, {
+      id: 'todo',
+      session: 'required',
+      surfaces: ['tui'],
+    });
+    assert.equal(
+      slashCommandsForSurface('desktop').some((command) => (command.id as string) === 'todo'),
+      false,
+    );
+  });
+});

--- a/packages/core/src/slash-command-catalog.ts
+++ b/packages/core/src/slash-command-catalog.ts
@@ -51,6 +51,7 @@ export const SLASH_COMMAND_CATALOG = [
   { id: 'skill', session: 'required', surfaces: ['tui'] },
   { id: 'swarm', session: 'none', surfaces: ['desktop', 'tui'] },
   { id: 'thinking', session: 'required', surfaces: ['tui'] },
+  { id: 'todo', session: 'required', surfaces: ['tui'] },
   { id: 'transcript', session: 'required', surfaces: ['tui'] },
   { id: 'update', session: 'none', surfaces: ['tui'] },
 ] as const satisfies readonly SlashCommandSpec[];

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -181,6 +181,54 @@ test('PTY callbacks bypass a stalled Session iterator and isolate consumer failu
   await subscription.close();
 });
 
+test('domain callbacks validate identity, support unsubscribe, and stop on close', async () => {
+  const subscription = new ClientSessionSubscription(
+    openResult('host-1', 'subscription-domain'),
+    async () => undefined,
+    async () => {
+      throw new Error('unexpected read');
+    },
+  );
+  const domains: string[] = [];
+  const unsubscribe = subscription.subscribeSessionDomainChanges((frame) => {
+    domains.push(frame.domain);
+  });
+  subscription.accept({
+    kind: 'subscription.session_domain_changed',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-domain',
+    sequence: 1,
+    sessionId: 'session-1',
+    domain: 'todo',
+  });
+  assert.deepEqual(domains, ['todo']);
+
+  unsubscribe();
+  subscription.accept({
+    kind: 'subscription.session_domain_changed',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-domain',
+    sequence: 2,
+    sessionId: 'session-1',
+    domain: 'usage',
+  });
+  assert.deepEqual(domains, ['todo']);
+
+  await subscription.close();
+  assert.throws(
+    () =>
+      subscription.accept({
+        kind: 'subscription.session_domain_changed',
+        hostEpoch: 'host-1',
+        subscriptionId: 'subscription-domain',
+        sequence: 3,
+        sessionId: 'other-session',
+        domain: 'todo',
+      }),
+    /Session subscription is closed|Session subscription frame identity changed/,
+  );
+});
+
 test('isolates a sequence gap and continues requests on the same connection', async () => {
   await withProtocolPeer(
     async (transport, hostEpoch, rootId) => {

--- a/packages/runtime-host/src/client/session-subscription.ts
+++ b/packages/runtime-host/src/client/session-subscription.ts
@@ -22,6 +22,7 @@ import {
   encodeProtocolMessage,
   type SessionAssistantStreamIdentity,
   type SessionRuntimeResourcePtyDataFrame,
+  type SessionDomainChangedFrame,
   type SessionContinuitySnapshot,
   SESSION_TRANSCRIPT_PAGE_MAX_BYTES,
   SESSION_TRANSCRIPT_RANGE_MAX_BYTES,
@@ -63,6 +64,7 @@ function errorMessage(error: unknown): string {
 
 export interface RuntimeHostSessionSubscription extends AsyncIterable<SubscriptionFrame> {
   subscribePtyData(listener: (frame: SessionRuntimeResourcePtyDataFrame) => void): () => void;
+  subscribeSessionDomainChanges(listener: (frame: SessionDomainChangedFrame) => void): () => void;
   readonly hostEpoch: string;
   readonly subscriptionId: string;
   readonly snapshot: SessionContinuitySnapshot;
@@ -115,6 +117,7 @@ export class ClientSessionSubscription
   readonly #expectedSessionId: string;
   readonly #queue: QueuedFrame[] = [];
   readonly #ptyListeners = new Set<(frame: SessionRuntimeResourcePtyDataFrame) => void>();
+  readonly #sessionDomainListeners = new Set<(frame: SessionDomainChangedFrame) => void>();
   #queuedBytes = 0;
   #expectedSequence: number;
   #latestProjectionRevision: number;
@@ -162,6 +165,12 @@ export class ClientSessionSubscription
     if (this.#done || this.#terminalError || this.#closing) return () => undefined;
     this.#ptyListeners.add(listener);
     return () => this.#ptyListeners.delete(listener);
+  }
+
+  subscribeSessionDomainChanges(listener: (frame: SessionDomainChangedFrame) => void): () => void {
+    if (this.#done || this.#terminalError || this.#closing) return () => undefined;
+    this.#sessionDomainListeners.add(listener);
+    return () => this.#sessionDomainListeners.delete(listener);
   }
 
   next(): Promise<IteratorResult<SubscriptionFrame>> {
@@ -587,12 +596,23 @@ export class ClientSessionSubscription
       this.#latestTranscriptThroughSequence = frame.throughSequence;
     }
 
+    if (frame.kind === 'subscription.session_domain_changed') {
+      for (const listener of this.#sessionDomainListeners) {
+        try {
+          listener(frame);
+        } catch {
+          /* An invalidation consumer cannot terminate Session state. */
+        }
+      }
+    }
+
     this.#offer(frame);
     if (frame.kind === 'subscription.closed') this.#doneAfterQueue = true;
   }
 
   finish(): void {
     this.#ptyListeners.clear();
+    this.#sessionDomainListeners.clear();
     if (this.#done || this.#terminalError) return;
     this.#doneAfterQueue = true;
     if (this.#queue.length === 0) {
@@ -604,6 +624,7 @@ export class ClientSessionSubscription
 
   fail(error: Error): void {
     this.#ptyListeners.clear();
+    this.#sessionDomainListeners.clear();
     if (this.#done || this.#terminalError) return;
     this.#terminalError = error;
     this.#queue.length = 0;

--- a/scripts/check-tui-copy.mjs
+++ b/scripts/check-tui-copy.mjs
@@ -43,6 +43,7 @@ export const COVERED_FILES = [
   'packages/cli/src/tui-copy-command.ts',
   'packages/cli/src/tui-shortcut-copy.ts',
   'packages/cli/src/pi-tui-layout.ts',
+  'packages/cli/src/pi-tui-todo.ts',
 ];
 
 export const EXCLUDED_TUI_FILES = [


### PR DESCRIPTION
## Summary

Refs #5016

Add a current-session Todo indicator above the TUI composer and a read-only `/todo` view. The command is available during a running turn; Escape closes the view without interrupting the turn.

- Read the existing `session.todo.query` projection and refresh from existing Todo domain notifications, including recovery invalidation. No polling.
- Share one current-session state between the indicator and overlay; discard late results after session changes and disposal.
- Keep empty lists hidden, distinguish unavailable queries, wrap long items, and give the composer priority on short terminals.
- Keep Ctrl+O for the detailed transcript. Todo tools, tool result text, storage, Host wire protocol, and historical tool rows are unchanged. Completion is model-reported, not independent execution evidence.

Before:
```text
● Todo Write (4 lines · 202 bytes)
```

After (the historical row above remains unchanged; output below comes from the actual component renderer with a three-item fixture):
<details>
<summary>Rendered example (Chinese locale)</summary>

```text
◐ 测试切换会话与后台刷新 · 待办 1/3 · /todo 查看

当前待办 · 1/3 标记完成
✓ 验证当前待办视图
● 测试切换会话与后台刷新
○ 补充回归测试并提交 PR

↑↓/PgUp/PgDn 滚动 · Home/End · Esc 关闭
```

</details>

<details>
<summary>中文说明</summary>

输入框上方用一行展示当前待办，`/todo` 打开只读清单，Esc 返回；Ctrl+O 仍用于详细记录。直接查询 Host 已有的当前快照，不解析工具文本，不修改 Todo 工具或存储，也不把最新清单补到历史工具记录上。切换会话时丢弃过期结果；失败显示不可用，空清单隐藏提示。长文本换行，窄终端优先保证输入空间。

</details>

## Verification

- `npm run lint`, `npm run format:check`, `npm run build`, `npm run typecheck` — passed.
- `npx knip --workspace apps/desktop`, `npx knip --workspace packages/ui` — passed.
- `npm --workspace maka-agent run test:dist` — 906 passed, 0 failed, 3 existing skips.
- Runtime Host client subscription suite — 28 passed; core slash-command catalog regression — 1 passed.
- `npm run check:tui-copy` and copy-checker tests — passed (7 tests).
- Fake-terminal integration covers domain refresh, new-session clearing, mid-turn command routing, Escape, and unsupported drivers. State/component regressions cover late responses, disposal, session re-entry, errors, wrapping and navigation.
- Independent implementation review completed; its missing-capability empty-state finding was fixed and tested.
- Evidence above is rendered command output; no live-provider/manual terminal recording was performed. Build retains existing renderer chunk-size warnings.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented and tested this change; subagents assisted client wiring, UI implementation and independent review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
