### PR TITLE
fix(runtime-host): distinguish idle retention from active background work

### DIFF
--- a/packages/runtime-host/src/__tests__/daily-review-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/daily-review-coordinator.test.ts
@@ -22,6 +22,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { deferred, waitFor } from '@maka/core/test-only/async-primitives';
 import {
   dailyReviewArchiveId,
   localDayBoundsAt,
@@ -34,6 +35,7 @@ import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storag
 import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
 import { HostDailyReviewCoordinator } from '../server/daily-review-coordinator.js';
+import { HostResidencyRegistry } from '../server/host-residency-registry.js';
 
 const CONTEXT: ConnectionContext = {
   hostEpoch: 'host-epoch',
@@ -41,6 +43,122 @@ const CONTEXT: ConnectionContext = {
   principal: 'local_os_user',
   acquireResidency: () => ({ release: () => undefined }),
 };
+
+test('Daily Review handoff fences an admitted timer tick and cancellation resumes a due review', async () => {
+  let now = new Date(2026, 8, 9, 12).getTime();
+  const timers = new Set<() => void>();
+  const residencies = new HostResidencyRegistry();
+  await withCoordinator(
+    async ({ coordinator, store }) => {
+      const snapshot = await store.readConfig();
+      await store.updateConfig(snapshot.revision, {
+        enabled: true,
+        executeTime: '13:00',
+        modelKey: '',
+      });
+      await coordinator.recover();
+      assert.equal(timers.size, 1);
+      assert.equal(residencies.drainCount, 1);
+      const tick = [...timers][0]!;
+      now = new Date(2026, 8, 9, 13).getTime();
+      tick(); // The config read has started, but has not returned yet.
+      const hold = coordinator.holdForHandoff();
+      assert.ok(hold);
+      assert.equal(coordinator.holdForHandoff(), undefined);
+      assert.equal(timers.size, 0);
+      tick(); // A callback already queued before clearInterval must also be fenced.
+      await hold.settled();
+      const archiveId = dailyReviewArchiveId(localDayBoundsAt(now, -1), 1);
+      assert.equal(await store.getArchive(archiveId), null);
+      const proof = hold.residencies();
+      assert.ok(proof);
+      assert.equal(residencies.hasDrainResidenciesExcept(proof), false);
+      hold.release();
+      hold.release();
+      assert.equal(timers.size, 1);
+      await waitFor(async () => (await store.getArchive(archiveId)) !== null);
+      assert.equal((await store.getArchive(archiveId))?.trigger, 'cron');
+      assert.equal((await store.readConfig()).config.enabled, true);
+      const next = coordinator.holdForHandoff();
+      assert.ok(next);
+      await next.settled();
+      coordinator.beginDrain();
+      next.release();
+      assert.equal(timers.size, 0);
+      assert.equal(residencies.drainCount, 0);
+    },
+    undefined,
+    false,
+    undefined,
+    {
+      now: () => now,
+      acquireResidency: () => residencies.acquire('daily-review'),
+      setInterval: (callback) => {
+        timers.add(callback);
+        return callback;
+      },
+      clearInterval: (timer) => {
+        timers.delete(timer as () => void);
+      },
+    },
+  );
+});
+
+test('Daily Review handoff waits for an active analysis to publish without interrupting it', async () => {
+  const entered = deferred<void>();
+  const finish = deferred<void>();
+  const residencies = new HostResidencyRegistry();
+  await withCoordinator(
+    async ({ coordinator, store }) => {
+      const running = coordinator.handlers['daily-review.mutate'](
+        {
+          kind: 'run',
+          range: 1,
+          offsetDays: 0,
+          modelKeyOverride: '',
+          replaceExisting: false,
+        },
+        CONTEXT,
+      );
+      await entered.promise;
+      assert.equal(residencies.drainCount, 1);
+      const hold = coordinator.holdForHandoff();
+      assert.ok(hold);
+      try {
+        assert.equal(hold.residencies(), undefined);
+        let settled = false;
+        const waiting = hold.settled().then(() => {
+          settled = true;
+        });
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        assert.equal(settled, false);
+        finish.resolve();
+        const result = await running;
+        await waiting;
+        assert.equal(result.ok, true);
+        assert.ok(hold.residencies());
+        assert.equal(residencies.drainCount, 0);
+        assert.equal((await store.listArchivePage(null, 1)).archives.length, 1);
+      } finally {
+        finish.resolve();
+        hold.release();
+        await running;
+      }
+    },
+    undefined,
+    true,
+    {
+      list: async () => {
+        entered.resolve();
+        await finish.promise;
+        return [];
+      },
+    },
+    {
+      acquireResidency: () => residencies.acquire('daily-review'),
+    },
+  );
+});
 
 test('Daily Review refuses to archive an incomplete canonical Usage projection', async () => {
   await withCoordinator(async ({ coordinator, store, root, drainCount }) => {
@@ -401,6 +519,12 @@ async function withCoordinator(
   sessions: ConstructorParameters<typeof HostDailyReviewCoordinator>[0]['sessions'] = {
     list: async () => [],
   },
+  lifecycle: Partial<
+    Pick<
+      ConstructorParameters<typeof HostDailyReviewCoordinator>[0],
+      'now' | 'acquireResidency' | 'setInterval' | 'clearInterval'
+    >
+  > = {},
 ): Promise<void> {
   const base = await mkdtemp(join(tmpdir(), 'maka-daily-review-coordinator-'));
   const root = join(base, 'interactive');
@@ -423,6 +547,7 @@ async function withCoordinator(
     requestDrain: () => {
       drains += 1;
     },
+    ...lifecycle,
   });
   try {
     if (recoverBeforeRun) await coordinator.recover();

--- a/packages/runtime-host/src/__tests__/daily-review-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/daily-review-coordinator.test.ts
@@ -58,7 +58,8 @@ test('Daily Review handoff fences an admitted timer tick and cancellation resume
       });
       await coordinator.recover();
       assert.equal(timers.size, 1);
-      assert.equal(residencies.drainCount, 1);
+      assert.equal(residencies.activeCount, 1);
+      assert.equal(residencies.drainCount, 0);
       const tick = [...timers][0]!;
       now = new Date(2026, 8, 9, 13).getTime();
       tick(); // The config read has started, but has not returned yet.
@@ -92,7 +93,7 @@ test('Daily Review handoff fences an admitted timer tick and cancellation resume
     undefined,
     {
       now: () => now,
-      acquireResidency: () => residencies.acquire('daily-review'),
+      acquireResidency: (kind) => residencies.acquire('daily-review', kind),
       setInterval: (callback) => {
         timers.add(callback);
         return callback;
@@ -155,7 +156,7 @@ test('Daily Review handoff waits for an active analysis to publish without inter
       },
     },
     {
-      acquireResidency: () => residencies.acquire('daily-review'),
+      acquireResidency: (kind) => residencies.acquire('daily-review', kind),
     },
   );
 });

--- a/packages/runtime-host/src/__tests__/execution-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-composition.test.ts
@@ -60,6 +60,7 @@ import {
   type InteractiveRootOwner,
 } from '@maka/storage/root-authority';
 import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
+import { openInteractiveDailyReviewAuthorityForWrite } from '@maka/storage/daily-review-authority';
 import { openInteractiveShellRunStoreForWrite } from '@maka/storage/shell-run-authority';
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import { HostResidencyRegistry } from '../server/host-residency-registry.js';
@@ -85,6 +86,57 @@ const HANDOFF_TEST_COMPOSITION = createRunCompositionSnapshot({
   baseProviderOptionsHash: `sha256:${'0'.repeat(64)}`,
   toolNames: [],
   contextWindow: null,
+});
+
+test('an idle enabled Daily Review scheduler participates in production handoff and recovers in the successor', {
+  timeout: 20_000,
+}, async () => {
+  await withCompositionRoot(async ({ root, owner }) => {
+    const store = await openInteractiveDailyReviewAuthorityForWrite(owner.lease);
+    const snapshot = await store.readConfig();
+    await store.updateConfig(snapshot.revision, {
+      enabled: true,
+      executeTime: '00:00',
+      modelKey: '',
+    });
+    const residencies = new HostResidencyRegistry();
+    const { composition } = await createCapturedExecutionComposition(owner, { residencies });
+    try {
+      assert.deepEqual(residencies.snapshot(), [{ label: 'daily-review', count: 1 }]);
+      const cancelled = await composition.prepareHandoff!('old-host', new AbortController().signal);
+      assert.ok(cancelled);
+      assert.equal(await cancelled.seal(), true);
+      const cancelledProof = await cancelled.residencies();
+      assert.ok(cancelledProof);
+      assert.equal(residencies.hasDrainResidenciesExcept(cancelledProof), false);
+      cancelled.cancel();
+      const prepared = await composition.prepareHandoff!('old-host', new AbortController().signal);
+      assert.ok(prepared);
+      assert.equal(await prepared.seal(), true);
+      const proof = await prepared.residencies();
+      assert.ok(proof);
+      assert.equal(residencies.hasDrainResidenciesExcept(proof), false);
+      await prepared.detach();
+    } finally {
+      await composition.close();
+    }
+    assert.equal(residencies.activeCount, 0);
+    await owner.close();
+    const successorOwner = await tryAcquireInteractiveRootOwner(
+      await resolveStorageRoot({ path: root, kind: 'interactive' }),
+    );
+    assert.ok(successorOwner);
+    try {
+      const successor = await createCapturedExecutionComposition(successorOwner, { residencies });
+      try {
+        assert.deepEqual(residencies.snapshot(), [{ label: 'daily-review', count: 1 }]);
+      } finally {
+        await successor.composition.close();
+      }
+    } finally {
+      await successorOwner.close();
+    }
+  });
 });
 
 test('production composition resumes a sealed logical Root after all stores and runtime owners reopen', {

--- a/packages/runtime-host/src/__tests__/execution-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-composition.test.ts
@@ -61,9 +61,13 @@ import {
 } from '@maka/storage/root-authority';
 import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
 import { openInteractiveDailyReviewAuthorityForWrite } from '@maka/storage/daily-review-authority';
+import { openInteractiveScheduledTaskStoreForWrite } from '@maka/storage/scheduled-task-store';
 import { openInteractiveShellRunStoreForWrite } from '@maka/storage/shell-run-authority';
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
-import { HostResidencyRegistry } from '../server/host-residency-registry.js';
+import {
+  HostResidencyRegistry,
+  type HostResidencyKind,
+} from '../server/host-residency-registry.js';
 import {
   createExecutionRuntimeHostComposition,
   runtimeHostFilesystemWorkerRuntime,
@@ -88,7 +92,7 @@ const HANDOFF_TEST_COMPOSITION = createRunCompositionSnapshot({
   contextWindow: null,
 });
 
-test('an idle enabled Daily Review scheduler participates in production handoff and recovers in the successor', {
+test('idle schedules and armed or paused Goals allow production handoff and recover in the successor', {
   timeout: 20_000,
 }, async () => {
   await withCompositionRoot(async ({ root, owner }) => {
@@ -99,10 +103,67 @@ test('an idle enabled Daily Review scheduler participates in production handoff 
       executeTime: '00:00',
       modelKey: '',
     });
+    const schedules = await openInteractiveScheduledTaskStoreForWrite(owner.lease);
+    await schedules.create(
+      {
+        title: 'Future reminder',
+        intentBody: 'Remind me tomorrow',
+        schedule: { kind: 'once', runAt: Date.now() + 86_400_000 },
+        effect: { kind: 'notify', channel: 'local' },
+        createdBy: { kind: 'user' },
+      },
+      Date.now(),
+    );
+    schedules.close();
     const residencies = new HostResidencyRegistry();
-    const { composition } = await createCapturedExecutionComposition(owner, { residencies });
+    const { composition, manager } = await createCapturedExecutionComposition(owner, {
+      residencies,
+    });
+    const expected = [
+      { label: 'daily-review', count: 1 },
+      { label: 'goal', count: 2 },
+      { label: 'scheduled-task', count: 1 },
+    ];
     try {
-      assert.deepEqual(residencies.snapshot(), [{ label: 'daily-review', count: 1 }]);
+      const context = {
+        hostEpoch: 'old-host',
+        connectionId: 'test',
+        principal: 'local_os_user' as const,
+        acquireResidency: () => ({ release() {} }),
+      };
+      for (const pause of [false, true]) {
+        const session = await manager.createSession({
+          cwd: root,
+          llmConnectionId: FAKE_CONNECTION_ID,
+          llmConnectionSlug: 'fake',
+          model: 'fake-model',
+          permissionMode: 'ask',
+        });
+        const armed = await composition.handlers['goal.arm'](
+          {
+            sessionId: session.id,
+            condition: 'Finish later',
+            maxIterations: null,
+            tokenBudget: null,
+          },
+          context,
+        );
+        assert.ok(armed.ok);
+        if (pause) {
+          const paused = await composition.handlers['goal.control'](
+            {
+              sessionId: session.id,
+              goalId: armed.result.goal.goalId,
+              expectedRevision: armed.result.goal.revision,
+              action: 'pause',
+            },
+            context,
+          );
+          assert.ok(paused.ok);
+        }
+      }
+      await waitFor(async () => residencies.drainCount === 0);
+      assert.deepEqual(residencies.snapshot(), expected);
       const cancelled = await composition.prepareHandoff!('old-host', new AbortController().signal);
       assert.ok(cancelled);
       assert.equal(await cancelled.seal(), true);
@@ -129,7 +190,8 @@ test('an idle enabled Daily Review scheduler participates in production handoff 
     try {
       const successor = await createCapturedExecutionComposition(successorOwner, { residencies });
       try {
-        assert.deepEqual(residencies.snapshot(), [{ label: 'daily-review', count: 1 }]);
+        await waitFor(async () => residencies.drainCount === 0);
+        assert.deepEqual(residencies.snapshot(), expected);
       } finally {
         await successor.composition.close();
       }
@@ -2180,7 +2242,12 @@ async function createCapturedExecutionComposition(
     const composition = await createExecutionRuntimeHostComposition(
       {
         ...compositionContext(owner),
-        ...(residencies ? { acquireResidency: (label: string) => residencies.acquire(label) } : {}),
+        ...(residencies
+          ? {
+              acquireResidency: (label: string, kind?: HostResidencyKind) =>
+                residencies.acquire(label, kind),
+            }
+          : {}),
       },
       {},
       { primaryBackendFactory },

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -87,7 +87,8 @@ test('one Host Goal is shared across clients with CAS control and crash-clear re
           start: () => goalTurn,
         };
       },
-      acquireResidency: () => {
+      acquireResidency: (kind) => {
+        if (kind !== 'idle') return { release() {} };
         acquired++;
         return { release: () => released++ };
       },
@@ -288,7 +289,10 @@ test('session retirement forgets a terminal Goal without recreating deleted auth
         close: async () => {},
       },
       admitTurn: () => assert.fail('A terminal Goal must not admit a continuation'),
-      acquireResidency: () => assert.fail('A terminal Goal must not retain Host residency'),
+      acquireResidency: (kind) => {
+        assert.notEqual(kind, 'idle', 'A terminal Goal must not retain Host residency');
+        return { release() {} };
+      },
       onProjectionChanged: (sessionId) => projectionChanges.push(sessionId),
       requestDrain: () => drainRequests++,
     });

--- a/packages/runtime-host/src/__tests__/host-handoff.test.ts
+++ b/packages/runtime-host/src/__tests__/host-handoff.test.ts
@@ -31,6 +31,7 @@ import {
 } from '../client/host-handoff.js';
 import { decodeClientFrame, decodeHostFrame } from '../protocol/index.js';
 import { decodeHostActivitySnapshot, isHostActivityIdle } from '../protocol/host-status.js';
+import { formatHostHandoff } from '../client/host-handoff-copy.js';
 
 const idle = { connections: 0, activeOperations: 0, processUptimeSeconds: 1, residencies: [] };
 const target = {
@@ -92,6 +93,31 @@ test('compatible connection needs no handoff surface', async () => {
     (await runHostHandoff({ observe: async () => ({ kind: 'ready', value: resource(42) }) })).value,
     42,
   );
+});
+
+test('handoff copy exposes background work even with zero operations and keeps legacy counts unknown', () => {
+  const view: HostHandoffView = {
+    revision: 'test',
+    target,
+    state: 'attention',
+    reason: 'busy',
+    mayExitNaturally: false,
+    actions: ['cancel', 'interrupt'],
+    defaultAction: 'cancel',
+    activity: {
+      ...idle,
+      residencies: [{ label: 'memory-extraction', count: 2 }],
+      drainResidencies: 2,
+    },
+  };
+  for (const [locale, known, unknown] of [
+    ['en', '2 background activities', 'Background activity count unknown'],
+    ['zh-CN', '2 个后台工作', '后台工作数量未知'],
+    ['zh-TW', '2 個背景工作', '背景工作數量未知'],
+  ] as const) {
+    assert.ok(formatHostHandoff(view, locale).detail.includes(known));
+    assert.ok(formatHostHandoff({ ...view, activity: idle }, locale).detail.includes(unknown));
+  }
 });
 
 test('maintenance evidence distinguishes idle retention without guessing for legacy activity', () => {

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -1333,6 +1333,63 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
+  test('quit activity ignores idle scheduler retention but preserves active work protection', async () => {
+    await withHostPaths(async (paths) => {
+      const owner = await tryAcquireInteractiveRootOwner(
+        await resolveStorageRoot({ path: paths.root, kind: 'interactive' }),
+      );
+      assert.ok(owner);
+      let context!: RuntimeHostCompositionContext;
+      const host = await RuntimeHostKernel.start({
+        owner,
+        composition: defineInteractiveRuntimeHostComposition(async (value) => {
+          context = value;
+          const retained = ['daily-review', 'scheduled-task', 'goal'].map((label) =>
+            context.acquireResidency(label, 'idle'),
+          );
+          return testComposition({
+            beginDrain: () => retained.forEach((lease) => lease.release()),
+          });
+        }),
+      });
+      try {
+        const connected = await retryConnect(paths, CURRENT_PROTOCOL);
+        assert.equal(connected.kind, 'connected');
+        if (connected.kind !== 'connected') return;
+        const diagnostics = () => connected.connection.request('host.diagnostics.query', {});
+        const idle = await diagnostics();
+        assert.equal(idle.activeResidencies, 3);
+        assert.equal(idle.upgradeBlockingActivity, false);
+        for (const label of ['daily-review', 'scheduled-task', 'goal', 'runtime-resource']) {
+          const active = context.acquireResidency(label);
+          try {
+            assert.equal((await diagnostics()).upgradeBlockingActivity, true, label);
+            assert.deepEqual(
+              await connected.connection.request('host.upgrade.prepare', {
+                expectedHostEpoch: host.hostEpoch,
+                allowInterruptActiveTasks: false,
+              }),
+              { kind: 'active_tasks' },
+            );
+          } finally {
+            active.release();
+          }
+          assert.equal((await diagnostics()).upgradeBlockingActivity, false);
+        }
+        assert.deepEqual(
+          await connected.connection.request('host.upgrade.prepare', {
+            expectedHostEpoch: host.hostEpoch,
+            allowInterruptActiveTasks: false,
+          }),
+          { kind: 'prepared', pid: process.pid },
+        );
+        await host.closed;
+      } finally {
+        await host.close();
+      }
+    });
+  });
+
   test('idle process retention permits a fenced handoff but never claims natural exit', async () => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -20,6 +20,12 @@
 import { deferred, withTimeout } from '@maka/core/test-only/async-primitives';
 import assert from 'node:assert/strict';
 import { readInvocation, seedInvocation } from '@maka/runtime/test-only/invocation-fixture';
+import { GoalManager } from '@maka/runtime/goal-state';
+import {
+  GoalContinuationCoordinator,
+  volatileGoalDurability,
+} from '@maka/runtime/goal-continuation';
+import { HostGoalExecutionCoordinator } from '../server/goal-execution-coordinator.js';
 import { runtimeInvocationOutcome } from '@maka/core/runtime-invocation';
 import { createRunCompositionSnapshot } from '@maka/core/run-composition';
 import {
@@ -135,6 +141,148 @@ function assertStartedTurn(outcome: TurnStartOutcome): asserts outcome is Starte
   if (!outcome.ok || outcome.result.kind !== 'started') {
     assert.fail('Expected a started Turn outcome');
   }
+}
+
+for (const cancel of [false, true]) {
+  test(`Goal admission retains activity across the Session gate (${cancel ? 'cancel' : 'complete'})`, async () => {
+    const admissionGate = deferred<void>();
+    const backendStarted = deferred<void>();
+    const finishBackend = deferred<void>();
+    const fixture = await createFailureFixture({
+      registerBackend: (backends) =>
+        backends.register(
+          'ai-sdk',
+          (context) =>
+            new (class extends FakeBackend {
+              override async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+                backendStarted.resolve();
+                await finishBackend.promise;
+                yield* super.send(input);
+              }
+            })(context),
+        ),
+    });
+    const goals = new GoalManager({ generateId: randomUUID, now: Date.now });
+    const executions = new HostGoalExecutionCoordinator({
+      executions: fixture.coordinator,
+      runtime: fixture.manager,
+      matchesActive: (sessionId, checkpoint, lease) =>
+        goals.matchesActive(sessionId, checkpoint) && goals.matchesControlLease(sessionId, lease),
+    });
+    let goalActivities = 0;
+    const continuation = new GoalContinuationCoordinator({
+      goalManager: goals,
+      acquireActivity: () => {
+        goalActivities++;
+        const residency = fixture.acquireResidency();
+        return {
+          release: () => {
+            goalActivities--;
+            residency.release();
+          },
+        };
+      },
+      evaluator: {
+        evaluate: async () =>
+          '{"met":true,"impossible":false,"progress":true,"waiting":false,"reason":"done"}',
+      },
+      getRecentContext: async () => '',
+      durability: volatileGoalDurability,
+      admitTurn: (...args) => executions.admitTurn(...args),
+    });
+    const blocker = fixture.sessionAdmission.run(fixture.sessionId, () => admissionGate.promise);
+    try {
+      const queued = fixture.sessionAdmission.waitForNextQueuedRun();
+      goals.create(fixture.sessionId, 'finish work');
+      continuation.recoverActiveGoal(fixture.sessionId);
+      await queued;
+      await waitUntil(() => goalActivities === 0);
+      assert.equal(
+        fixture.liveResidencies(),
+        1,
+        'Hosted admission must own activity after the Goal drain has finished',
+      );
+
+      if (cancel) goals.pause(fixture.sessionId);
+      admissionGate.resolve();
+      await blocker;
+      if (!cancel) {
+        await backendStarted.promise;
+        // Admission must release its temporary lease while the execution remains live.
+        await waitUntil(() => fixture.liveResidencies() === 1);
+        const hold = continuation.holdForHandoff();
+        assert.ok(hold);
+        await withTimeout(hold.settled(), 1_000, 'Goal handoff must not await the full execution');
+        finishBackend.resolve();
+        await fixture.coordinator.whenIdle(fixture.sessionId);
+        hold.release();
+      }
+      await waitUntil(() => fixture.liveResidencies() === 0);
+      assert.equal(fixture.drainRequested(), false);
+      assert.equal(goals.get(fixture.sessionId)?.status, cancel ? 'paused' : 'achieved');
+    } finally {
+      admissionGate.resolve();
+      finishBackend.resolve();
+      await blocker;
+      executions.beginDrain();
+      await continuation.close();
+      await fixture.coordinator.close();
+      await fixture.messages.close();
+      await fixture.dispose();
+    }
+  });
+}
+
+for (const prepared of [false, true]) {
+  test(`Hosted admission releases activity after a rejected gate (${prepared ? 'prepared' : 'direct'})`, async () => {
+    const gate = deferred<'executing' | 'cancelled'>();
+    const entered = deferred<void>();
+    const fixture = await createFailureFixture({
+      registerBackend: (backends) =>
+        backends.register('ai-sdk', (context) => new FakeBackend(context)),
+    });
+    const input = {
+      sessionId: fixture.sessionId,
+      turnId: randomUUID(),
+      runId: randomUUID(),
+      userMessageId: randomUUID(),
+      execution: { kind: 'goal' as const, goalId: randomUUID() },
+      content: { text: 'continue' },
+      admitExecution: () => {
+        entered.resolve();
+        return gate.promise;
+      },
+      start: () => assert.fail('Rejected admission must never start execution'),
+    };
+    const preparation = prepared ? fixture.coordinator.prepare(fixture.sessionId) : undefined;
+    if (preparation) assert.equal(preparation.kind, 'prepared');
+    const admission =
+      preparation?.kind === 'prepared'
+        ? preparation.admission.admit(input)
+        : fixture.coordinator.admit(input);
+    const rejected = assert.rejects(admission, /admission gate failed/);
+    try {
+      await entered.promise;
+      assert.equal(fixture.liveResidencies(), 1);
+      gate.reject(new Error('admission gate failed'));
+      await rejected;
+      assert.equal(fixture.liveResidencies(), 0);
+      assert.equal(fixture.coordinator.whenIdle(fixture.sessionId), undefined);
+      assert.equal(fixture.drainRequested(), false);
+      // A consumed preparation rejects without acquiring a second lease.
+      if (preparation?.kind === 'prepared') {
+        await assert.rejects(preparation.admission.admit(input), /already consumed/);
+        preparation.admission.release();
+        assert.equal(fixture.liveResidencies(), 0);
+      }
+    } finally {
+      gate.reject(new Error('admission gate failed'));
+      await rejected;
+      await fixture.coordinator.close();
+      await fixture.messages.close();
+      await fixture.dispose();
+    }
+  });
 }
 
 test('turn.start rejects the reserved WorkHub Coordination Session identity', async () => {

--- a/packages/runtime-host/src/__tests__/scheduled-task-coordinator-recovery.test.ts
+++ b/packages/runtime-host/src/__tests__/scheduled-task-coordinator-recovery.test.ts
@@ -27,6 +27,7 @@ import type { RootTurnAdmission } from '@maka/storage/execution-stores';
 import { openInteractiveScheduledTaskStoreForWrite } from '@maka/storage/scheduled-task-store';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import { SessionNotFoundError } from '@maka/storage/session-store';
+import { HostResidencyRegistry } from '../server/host-residency-registry.js';
 import {
   HostScheduledTaskCoordinator,
   scheduledTaskExecutionFingerprint,
@@ -407,7 +408,7 @@ test('scheduler handoff waits for an admitted native effect and cancellation res
   let clock = 1_000;
   let timer: (() => void) | undefined;
   let effects = 0;
-  const residency = { release: () => {} };
+  const residencies = new HostResidencyRegistry();
   const coordinator = new HostScheduledTaskCoordinator({
     store,
     sessions: null as never,
@@ -428,7 +429,7 @@ test('scheduler handoff waits for an admitted native effect and cancellation res
     },
     createSession: async () => {},
     changes: { publish: () => {} },
-    acquireResidency: () => residency,
+    acquireResidency: (kind) => residencies.acquire('scheduled-task', kind),
     requestDrain: () => assert.fail('scheduler must not drain'),
     now: () => clock,
     setTimeout: (callback) => {
@@ -453,11 +454,14 @@ test('scheduler handoff waits for an admitted native effect and cancellation res
     await coordinator.prepareRecovery();
     coordinator.start();
     await waitFor(() => timer !== undefined);
+    await waitFor(() => residencies.drainCount === 0);
+    assert.equal(residencies.activeCount, 1);
     clock = task.nextFireAt!;
     const fire = timer!;
     timer = undefined;
     fire();
     await entered.promise;
+    assert.equal(residencies.drainCount, 1);
     const hold = coordinator.holdForHandoff();
     assert.ok(hold);
     let settled = false;
@@ -470,10 +474,12 @@ test('scheduler handoff waits for an admitted native effect and cancellation res
     await ready;
     assert.equal(timer, undefined);
     assert.equal(effects, 1);
-    assert.deepEqual(hold.residencies(), [residency]);
+    assert.equal(residencies.hasDrainResidenciesExcept(hold.residencies()), false);
+    assert.equal(residencies.activeCount, 1);
     assert.equal((await store.listPendingFires()).length, 0);
     hold.release();
     await waitFor(() => timer !== undefined);
+    await waitFor(() => residencies.drainCount === 0);
     assert.equal(effects, 1);
   } finally {
     effect.resolve({});

--- a/packages/runtime-host/src/client/host-handoff-copy.ts
+++ b/packages/runtime-host/src/client/host-handoff-copy.ts
@@ -116,6 +116,20 @@ export function formatHostHandoff(
     descriptions.operator_required = guidance[view.recoveryBlocker];
   }
   const activity = view.activity;
+  const background = activity?.drainResidencies;
+  const backgroundFacts = !activity
+    ? ''
+    : background !== undefined
+      ? tw
+        ? `${background} 個背景工作`
+        : zh
+          ? `${background} 个后台工作`
+          : `${background} background activities`
+      : tw
+        ? '背景工作數量未知'
+        : zh
+          ? '后台工作数量未知'
+          : 'Background activity count unknown';
   const facts = activity
     ? tw
       ? `${activity.connections} 個連線 · ${activity.activeOperations} 個進行中的操作`
@@ -203,7 +217,9 @@ export function formatHostHandoff(
           : zh
             ? '正在完成交接或安全收尾，请稍候。'
             : 'Finishing the handoff or its safe recovery. Please wait.'
-        : [facts, waiting, repairNotice, view.operatorStep].filter(Boolean).join('\n'),
+        : [facts, backgroundFacts, waiting, repairNotice, view.operatorStep]
+            .filter(Boolean)
+            .join('\n'),
     actions: view.actions.map((action) => ({ action, label: labels[action] })),
   };
 }

--- a/packages/runtime-host/src/server/daily-review-coordinator.ts
+++ b/packages/runtime-host/src/server/daily-review-coordinator.ts
@@ -52,6 +52,7 @@ import {
 import type { DailyReviewOperationHandlerMap } from './operation-dispatcher.js';
 import type { HostDailyReviewModel } from './execution-model-authority.js';
 import type { RuntimeHostResidency } from './host-kernel.js';
+import type { HostResidencyKind } from './host-residency-registry.js';
 import {
   CanonicalUsageProjectionIncompleteError,
   readCanonicalUsageBuckets,
@@ -66,7 +67,7 @@ export interface HostDailyReviewCoordinatorInput {
   readonly usage: InteractiveUsageStoresWriter;
   readonly sessions: Pick<ExecutionSessionWriter, 'list'>;
   readonly model: HostDailyReviewModel;
-  readonly acquireResidency: () => RuntimeHostResidency;
+  readonly acquireResidency: (kind?: HostResidencyKind) => RuntimeHostResidency;
   readonly requestDrain: () => void;
   readonly now?: () => number;
   readonly setInterval?: (callback: () => void, delayMs: number) => unknown;
@@ -84,7 +85,7 @@ export class HostDailyReviewCoordinator {
   readonly #usage: InteractiveUsageStoresWriter;
   readonly #sessions: HostDailyReviewCoordinatorInput['sessions'];
   readonly #model: HostDailyReviewModel;
-  readonly #acquireResidency: () => RuntimeHostResidency;
+  readonly #acquireResidency: HostDailyReviewCoordinatorInput['acquireResidency'];
   readonly #requestDrain: () => void;
   readonly #now: () => number;
   readonly #setInterval: (callback: () => void, delayMs: number) => unknown;
@@ -480,7 +481,7 @@ export class HostDailyReviewCoordinator {
       return;
     }
     if (this.#handoffHeld) return;
-    this.#residency ??= this.#acquireResidency();
+    this.#residency ??= this.#acquireResidency('idle');
     this.#timer ??= this.#setInterval(() => {
       void this.#tickScheduler().catch((error: unknown) => this.#handleSchedulerError(error));
     }, SCHEDULER_INTERVAL_MS);

--- a/packages/runtime-host/src/server/daily-review-coordinator.ts
+++ b/packages/runtime-host/src/server/daily-review-coordinator.ts
@@ -103,6 +103,8 @@ export class HostDailyReviewCoordinator {
   #prepared = false;
   #started = false;
   #schedulerEnabled = false;
+  #handoffHeld = false;
+  #schedulerTask: Promise<void> | undefined;
   #draining = false;
   #timer: unknown;
   #residency: RuntimeHostResidency | undefined;
@@ -156,10 +158,51 @@ export class HostDailyReviewCoordinator {
     }
   }
 
+  holdForHandoff():
+    | {
+        settled(): Promise<void>;
+        residencies(): readonly RuntimeHostResidency[] | undefined;
+        release(): void;
+      }
+    | undefined {
+    if (this.#draining || this.#handoffHeld) return undefined;
+    this.#handoffHeld = true;
+    this.#stopTimer();
+    let released = false;
+    return {
+      settled: async () => {
+        // Include scheduler reads as well as generation: a tick may still be
+        // checking configuration or an archive when the hold is acquired.
+        while (this.#schedulerTask || this.#inFlight.size > 0) {
+          await Promise.allSettled([
+            this.#schedulerTask,
+            ...[...this.#inFlight.values()].map((entry) => entry.promise),
+          ]);
+        }
+      },
+      residencies: () => {
+        if (released || this.#draining || this.#schedulerTask || this.#inFlight.size > 0)
+          return undefined;
+        return this.#residency ? [this.#residency] : [];
+      },
+      release: () => {
+        if (released) return;
+        released = true;
+        this.#handoffHeld = false;
+        if (this.#draining) return;
+        this.#reconcileScheduler(this.#schedulerEnabled);
+        void this.#tickScheduler().catch((error: unknown) => this.#handleSchedulerError(error));
+      },
+    };
+  }
+
   close(): Promise<void> {
     this.#closeTask ??= (async () => {
       this.beginDrain();
-      await Promise.allSettled([...this.#inFlight.values()].map((entry) => entry.promise));
+      await Promise.allSettled([
+        this.#schedulerTask,
+        ...[...this.#inFlight.values()].map((entry) => entry.promise),
+      ]);
     })();
     return this.#closeTask;
   }
@@ -315,6 +358,10 @@ export class HostDailyReviewCoordinator {
       await inFlight.promise.catch(() => undefined);
       return this.#run(input);
     }
+    // Keep actual generation distinct from the idle scheduler hold. Besides
+    // protecting a run when scheduling is disabled, its release tells handoff
+    // observers that work finished after a bounded safe-pause attempt timed out.
+    const residency = this.#acquireResidency();
     const pending = this.#generateArchive(archiveId, day, now, modelKeyOverride, input);
     const entry = {
       modelKeyOverride,
@@ -327,6 +374,7 @@ export class HostDailyReviewCoordinator {
       return await pending;
     } finally {
       if (this.#inFlight.get(archiveId) === entry) this.#inFlight.delete(archiveId);
+      residency.release();
     }
   }
 
@@ -426,10 +474,12 @@ export class HostDailyReviewCoordinator {
   }
 
   #reconcileScheduler(enabled: boolean): void {
+    this.#schedulerEnabled = enabled;
     if (!enabled || this.#draining) {
       this.#stopScheduler();
       return;
     }
+    if (this.#handoffHeld) return;
     this.#residency ??= this.#acquireResidency();
     this.#timer ??= this.#setInterval(() => {
       void this.#tickScheduler().catch((error: unknown) => this.#handleSchedulerError(error));
@@ -437,17 +487,29 @@ export class HostDailyReviewCoordinator {
   }
 
   #stopScheduler(): void {
-    if (this.#timer !== undefined) {
-      this.#clearInterval(this.#timer);
-      this.#timer = undefined;
-    }
+    this.#stopTimer();
     this.#residency?.release();
     this.#residency = undefined;
   }
 
-  async #tickScheduler(): Promise<void> {
-    if (!this.#prepared || this.#draining) return;
+  #stopTimer(): void {
+    if (this.#timer !== undefined) {
+      this.#clearInterval(this.#timer);
+      this.#timer = undefined;
+    }
+  }
+
+  #tickScheduler(): Promise<void> {
+    if (!this.#prepared || this.#draining || this.#handoffHeld) return Promise.resolve();
+    this.#schedulerTask ??= this.#runScheduler().finally(() => {
+      this.#schedulerTask = undefined;
+    });
+    return this.#schedulerTask;
+  }
+
+  async #runScheduler(): Promise<void> {
     const { config } = await this.#store.readConfig();
+    if (this.#draining || this.#handoffHeld) return;
     this.#reconcileScheduler(config.enabled);
     const now = this.#now();
     if (!config.enabled || !scheduledTimeHasPassed(now, config.executeTime)) return;
@@ -456,6 +518,7 @@ export class HostDailyReviewCoordinator {
     const day = localDayBoundsAt(now, -1);
     const archiveId = dailyReviewArchiveId(day, 1);
     if (await this.#store.getArchive(archiveId)) return;
+    if (this.#draining || this.#handoffHeld) return;
     await this.#run({
       range: 1,
       offsetDays: -1,

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -2127,6 +2127,7 @@ export async function createExecutionRuntimeHostComposition(
         if (draining || signal.aborted) return undefined;
         const goalHold = goal?.holdForHandoff();
         const scheduleHold = scheduledTasks?.holdForHandoff();
+        const dailyReviewHold = dailyReview?.holdForHandoff();
         let root: Awaited<ReturnType<RootTurnCoordinator['prepareHandoff']>>;
         let detached = false;
         const cancel = () => {
@@ -2134,16 +2135,21 @@ export async function createExecutionRuntimeHostComposition(
           root?.cancel();
           goalHold?.release();
           scheduleHold?.release();
+          dailyReviewHold?.release();
           signal.removeEventListener('abort', cancel);
         };
         signal.addEventListener('abort', cancel, { once: true });
         try {
-          if (!goalHold || !scheduleHold) {
+          if (!goalHold || !scheduleHold || !dailyReviewHold) {
             cancel();
             return undefined;
           }
           await waitForHostedExecutionIdleOrAbort(
-            Promise.all([goalHold.settled(), scheduleHold.settled()]).then(() => undefined),
+            Promise.all([
+              goalHold.settled(),
+              scheduleHold.settled(),
+              dailyReviewHold.settled(),
+            ]).then(() => undefined),
             signal,
           );
           root = await requireRootCoordinator(coordinator).prepareHandoff(hostEpoch, signal);
@@ -2158,8 +2164,9 @@ export async function createExecutionRuntimeHostComposition(
               await waitForHostedExecutionIdleOrAbort(scheduleHold.settled(), signal);
               const goals = await goalHold.residencies(prepared.executions);
               const roots = await prepared.residencies();
-              if (!goals || !roots || signal.aborted || draining) return undefined;
-              return [...roots, ...goals, ...scheduleHold.residencies()];
+              const reviews = dailyReviewHold.residencies();
+              if (!goals || !roots || !reviews || signal.aborted || draining) return undefined;
+              return [...roots, ...goals, ...scheduleHold.residencies(), ...reviews];
             },
             detach: async () => {
               detached = true;

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -671,7 +671,7 @@ export async function createExecutionRuntimeHostComposition(
         usage: openedUsageStores,
         requestDrain: context.requestDrain,
       }),
-      acquireResidency: () => context.acquireResidency('daily-review'),
+      acquireResidency: (kind) => context.acquireResidency('daily-review', kind),
       requestDrain: context.requestDrain,
     });
     let poisonFailure: Error | undefined;
@@ -1360,7 +1360,7 @@ export async function createExecutionRuntimeHostComposition(
       }),
       admitTurn: (sessionId, text, checkpoint, controlLease) =>
         goalExecutionCoordinator.admitTurn(sessionId, text, checkpoint, controlLease),
-      acquireResidency: () => context.acquireResidency('goal'),
+      acquireResidency: (kind) => context.acquireResidency('goal', kind),
       onProjectionChanged: (sessionId) => continuityCoordinator.enqueueCanonicalRefresh(sessionId),
       requestDrain: context.requestDrain,
     });
@@ -1723,7 +1723,7 @@ export async function createExecutionRuntimeHostComposition(
           taskId: string,
         ) => hostChanges.publishScheduledTask(revision, reason, taskId),
       },
-      acquireResidency: () => context.acquireResidency('scheduled-task'),
+      acquireResidency: (kind) => context.acquireResidency('scheduled-task', kind),
       requestDrain: context.requestDrain,
     });
     scheduledTaskTool = scheduledTasks.modelTool;

--- a/packages/runtime-host/src/server/goal-coordinator.ts
+++ b/packages/runtime-host/src/server/goal-coordinator.ts
@@ -58,6 +58,7 @@ import type {
   OperationOutcome,
 } from '../protocol/index.js';
 import type { RuntimeHostResidency } from './host-kernel.js';
+import type { HostResidencyKind } from './host-residency-registry.js';
 import type { GoalOperationHandlerMap } from './operation-dispatcher.js';
 import { projectGoalState } from './goal-projection.js';
 import {
@@ -86,7 +87,7 @@ export interface HostGoalCoordinatorOptions {
     checkpoint: GoalCheckpoint,
     controlLease: GoalControlLease,
   ) => GoalTurnAdmission;
-  readonly acquireResidency: () => RuntimeHostResidency;
+  readonly acquireResidency: (kind?: HostResidencyKind) => RuntimeHostResidency;
   readonly onProjectionChanged: (sessionId: string) => void;
   readonly requestDrain: () => void;
   readonly now?: () => number;
@@ -116,7 +117,7 @@ export class HostGoalCoordinator {
   readonly #onProjectionChanged: (sessionId: string) => void;
   readonly #newId: () => string;
   readonly #requestDrain: () => void;
-  readonly #acquireResidency: () => RuntimeHostResidency;
+  readonly #acquireResidency: HostGoalCoordinatorOptions['acquireResidency'];
   readonly #executions: Pick<HostedExecutionAuthority, 'reconcile' | 'subscribe'>;
   readonly #authorityBySession = new Map<string, GoalAuthoritySnapshot>();
   /**
@@ -156,6 +157,7 @@ export class HostGoalCoordinator {
     const tokenCache = this.#tokenCache;
     this.continuation = new GoalContinuationCoordinator({
       goalManager: this.manager,
+      acquireActivity: () => this.#acquireResidency(),
       evaluator: options.evaluator,
       getRecentContext: async (sessionId) => {
         const messages = await options.readSessionMessages(sessionId);
@@ -579,6 +581,7 @@ export class HostGoalCoordinator {
         record,
       });
     }
+    const residency = this.#acquireResidency();
     const commit = this.#persistenceLane.then(async () => {
       let result;
       try {
@@ -607,10 +610,12 @@ export class HostGoalCoordinator {
         throw new Error(`Goal authority changed its committed revision for Session ${sessionId}`);
       }
     });
-    this.#persistenceLane = commit.catch((error) => {
-      this.#persistenceFailure ??= error;
-      this.#requestDrain();
-    });
+    this.#persistenceLane = commit
+      .catch((error) => {
+        this.#persistenceFailure ??= error;
+        this.#requestDrain();
+      })
+      .finally(() => residency.release());
   }
 
   async #deleteOrphanedAuthority(snapshot: GoalAuthoritySnapshot): Promise<void> {
@@ -631,10 +636,10 @@ export class HostGoalCoordinator {
     if (this.#persistenceFailure !== undefined) throw this.#persistenceFailure;
   }
 
-  #syncResidency(goal: GoalState, acquire: () => RuntimeHostResidency): void {
+  #syncResidency(goal: GoalState, acquire: HostGoalCoordinatorOptions['acquireResidency']): void {
     const retained = this.#residencies.get(goal.sessionId);
     if (!TERMINAL_GOAL_STATUSES.has(goal.status)) {
-      if (!retained && !this.#draining) this.#residencies.set(goal.sessionId, acquire());
+      if (!retained && !this.#draining) this.#residencies.set(goal.sessionId, acquire('idle'));
       return;
     }
     retained?.release();

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -92,7 +92,7 @@ import {
   type RuntimeHostListenerSet,
   type RuntimeHostListenerSetFactory,
 } from './listener-set.js';
-import { HostResidencyRegistry } from './host-residency-registry.js';
+import { HostResidencyRegistry, type HostResidencyKind } from './host-residency-registry.js';
 import type { PeerMeshNode } from '../peer-mesh/node.js';
 import { createPeerMeshOperationHandlers } from './peer-mesh-authority.js';
 import { createHostResourceCollector } from './host-resource-collector.js';
@@ -122,7 +122,8 @@ export class RuntimeHostProcessTerminationRequiredError extends Error {
 export interface RuntimeHostCompositionContext {
   owner: InteractiveRootOwner;
   hostEpoch: string;
-  acquireResidency(label: string): RuntimeHostResidency;
+  /** Idle retention keeps schedulers alive without claiming work is in flight. */
+  acquireResidency(label: string, kind?: HostResidencyKind): RuntimeHostResidency;
   /** Irreversible fail-stop latch; normal residency still uses acquireResidency(). */
   retainUntilProcessExit(): void;
   requestDrain(): void;
@@ -388,7 +389,7 @@ export class RuntimeHostKernel {
         this.#composition = await this.#options.composition.create({
           owner: this.#options.owner,
           hostEpoch: this.hostEpoch,
-          acquireResidency: (label) => this.#acquireResidency(label),
+          acquireResidency: (label, kind) => this.#acquireResidency(label, kind),
           retainUntilProcessExit: () => this.#retainUntilProcessExit(),
           requestDrain: () => this.#requestDrain(),
           ...(this.#options.accessAuthority
@@ -695,8 +696,8 @@ export class RuntimeHostKernel {
     this.#settleLifecycleAfterWork();
   }
 
-  #acquireResidency(label: string): RuntimeHostResidency {
-    const residency = this.#residencies.acquire(label, 'drain', () =>
+  #acquireResidency(label: string, kind: HostResidencyKind = 'drain'): RuntimeHostResidency {
+    const residency = this.#residencies.acquire(label, kind, () =>
       this.#settleLifecycleAfterWork(),
     );
     this.#cancelIdle();

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -938,7 +938,10 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
         ),
       );
     }
-    return this.runCommand(async () => {
+    // Admission is active work even while queued behind a Session gate. Its
+    // residency overlaps the execution residency until admission settles.
+    const residency = this.acquireRecoveryResidency();
+    const admission = this.runCommand(async () => {
       const activeAtEntry = this.#executions.has(input.sessionId);
       let reservation =
         preparedReservation ?? (activeAtEntry ? undefined : this.reserveRootTurn(input.sessionId));
@@ -1105,6 +1108,7 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
       if (error instanceof HostedRootAdmissionGateError) throw error.cause;
       throw error;
     });
+    return admission.finally(() => residency.release());
   }
 
   lookup(sessionId: string, turnId: string): Promise<HostedExecutionIdentity | undefined> {

--- a/packages/runtime-host/src/server/scheduled-task-coordinator.ts
+++ b/packages/runtime-host/src/server/scheduled-task-coordinator.ts
@@ -63,6 +63,7 @@ import {
 } from '../protocol/index.js';
 import type { ScheduledTaskOperationHandlerMap } from './operation-dispatcher.js';
 import type { RuntimeHostResidency } from './host-kernel.js';
+import type { HostResidencyKind } from './host-residency-registry.js';
 import type { HostedExecutionAuthority } from './hosted-execution-authority.js';
 import type { SessionCreateInput } from '../protocol/session-catalog.js';
 
@@ -97,7 +98,7 @@ export interface HostScheduledTaskCoordinatorInput {
   readonly changes: {
     publish(revision: number, reason: ScheduledTaskChangedReason, taskId: string): void;
   };
-  readonly acquireResidency: () => RuntimeHostResidency;
+  readonly acquireResidency: (kind?: HostResidencyKind) => RuntimeHostResidency;
   readonly requestDrain: () => void;
   readonly now?: () => number;
   readonly newId?: () => string;
@@ -143,7 +144,7 @@ export class HostScheduledTaskCoordinator implements ScheduledTaskToolAuthority 
   readonly #nativeEffects: ScheduledTaskNativeEffects;
   readonly #createSession: HostScheduledTaskCoordinatorInput['createSession'];
   readonly #changes: HostScheduledTaskChangeServiceLike;
-  readonly #acquireResidency: () => RuntimeHostResidency;
+  readonly #acquireResidency: HostScheduledTaskCoordinatorInput['acquireResidency'];
   readonly #requestDrain: () => void;
   readonly #now: () => number;
   readonly #newId: () => string;
@@ -561,24 +562,32 @@ export class HostScheduledTaskCoordinator implements ScheduledTaskToolAuthority 
   }
 
   async #refresh(): Promise<void> {
-    await this.#exclusive(async () => {
-      if (this.#handoffHeld || this.#draining) return;
-      for (const claim of await this.#store.listPendingFires()) {
-        if (this.#handoffHeld || this.#draining) break;
-        if (claim.nativeState === 'waiting_for_provider') {
-          await this.#fulfill(claim, true);
+    if (this.#handoffHeld || this.#draining) return;
+    // Cover claim admission, native delivery, and persistence, while an idle
+    // schedule or a read-only catalog query does not claim active work.
+    const residency = this.#acquireResidency();
+    try {
+      await this.#exclusive(async () => {
+        if (this.#handoffHeld || this.#draining) return;
+        for (const claim of await this.#store.listPendingFires()) {
+          if (this.#handoffHeld || this.#draining) break;
+          if (claim.nativeState === 'waiting_for_provider') {
+            await this.#fulfill(claim, true);
+          }
         }
-      }
-      while (!this.#draining && !this.#handoffHeld) {
-        const scan = await this.#store.claimNextDue(this.#now());
-        for (const expired of scan.expired) this.#publish('updated', expired.id);
-        const claim = scan.claim;
-        if (!claim) break;
-        await this.#refreshResidency();
-        await this.#fulfill(claim, false);
-      }
-      await this.#refreshSchedule();
-    });
+        while (!this.#draining && !this.#handoffHeld) {
+          const scan = await this.#store.claimNextDue(this.#now());
+          for (const expired of scan.expired) this.#publish('updated', expired.id);
+          const claim = scan.claim;
+          if (!claim) break;
+          await this.#refreshResidency();
+          await this.#fulfill(claim, false);
+        }
+        await this.#refreshSchedule();
+      });
+    } finally {
+      residency.release();
+    }
   }
 
   async #fulfill(
@@ -876,7 +885,7 @@ export class HostScheduledTaskCoordinator implements ScheduledTaskToolAuthority 
       !this.#draining &&
       (claims.length > 0 ||
         tasks.some((task) => task.status === 'active' && task.nextFireAt !== null));
-    if (shouldHold && !this.#residency) this.#residency = this.#acquireResidency();
+    if (shouldHold && !this.#residency) this.#residency = this.#acquireResidency('idle');
     if (!shouldHold) this.#releaseResidency();
   }
 

--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -185,6 +185,41 @@ function setup(opts?: {
   };
 }
 
+test('Goal activity covers evaluation through settlement but not a paused durable Goal', async () => {
+  const { manager, coordinator, deps, admitted } = setup();
+  const evaluation = controlledCall<string>();
+  let activities = 0;
+  deps.acquireActivity = () => {
+    activities++;
+    return {
+      release: () => {
+        activities--;
+      },
+    };
+  };
+  deps.evaluator.evaluate = () => evaluation.invoke();
+  manager.create(SESSION, 'ship');
+  assert.equal(activities, 0);
+  const settlement = settleExternal(coordinator, SESSION, { kind: 'completed', turnId: 'turn-1' });
+  try {
+    await evaluation.started;
+    assert.equal(activities, 1);
+    manager.pause(SESSION);
+    assert.equal(activities, 1, 'pausing must not hide an evaluation still settling');
+    evaluation.resolve(
+      '{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"continue"}',
+    );
+    await settlement;
+    await waitFor(() => activities === 0);
+    assert.equal(manager.get(SESSION)?.status, 'paused');
+    assert.equal(admitted.length, 0);
+  } finally {
+    evaluation.resolve('{}');
+    await settlement;
+    await coordinator.close();
+  }
+});
+
 test('handoff hold finishes Goal accounting without admitting a successor; release resumes it', async () => {
   const { manager, coordinator, admitted } = setup();
   manager.create(SESSION, 'finish the work');

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -93,6 +93,8 @@ export const volatileGoalDurability: GoalDurabilityPort = Object.freeze({
 
 export interface GoalContinuationDeps {
   goalManager: GoalManager;
+  /** Own active evaluation/admission work separately from a durable Goal's lifetime. */
+  acquireActivity?: () => { release(): void };
   evaluator: GoalEvaluatorDeps & Partial<Pick<GoalEvaluatorResource, 'close'>>;
   /** Summarized recent conversation (last ~5 messages) for the evaluator. */
   getRecentContext: (sessionId: string) => Promise<string>;
@@ -598,12 +600,16 @@ export class GoalContinuationCoordinator {
   private scheduleDrain(lane: SessionLane): void {
     if (!this.isCurrent(lane) || lane.draining) return;
     if (this.handoffHeld && lane.queue.length === 0) return;
+    const activity = this.deps.acquireActivity?.();
     const task = this.drainLane(lane).catch((error) => {
       if (!this.isCurrent(lane)) return;
       this.pauseCurrentGoal(lane, `Goal continuation coordinator failed: ${errorMessage(error)}`);
     });
     this.activeDrains.add(task);
-    void task.finally(() => this.activeDrains.delete(task));
+    void task.finally(() => {
+      this.activeDrains.delete(task);
+      activity?.release();
+    });
   }
 
   private async drainLane(lane: SessionLane): Promise<void> {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Idle Daily Review schedulers, future scheduled tasks, and persisted Goals were counted as active background work. This could block startup handoff or show an unnecessary quit confirmation even when no task was executing; startup copy only displayed connection and operation counts.

Use the existing idle/drain residency distinction consistently. Durable schedules and Goals keep the Host alive without claiming active work; review generation, scheduled dispatch, Goal evaluation/admission, and persistence hold separate active leases. The shared Hosted Execution admission entry owns a drain lease before its first async gate and releases it after execution takes over or admission fails. Daily Review pauses new triggers during cooperative handoff, finishes admitted generation, and resumes scheduling on cancellation or successor recovery. Startup copy now shows background activity separately and reports an unknown count for older Hosts.

Actual running work still requires protection. Quitting an owned Host stops its schedulers; persisted pending work resumes when a Host runs again.

## Verification

- 200 tests passed across root execution, Daily Review, scheduled-task recovery, Goal coordination/continuation, production composition, and handoff suites.
- 15 selected Host kernel startup, quit-activity, idle, and retirement tests passed.
- 72 Desktop quit/manager, CLI handoff, and retirement tests passed: **287 tests total**.
- Four admission regressions fail before the fix with zero activity while admission is pending; they pass after the fix and cover execution takeover, cancellation, rejected gates, and consumed preparations.
- The new quit regression fails with the previous Host kernel because idle retention incorrectly reports blocking activity.
- `npm run lint`, `npm run format:check`, `npm run build`, `npm run typecheck`, both Desktop/UI `knip` checks, ASF header checks, the protocol epoch guard, and `git diff --check` passed.
- Full repository tests and manual Desktop startup/quit testing were not run.

Behavior evidence:

```text
✔ idle schedules and armed or paused Goals allow production handoff and recover in the successor
✔ quit activity ignores idle scheduler retention but preserves active work protection
✔ Goal activity covers evaluation through settlement but not a paused durable Goal
```

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated startup/quit accounting, implemented the fixes and regression tests, ran verification, and prepared this PR. All commits include `Generated-by: OpenAI Codex`; retain the trailer in the final squash commit.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## Summary

空闲的每日回顾调度器、未来定时任务和持久化 Goal 被计为正在执行的后台工作，导致没有任务执行时仍阻塞启动交接或弹出退出确认；启动提示又只显示连接数和操作数。

统一使用现有的 idle/drain 占用分类。持久化调度与 Goal 只保持 Host 存活，实际回顾生成、定时任务派发、Goal 评估与执行准入、状态持久化分别持有活动占用。共用的 Hosted Execution 准入入口在首次异步等待前获取 drain 占用，执行接管或准入失败后释放。每日回顾在协作交接期间暂停新触发、等待已开始的生成完成，取消交接或后继服务启动后恢复调度。启动提示补充后台工作数量，旧 Host 无法提供时明确显示未知。

实际执行中的工作仍受保护。退出由当前桌面端持有的 Host 会停止其调度器；持久化的待办工作会在 Host 再次运行时恢复。

## Verification

- Root 执行、每日回顾、定时任务恢复、Goal 协调与续跑、生产组合、交接相关套件共 200 项测试通过。
- 15 项 Host 内核启动、退出活动判断、空闲与停止相关测试通过。
- 桌面退出及管理器、CLI 交接、停止流程共 72 项测试通过，**合计 287 项**。
- 4 项准入回归用例在修复前因等待准入时活动计数为零而失败，修复后通过；覆盖执行接管、取消、准入异常和重复使用已消费的准入凭据。
- 将 Host 内核替换为本次修复前的实现后，新增退出回归用例因空闲占用被误报为阻塞活动而失败。
- `npm run lint`、`npm run format:check`、`npm run build`、`npm run typecheck`、Desktop/UI 两项 `knip`、ASF 文件头、协议 epoch 及 `git diff --check` 均通过。
- 未运行全仓库测试，也未进行桌面端手动启动及退出验证。

行为验证输出：

```text
✔ idle schedules and armed or paused Goals allow production handoff and recover in the successor
✔ quit activity ignores idle scheduler retention but preserves active work protection
✔ Goal activity covers evaluation through settlement but not a paused durable Goal
```

## AI use

- [ ] 生成式工具没有作出实质贡献
- [x] 生成式工具作出了实质贡献

工具及范围：OpenAI Codex 排查启动与退出的活动计数、实现修复与回归测试、执行验证并准备本 PR。所有提交均包含 `Generated-by: OpenAI Codex`，请在最终 squash 提交中保留。

## Checklist

- [x] 测试覆盖本次变更，且没有修复时会失败
- [x] Lint、格式、类型检查及受影响的测试套件在本地通过

本 PR 是否改变行为？

- [x] 是，已在上方 Summary 中说明
- [ ] 否

</details>
