### PR TITLE
feat(computer-use): move overlay cursor for set_value and press_key

### DIFF
--- a/packages/computer-use/src/__tests__/computer-use-overlay-hook.test.ts
+++ b/packages/computer-use/src/__tests__/computer-use-overlay-hook.test.ts
@@ -195,6 +195,31 @@ test('non-presented actions keep the session cursor without moving it', () => {
   assert.deepEqual(ensured, ['s1', 's1', 's1', 's1']);
 });
 
+test('set_value moves the cursor to the bound element point', () => {
+  const { controller, moves, ensured } = fakeController();
+  const hook = createComputerUseOverlayHook(controller as never);
+  hook.onActionBegin(
+    { type: 'set_value' },
+    {
+      sessionId: 's1',
+      toolCallId: 'a1',
+      presentationScreenPoint: { x: 201, y: 151 },
+      targetWindowId: 4321,
+    },
+  );
+  assert.deepEqual(ensured, []);
+  assert.equal((moves[0] as { kind: string }).kind, 'click');
+  assert.equal((moves[0] as { screenX: number }).screenX, 201);
+});
+
+test('press_key without a presentation point still only ensures', () => {
+  const { controller, moves, ensured } = fakeController();
+  const hook = createComputerUseOverlayHook(controller as never);
+  hook.onActionBegin({ type: 'press_key' }, { sessionId: 's1', toolCallId: 'a1' });
+  assert.deepEqual(moves, []);
+  assert.deepEqual(ensured, ['s1']);
+});
+
 // ── The seam, not the fixture ───────────────────────────────────────────────
 //
 // Every test above hands `presentationScreenPoint` to the hook by name. Nothing
@@ -330,6 +355,18 @@ test('a semantic action reaches the sink with the point it is aimed at', async (
     pulse: true,
     targetWindowId: 4321,
   });
+});
+
+test('set_value reaches the sink with the point it is aimed at', async () => {
+  const events = await driveRealTool({}, { action: 'set_value', element_id: '5', value: 'hi' });
+  assert.deepEqual(
+    events.map((event) => event.call),
+    ['move', 'complete'],
+    'writing into a field must move the cursor and land it, not ensure-then-cancel',
+  );
+  assert.equal((events[0]?.input as { kind?: string }).kind, 'click');
+  assert.equal((events[0]?.input as { screenX?: number }).screenX, 220);
+  assert.equal((events[0]?.input as { screenY?: number }).screenY, 110);
 });
 
 test('an element whose observed frame is outside its window is not aimed at', async () => {

--- a/packages/computer-use/src/__tests__/computer-use-overlay-hook.test.ts
+++ b/packages/computer-use/src/__tests__/computer-use-overlay-hook.test.ts
@@ -19,7 +19,6 @@
 
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { CuAction } from '@maka/core/computer-use';
 import { buildComputerUseTools } from '@maka/runtime/computer-use-tools';
 import { parseObservationText } from '@maka/runtime/test-only/observation-text-reader';
 import { createComputerUseOverlayHook } from '../computer-use-overlay-hook.js';
@@ -188,11 +187,12 @@ test('non-presented actions keep the session cursor without moving it', () => {
     { type: 'key', text: 'Return' },
     { type: 'screenshot' },
     { type: 'wait', durationMs: 100 },
-  ] as CuAction[]) {
+    { type: 'window_action' },
+  ] as const) {
     hook.onActionBegin(action, { sessionId: 's1', toolCallId: 'a1' });
   }
   assert.deepEqual(moves, []);
-  assert.deepEqual(ensured, ['s1', 's1', 's1', 's1']);
+  assert.deepEqual(ensured, ['s1', 's1', 's1', 's1', 's1']);
 });
 
 test('set_value moves the cursor to the bound element point', () => {
@@ -216,6 +216,42 @@ test('press_key without a presentation point still only ensures', () => {
   const { controller, moves, ensured } = fakeController();
   const hook = createComputerUseOverlayHook(controller as never);
   hook.onActionBegin({ type: 'press_key' }, { sessionId: 's1', toolCallId: 'a1' });
+  assert.deepEqual(moves, []);
+  assert.deepEqual(ensured, ['s1']);
+});
+
+test('press_key with a presentation point moves the click cursor', () => {
+  const { controller, moves, ensured } = fakeController();
+  const hook = createComputerUseOverlayHook(controller as never);
+  hook.onActionBegin(
+    { type: 'press_key' },
+    {
+      sessionId: 's1',
+      toolCallId: 'a1',
+      presentationScreenPoint: { x: 201, y: 151 },
+      targetWindowId: 4321,
+    },
+  );
+  assert.deepEqual(ensured, []);
+  assert.equal((moves[0] as { kind: string }).kind, 'click');
+  assert.equal((moves[0] as { screenX: number }).screenX, 201);
+});
+
+test('window_action with a presentation point still only ensures', () => {
+  // Production can attach a point: window_action has an elementId, and binding
+  // derives presentationScreenPoint from that frame. Without a point the
+  // ensure path hides a kindOf regression into the click group.
+  const { controller, moves, ensured } = fakeController();
+  const hook = createComputerUseOverlayHook(controller as never);
+  hook.onActionBegin(
+    { type: 'window_action' },
+    {
+      sessionId: 's1',
+      toolCallId: 'a1',
+      presentationScreenPoint: { x: 201, y: 151 },
+      targetWindowId: 4321,
+    },
+  );
   assert.deepEqual(moves, []);
   assert.deepEqual(ensured, ['s1']);
 });
@@ -364,9 +400,45 @@ test('set_value reaches the sink with the point it is aimed at', async () => {
     ['move', 'complete'],
     'writing into a field must move the cursor and land it, not ensure-then-cancel',
   );
-  assert.equal((events[0]?.input as { kind?: string }).kind, 'click');
-  assert.equal((events[0]?.input as { screenX?: number }).screenX, 220);
-  assert.equal((events[0]?.input as { screenY?: number }).screenY, 110);
+  assert.deepEqual(events[0]?.input, {
+    screenX: 220,
+    screenY: 110,
+    kind: 'click',
+    instant: true,
+    keepElevated: false,
+    targetWindowId: 4321,
+  });
+  assert.deepEqual(events[1]?.input, {
+    screenX: 220,
+    screenY: 110,
+    kind: 'click',
+    pulse: true,
+    targetWindowId: 4321,
+  });
+});
+
+test('press_key with an element reaches the sink with the point it is aimed at', async () => {
+  const events = await driveRealTool({}, { action: 'press_key', element_id: '5', text: 'Return' });
+  assert.deepEqual(
+    events.map((event) => event.call),
+    ['move', 'complete'],
+    'a key aimed at a named control must move the cursor and land it, not ensure-then-cancel',
+  );
+  assert.deepEqual(events[0]?.input, {
+    screenX: 220,
+    screenY: 110,
+    kind: 'click',
+    instant: true,
+    keepElevated: false,
+    targetWindowId: 4321,
+  });
+  assert.deepEqual(events[1]?.input, {
+    screenX: 220,
+    screenY: 110,
+    kind: 'click',
+    pulse: true,
+    targetWindowId: 4321,
+  });
 });
 
 test('an element whose observed frame is outside its window is not aimed at', async () => {

--- a/packages/computer-use/src/computer-use-overlay-hook.ts
+++ b/packages/computer-use/src/computer-use-overlay-hook.ts
@@ -76,6 +76,8 @@ function kindOf(action: CuPresentationAction): CursorActionKind | undefined {
     case 'click_element':
     case 'select_text':
     case 'secondary_action':
+    case 'set_value':
+    case 'press_key':
       return 'click';
     case 'scroll_element':
       return 'scroll';

--- a/packages/computer-use/src/computer-use-overlay-hook.ts
+++ b/packages/computer-use/src/computer-use-overlay-hook.ts
@@ -72,6 +72,9 @@ const RESOLVED_PRESENTATION_FENCE: CuPresentationFence = {
 };
 
 function kindOf(action: CuPresentationAction): CursorActionKind | undefined {
+  // Every presentation type has to decide here. The original omission of
+  // set_value and press_key was this switch being an allow-list with a silent
+  // default; `never` makes the next new type fail to compile instead.
   switch (action.type) {
     case 'click_element':
     case 'select_text':
@@ -81,8 +84,26 @@ function kindOf(action: CuPresentationAction): CursorActionKind | undefined {
       return 'click';
     case 'scroll_element':
       return 'scroll';
-    default:
+    case 'type':
+      // Typed at whatever currently has focus; flying would invent a target.
       return undefined;
+    case 'key':
+      // Posted at whatever currently has focus; flying would invent a target.
+      return undefined;
+    case 'screenshot':
+      // A capture does not aim at a control; moving the cursor would lie about where work happened.
+      return undefined;
+    case 'wait':
+      // A pause does not aim at a control; moving the cursor would lie about where work happened.
+      return undefined;
+    case 'window_action':
+      // The window itself often has no element frame, and #5049 left flying to it out of scope.
+      return undefined;
+    default: {
+      const unhandled: never = action;
+      void unhandled;
+      return undefined;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

`set_value` and element-targeted `press_key` already get a `presentationScreenPoint` from `claimBoundAction`. Overlay `kindOf` only treated click/select/secondary/scroll as movable, so those two actions only ensured the session cursor.

This PR maps `set_value` and `press_key` to the click cursor. A `press_key` without a point still only ensures. Coordinate-dialect `type` / `key` / `screenshot` / `wait` stay unmoved. `window_action` is out of scope.

Fixes #5049

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

## Verification

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/runtime run build`
- `npm --workspace @maka/computer-use run build`
- `npm --workspace @maka/computer-use run test:dist` — 120 pass, including hook `set_value` move, `press_key` without a point still ensure, and `driveRealTool` `set_value` → move+complete
- Did not run root `lint` / `format:check` / full `typecheck`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

pi-coding-agent drafted the `kindOf` mapping, tests, and this description. Commits carry `Generated-by: pi-coding-agent`.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally
