### PR TITLE
fix(desktop): keep inactive Graph panels hidden on read failure

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-graph-panel-visibility.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel-visibility.test.ts
@@ -60,7 +60,6 @@ describe('shouldShowAgentGraphPanel', () => {
       shouldShowAgentGraphPanel({
         enabled: true,
         hasGraphActivity: true,
-        error: false,
         sessionId: 'session-1',
         graphId: 'graph-1',
         status: 'completed',
@@ -75,7 +74,6 @@ describe('shouldShowAgentGraphPanel', () => {
       shouldShowAgentGraphPanel({
         enabled: true,
         hasGraphActivity: true,
-        error: false,
         sessionId: 'session-1',
         graphId: 'graph-2',
         status: 'active',
@@ -90,7 +88,6 @@ describe('shouldShowAgentGraphPanel', () => {
       shouldShowAgentGraphPanel({
         enabled: true,
         hasGraphActivity: true,
-        error: false,
         sessionId: 'session-1',
         graphId: 'graph-1',
         status: 'active',
@@ -105,7 +102,6 @@ describe('shouldShowAgentGraphPanel', () => {
       shouldShowAgentGraphPanel({
         enabled: true,
         hasGraphActivity: true,
-        error: false,
         sessionId: 'session-2',
         graphId: 'graph-1',
         status: 'completed',
@@ -120,7 +116,6 @@ describe('shouldShowAgentGraphPanel', () => {
       shouldShowAgentGraphPanel({
         enabled: false,
         hasGraphActivity: false,
-        error: false,
         sessionId: 'session-1',
         dismissedBySession: {},
       }),
@@ -133,7 +128,6 @@ describe('shouldShowAgentGraphPanel', () => {
       shouldShowAgentGraphPanel({
         enabled: true,
         hasGraphActivity: false,
-        error: false,
         sessionId: 'session-1',
         dismissedBySession: {},
       }),

--- a/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
@@ -109,7 +109,8 @@ function installGraphRenderer(
   root: Root;
   setSnapshot(next: AgentGraphClientSnapshot): Promise<void>;
   evict(graphId: string): void;
-  renderSession(sessionId: string): Promise<void>;
+  renderSession(sessionId: string, enabled?: boolean): Promise<void>;
+  failReads(fail: boolean): void;
   holdNextEpochList(sessionId: string): DeferredRead;
   holdNextSnapshot(graphId: string): DeferredRead;
   holdNextStop(sessionId: string): DeferredRead;
@@ -155,9 +156,11 @@ function installGraphRenderer(
   const snapshotGates = new Map<string, DeferredReadGate>();
   const stopGates = new Map<string, DeferredReadGate>();
   const stopCalls: Array<{ sessionId: string; expectedGraphId: string }> = [];
+  let readsFail = false;
   let fullEpochReads = 0;
   let currentEpochReads = 0;
   const epochDirectory = (sessionId: string) => {
+    if (readsFail) throw new Error('Runtime Host unavailable');
     const currentGraphId = currentGraphIds.get(sessionId);
     const entries = [...snapshots.values()]
       .filter((entry) => entry.rootSessionId === sessionId)
@@ -257,12 +260,15 @@ function installGraphRenderer(
     epochReadCounts() {
       return { full: fullEpochReads, current: currentEpochReads };
     },
-    async renderSession(sessionId) {
+    failReads(fail) {
+      readsFail = fail;
+    },
+    async renderSession(sessionId, enabled = true) {
       await act(async () => {
         root.render(
           createElement(AgentGraphPanel, {
             rootSessionId: sessionId,
-            enabled: true,
+            enabled,
             locale: 'en',
             onOpenSession: () => undefined,
           }),
@@ -306,6 +312,52 @@ async function renderPanel(
   });
   return harness;
 }
+
+describe('AgentGraphPanel read failures', () => {
+  for (const initiallyUnavailable of [true, false]) {
+    it(`keeps an inactive ordinary session hidden when ${initiallyUnavailable ? 'the initial read' : 'a refresh'} fails and discovers later activity`, async () => {
+      const empty = snapshot({ graphId: 'graph-1', status: 'empty', scheduleRevision: 0 });
+      const harness = installGraphRenderer(empty);
+      harness.failReads(initiallyUnavailable);
+      await harness.renderSession('session-1', false);
+      if (!initiallyUnavailable) {
+        assert.equal(harness.container.textContent, '');
+        harness.failReads(true);
+        await harness.setSnapshot(empty);
+      }
+      assert.equal(harness.container.textContent, '');
+      harness.failReads(false);
+      await harness.setSnapshot({ ...empty, status: 'active', scheduleRevision: 1 });
+      assert.match(harness.container.textContent ?? '', /Agent Graph/);
+      assert.doesNotMatch(harness.container.textContent ?? '', /Could not refresh graph state/);
+      await act(async () => harness.root.unmount());
+    });
+  }
+
+  it('shows initial read errors for enabled Graph sessions', async () => {
+    const harness = installGraphRenderer(snapshot({ graphId: 'graph-1', status: 'empty' }));
+    harness.failReads(true);
+    await harness.renderSession('session-1');
+    assert.match(harness.container.textContent ?? '', /Could not refresh graph state/);
+    await act(async () => harness.root.unmount());
+  });
+
+  for (const historyOnly of [false, true]) {
+    it(`keeps refresh errors visible for ordinary sessions with known ${historyOnly ? 'history' : 'activity'}`, async () => {
+      const current = snapshot({
+        graphId: 'graph-2', status: 'empty', scheduleRevision: historyOnly ? 0 : 1,
+      });
+      const harness = installGraphRenderer(current, historyOnly
+        ? [snapshot({ graphId: 'graph-1', status: 'completed' })] : []);
+      await harness.renderSession('session-1', false);
+      assert.match(harness.container.textContent ?? '', /Agent Graph/);
+      harness.failReads(true);
+      await harness.setSnapshot(current);
+      assert.match(harness.container.textContent ?? '', /Could not refresh graph state/);
+      await act(async () => harness.root.unmount());
+    });
+  }
+});
 
 describe('AgentGraphPanel dismiss', () => {
   it('keeps the new session loading when a disposed read settles later', async () => {

--- a/apps/desktop/src/renderer/agent-graph-panel-visibility.ts
+++ b/apps/desktop/src/renderer/agent-graph-panel-visibility.ts
@@ -82,7 +82,6 @@ export function reconcileAgentGraphPanelDismissals(
 export function shouldShowAgentGraphPanel(input: {
   enabled: boolean;
   hasGraphActivity: boolean;
-  error: boolean;
   sessionId: string;
   graphId?: string;
   status?: AgentGraphPanelStatus;
@@ -95,5 +94,5 @@ export function shouldShowAgentGraphPanel(input: {
   ) {
     return false;
   }
-  return input.enabled || input.hasGraphActivity || input.error;
+  return input.enabled || input.hasGraphActivity;
 }

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -193,7 +193,6 @@ export function AgentGraphPanel(props: {
     !shouldShowAgentGraphPanel({
       enabled: props.enabled,
       hasGraphActivity: hasGraphActivity || hasGraphHistory,
-      error,
       sessionId: props.rootSessionId,
       graphId: snapshot?.graphId,
       status: snapshot?.status,


### PR DESCRIPTION
## Summary

A failed background Graph read could reveal Agent Graph in an ordinary session with no Graph activity. Visibility now depends on Graph mode or known activity/history; refresh errors remain visible for relevant Graph panels, and background discovery continues.

Fixes #5088

## Verification

- Added five component regression cases. The initial-read and refresh-failure cases fail before the fix; all 42 Graph component, visibility, copy, and refresh tests pass after rebuilding.
- Passed repository lint, format check, full build, all-workspace typecheck, and Knip for Desktop and UI.
- Browser evidence uses the actual AgentGraphPanel and Desktop styles with an injected failing Graph read (Linux Chromium component harness, based on main 30cf0beb0). These are not captures of the reported Windows session. Full Electron E2E was not run; Host disconnection and streaming scroll behavior remain outside this fix.

| Before | After |
| --- | --- |
| ![Ordinary session incorrectly reveals Graph error](https://raw.githubusercontent.com/me2seeks/maka-agent/bf629db6d0c6cdba3b53e856c5941e7180689a33/before.png) | ![Ordinary session keeps Graph hidden](https://raw.githubusercontent.com/me2seeks/maka-agent/bf629db6d0c6cdba3b53e856c5941e7180689a33/after.png) |

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the fix, regression tests, verification, and this automated PR description at the contributor's request.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
