### PR TITLE
feat(computer-use): keep overlay cursor elevated when the aim point is covered

### DIFF
--- a/packages/computer-use/src/__tests__/computer-use-overlay-hook.test.ts
+++ b/packages/computer-use/src/__tests__/computer-use-overlay-hook.test.ts
@@ -111,6 +111,55 @@ test('with no window to order against the cursor stays elevated', () => {
   assert.equal((moves[0] as { targetWindowId?: number }).targetWindowId, undefined);
 });
 
+test('a covered aim point stays elevated even with a window to sink onto', () => {
+  // A rect list is not a whole-window cover: the top-edge control can still
+  // be visible. Only the point about to be drawn decides elevation.
+  const { controller, moves } = fakeController();
+  const hook = createComputerUseOverlayHook(controller as never);
+  hook.onActionBegin(
+    { type: 'click_element' },
+    {
+      sessionId: 's1',
+      toolCallId: 'a1',
+      presentationScreenPoint: { x: 201, y: 151 },
+      targetWindowId: 4321,
+      obscuringRects: [{ x: 200, y: 150, width: 20, height: 20 }],
+    },
+  );
+  assert.equal((moves[0] as { keepElevated: boolean }).keepElevated, true);
+});
+
+test('an uncovered aim point still sinks when a window is there to order against', () => {
+  const { controller, moves } = fakeController();
+  const hook = createComputerUseOverlayHook(controller as never);
+  hook.onActionBegin(
+    { type: 'click_element' },
+    {
+      sessionId: 's1',
+      toolCallId: 'a1',
+      presentationScreenPoint: { x: 201, y: 151 },
+      targetWindowId: 4321,
+      obscuringRects: [{ x: 0, y: 0, width: 10, height: 10 }],
+    },
+  );
+  assert.equal((moves[0] as { keepElevated: boolean }).keepElevated, false);
+});
+
+test('missing obscuring rects do not flip a window-bound cursor to stay up', () => {
+  const { controller, moves } = fakeController();
+  const hook = createComputerUseOverlayHook(controller as never);
+  hook.onActionBegin(
+    { type: 'click_element' },
+    {
+      sessionId: 's1',
+      toolCallId: 'a1',
+      presentationScreenPoint: { x: 201, y: 151 },
+      targetWindowId: 4321,
+    },
+  );
+  assert.equal((moves[0] as { keepElevated: boolean }).keepElevated, false);
+});
+
 test('the landing carries the window the cursor has to come back down to', () => {
   // `complete` raises the cursor for the trip to the executor's coordinate, so
   // it is the last thing that can tell the sink which window to sink onto. An

--- a/packages/computer-use/src/__tests__/computer-use-overlay-hook.test.ts
+++ b/packages/computer-use/src/__tests__/computer-use-overlay-hook.test.ts
@@ -381,6 +381,25 @@ test('a semantic action reaches the sink with the point it is aimed at', async (
   });
 });
 
+test('a covered aim point from a real observation stays elevated', async () => {
+  // The hook-only cases cannot see computer-use-tools copying record.obscuringRects
+  // onto overlay context. A rect covering the element centre (220,110) must survive
+  // observe → registerObservation → runWithPresentation.
+  const events = await driveRealTool(
+    { obscuringRects: [{ x: 210, y: 100, width: 20, height: 20 }] },
+    { action: 'click_element', element_id: '5' },
+  );
+  assert.equal((events[0]?.input as { keepElevated?: boolean }).keepElevated, true);
+});
+
+test('an uncovered aim point from a real observation still sinks', async () => {
+  const events = await driveRealTool(
+    { obscuringRects: [{ x: 0, y: 0, width: 10, height: 10 }] },
+    { action: 'click_element', element_id: '5' },
+  );
+  assert.equal((events[0]?.input as { keepElevated?: boolean }).keepElevated, false);
+});
+
 test('an element whose observed frame is outside its window is not aimed at', async () => {
   // A frame that no longer lies inside the window is stale or the element has
   // moved, which is what the executor refuses the action for. Flying the cursor

--- a/packages/computer-use/src/computer-use-overlay-hook.ts
+++ b/packages/computer-use/src/computer-use-overlay-hook.ts
@@ -90,21 +90,34 @@ function kindOf(action: CuPresentationAction): CursorActionKind | undefined {
  * just been launched to a new position — and only lets it sink into the
  * target's own layer once the target is genuinely the window under the cursor.
  *
- * Maka has one of those two reasons available and not the other. The launch
- * half is the sink's own business (the presentation layer is what knows when a
- * motion settles). The frontmost/covered half needs a per-observation record of
- * what is stacked over the target, which the runtime does not collect, so it is
- * deliberately not modelled here rather than declared as a field nothing sets.
- *
- * What is left is the ordering: with a window id to order against, the cursor
- * does not need a level to stay visible — its position in the target's own
- * z-order is what keeps it readable, exactly as it is for Codex. Staying
- * elevated on top of that is what put the cursor over the user's own windows.
- * With no window to order against there is nothing to sink to, so it stays up:
- * an unseen cursor is the failure this whole path exists to avoid.
+ * The launch half is the sink's own business. The covered half is the aim
+ * point against `obscuringRects` from the last observation: a control on the
+ * top edge can be visible while the middle of the window is buried, so a
+ * non-empty rect list is not enough to stay up. Missing rects must not flip
+ * window-bound cursors to stay-up — that is what put the cursor over the
+ * user's own windows. With no window to order against there is nothing to
+ * sink to, so it stays up: an unseen cursor is the failure this path exists
+ * to avoid.
  */
+function pointInRect(
+  point: { x: number; y: number },
+  rect: { x: number; y: number; width: number; height: number },
+): boolean {
+  if (!(rect.width > 0) || !(rect.height > 0)) return false;
+  return (
+    point.x >= rect.x &&
+    point.x < rect.x + rect.width &&
+    point.y >= rect.y &&
+    point.y < rect.y + rect.height
+  );
+}
+
 function keepElevated(context: CuOverlayHookContext): boolean {
-  return context.targetWindowId === undefined;
+  if (context.targetWindowId === undefined) return true;
+  const point = context.presentationScreenPoint;
+  const rects = context.obscuringRects;
+  if (!point || !rects || rects.length === 0) return false;
+  return rects.some((rect) => pointInRect(point, rect));
 }
 
 export function createComputerUseOverlayHook(controller: OverlayCursorSink): CuOverlayHook {

--- a/packages/computer-use/src/maka-cu-backend.ts
+++ b/packages/computer-use/src/maka-cu-backend.ts
@@ -1478,12 +1478,10 @@ export function createMakaCuBackend(opts: MakaCuBackendOptions): MakaCuBackend {
       // titleless full-screen surface that is the Dock and not a cover. maka-cu
       // answers it directly.
       //
-      // Nothing reads it yet. This comment used to say the runtime already knew
-      // what to do with the answer, naming `frontmost` and `destinationCovered`
-      // as the two readings of it, and neither symbol exists anywhere in the
-      // tree. It is carried because the executor's answer is the authoritative
-      // one and re-deriving it later would repeat the cua-driver mistake, but
-      // "carried, unread" is what is true today.
+      // The overlay cursor reads these as point-in-rect cover. The host still
+      // does not re-derive occlusion — the executor's answer is the
+      // authoritative one, and reconstructing it from the window server was the
+      // cua-driver mistake.
       obscuringRects: snapshot.obscuringRects,
       // §4.3: the window digest already is a content fingerprint over every
       // element digest plus bounds and title, computed where the tree lives.

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -1407,6 +1407,7 @@ export function buildComputerUseTools(deps: {
     // -1 is not undefined — an unguarded field would hand `window:-1:0` to the
     // reorder and rely on it throwing.
     const targetWindowId = context.boundAction?.target.windowId;
+    const overlayRects = observations.get(context.sessionId)?.obscuringRects;
     const overlayContext: CuOverlayHookContext = {
       sessionId: context.sessionId,
       toolCallId: context.toolCallId,
@@ -1414,6 +1415,7 @@ export function buildComputerUseTools(deps: {
       ...(Number.isInteger(targetWindowId) && (targetWindowId as number) > 0
         ? { targetWindowId: targetWindowId as number }
         : {}),
+      ...(overlayRects && overlayRects.length > 0 ? { obscuringRects: overlayRects } : {}),
     };
     let fence: CuPresentationFence | undefined;
     try {

--- a/packages/runtime/src/computer-use-types.ts
+++ b/packages/runtime/src/computer-use-types.ts
@@ -23,6 +23,7 @@ import type {
   ComputerUseEffect,
   ComputerUseErrorCode,
   ComputerUsePageIdentity,
+  ComputerUseRect,
   CuAction,
   CuPoint,
 } from '@maka/core/computer-use';
@@ -352,6 +353,14 @@ export interface CuOverlayHookContext {
    * the cursor rests at a fixed level instead.
    */
   targetWindowId?: number;
+  /**
+   * Screen rectangles stacked above the target window, from the last
+   * observation. Presentation-only: the cursor checks the point it is about
+   * to draw at, since a control near the top edge can be visible while the
+   * middle of the window is buried. Absent or empty means no evidence of
+   * cover, so a window-bound cursor may sink.
+   */
+  obscuringRects?: ComputerUseRect[];
 }
 
 export interface CuOverlayHook {


### PR DESCRIPTION
## Summary

`obscuringRects` already travel from maka-cu through the observation record, and `CuObservation` says the agent cursor should test the point it is about to draw. `keepElevated` still sank whenever a window id existed, so a covered aim point could disappear under the covering window.

This PR:

- adds `obscuringRects` to overlay context
- copies them from the session observation record
- stays elevated only when the aim point hits a rect
- keeps today's sink behaviour when rects are missing or the point is clear

Does not change the desktop sink z-order implementation. Elevation is per point, not per whole window.

Fixes #5048

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

## Verification

- `npm --workspace @maka/runtime run build`
- `npm --workspace @maka/computer-use run build`
- `npm --workspace @maka/computer-use run test:dist` — 122 pass, including hook-only point-in-rect cases and `driveRealTool` wiring (covered centre stays up, uncovered centre still sinks)
- Did not run root `lint` / `format:check` / full `typecheck`
- No overlay recording attached (behaviour is asserted in tests; desktop sink is unchanged)

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

pi-coding-agent drafted the overlay context wiring, point-in-rect `keepElevated`, tests, and this description. Commits carry `Generated-by: pi-coding-agent`.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally
