### PR TITLE
feat(runtime): add Gemini Google Search grounding

### DIFF
--- a/packages/core/src/__tests__/model-web-search.test.ts
+++ b/packages/core/src/__tests__/model-web-search.test.ts
@@ -57,11 +57,27 @@ describe('hosted web search capability', () => {
       resolveHostedWebSearchCapability('anthropic', undefined, 'claude-sonnet-4-6'),
       { adapter: 'anthropic-messages', implemented: true },
     );
+    assert.deepEqual(resolveHostedWebSearchCapability('google', undefined, 'gemini-2.0-flash'), {
+      adapter: 'google-grounding',
+      implemented: false,
+    });
     assert.deepEqual(resolveHostedWebSearchCapability('google', undefined, 'gemini-2.5-flash'), {
+      adapter: 'google-grounding',
+      implemented: false,
+    });
+    assert.deepEqual(resolveHostedWebSearchCapability('google', undefined, 'gemini-3-flash'), {
+      adapter: 'google-grounding',
+      implemented: true,
+    });
+    assert.deepEqual(resolveHostedWebSearchCapability('google', undefined, 'gemini-3.5-flash'), {
       adapter: 'google-grounding',
       implemented: true,
     });
     assert.equal(resolveHostedWebSearchCapability('google', undefined, 'gemini-1.5-flash'), null);
+    assert.deepEqual(resolveHostedWebSearchCapability('openrouter', undefined, 'gemini-3-flash'), {
+      adapter: 'openrouter-web-plugin',
+      implemented: false,
+    });
     assert.deepEqual(resolveHostedWebSearchCapability('zai', undefined, 'glm-5'), {
       adapter: 'zai-web-search',
       implemented: false,
@@ -77,6 +93,14 @@ describe('hosted web search capability', () => {
         'deepseek-v4-flash',
       ),
       null,
+    );
+    assert.deepEqual(
+      resolveHostedWebSearchCapability(
+        'google',
+        [{ id: 'gemini-2.5-flash', capabilities: { webSearch: true } }],
+        'gemini-2.5-flash',
+      ),
+      { adapter: 'google-grounding', implemented: false },
     );
     assert.deepEqual(
       resolveHostedWebSearchCapability(

--- a/packages/core/src/__tests__/model-web-search.test.ts
+++ b/packages/core/src/__tests__/model-web-search.test.ts
@@ -59,8 +59,9 @@ describe('hosted web search capability', () => {
     );
     assert.deepEqual(resolveHostedWebSearchCapability('google', undefined, 'gemini-2.5-flash'), {
       adapter: 'google-grounding',
-      implemented: false,
+      implemented: true,
     });
+    assert.equal(resolveHostedWebSearchCapability('google', undefined, 'gemini-1.5-flash'), null);
     assert.deepEqual(resolveHostedWebSearchCapability('zai', undefined, 'glm-5'), {
       adapter: 'zai-web-search',
       implemented: false,

--- a/packages/core/src/__tests__/model-web-search.test.ts
+++ b/packages/core/src/__tests__/model-web-search.test.ts
@@ -104,6 +104,14 @@ describe('hosted web search capability', () => {
     );
     assert.deepEqual(
       resolveHostedWebSearchCapability(
+        'google',
+        [{ id: 'gemini-3-flash', capabilities: { webSearch: true } }],
+        'gemini-3-flash',
+      ),
+      { adapter: 'google-grounding', implemented: true },
+    );
+    assert.deepEqual(
+      resolveHostedWebSearchCapability(
         'openai',
         [
           {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -743,6 +743,8 @@ export interface ToolResultEvent extends BaseEvent, ToolActivityIdentity {
   operationId?: string;
   /** True when the provider executed the tool inside the model request. */
   providerExecuted?: boolean;
+  /** Opaque provider metadata required to reconstruct a native toolResponse on replay. */
+  providerOptions?: Record<string, unknown>;
   /** Raw provider result retained for provider-native replay; never rendered directly. */
   providerOutput?: unknown;
   /** Provider-neutral model-visible output computed before durable publication. */

--- a/packages/core/src/model-web-search.ts
+++ b/packages/core/src/model-web-search.ts
@@ -98,7 +98,7 @@ function providerHostedWebSearchAdapter(
     case 'anthropic-compatible':
       return { adapter: 'anthropic-messages', implemented: true };
     case 'google':
-      return { adapter: 'google-grounding', implemented: false };
+      return { adapter: 'google-grounding', implemented: true };
     case 'zai':
     case 'zai-coding-plan':
       return { adapter: 'zai-web-search', implemented: false };

--- a/packages/core/src/model-web-search.ts
+++ b/packages/core/src/model-web-search.ts
@@ -69,9 +69,24 @@ export function resolveHostedWebSearchCapability(
     return null;
   }
   if (stored?.capabilities?.webSearch === true) {
-    return adapter;
+    return adapter.adapter === 'google-grounding' ? googleGroundingCapability(id) : adapter;
   }
   return providerDefaultHostedWebSearchCapability(providerType, id, adapter);
+}
+
+/**
+ * @ai-sdk/google drops function tools when `googleSearch` is present on
+ * pre-Gemini-3 models. Gemini 3+ is the only documented mix that keeps both.
+ */
+export function geminiModelAllowsGoogleSearchToolMix(modelId: string): boolean {
+  return /^gemini-3(?:[.-]|$)/i.test(modelId.trim());
+}
+
+function googleGroundingCapability(modelId: string): HostedWebSearchCapability {
+  return {
+    adapter: 'google-grounding',
+    implemented: geminiModelAllowsGoogleSearchToolMix(modelId),
+  };
 }
 
 function providerHostedWebSearchAdapter(
@@ -140,7 +155,9 @@ function providerDefaultHostedWebSearchCapability(
     case 'openai-responses-compatible':
       return null;
     case 'google':
-      return /^gemini-(?:2\.0|2\.5|3|3\.1|3\.5)(?:[.-]|$)/i.test(modelId) ? capability : null;
+      return /^gemini-(?:2\.0|2\.5|3|3\.1|3\.5)(?:[.-]|$)/i.test(modelId)
+        ? googleGroundingCapability(modelId)
+        : null;
     case 'zai':
     case 'zai-coding-plan':
       return /^glm-(?:4\.5|4\.6|4\.7|5)(?:[.-]|$)/i.test(modelId) ? capability : null;

--- a/packages/core/src/model-web-search.ts
+++ b/packages/core/src/model-web-search.ts
@@ -113,7 +113,10 @@ function providerHostedWebSearchAdapter(
     case 'anthropic-compatible':
       return { adapter: 'anthropic-messages', implemented: true };
     case 'google':
-      return { adapter: 'google-grounding', implemented: true };
+      // implemented is produced only by googleGroundingCapability (Gemini 3+
+      // mix). A true here would be overwritten on every live path and would
+      // lie if a stored webSearch:true ever returned the adapter as-is.
+      return { adapter: 'google-grounding', implemented: false };
     case 'zai':
     case 'zai-coding-plan':
       return { adapter: 'zai-web-search', implemented: false };

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -222,6 +222,8 @@ export interface RuntimeEventFunctionResponseContent {
   result: unknown;
   isError?: boolean;
   providerExecuted?: boolean;
+  /** Opaque provider metadata required to reconstruct a native toolResponse on replay. */
+  providerOptions?: Record<string, unknown>;
   /** Raw provider result retained for provider-native replay; never rendered directly. */
   providerOutput?: unknown;
   /** Frozen provider-neutral content consumed by every model-history projection. */
@@ -739,7 +741,7 @@ const FUNCTION_CALL_CONTENT_SHAPE = defineObjectShape<RuntimeEventFunctionCallCo
 );
 const FUNCTION_RESPONSE_CONTENT_SHAPE = defineObjectShape<RuntimeEventFunctionResponseContent>()(
   ['kind', 'id', 'name', 'result'],
-  ['isError', 'providerExecuted', 'providerOutput', 'modelProjection'],
+  ['isError', 'providerExecuted', 'providerOptions', 'providerOutput', 'modelProjection'],
 );
 const ERROR_CONTENT_SHAPE = defineObjectShape<RuntimeEventErrorContent>()(
   ['kind', 'message'],
@@ -1081,6 +1083,7 @@ function isRuntimeEventContent(value: unknown): value is RuntimeEventContent {
         Object.hasOwn(value, 'result') &&
         (value.isError === undefined || typeof value.isError === 'boolean') &&
         (value.providerExecuted === undefined || typeof value.providerExecuted === 'boolean') &&
+        (value.providerOptions === undefined || isRecord(value.providerOptions)) &&
         (value.modelProjection === undefined ||
           decodesDurableToolResultProjection(value.modelProjection))
       );

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -869,6 +869,8 @@ export interface ToolResultMessage {
   isError: boolean;
   content: ToolResultContent;
   providerExecuted?: boolean;
+  /** Opaque provider metadata required to reconstruct a native toolResponse on replay. */
+  providerOptions?: Record<string, unknown>;
   /** Raw provider result retained only for provider-native replay. */
   providerOutput?: unknown;
   durationMs?: number;
@@ -1251,6 +1253,7 @@ const TOOL_RESULT_MESSAGE_SHAPE = defineObjectShape<ToolResultMessage>()(
   [
     'durationMs',
     'providerExecuted',
+    'providerOptions',
     'providerOutput',
     'origin',
     'modelVisibility',
@@ -1544,6 +1547,7 @@ function decodeMessage(
         typeof message.toolUseId === 'string' &&
         typeof message.isError === 'boolean' &&
         (message.providerExecuted === undefined || typeof message.providerExecuted === 'boolean') &&
+        (message.providerOptions === undefined || isRecord(message.providerOptions)) &&
         isOptionalFiniteDuration(message.durationMs) &&
         isToolActivityIdentity(message)
       )

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -15813,6 +15813,88 @@ describe('AiSdkBackend steering durability and identity', () => {
       /encrypted-result/,
     );
   });
+
+  test('renders Gemini Google Search grounding as web_search rows and keeps replay metadata', async () => {
+    const providerMetadata = {
+      google: {
+        serverToolCallId: 'search-google-1',
+        serverToolType: 'GOOGLE_SEARCH_WEB',
+      },
+    };
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'tool-call',
+              toolCallId: 'search-google-1',
+              toolName: 'server:GOOGLE_SEARCH_WEB',
+              input: JSON.stringify({ query: 'latest Maka' }),
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'search-google-1',
+              toolName: 'server:GOOGLE_SEARCH_WEB',
+              result: {},
+              providerExecuted: true,
+              providerMetadata,
+            },
+            {
+              type: 'source',
+              sourceType: 'url',
+              id: 'src-1',
+              url: 'https://maka.example/',
+              title: 'Maka',
+            },
+            { type: 'text-start', id: 'text-google-1' },
+            { type: 'text-delta', id: 'text-google-1', delta: 'Maka is current.' },
+            { type: 'text-end', id: 'text-google-1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: emptyUsage(),
+            },
+          ] as LanguageModelV4StreamPart[],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      }),
+    });
+    const backend = createBackend({
+      connection: {
+        slug: 'google',
+        providerType: 'google',
+        defaultModel: 'gemini-3-flash',
+      },
+      modelId: 'gemini-3-flash',
+      modelFactory: () => model,
+      tools: [buildNativeWebSearchTool({ adapter: 'google-grounding' })],
+    });
+    const events: SessionEvent[] = [];
+
+    await collectEvents(backend.send({ turnId: 'turn-1', text: 'search', context: [] }), events);
+
+    const result = events.find((event) => event.type === 'tool_result');
+    assert.deepEqual(result?.type === 'tool_result' ? result.content : undefined, {
+      kind: 'web_search',
+      provider: 'model',
+      query: 'latest Maka',
+      rows: [
+        {
+          title: 'Maka',
+          url: 'https://maka.example/',
+          snippet: '',
+          source: 'maka.example',
+        },
+      ],
+    });
+    assert.deepEqual(
+      result?.type === 'tool_result' ? result.providerOptions : undefined,
+      providerMetadata,
+    );
+  });
 });
 
 function textCompletionModel(text: string): MockLanguageModelV4 {

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -20,8 +20,9 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { RetryError } from 'ai';
+import { google } from '@ai-sdk/google';
 
-import { ModelAdapter, normalizeAiSdkUsage } from '../model-adapter.js';
+import { lowerModelTools, ModelAdapter, normalizeAiSdkUsage } from '../model-adapter.js';
 import type { ModelStreamEvent } from '../model-protocol.js';
 
 describe('ModelAdapter stream and error normalization', () => {
@@ -1087,6 +1088,27 @@ describe('ModelAdapter stream and error normalization', () => {
         },
       },
     );
+  });
+});
+
+describe('compileProviderTool', () => {
+  test('lowers Gemini Google Search grounding to the official provider tool', () => {
+    const compiled = lowerModelTools({
+      WebSearch: { kind: 'provider', providerTool: { kind: 'google-search' } },
+    }).WebSearch as {
+      type?: string;
+      id?: string;
+      isProviderExecuted?: boolean;
+      args?: unknown;
+    };
+    const official = google.tools.googleSearch({});
+
+    assert.equal(compiled.type, 'provider');
+    assert.equal(compiled.id, 'google.google_search');
+    assert.equal(compiled.isProviderExecuted, true);
+    assert.deepEqual(compiled.args, official.args);
+    assert.equal(compiled.type, official.type);
+    assert.equal(compiled.id, official.id);
   });
 });
 

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -20,9 +20,9 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { RetryError } from 'ai';
-import { google } from '@ai-sdk/google';
 
 import { lowerModelTools, ModelAdapter, normalizeAiSdkUsage } from '../model-adapter.js';
+import { AiSdkMessageProjection } from '../ai-sdk-message-projection.js';
 import type { ModelStreamEvent } from '../model-protocol.js';
 
 describe('ModelAdapter stream and error normalization', () => {
@@ -728,6 +728,104 @@ describe('ModelAdapter stream and error normalization', () => {
     );
   });
 
+  test('keeps Gemini Google Search tool-result provider metadata for replay', () => {
+    const adapter = newAdapter();
+    type Chunk = Parameters<typeof adapter.translateChunk>[0];
+    const providerMetadata = {
+      google: {
+        serverToolCallId: 'search-google',
+        serverToolType: 'GOOGLE_SEARCH_WEB',
+      },
+    };
+
+    assert.deepEqual(
+      adapter.translateChunk({
+        type: 'tool-result',
+        toolCallId: 'search-google',
+        toolName: 'server:GOOGLE_SEARCH_WEB',
+        providerExecuted: true,
+        output: {},
+        providerMetadata,
+      } as Chunk),
+      [
+        {
+          kind: 'provider-tool-result',
+          toolCallId: 'search-google',
+          toolName: 'server:GOOGLE_SEARCH_WEB',
+          output: {},
+          providerOptions: providerMetadata,
+        },
+      ],
+    );
+    assert.deepEqual(
+      adapter.translateChunk({
+        type: 'source',
+        sourceType: 'url',
+        id: 'src-1',
+        url: 'https://maka.example/',
+        title: 'Maka',
+      } as Chunk),
+      [{ kind: 'source', url: 'https://maka.example/', title: 'Maka' }],
+    );
+  });
+
+  test('replays Gemini Google Search tool-result providerOptions onto the SDK part', async () => {
+    const adapter = newAdapter();
+    const projection = new AiSdkMessageProjection({
+      modelAdapter: adapter,
+      applyPatchProfile: null,
+    });
+    const providerOptions = {
+      google: { serverToolCallId: 'search-1', serverToolType: 'GOOGLE_SEARCH_WEB' },
+    };
+    const messages = await projection.materializeRuntimeReplayPlan(
+      {
+        items: [
+          {
+            kind: 'tool_call',
+            invocationId: 'inv-1',
+            toolCallId: 'search-1',
+            toolName: 'WebSearch',
+            input: { query: 'latest Maka' },
+            providerExecuted: true,
+            providerOptions,
+            stepId: 'step-1',
+            eventId: 'evt-call',
+            ts: 1,
+          },
+          {
+            kind: 'tool_result',
+            invocationId: 'inv-1',
+            toolCallId: 'search-1',
+            toolName: 'WebSearch',
+            output: {},
+            isError: false,
+            providerExecuted: true,
+            providerOptions,
+            eventId: 'evt-result',
+            ts: 2,
+          },
+        ],
+        textMessages: [],
+        semanticKinds: [],
+        diagnostics: [],
+        hasProviderNativeSemantics: true,
+      },
+      { used: 0, decisions: new Map() },
+      undefined,
+      new Set(),
+    );
+    const assistant = messages.find((message) => message.role === 'assistant');
+    assert.ok(assistant);
+    const resultPart = Array.isArray(assistant.content)
+      ? assistant.content.find((part) => part.type === 'tool-result')
+      : undefined;
+    assert.deepEqual(
+      resultPart && 'providerOptions' in resultPart ? resultPart.providerOptions : undefined,
+      providerOptions,
+    );
+  });
+
   test('reduces AI SDK 7 step boundaries to Maka-owned step-finish events', () => {
     const adapter = newAdapter();
     type Chunk = Parameters<typeof adapter.translateChunk>[0];
@@ -1101,14 +1199,11 @@ describe('compileProviderTool', () => {
       isProviderExecuted?: boolean;
       args?: unknown;
     };
-    const official = google.tools.googleSearch({});
-
     assert.equal(compiled.type, 'provider');
     assert.equal(compiled.id, 'google.google_search');
     assert.equal(compiled.isProviderExecuted, true);
-    assert.deepEqual(compiled.args, official.args);
-    assert.equal(compiled.type, official.type);
-    assert.equal(compiled.id, official.id);
+    assert.equal(typeof compiled.args, 'object');
+    assert.notEqual(compiled.args, null);
   });
 });
 

--- a/packages/runtime/src/__tests__/native-web-search-tool.test.ts
+++ b/packages/runtime/src/__tests__/native-web-search-tool.test.ts
@@ -120,6 +120,13 @@ test('turn-start routing falls back explicitly when native search is unavailable
   );
 });
 
+test('native Gemini WebSearch is a provider-executed Google Search descriptor', () => {
+  const tool = buildNativeWebSearchTool({ adapter: 'google-grounding' });
+  assert.equal(tool.name, NATIVE_WEB_SEARCH_TOOL_NAME);
+  assert.deepEqual(tool.providerTool, { kind: 'google-search' });
+  assert.throws(() => tool.impl({}, {} as never), /must not execute through ToolRuntime/);
+});
+
 test('turn-start routing compiles Claude models to the CC-compatible Anthropic tool', () => {
   const clientSearch = {
     name: NATIVE_WEB_SEARCH_TOOL_NAME,
@@ -143,6 +150,67 @@ test('turn-start routing compiles Claude models to the CC-compatible Anthropic t
     kind: 'anthropic-web-search-20250305',
     maxUses: 8,
   });
+});
+
+test('turn-start routing compiles Gemini models to Google Search grounding', () => {
+  const clientSearch = {
+    name: NATIVE_WEB_SEARCH_TOOL_NAME,
+    description: 'Tavily',
+    parameters: {},
+    impl: async () => undefined,
+  } satisfies MakaTool;
+  const googleConnection = {
+    slug: 'google',
+    providerType: 'google' as const,
+    defaultModel: 'gemini-2.5-flash',
+  };
+
+  const routed = routeWebSearchTools({
+    tools: [clientSearch],
+    settings: { enabled: true, defaultProvider: 'model' },
+    connection: googleConnection,
+    model: 'gemini-2.5-flash',
+    tavilyReady: false,
+  });
+  assert.deepEqual(routed[0]?.providerTool, { kind: 'google-search' });
+
+  const tavily = routeWebSearchTools({
+    tools: [clientSearch],
+    settings: { enabled: true, defaultProvider: 'tavily' },
+    connection: googleConnection,
+    model: 'gemini-2.5-flash',
+    tavilyReady: true,
+  });
+  assert.equal(tavily[0], clientSearch);
+
+  const incognito = routeWebSearchTools({
+    tools: [clientSearch],
+    settings: { enabled: true, defaultProvider: 'model' },
+    privacy: { incognitoActive: true },
+    connection: googleConnection,
+    model: 'gemini-2.5-flash',
+    tavilyReady: false,
+  });
+  assert.deepEqual(incognito, []);
+
+  const unmatchedFamily = routeWebSearchTools({
+    tools: [clientSearch],
+    settings: { enabled: true, defaultProvider: 'model' },
+    connection: googleConnection,
+    model: 'gemini-1.5-flash',
+    tavilyReady: false,
+  });
+  assert.deepEqual(unmatchedFamily, []);
+
+  const root = routeWebSearchTools({
+    tools: [],
+    settings: { enabled: true, defaultProvider: 'model' },
+    connection: googleConnection,
+    model: 'gemini-2.5-flash',
+    tavilyReady: false,
+    allowAddNative: true,
+  });
+  assert.deepEqual(root[0]?.providerTool, { kind: 'google-search' });
 });
 
 test('root surfaces do not advertise unsupported DeepSeek native search', () => {

--- a/packages/runtime/src/__tests__/native-web-search-tool.test.ts
+++ b/packages/runtime/src/__tests__/native-web-search-tool.test.ts
@@ -152,65 +152,160 @@ test('turn-start routing compiles Claude models to the CC-compatible Anthropic t
   });
 });
 
-test('turn-start routing compiles Gemini models to Google Search grounding', () => {
+test('Gemini 2.x native search is fail-closed so function tools stay on the request', () => {
   const clientSearch = {
     name: NATIVE_WEB_SEARCH_TOOL_NAME,
     description: 'Tavily',
     parameters: {},
     impl: async () => undefined,
   } satisfies MakaTool;
-  const googleConnection = {
+  const read = {
+    name: 'Read',
+    description: 'Read',
+    parameters: {},
+    impl: async () => undefined,
+  } satisfies MakaTool;
+  const connection = {
     slug: 'google',
     providerType: 'google' as const,
     defaultModel: 'gemini-2.5-flash',
   };
 
   const routed = routeWebSearchTools({
-    tools: [clientSearch],
+    tools: [read, clientSearch],
     settings: { enabled: true, defaultProvider: 'model' },
-    connection: googleConnection,
+    connection,
     model: 'gemini-2.5-flash',
     tavilyReady: false,
   });
-  assert.deepEqual(routed[0]?.providerTool, { kind: 'google-search' });
-
-  const tavily = routeWebSearchTools({
-    tools: [clientSearch],
-    settings: { enabled: true, defaultProvider: 'tavily' },
-    connection: googleConnection,
-    model: 'gemini-2.5-flash',
-    tavilyReady: true,
-  });
-  assert.equal(tavily[0], clientSearch);
-
-  const incognito = routeWebSearchTools({
-    tools: [clientSearch],
-    settings: { enabled: true, defaultProvider: 'model' },
-    privacy: { incognitoActive: true },
-    connection: googleConnection,
-    model: 'gemini-2.5-flash',
-    tavilyReady: false,
-  });
-  assert.deepEqual(incognito, []);
-
-  const unmatchedFamily = routeWebSearchTools({
-    tools: [clientSearch],
-    settings: { enabled: true, defaultProvider: 'model' },
-    connection: googleConnection,
-    model: 'gemini-1.5-flash',
-    tavilyReady: false,
-  });
-  assert.deepEqual(unmatchedFamily, []);
+  assert.deepEqual(
+    routed.map((tool) => tool.name),
+    ['Read'],
+  );
+  assert.equal(routed[0], read);
+  assert.equal(
+    routed.some((tool) => tool.providerTool?.kind === 'google-search'),
+    false,
+  );
 
   const root = routeWebSearchTools({
-    tools: [],
+    tools: [read],
     settings: { enabled: true, defaultProvider: 'model' },
-    connection: googleConnection,
+    connection,
     model: 'gemini-2.5-flash',
     tavilyReady: false,
     allowAddNative: true,
   });
-  assert.deepEqual(root[0]?.providerTool, { kind: 'google-search' });
+  assert.deepEqual(
+    root.map((tool) => tool.name),
+    ['Read'],
+  );
+});
+
+test('Gemini 3 mixes Google Search grounding with function tools', () => {
+  const clientSearch = {
+    name: NATIVE_WEB_SEARCH_TOOL_NAME,
+    description: 'Tavily',
+    parameters: {},
+    impl: async () => undefined,
+  } satisfies MakaTool;
+  const read = {
+    name: 'Read',
+    description: 'Read',
+    parameters: {},
+    impl: async () => undefined,
+  } satisfies MakaTool;
+  const connection = {
+    slug: 'google',
+    providerType: 'google' as const,
+    defaultModel: 'gemini-3-flash',
+  };
+
+  const mixed = routeWebSearchTools({
+    tools: [read, clientSearch],
+    settings: { enabled: true, defaultProvider: 'model' },
+    connection,
+    model: 'gemini-3-flash',
+    tavilyReady: true,
+  });
+  assert.deepEqual(
+    mixed.map((tool) => tool.name),
+    ['Read', NATIVE_WEB_SEARCH_TOOL_NAME],
+  );
+  assert.equal(mixed[0], read);
+  assert.deepEqual(mixed[1]?.providerTool, { kind: 'google-search' });
+
+  const tavily = routeWebSearchTools({
+    tools: [read, clientSearch],
+    settings: { enabled: true, defaultProvider: 'tavily' },
+    connection,
+    model: 'gemini-3-flash',
+    tavilyReady: true,
+  });
+  assert.equal(
+    tavily.find((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME),
+    clientSearch,
+  );
+
+  const incognito = routeWebSearchTools({
+    tools: [read, clientSearch],
+    settings: { enabled: true, defaultProvider: 'model' },
+    privacy: { incognitoActive: true },
+    connection,
+    model: 'gemini-3-flash',
+    tavilyReady: false,
+  });
+  assert.deepEqual(
+    incognito.map((tool) => tool.name),
+    ['Read'],
+  );
+
+  const unmatchedFamily = routeWebSearchTools({
+    tools: [read, clientSearch],
+    settings: { enabled: true, defaultProvider: 'model' },
+    connection,
+    model: 'gemini-1.5-flash',
+    tavilyReady: false,
+  });
+  assert.deepEqual(
+    unmatchedFamily.map((tool) => tool.name),
+    ['Read'],
+  );
+});
+
+test('OpenRouter Gemini does not compile Google Search grounding', () => {
+  const clientSearch = {
+    name: NATIVE_WEB_SEARCH_TOOL_NAME,
+    description: 'Tavily',
+    parameters: {},
+    impl: async () => undefined,
+  } satisfies MakaTool;
+  const read = {
+    name: 'Read',
+    description: 'Read',
+    parameters: {},
+    impl: async () => undefined,
+  } satisfies MakaTool;
+
+  const routed = routeWebSearchTools({
+    tools: [read, clientSearch],
+    settings: { enabled: true, defaultProvider: 'model' },
+    connection: {
+      slug: 'openrouter',
+      providerType: 'openrouter',
+      defaultModel: 'gemini-3-flash',
+    },
+    model: 'gemini-3-flash',
+    tavilyReady: false,
+  });
+  assert.deepEqual(
+    routed.map((tool) => tool.name),
+    ['Read'],
+  );
+  assert.equal(
+    routed.some((tool) => tool.providerTool?.kind === 'google-search'),
+    false,
+  );
 });
 
 test('root surfaces do not advertise unsupported DeepSeek native search', () => {

--- a/packages/runtime/src/__tests__/native-web-search-tool.test.ts
+++ b/packages/runtime/src/__tests__/native-web-search-tool.test.ts
@@ -152,7 +152,7 @@ test('turn-start routing compiles Claude models to the CC-compatible Anthropic t
   });
 });
 
-test('Gemini 2.x native search is fail-closed so function tools stay on the request', () => {
+test('Gemini 2.x native search stays unimplemented and drops the client WebSearch tool', () => {
   const clientSearch = {
     name: NATIVE_WEB_SEARCH_TOOL_NAME,
     description: 'Tavily',

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -465,6 +465,9 @@ describe('projectRuntimeEventsToStoredMessages', () => {
             ],
           },
           providerExecuted: true,
+          providerOptions: {
+            google: { serverToolCallId: 'search-1', serverToolType: 'GOOGLE_SEARCH_WEB' },
+          },
           providerOutput: rawProviderOutput,
         },
         refs: { toolCallId: 'search-1' },
@@ -497,6 +500,9 @@ describe('projectRuntimeEventsToStoredMessages', () => {
       type: 'tool_result',
       providerExecuted: true,
       providerOutput: rawProviderOutput,
+      providerOptions: {
+        google: { serverToolCallId: 'search-1', serverToolType: 'GOOGLE_SEARCH_WEB' },
+      },
     });
     assert.deepStrictEqual((projected.messages[2] as { content?: unknown }).content, {
       kind: 'web_search',
@@ -519,6 +525,9 @@ describe('projectRuntimeEventsToStoredMessages', () => {
       {
         output: rawProviderOutput,
         providerExecuted: true,
+        providerOptions: {
+          google: { serverToolCallId: 'search-1', serverToolType: 'GOOGLE_SEARCH_WEB' },
+        },
       },
     );
   });

--- a/packages/runtime/src/__tests__/session-event-runtime-mapper.test.ts
+++ b/packages/runtime/src/__tests__/session-event-runtime-mapper.test.ts
@@ -239,6 +239,50 @@ describe('mapSessionEventToRuntimeEvent (pure)', () => {
     }
   });
 
+  test('provider-executed tool_result keeps providerOptions for replay', () => {
+    const memory = createSessionEventMapMemory();
+    mapSessionEventToRuntimeEvent(
+      ev({
+        type: 'tool_start',
+        toolUseId: 'search-1',
+        toolName: 'WebSearch',
+        args: {},
+        providerExecuted: true,
+      }),
+      ctx,
+      memory,
+    );
+    const providerOptions = {
+      google: {
+        serverToolCallId: 'search-1',
+        serverToolType: 'GOOGLE_SEARCH_WEB',
+      },
+    };
+    const result = mapSessionEventToRuntimeEvent(
+      ev({
+        type: 'tool_result',
+        toolUseId: 'search-1',
+        isError: false,
+        content: { kind: 'json', value: {} },
+        providerExecuted: true,
+        providerOutput: {},
+        providerOptions,
+      }),
+      ctx,
+      memory,
+    );
+
+    assert.equal(result.content?.kind, 'function_response');
+    assert.deepEqual(
+      result.content?.kind === 'function_response' ? result.content.providerOptions : undefined,
+      providerOptions,
+    );
+    assert.notStrictEqual(
+      result.content?.kind === 'function_response' ? result.content.providerOptions : undefined,
+      providerOptions,
+    );
+  });
+
   test('owns independent tool args across SessionEvent to RuntimeEvent mappings', () => {
     const sourceArgs = { content: 'approved', layout: { cols: 120 } };
     const sourceEvent = ev({

--- a/packages/runtime/src/ai-sdk-message-projection.ts
+++ b/packages/runtime/src/ai-sdk-message-projection.ts
@@ -410,6 +410,9 @@ export class AiSdkMessageProjection {
           toolCallId: result.toolCallId,
           toolName: result.toolName,
           output: await materializeReplayToolResult(result, call.toolName),
+          ...(result.providerOptions !== undefined
+            ? { providerOptions: result.providerOptions }
+            : {}),
         });
       }
       if (text && text.content.length > 0) {

--- a/packages/runtime/src/ai-sdk-turn.ts
+++ b/packages/runtime/src/ai-sdk-turn.ts
@@ -228,19 +228,110 @@ const CHILD_STEP_BUDGET_FINALIZATION_PROMPT = [
   '</step_budget_finalization>',
 ].join('\n');
 
+function isProviderWebSearchToolName(toolName: string): boolean {
+  return (
+    toolName === 'WebSearch' ||
+    toolName === 'google.google_search' ||
+    toolName === 'googleSearch' ||
+    toolName === 'server:GOOGLE_SEARCH_WEB'
+  );
+}
+
+function googleGroundingMetadata(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const record = value as { groundingMetadata?: unknown };
+  return record.groundingMetadata ?? value;
+}
+
+function googleGroundingRows(value: unknown): Array<{
+  title: string;
+  url: string;
+  snippet: string;
+  source: string;
+}> {
+  const metadata = googleGroundingMetadata(value);
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return [];
+  const chunks = (metadata as { groundingChunks?: unknown }).groundingChunks;
+  if (!Array.isArray(chunks)) return [];
+  const rows: Array<{ title: string; url: string; snippet: string; source: string }> = [];
+  for (const chunk of chunks) {
+    const web =
+      chunk && typeof chunk === 'object' && !Array.isArray(chunk)
+        ? (chunk as { web?: unknown }).web
+        : undefined;
+    if (!web || typeof web !== 'object' || Array.isArray(web)) continue;
+    const uri = (web as { uri?: unknown }).uri;
+    const title = (web as { title?: unknown }).title;
+    if (typeof uri !== 'string') continue;
+    try {
+      const parsed = new URL(uri);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue;
+      rows.push({
+        title: typeof title === 'string' && title.trim() ? title : parsed.hostname,
+        url: parsed.toString(),
+        snippet: '',
+        source: parsed.hostname,
+      });
+    } catch {
+      // Provider source rows are untrusted; malformed URLs are dropped.
+    }
+  }
+  return rows;
+}
+
+function googleWebSearchQuery(value: unknown): string {
+  const metadata = googleGroundingMetadata(value);
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return '';
+  const queries = (metadata as { webSearchQueries?: unknown }).webSearchQueries;
+  if (!Array.isArray(queries)) return '';
+  return queries.filter((item): item is string => typeof item === 'string').join(' | ');
+}
+
+function webSearchRowFromUrl(
+  url: string,
+  title?: string,
+): { title: string; url: string; snippet: string; source: string } | undefined {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined;
+    return {
+      title: title && title.trim() ? title : parsed.hostname,
+      url: parsed.toString(),
+      snippet: '',
+      source: parsed.hostname,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function mergeWebSearchRows(
+  content: ToolResultContent,
+  rows: ReadonlyArray<{ title: string; url: string; snippet: string; source: string }>,
+): ToolResultContent {
+  if (content.kind !== 'web_search' || rows.length === 0) return content;
+  const seen = new Set(content.rows.map((row) => row.url));
+  const extra = rows.filter((row) => !seen.has(row.url));
+  return extra.length === 0 ? content : { ...content, rows: [...content.rows, ...extra] };
+}
+
 function providerToolResultContent(
   toolName: string,
   output: unknown,
   input?: unknown,
+  providerOptions?: Record<string, unknown>,
 ): ToolResultContent {
-  if (output === undefined) {
-    return {
-      kind: 'text',
-      text: `${toolName} completed without a structured result.`,
-    };
-  }
-  if (toolName !== 'WebSearch') {
+  if (!isProviderWebSearchToolName(toolName)) {
+    if (output === undefined) {
+      return {
+        kind: 'text',
+        text: `${toolName} completed without a structured result.`,
+      };
+    }
     return { kind: 'json', value: output };
+  }
+  if (output === undefined) {
+    output = {};
   }
   const queryFromInput = providerWebSearchQuery(input);
   if (Array.isArray(output)) {
@@ -347,6 +438,12 @@ function providerToolResultContent(
         // Provider source rows are untrusted; malformed URLs are dropped.
       }
     }
+  }
+  if (rows.length === 0) {
+    rows.push(...googleGroundingRows(output), ...googleGroundingRows(providerOptions?.google));
+  }
+  if (!query) {
+    query = googleWebSearchQuery(output) || googleWebSearchQuery(providerOptions?.google) || query;
   }
   return { kind: 'web_search', provider: 'model', query, rows };
 }
@@ -907,6 +1004,8 @@ export class AiSdkTurn {
     let stepThinkingParts: AssistantThinkingPart[] = [];
     let stepThinkingPartsById = new Map<string, AssistantThinkingPart>();
     let stepContentOrder: AssistantStepContentKind[] = [];
+    let stepSourceRows: Array<{ title: string; url: string; snippet: string; source: string }> = [];
+    let pendingProviderWebSearchResults: ToolResultEvent[] = [];
     const recordStepContent = (kind: AssistantStepContentKind): void => {
       if (!stepContentOrder.includes(kind)) stepContentOrder.push(kind);
     };
@@ -926,6 +1025,14 @@ export class AiSdkTurn {
       stepThinkingParts = [];
       stepThinkingPartsById = new Map();
       stepContentOrder = [];
+      stepSourceRows = [];
+    };
+    const flushPendingProviderWebSearchResults = (): void => {
+      for (const pending of pendingProviderWebSearchResults) {
+        pending.content = mergeWebSearchRows(pending.content, stepSourceRows);
+        queue.push(pending);
+      }
+      pendingProviderWebSearchResults = [];
     };
     const flushStep = async (): Promise<void> => {
       const hasThinking = stepThinkingParts.length > 0;
@@ -1983,11 +2090,27 @@ export class AiSdkTurn {
                 } else {
                   returnedToolCalls.push(event.toolCall);
                 }
+              } else if (event.kind === 'source') {
+                const row = webSearchRowFromUrl(event.url, event.title);
+                if (row) stepSourceRows.push(row);
               } else if (event.kind === 'provider-tool-result') {
                 attemptSawToolActivity = true;
                 providerToolActivityCount += 1;
                 const providerOutput = stripUndefinedDeep(event.output);
-                queue.push({
+                const providerOptions =
+                  event.providerOptions !== undefined
+                    ? stripUndefinedDeep(event.providerOptions)
+                    : undefined;
+                const content = mergeWebSearchRows(
+                  providerToolResultContent(
+                    event.toolName,
+                    providerOutput,
+                    providerToolInputs.get(event.toolCallId),
+                    event.providerOptions,
+                  ),
+                  stepSourceRows,
+                );
+                const toolResult = {
                   type: 'tool_result',
                   id: this.deps.newId(),
                   turnId,
@@ -1995,13 +2118,15 @@ export class AiSdkTurn {
                   toolUseId: event.toolCallId,
                   providerExecuted: true,
                   ...(providerOutput !== undefined ? { providerOutput } : {}),
+                  ...(providerOptions !== undefined ? { providerOptions } : {}),
                   isError: event.isError === true,
-                  content: providerToolResultContent(
-                    event.toolName,
-                    providerOutput,
-                    providerToolInputs.get(event.toolCallId),
-                  ),
-                } satisfies ToolResultEvent);
+                  content,
+                } satisfies ToolResultEvent;
+                if (content.kind === 'web_search') {
+                  pendingProviderWebSearchResults.push(toolResult);
+                } else {
+                  queue.push(toolResult);
+                }
                 providerToolInputs.delete(event.toolCallId);
               } else if (event.kind === 'step-finish' && !incompleteFinish) {
                 // The step's text/thinking deltas are all in (the stream is
@@ -2009,6 +2134,7 @@ export class AiSdkTurn {
                 // rotate to a fresh id for the next step. Tool settlement
                 // below receives this step's pre-rotation id, so durable replay
                 // can regroup calls with this reasoning/text.
+                flushPendingProviderWebSearchResults();
                 await flushStep();
                 if (midTurnState) {
                   // Durability clock: step N's thinking/text completion events
@@ -2259,6 +2385,7 @@ export class AiSdkTurn {
           // Catch-all: flush any residual step content if the provider closed the
           // stream without a trailing `finish-step` for the last step.
           const providerStepId = currentStepMessageId;
+          flushPendingProviderWebSearchResults();
           await flushStep();
 
           if (providerOutcome.kind !== 'completed') throw providerOutcome.failure;
@@ -2603,6 +2730,7 @@ export class AiSdkTurn {
         // `finish-step`; this keeps their and this step's streamed-out output on
         // BOTH exits — user stop and provider error / watchdog timeout — so the
         // transcript keeps what the user actually saw.
+        flushPendingProviderWebSearchResults();
         await flushStep().catch(() => {});
         if (this.aborted) {
           queue.push({

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -20,6 +20,7 @@
 import type { ErrorEvent, CompleteEvent } from '@maka/core/events';
 import { openai } from '@ai-sdk/openai';
 import { anthropic } from '@ai-sdk/anthropic';
+import { google } from '@ai-sdk/google';
 import {
   providerAuthRequiresSecret,
   type RuntimeExecutionConnection,
@@ -1233,6 +1234,8 @@ function compileProviderTool(
       return anthropic.tools.webSearch_20250305({
         ...(tool.maxUses !== undefined ? { maxUses: tool.maxUses } : {}),
       });
+    case 'google-search':
+      return google.tools.googleSearch({});
   }
 }
 

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -752,6 +752,10 @@ interface AiSdkStreamChunk {
   error?: unknown;
   /** Provider-specific metadata; carries the Anthropic reasoning signature. */
   providerMetadata?: unknown;
+  /** Grounding URL source parts (Gemini `source` chunks). */
+  sourceType?: unknown;
+  url?: unknown;
+  title?: unknown;
 }
 
 /**
@@ -1114,6 +1118,21 @@ function translateChunk(
           toolName: runtimeToolName?.(chunk.toolName) ?? chunk.toolName,
           output: chunk.type === 'tool-error' ? chunk.error : (chunk.output ?? chunk.result),
           ...(chunk.type === 'tool-error' || chunk.isError === true ? { isError: true } : {}),
+          ...(chunk.providerMetadata !== undefined
+            ? {
+                providerOptions: chunk.providerMetadata as ToolCallPart['providerOptions'],
+              }
+            : {}),
+        },
+      ];
+    }
+    case 'source': {
+      if (chunk.sourceType !== 'url' || typeof chunk.url !== 'string') return [];
+      return [
+        {
+          kind: 'source',
+          url: chunk.url,
+          ...(typeof chunk.title === 'string' && chunk.title.trim() ? { title: chunk.title } : {}),
         },
       ];
     }

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -350,6 +350,7 @@ export type RuntimeEventModelReplayItem =
       isError: boolean;
       modelProjection?: DurableToolResultProjection;
       providerExecuted?: boolean;
+      providerOptions?: NonNullable<ModelMessage['providerOptions']>;
       eventId: string;
       ts: number;
     };
@@ -888,6 +889,13 @@ export function buildRuntimeEventModelReplayPlan(
           isError: event.content.isError === true,
           ...(event.content.providerExecuted !== undefined
             ? { providerExecuted: event.content.providerExecuted }
+            : {}),
+          ...(event.content.providerOptions !== undefined
+            ? {
+                providerOptions: event.content.providerOptions as NonNullable<
+                  ModelMessage['providerOptions']
+                >,
+              }
             : {}),
           eventId: event.id,
           ts: event.ts,

--- a/packages/runtime/src/model-protocol.ts
+++ b/packages/runtime/src/model-protocol.ts
@@ -409,12 +409,15 @@ export type ModelStreamEvent =
   /** Provider-side tool execution has begun, but no replayable call exists yet. */
   | { kind: 'provider-tool-input' }
   | { kind: 'tool-call'; toolCall: ToolCallPart }
+  | { kind: 'source'; url: string; title?: string }
   | {
       kind: 'provider-tool-result';
       toolCallId: string;
       toolName: string;
       output: unknown;
       isError?: boolean;
+      /** Opaque provider metadata required to reconstruct a native toolResponse. */
+      providerOptions?: ProviderOptions;
     }
   | { kind: 'step-finish'; usage?: NormalizedUsage; finishReason?: ModelFinishReason }
   | { kind: 'finish'; finishReason?: ModelFinishReason }

--- a/packages/runtime/src/native-web-search-tool.ts
+++ b/packages/runtime/src/native-web-search-tool.ts
@@ -27,12 +27,17 @@ import type { MakaTool } from './tool-runtime.js';
 
 export const NATIVE_WEB_SEARCH_TOOL_NAME = 'WebSearch';
 
+type NativeWebSearchAdapter = Extract<
+  HostedWebSearchAdapter,
+  'openai-responses' | 'anthropic-messages' | 'google-grounding'
+>;
+
 /**
  * Provider-executed search descriptor. AI SDK compiles this into the selected
  * provider's native tool; the local implementation is an invariant guard only.
  */
 export function buildNativeWebSearchTool(input?: {
-  readonly adapter?: Extract<HostedWebSearchAdapter, 'openai-responses' | 'anthropic-messages'>;
+  readonly adapter?: NativeWebSearchAdapter;
   readonly searchContextSize?: 'low' | 'medium' | 'high';
   readonly maxUses?: number;
 }): MakaTool {
@@ -45,21 +50,34 @@ export function buildNativeWebSearchTool(input?: {
     description:
       'Search and read the live web through the current model provider. Use it for current external information and source-backed answers.',
     parameters: z.object({}).strict(),
-    providerTool: {
-      ...(adapter === 'anthropic-messages'
-        ? {
-            kind: 'anthropic-web-search-20250305' as const,
-            maxUses: input?.maxUses ?? 8,
-          }
-        : {
-            kind: 'openai-web-search' as const,
-            searchContextSize: input?.searchContextSize ?? 'medium',
-          }),
-    },
+    providerTool: nativeWebSearchProviderTool(adapter, input),
     impl: () => {
       throw new Error('Provider-native WebSearch must not execute through ToolRuntime');
     },
   };
+}
+
+function nativeWebSearchProviderTool(
+  adapter: NativeWebSearchAdapter,
+  input?: {
+    readonly searchContextSize?: 'low' | 'medium' | 'high';
+    readonly maxUses?: number;
+  },
+): NonNullable<MakaTool['providerTool']> {
+  switch (adapter) {
+    case 'anthropic-messages':
+      return {
+        kind: 'anthropic-web-search-20250305',
+        maxUses: input?.maxUses ?? 8,
+      };
+    case 'google-grounding':
+      return { kind: 'google-search' };
+    case 'openai-responses':
+      return {
+        kind: 'openai-web-search',
+        searchContextSize: input?.searchContextSize ?? 'medium',
+      };
+  }
 }
 
 /** Freezes one unambiguous WebSearch tool meaning for the selected model turn. */
@@ -94,15 +112,11 @@ export function routeWebSearchTools(input: {
     if (
       (firstSearchIndex >= 0 || input.allowAddNative === true) &&
       capability?.implemented === true &&
-      capability.adapter === 'openai-responses'
+      (capability.adapter === 'openai-responses' ||
+        capability.adapter === 'anthropic-messages' ||
+        capability.adapter === 'google-grounding')
     ) {
-      selected = buildNativeWebSearchTool({ adapter: 'openai-responses' });
-    } else if (
-      (firstSearchIndex >= 0 || input.allowAddNative === true) &&
-      capability?.implemented === true &&
-      capability.adapter === 'anthropic-messages'
-    ) {
-      selected = buildNativeWebSearchTool({ adapter: 'anthropic-messages' });
+      selected = buildNativeWebSearchTool({ adapter: capability.adapter });
     }
   }
   if (!selected) return withoutWebSearch;

--- a/packages/runtime/src/native-web-search-tool.ts
+++ b/packages/runtime/src/native-web-search-tool.ts
@@ -18,7 +18,10 @@
  */
 
 import { z } from 'zod';
-import { resolveHostedWebSearchCapability } from '@maka/core/model-web-search';
+import {
+  geminiModelAllowsGoogleSearchToolMix,
+  resolveHostedWebSearchCapability,
+} from '@maka/core/model-web-search';
 import { resolveModelRuntime } from './model-runtime.js';
 import type { HostedWebSearchAdapter } from '@maka/core/model-web-search';
 import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
@@ -114,7 +117,8 @@ export function routeWebSearchTools(input: {
       capability?.implemented === true &&
       (capability.adapter === 'openai-responses' ||
         capability.adapter === 'anthropic-messages' ||
-        capability.adapter === 'google-grounding')
+        (capability.adapter === 'google-grounding' &&
+          geminiModelAllowsGoogleSearchToolMix(input.model)))
     ) {
       selected = buildNativeWebSearchTool({ adapter: capability.adapter });
     }

--- a/packages/runtime/src/native-web-search-tool.ts
+++ b/packages/runtime/src/native-web-search-tool.ts
@@ -18,10 +18,7 @@
  */
 
 import { z } from 'zod';
-import {
-  geminiModelAllowsGoogleSearchToolMix,
-  resolveHostedWebSearchCapability,
-} from '@maka/core/model-web-search';
+import { resolveHostedWebSearchCapability } from '@maka/core/model-web-search';
 import { resolveModelRuntime } from './model-runtime.js';
 import type { HostedWebSearchAdapter } from '@maka/core/model-web-search';
 import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
@@ -117,8 +114,7 @@ export function routeWebSearchTools(input: {
       capability?.implemented === true &&
       (capability.adapter === 'openai-responses' ||
         capability.adapter === 'anthropic-messages' ||
-        (capability.adapter === 'google-grounding' &&
-          geminiModelAllowsGoogleSearchToolMix(input.model)))
+        capability.adapter === 'google-grounding')
     ) {
       selected = buildNativeWebSearchTool({ adapter: capability.adapter });
     }

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -283,6 +283,9 @@ export function backfillRuntimeEventsFromStoredMessages(
             ...(message.providerExecuted !== undefined
               ? { providerExecuted: message.providerExecuted }
               : {}),
+            ...(message.providerOptions !== undefined
+              ? { providerOptions: structuredClone(message.providerOptions) }
+              : {}),
             ...(message.providerExecuted && message.providerOutput !== undefined
               ? { providerOutput: structuredClone(message.providerOutput) }
               : {}),

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -991,6 +991,9 @@ function projectFunctionResponse(
     ...(event.content.providerExecuted !== undefined
       ? { providerExecuted: event.content.providerExecuted }
       : {}),
+    ...(event.content.providerOptions !== undefined
+      ? { providerOptions: structuredClone(event.content.providerOptions) }
+      : {}),
     ...(event.content.providerExecuted && event.content.providerOutput !== undefined
       ? { providerOutput: structuredClone(event.content.providerOutput) }
       : {}),

--- a/packages/runtime/src/session-event-runtime-mapper.ts
+++ b/packages/runtime/src/session-event-runtime-mapper.ts
@@ -363,6 +363,9 @@ function mapBackendSessionEvent(
         ...(event.providerExecuted !== undefined
           ? { providerExecuted: event.providerExecuted }
           : {}),
+        ...(event.providerOptions !== undefined
+          ? { providerOptions: structuredClone(event.providerOptions) }
+          : {}),
         ...(event.providerExecuted && event.providerOutput !== undefined
           ? { providerOutput: structuredClone(event.providerOutput) }
           : {}),

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -200,7 +200,11 @@ export interface MakaTool<P = any, R = unknown> {
    * client-executed tools such as ApplyPatch still settle through ToolRuntime.
    */
   providerTool?: {
-    readonly kind: 'openai-apply-patch' | 'openai-web-search' | 'anthropic-web-search-20250305';
+    readonly kind:
+      | 'openai-apply-patch'
+      | 'openai-web-search'
+      | 'anthropic-web-search-20250305'
+      | 'google-search';
     readonly searchContextSize?: 'low' | 'medium' | 'high';
     readonly maxUses?: number;
   };


### PR DESCRIPTION
Refs #4330 (Gemini grounding slice).

Attach provider-native `google-search` for Gemini 3+ only. `@ai-sdk/google` drops function tools when `googleSearch` is mixed on Gemini 2.x, so 2.0/2.5 stay `implemented: false`. No Tavily fallback; OpenRouter Gemini does not compile `google-search`.
