### PR TITLE
fix(mcp): default new Desktop and TUI servers to auto

### DIFF
--- a/apps/desktop/src/main/__tests__/mcp-page-model.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-page-model.test.ts
@@ -106,14 +106,14 @@ test('legacy SSE projects legacy without erasing an explicit remote pin', () => 
   );
 });
 
-test('a newly-authored stdio MCP persists the one-child legacy default', () => {
+test('a newly-authored stdio MCP persists an explicit auto preference', () => {
   const saved = mcpConfigFromDraft(
     { ...createEmptyMcpDraft(), id: 'local', commandLine: ' node ' },
     copy,
   );
 
   assert.equal(isMcpStdioConfig(saved), true);
-  assert.equal(isMcpStdioConfig(saved) && saved.protocol, 'legacy');
+  assert.equal(isMcpStdioConfig(saved) && saved.protocol, 'auto');
 });
 
 test('stdio editing presents omitted legacy and round-trips explicit modern preferences', () => {
@@ -132,7 +132,7 @@ test('stdio editing presents omitted legacy and round-trips explicit modern pref
 
 test('kind changes preserve an explicit protocol choice and derive only unselected defaults', () => {
   const empty = createEmptyMcpDraft();
-  assert.equal(mcpDraftProtocolPreference(empty), 'legacy');
+  assert.equal(mcpDraftProtocolPreference(empty), 'auto');
   assert.equal(mcpDraftProtocolPreference({ ...empty, kind: 'remote' }), 'auto');
 
   const pinned = { ...empty, kind: 'remote' as const, protocol: '2026-07-28' as const };

--- a/apps/desktop/src/renderer/mcp-page-model.ts
+++ b/apps/desktop/src/renderer/mcp-page-model.ts
@@ -36,7 +36,7 @@ export type McpEditorDraft = {
   env: string;
   url: string;
   transport: 'auto' | 'streamable-http' | 'sse';
-  /** Undefined means the authoring default for the current kind. Stored
+  /** Undefined means the auto authoring default. Stored
    * configs are projected to an explicit value before editing. */
   protocol?: McpProtocolPreference;
   headers: string;
@@ -89,7 +89,7 @@ export function mcpDraftFromConfig(id: string, config: McpServerConfig): McpEdit
 
 export function mcpDraftProtocolPreference(draft: McpEditorDraft): McpProtocolPreference {
   if (draft.kind === 'remote' && draft.transport === 'sse') return 'legacy';
-  return draft.protocol ?? (draft.kind === 'remote' ? 'auto' : 'legacy');
+  return draft.protocol ?? 'auto';
 }
 
 export function mcpConfigFromDraft(draft: McpEditorDraft, copy: McpCopy): McpServerConfig {

--- a/apps/desktop/src/renderer/mcp-page-model.ts
+++ b/apps/desktop/src/renderer/mcp-page-model.ts
@@ -36,8 +36,8 @@ export type McpEditorDraft = {
   env: string;
   url: string;
   transport: 'auto' | 'streamable-http' | 'sse';
-  /** Undefined means the auto authoring default. Stored
-   * configs are projected to an explicit value before editing. */
+  /** Undefined selects auto, except remote SSE which stays legacy.
+   * Stored configs are projected to an explicit value before editing. */
   protocol?: McpProtocolPreference;
   headers: string;
   /** Opaque round-trip state: the editor has no OAuth fields, but an

--- a/packages/cli/src/__tests__/pi-tui-mcp-status.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-mcp-status.test.ts
@@ -364,7 +364,8 @@ describe('MCP management overlay', () => {
       assert.ok(text.includes(expected.argsHint));
       overlay.handleInput('\r');
       assert.ok(rendered().includes(expected.protocol));
-      overlay.handleInput('2');
+      assert.ok(rendered().includes('auto (Enter)'));
+      overlay.handleInput('\r');
       text = rendered();
       assert.ok(text.includes(expected.cwd));
       assert.ok(text.includes(expected.optionalHint));

--- a/packages/cli/src/__tests__/pi-tui-mcp-status.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-mcp-status.test.ts
@@ -334,52 +334,54 @@ describe('MCP management overlay', () => {
   for (const locale of ['en', 'zh-CN'] as const) {
     const expected = editorCopy[locale];
 
-    test(`walks the guided add flow with ${locale} headings, labels, and hints`, () => {
-      const overlay = new McpManagementOverlay({
-        locale,
-        tui: fakeTui(),
-        surface: surface(listSnapshot()),
-        viewportRows: () => 14,
-        onClose: () => undefined,
-        onChange: () => undefined,
-      });
-      const rendered = () => overlay.render(100).map(stripAnsi).join('\n');
+    for (const protocolKey of ['2', '\r']) {
+      test(`walks the guided add flow with ${locale}, protocol key ${JSON.stringify(protocolKey)}, headings, labels, and hints`, () => {
+        const overlay = new McpManagementOverlay({
+          locale,
+          tui: fakeTui(),
+          surface: surface(listSnapshot()),
+          viewportRows: () => 14,
+          onClose: () => undefined,
+          onChange: () => undefined,
+        });
+        const rendered = () => overlay.render(100).map(stripAnsi).join('\n');
 
-      overlay.handleInput('a');
-      assert.ok(rendered().includes(expected.add));
-      overlay.handleInput('g');
-      let text = rendered();
-      assert.ok(text.includes(expected.serverId));
-      assert.ok(text.includes(expected.submitHint));
-      for (const char of 'demo') overlay.handleInput(char);
-      overlay.handleInput('\r');
-      assert.ok(rendered().includes(expected.transport));
-      overlay.handleInput('1');
-      text = rendered();
-      assert.ok(text.includes(expected.command));
-      for (const char of 'echo') overlay.handleInput(char);
-      overlay.handleInput('\r');
-      text = rendered();
-      assert.ok(text.includes(expected.args));
-      assert.ok(text.includes(expected.argsHint));
-      overlay.handleInput('\r');
-      assert.ok(rendered().includes(expected.protocol));
-      assert.ok(rendered().includes('auto (Enter)'));
-      overlay.handleInput('\r');
-      text = rendered();
-      assert.ok(text.includes(expected.cwd));
-      assert.ok(text.includes(expected.optionalHint));
-      overlay.handleInput('\r');
-      text = rendered();
-      assert.ok(text.includes(expected.env));
-      assert.ok(text.includes(expected.mapHint));
-      overlay.handleInput('\r');
-      text = rendered();
-      assert.ok(text.includes(expected.confirmAdd));
-      assert.ok(text.includes('demo · stdio · auto'));
-      assert.ok(text.includes('echo'));
-      assert.ok(text.includes(expected.confirmHint));
-    });
+        overlay.handleInput('a');
+        assert.ok(rendered().includes(expected.add));
+        overlay.handleInput('g');
+        let text = rendered();
+        assert.ok(text.includes(expected.serverId));
+        assert.ok(text.includes(expected.submitHint));
+        for (const char of 'demo') overlay.handleInput(char);
+        overlay.handleInput('\r');
+        assert.ok(rendered().includes(expected.transport));
+        overlay.handleInput('1');
+        text = rendered();
+        assert.ok(text.includes(expected.command));
+        for (const char of 'echo') overlay.handleInput(char);
+        overlay.handleInput('\r');
+        text = rendered();
+        assert.ok(text.includes(expected.args));
+        assert.ok(text.includes(expected.argsHint));
+        overlay.handleInput('\r');
+        assert.ok(rendered().includes(expected.protocol));
+        assert.ok(rendered().includes('auto (Enter)'));
+        overlay.handleInput(protocolKey);
+        text = rendered();
+        assert.ok(text.includes(expected.cwd));
+        assert.ok(text.includes(expected.optionalHint));
+        overlay.handleInput('\r');
+        text = rendered();
+        assert.ok(text.includes(expected.env));
+        assert.ok(text.includes(expected.mapHint));
+        overlay.handleInput('\r');
+        text = rendered();
+        assert.ok(text.includes(expected.confirmAdd));
+        assert.ok(text.includes('demo · stdio · auto'));
+        assert.ok(text.includes('echo'));
+        assert.ok(text.includes(expected.confirmHint));
+      });
+    }
 
     test(`renders the ${locale} remove confirmation with the server id`, () => {
       const overlay = new McpManagementOverlay({

--- a/packages/cli/src/pi-tui-mcp-status.ts
+++ b/packages/cli/src/pi-tui-mcp-status.ts
@@ -334,7 +334,7 @@ export class McpManagementOverlay implements Component {
     if (this.phase.kind !== 'protocol') return;
     const protocol = matchesKey(data, '1')
       ? 'legacy'
-      : matchesKey(data, '2')
+      : matchesKey(data, '2') || matchesKey(data, 'enter')
         ? 'auto'
         : matchesKey(data, '3')
           ? '2026-07-28'
@@ -484,7 +484,7 @@ export class McpManagementOverlay implements Component {
       return [ansi.bold(editor.transportTitle), '', '1  stdio', '2  Streamable HTTP'];
     }
     if (this.phase.kind === 'protocol') {
-      return [ansi.bold(editor.protocolTitle), '', '1  legacy', '2  auto', '3  2026-07-28'];
+      return [ansi.bold(editor.protocolTitle), '', '1  legacy', '2  auto (Enter)', '3  2026-07-28'];
     }
     if (this.phase.kind === 'confirm_add') {
       return confirmAddDocument(this.phase.draft, this.input.locale);


### PR DESCRIPTION
## Summary

New Desktop stdio MCP configurations now default to `auto`, matching new remote configurations. TUI guided setup displays `auto (Enter)` and accepts Enter to select it. Existing saved preferences, explicit selections, legacy SSE, and JSON imports keep their current interpretation.

Fixes #5062

## Verification

- Bundled the two affected TypeScript suites from this worktree using esbuild (`--bundle --platform=node --format=esm --packages=external`) and ran them with `node --test`: 30/30 passed. Dependencies resolve through the existing workspace installation.
- Output includes `a newly-authored stdio MCP persists an explicit auto preference` and guided Enter-default flows in English and Chinese.
- Biome check on all four changed files and `git diff --check` passed.
- Full workspace typecheck/build and live Desktop/TUI smoke tests were not run.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex inspected the configuration flows, implemented the defaults, updated tests, and ran focused verification.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
