### PR TITLE
fix(runtime-host): fence shutdown admission and cancel pending startup

### DIFF
--- a/apps/desktop/e2e/workhub-layout.spec.ts
+++ b/apps/desktop/e2e/workhub-layout.spec.ts
@@ -92,6 +92,18 @@ test('WorkHub uses its coordination model and shared attachment composer', async
   await page.getByRole('menuitem', { name: '重命名', exact: true }).click();
   await expect(page.getByRole('textbox', { name: '重命名任务' })).toBeVisible();
   await page.keyboard.press('Escape');
+  await expect(page.getByRole('textbox', { name: '重命名任务' })).toBeHidden();
+  // Dialog focus restoration can open the action tooltip over the dock.
+  // Exercise that keyboard focus explicitly and dismiss the remaining overlay.
+  await actions.press('Tab');
+  await page.keyboard.press('Shift+Tab');
+  const actionTooltip = page.getByRole('tooltip', { name: 'Drag task 0 任务操作', exact: true });
+  await expect(actionTooltip).toBeVisible();
+  await expect.poll(nativeWorkHubVisible).toBe(false);
+  const workHubNavigation = page.getByRole('button', { name: 'WorkHub', exact: true });
+  await workHubNavigation.hover();
+  await workHubNavigation.focus();
+  await expect(actionTooltip).toBeHidden();
   await expect.poll(nativeWorkHubVisible).toBe(true);
   await page.getByRole('button', { name: '搜索任务', exact: true }).click();
   await expect(page.locator('[data-maka-contract="search-modal"]')).toBeVisible();

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -1146,6 +1146,31 @@ test('coalesces concurrent enable requests for one remote profile', async () => 
   await manager.close();
 });
 
+test('disable cancels queued starts without affecting a subsequent enable', async () => {
+  const local = candidateHarness();
+  const remote = candidateHarness({ ownership: 'external', hostId: 'office' });
+  let remoteStarts = 0;
+  const manager = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (input) => {
+      if (!input.profileTarget) return ready(local.candidate);
+      remoteStarts++;
+      return ready(remote.candidate);
+    },
+  });
+  try {
+    const first = assert.rejects(manager.enable(remoteTarget('office')), /profile was disabled/);
+    const second = assert.rejects(manager.enable(remoteTarget('office')), /profile was disabled/);
+    const disabling = manager.disable('office');
+    await Promise.all([first, second, disabling]);
+    assert.equal(remoteStarts, 0);
+    assert.equal(manager.entries().some((entry) => entry.target.profile.id === 'office'), false);
+    await manager.enable(remoteTarget('office'));
+    assert.equal(manager.current('office')?.readiness, 'ready');
+  } finally {
+    await manager.close();
+  }
+});
+
 test('close cancels an initial remote compatibility handoff', { timeout: 5_000 }, async () => {
   const local = candidateHarness();
   const shown = deferred<void>();

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -19,9 +19,11 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { deferred } from '@maka/core/test-only/async-primitives';
 import type { BotIncomingMessage } from '@maka/runtime/bots';
 import {
   RuntimeHostOperationError,
+  RuntimeHostRemoteCompatibilityError,
   RuntimeHostPeerError,
   RuntimeHostPermanentReconnectError,
   RuntimeHostRequestInterruptedError,
@@ -316,50 +318,77 @@ test('retires the owned ephemeral Host before Desktop quit', async () => {
   assert.ok(!events.includes('resume-launches'));
 });
 
-test('probes owned Host activity for the quit consent dialog without retiring it', async () => {
-  const active = candidateHarness({ upgradeBlockingActivity: true });
+test('quit refuses active work before asking for consent', async () => {
+  const active = candidateHarness({ activeTasks: true });
   const owner = await startRuntimeHostDesktopManager(
     {} as DesktopRuntimeHostCandidateStartInput,
     { startCandidate: async () => ready(active.candidate) },
   );
 
-  assert.deepEqual(await owner.probeOwnedLocalHostActivity(), { kind: 'active_tasks' });
-  assert.equal(active.prepareRetirementCalls, 0);
+  assert.deepEqual(await owner.prepareOwnedLocalHostQuit('refuse_active_work'), 'active_tasks');
+  assert.equal(active.prepareRetirementCalls, 1);
   await owner.close();
 });
 
-test('probe treats an idle activity report as clear and never retires', async () => {
+test('quit commits idle retirement without waiting for process exit', async () => {
   const current = candidateHarness({ upgradeBlockingActivity: false });
   const owner = await startRuntimeHostDesktopManager(
     {} as DesktopRuntimeHostCandidateStartInput,
-    { startCandidate: async () => ready(current.candidate) },
+    {
+      startCandidate: async () => ready(current.candidate),
+      waitForHostExit: async () => assert.fail('quit must not wait for process exit'),
+    },
   );
 
-  assert.deepEqual(await owner.probeOwnedLocalHostActivity(), { kind: 'clear' });
-  assert.equal(current.prepareRetirementCalls, 0);
+  assert.equal(await owner.prepareOwnedLocalHostQuit('refuse_active_work'), 'ready');
+  assert.equal(current.prepareRetirementCalls, 1);
   await owner.close();
 });
 
-test('probe reports not_owned for a Host this Desktop does not own', async () => {
+test('quit preserves a Host this Desktop does not own', async () => {
   const external = candidateHarness({ ownership: 'external' });
   const owner = await startRuntimeHostDesktopManager(
     {} as DesktopRuntimeHostCandidateStartInput,
     { startCandidate: async () => ready(external.candidate) },
   );
 
-  assert.deepEqual(await owner.probeOwnedLocalHostActivity(), { kind: 'not_owned' });
+  assert.deepEqual(await owner.prepareOwnedLocalHostQuit('refuse_active_work'), 'ready');
   await owner.close();
 });
 
-test('probe failure never blocks quit', async () => {
+test('an unreachable Host never blocks quit', async () => {
   const wedged = candidateHarness({ diagnosticsError: new Error('connection lost') });
   const owner = await startRuntimeHostDesktopManager(
     {} as DesktopRuntimeHostCandidateStartInput,
     { startCandidate: async () => ready(wedged.candidate) },
   );
 
-  assert.deepEqual(await owner.probeOwnedLocalHostActivity(), { kind: 'clear' });
+  assert.deepEqual(await owner.prepareOwnedLocalHostQuit('refuse_active_work'), 'ready');
   await owner.close();
+});
+
+test('replacement still waits for process exit after quit has prepared retirement', async () => {
+  const current = candidateHarness({ disconnectOnPrepare: true });
+  const exit = deferred<void>();
+  const waiting = deferred<void>();
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async () => ready(current.candidate),
+    waitForHostExit: async () => { waiting.resolve(); await exit.promise; },
+  });
+  try {
+    assert.equal(await owner.prepareOwnedLocalHostQuit('refuse_active_work'), 'ready');
+    let retired = false;
+    const replacement = owner.retireOwnedLocalHost('refuse_active_work').then(() => { retired = true; });
+    await waiting.promise;
+    assert.equal(retired, false);
+    assert.equal(current.prepareRetirementCalls, 1);
+    exit.resolve();
+    await replacement;
+    assert.equal(retired, true);
+  } finally {
+    exit.resolve();
+    await owner.close();
+  }
 });
 
 test('does not retire the local Host twice when an update handoff triggers quit', async () => {
@@ -1115,6 +1144,49 @@ test('coalesces concurrent enable requests for one remote profile', async () => 
   await Promise.all([first, second]);
   assert.equal(starts, 2);
   await manager.close();
+});
+
+test('close cancels an initial remote compatibility handoff', { timeout: 5_000 }, async () => {
+  const local = candidateHarness();
+  const shown = deferred<void>();
+  let signal: AbortSignal | undefined;
+  let surfaceClosed = false;
+  let submit: Parameters<OpenHostHandoffSurface>[0] | undefined;
+  let view: HostHandoffView | undefined;
+  const manager = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (input) => {
+      if (!input.profileTarget) return ready(local.candidate);
+      signal = input.signal;
+      throw new RuntimeHostRemoteCompatibilityError('office', {
+        kind: 'incompatible', hostEpoch: 'old-remote', compatibilityEpoch: 1,
+        protocolMin: 0, protocolMax: 0, compositionId: 'interactive',
+        compositionRevision: 'old', state: 'ready', replacement: 'blocked_by_residency',
+      });
+    },
+    handoffSurface: (choose) => {
+      submit = choose;
+      return {
+        update: (next) => { view = next; shown.resolve(); },
+        close: () => { surfaceClosed = true; },
+      };
+    },
+  });
+  const enabling = manager.enable(remoteTarget('office')).catch((error: unknown) => error);
+  await shown.promise;
+  const closing = manager.close();
+  try {
+    assert.equal(signal?.aborted, true);
+    await closing;
+    const error = await enabling;
+    assert.ok(error instanceof Error);
+    assert.match(error.message, /manager is closed/);
+    assert.equal(surfaceClosed, true);
+    assert.equal(local.closeCalls, 1);
+  } finally {
+    if (view) submit?.(view.revision, 'cancel');
+    await enabling;
+    await closing;
+  }
 });
 
 test('waits for an in-flight remote enable before closing', async () => {

--- a/apps/desktop/src/main/__tests__/runtime-host-profile-service.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-profile-service.test.ts
@@ -22,6 +22,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
+import { deferred } from "@maka/core/test-only/async-primitives";
 import {
   createClientRuntimeHostCredentialStore,
   createClientRuntimeHostProfileCatalog,
@@ -31,6 +32,7 @@ import {
   RuntimeHostPermanentReconnectError,
   RuntimeHostRemoteCompatibilityError,
   type ResolvedRuntimeHostProfile,
+  type HostHandoffView,
 } from "@maka/runtime-host/client";
 import {
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
@@ -39,8 +41,10 @@ import {
 } from "@maka/runtime-host/protocol";
 import {
   RuntimeHostPairingFinalizationInterruptedError,
+  startRuntimeHostDesktopManager,
   type RuntimeHostDesktopTargetState,
 } from "../runtime-host-desktop-manager.js";
+import type { DesktopRuntimeHostCandidate, DesktopRuntimeHostCandidateStartInput } from "../runtime-host-desktop-candidate.js";
 import {
   createDesktopRuntimeHostManagedServiceStore,
   findDesktopRuntimeHostManagedServiceBinding,
@@ -1632,50 +1636,81 @@ test("does not recover pairing through unreadable saved preferences", async () =
   assert.equal(await readFile(preferencesPath, "utf8"), savedPreferences);
 });
 
-test("does not retain a startup connection after its profile is disabled", async () => {
+test("disabling a startup compatibility handoff releases Host settings and permits re-enabling", { timeout: 5_000 }, async () => {
   const root = await clientRoot();
   const catalog = createClientRuntimeHostProfileCatalog(root);
   await catalog.create(PROFILE, "token");
-  await writeFile(
-    join(root, "runtime-host-profile-selection.json"),
-    `${JSON.stringify({
-      schemaVersion: 2,
-      defaultProfileId: "local",
-      enabledRemoteProfileIds: [PROFILE.id],
-    })}\n`,
-  );
+  await writeFile(join(root, "runtime-host-profile-selection.json"), JSON.stringify({
+    schemaVersion: 2, defaultProfileId: "local", enabledRemoteProfileIds: [PROFILE.id],
+  }));
   const startup = await resolveDesktopRuntimeHostStartup(root, { catalog });
-  let finishEnable!: () => void;
-  const enableReady = new Promise<void>((resolve) => {
-    finishEnable = resolve;
+  const shown = deferred<void>();
+  const disableCalled = deferred<void>();
+  const localClosed = deferred<void>();
+  const remoteClosed = deferred<void>();
+  let connectionSignal: AbortSignal | undefined;
+  let surfaceClosed = false;
+  let compatible = false;
+  const manager = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (input) => {
+      const remote = !!input.profileTarget;
+      if (remote) {
+        connectionSignal = input.signal;
+        if (!compatible) throw new RuntimeHostRemoteCompatibilityError(PROFILE.id, {
+          kind: 'incompatible', hostEpoch: 'old-remote', compatibilityEpoch: 1,
+          protocolMin: 0, protocolMax: 0, compositionId: 'interactive',
+          compositionRevision: 'old', state: 'ready', replacement: 'blocked_by_residency',
+        });
+      }
+      const closed = remote ? remoteClosed : localClosed;
+      return { kind: 'ready', candidate: {
+        client: { hostId: remote ? ROOT_ID : 'local-host', hostEpoch: remote ? 'remote' : 'local' },
+        hostOwnership: remote ? 'external' : 'owned_ephemeral',
+        closed: closed.promise, close: async () => { closed.resolve(); },
+      } as DesktopRuntimeHostCandidate };
+    },
+    handoffSurface: () => ({
+      update: (_view: HostHandoffView) => shown.resolve(),
+      close: () => { surfaceClosed = true; },
+    }),
   });
-  let connected = false;
   const service = createDesktopRuntimeHostProfileService({
-    clientDataRoot: root,
-    startup,
-    catalog,
-    states: () => [connectingLocal()],
-    enable: async () => {
-      await enableReady;
-      connected = true;
+    clientDataRoot: root, startup, catalog,
+    states: () => manager.entries(),
+    enable: (target) => {
+      assert.notEqual(target.profile.kind, 'local');
+      if (target.profile.kind === 'local') throw new Error('Expected remote profile');
+      return manager.enable({ profile: target.profile, credential: target.credential });
     },
-    disable: async () => {
-      connected = false;
+    disable: (id) => {
+      const task = manager.disable(id);
+      disableCalled.resolve();
+      return task;
     },
-    setDefault: () => undefined,
-    finalizePairing: async () => undefined,
+    setDefault: (id) => manager.setDefaultProfile(id),
+    finalizePairing: (id) => manager.finalizePairing(id),
   });
-
-  const startupTask = service.startEnabledProfiles();
-  await service.setEnabled(PROFILE.id, false);
-  finishEnable();
-  await startupTask;
-
-  assert.equal(connected, false);
-  assert.equal(
-    (await service.getSnapshot()).entries.find((entry) => entry.profile.id === PROFILE.id)?.enabled,
-    false,
-  );
+  const starting = service.startEnabledProfiles();
+  let disabling: Promise<unknown> | undefined;
+  let settings: Promise<unknown> | undefined;
+  try {
+    await shown.promise;
+    disabling = service.setEnabled(PROFILE.id, false);
+    settings = service.getSnapshot();
+    await disableCalled.promise;
+    assert.equal(connectionSignal?.aborted, true);
+    await Promise.all([starting, disabling, settings]);
+    assert.equal(surfaceClosed, true);
+    assert.equal(manager.entries().some((entry) => entry.target.profile.id === PROFILE.id), false);
+    assert.equal((await service.getSnapshot()).entries.find((entry) => entry.profile.id === PROFILE.id)?.enabled, false);
+    compatible = true;
+    const enabled = await service.setEnabled(PROFILE.id, true);
+    assert.equal(enabled.entries.find((entry) => entry.profile.id === PROFILE.id)?.readiness, 'ready');
+    assert.equal(connectionSignal?.aborted, false);
+  } finally {
+    await manager.close();
+    await Promise.allSettled([starting, disabling, settings]);
+  }
 });
 
 test("keeps enablement, default selection, and removal as separate states", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-host-quit-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-quit-uds.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { deferred } from '@maka/core/test-only/async-primitives';
+import { connectRuntimeHost } from '@maka/runtime-host/client';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '@maka/runtime-host/protocol';
+import {
+  createUnavailableDomainOperationHandlers,
+  defineInteractiveRuntimeHostComposition,
+  RuntimeHostKernel,
+} from '@maka/runtime-host/server';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import { DesktopRuntimeHostClient } from '../runtime-host-client.js';
+import type { DesktopRuntimeHostCandidate, DesktopRuntimeHostCandidateStartInput } from '../runtime-host-desktop-candidate.js';
+import { startRuntimeHostDesktopManager } from '../runtime-host-desktop-manager.js';
+import { prepareRuntimeHostQuit } from '../runtime-host-quit.js';
+
+test('quit fences a real Host before Desktop cleanup without waiting for Host cleanup', { timeout: 10_000 }, async () => {
+  const rootPath = await mkdtemp(join(tmpdir(), 'maka-desktop-quit-'));
+  const finishHostCleanup = deferred<void>();
+  let host: RuntimeHostKernel | undefined;
+  let manager: Awaited<ReturnType<typeof startRuntimeHostDesktopManager>> | undefined;
+  let draining = false;
+  let releaseActivity = () => {};
+  try {
+    const owner = await tryAcquireInteractiveRootOwner(await resolveStorageRoot({ path: rootPath, kind: 'interactive' }));
+    assert.ok(owner);
+    host = await RuntimeHostKernel.start({
+      owner,
+      composition: defineInteractiveRuntimeHostComposition(async (context) => {
+        const activity = context.acquireResidency('test-background-work');
+        releaseActivity = () => activity.release();
+        return {
+          handlers: createUnavailableDomainOperationHandlers(),
+          recover: async () => {},
+          beginDrain: () => { draining = true; },
+          close: () => finishHostCleanup.promise,
+        };
+      }),
+    });
+    const result = await connectRuntimeHost({
+      rootPath,
+      protocol: { min: RUNTIME_HOST_PROTOCOL_VERSION, max: RUNTIME_HOST_PROTOCOL_VERSION },
+    });
+    assert.equal(result.kind, 'connected');
+    if (result.kind !== 'connected') return;
+    const connection = result.connection;
+    manager = await startRuntimeHostDesktopManager({ rootPath } as DesktopRuntimeHostCandidateStartInput, {
+      startCandidate: async () => ({
+        kind: 'ready',
+        candidate: {
+          client: new DesktopRuntimeHostClient(connection),
+          hostOwnership: 'owned_ephemeral', hostPid: process.pid,
+          closed: connection.closed, close: () => connection.close(),
+        } as DesktopRuntimeHostCandidate,
+      }),
+      waitForHostExit: async () => assert.fail('quit must not wait for Host cleanup'),
+    });
+    assert.equal(await prepareRuntimeHostQuit(manager, {
+      confirmInterrupt: async () => false,
+    }), 'cancelled');
+    assert.equal(draining, false);
+    assert.equal(host.state, 'ready');
+    // Work settles after a cancelled quit; the next quit must atomically stop admission.
+    releaseActivity();
+    assert.equal(await prepareRuntimeHostQuit(manager, {
+      confirmInterrupt: async () => assert.fail('idle quit needs no consent'),
+    }), 'ready');
+    assert.equal(draining, true);
+    await manager.close();
+    assert.notEqual(host.state, 'closed');
+  } finally {
+    releaseActivity();
+    finishHostCleanup.resolve();
+    await manager?.close();
+    await host?.close();
+    await rm(rootPath, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-quit.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-quit.test.ts
@@ -21,12 +21,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { prepareRuntimeHostQuit } from '../runtime-host-quit.js';
 
-test('quit proceeds without consent when no owned Host is probed', async () => {
+test('quit proceeds without consent when there is no owned Host', async () => {
   const probes: string[] = [];
   const owner = {
-    probeOwnedLocalHostActivity: async () => {
-      probes.push('probe');
-      return { kind: 'not_owned' } as const;
+    prepareOwnedLocalHostQuit: async () => {
+      probes.push('prepare');
+      return 'ready' as const;
     },
   };
 
@@ -36,12 +36,12 @@ test('quit proceeds without consent when no owned Host is probed', async () => {
     }),
     'ready',
   );
-  assert.deepEqual(probes, ['probe']);
+  assert.deepEqual(probes, ['prepare']);
 });
 
-test('quit proceeds without consent when the owned Host is clear', async () => {
+test('quit proceeds without consent after the idle Host stops admission', async () => {
   const owner = {
-    probeOwnedLocalHostActivity: async () => ({ kind: 'clear' }) as const,
+    prepareOwnedLocalHostQuit: async () => 'ready' as const,
   };
 
   assert.equal(
@@ -55,9 +55,9 @@ test('quit proceeds without consent when the owned Host is clear', async () => {
 test('background work requires consent before quitting', async () => {
   const probes: string[] = [];
   const owner = {
-    probeOwnedLocalHostActivity: async () => {
-      probes.push('probe');
-      return { kind: 'active_tasks' } as const;
+    prepareOwnedLocalHostQuit: async (mode: string) => {
+      probes.push(mode);
+      return mode === 'interrupt_active_work' ? 'ready' as const : 'active_tasks' as const;
     },
   };
 
@@ -69,7 +69,7 @@ test('background work requires consent before quitting', async () => {
     await prepareRuntimeHostQuit(owner, { confirmInterrupt: async () => true }),
     'ready',
   );
-  assert.deepEqual(probes, ['probe', 'probe']);
+  assert.deepEqual(probes, ['refuse_active_work', 'refuse_active_work', 'interrupt_active_work']);
 });
 
 test('quit proceeds without an owner', async () => {

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -1331,11 +1331,14 @@ export class DesktopRuntimeHostClient {
 
   prepareHostRetirement(
     mode: RuntimeHostRetirementMode,
+    options?: { readonly timeoutMs?: number; readonly allowCooperativeHandoff?: boolean },
   ): Promise<RuntimeHostRetirementPreparation> {
     return prepareConnectedRuntimeHostRetirement(
       this.connection,
       mode,
-      RUNTIME_HOST_RETIREMENT_TIMEOUT_MS,
+      options?.timeoutMs ?? RUNTIME_HOST_RETIREMENT_TIMEOUT_MS,
+      undefined,
+      options,
     );
   }
 

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -289,7 +289,10 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
   readonly #ipcMain: RuntimeHostReconnectingIpcMain;
   readonly #observationRegistries = new Set<RuntimeHostSessionObservationRegistry>();
   readonly #targets = new Map<string, DesktopRuntimeHostTargetGeneration>();
-  readonly #targetMutations = new Map<string, Promise<void>>();
+  readonly #targetMutations = new Map<string, {
+    readonly settled: Promise<void>;
+    readonly connectionAbort: AbortController;
+  }>();
   readonly #baseInput: DesktopRuntimeHostCandidateStartInput;
   readonly #shutdown = new AbortController();
   #defaultProfileId: string = LOCAL_RUNTIME_HOST_PROFILE.id;
@@ -562,8 +565,8 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     if (isSessionGuestProfile(profileTarget.profile)) {
       throw new Error('Session Guest targets must be mounted instead of enabled as profiles');
     }
-    return this.#mutateTarget(profileTarget.profile.id, () =>
-      this.#enable(profileTarget, false, undefined, undefined, onHostStatus),
+    return this.#mutateTarget(profileTarget.profile.id, (signal) =>
+      this.#enable(profileTarget, false, signal, undefined, onHostStatus),
     );
   }
 
@@ -577,11 +580,11 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     if (!isSessionGuestProfile(profileTarget.profile)) {
       return Promise.reject(new Error('A Session Guest target is required'));
     }
-    return this.#mutateTarget(profileTarget.profile.id, () =>
+    return this.#mutateTarget(profileTarget.profile.id, (connectionSignal) =>
       this.#enable(
         profileTarget,
         true,
-        signal,
+        signal ? AbortSignal.any([signal, connectionSignal]) : connectionSignal,
         onConnectionPhase,
         onHostStatus,
         onSessionCatalogChanged,
@@ -667,6 +670,13 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
   }
 
   async disable(profileId: string): Promise<void> {
+    if (profileId === LOCAL_RUNTIME_HOST_PROFILE.id) {
+      throw new Error('Local Runtime Host cannot be disabled');
+    }
+    // Cancel both running and queued starts before waiting for their cleanup.
+    this.#targetMutations.get(profileId)?.connectionAbort.abort(
+      new Error('Runtime Host profile was disabled'),
+    );
     return this.#mutateTarget(profileId, () => this.#disable(profileId));
   }
 
@@ -957,7 +967,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
   async #close(): Promise<void> {
     this.#closed = true;
     this.#shutdown.abort(new Error('Desktop Runtime Host manager is closed'));
-    await Promise.allSettled([...this.#targetMutations.values()]);
+    await Promise.allSettled([...this.#targetMutations.values()].map((mutation) => mutation.settled));
     const results = await Promise.allSettled(
       [...this.#targets.values()].map((target) => this.#removeTarget(target)),
     );
@@ -1343,21 +1353,23 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     }
   }
 
-  #mutateTarget<T>(profileId: string, operation: () => Promise<T>): Promise<T> {
+  #mutateTarget<T>(profileId: string, operation: (connectionSignal: AbortSignal) => Promise<T>): Promise<T> {
     if (this.#closed) {
       return Promise.reject(new Error('Desktop Runtime Host manager is closed'));
     }
-    const previous = this.#targetMutations.get(profileId) ?? Promise.resolve();
-    const pending = previous.catch(() => undefined).then(operation);
+    const previous = this.#targetMutations.get(profileId);
+    const connectionAbort = previous && !previous.connectionAbort.signal.aborted
+      ? previous.connectionAbort : new AbortController();
+    const pending = (previous?.settled ?? Promise.resolve()).then(() => operation(connectionAbort.signal));
     const settled = pending.then(
       () => undefined,
       () => undefined,
     ).finally(() => {
-      if (this.#targetMutations.get(profileId) === settled) {
+      if (this.#targetMutations.get(profileId)?.settled === settled) {
         this.#targetMutations.delete(profileId);
       }
     });
-    this.#targetMutations.set(profileId, settled);
+    this.#targetMutations.set(profileId, { settled, connectionAbort });
     return pending;
   }
 

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -108,7 +108,7 @@ export interface RuntimeHostDesktopManager {
   runManagedLocalHostChange<T>(change: () => Promise<T>): Promise<T>;
   setDefaultProfile(profileId: string): void;
   retireOwnedLocalHost(mode: RuntimeHostRetirementMode): Promise<DesktopLocalHostRetirement>;
-  probeOwnedLocalHostActivity(): Promise<DesktopLocalHostActivityProbe>;
+  prepareOwnedLocalHostQuit(mode: RuntimeHostRetirementMode): Promise<'ready' | 'active_tasks'>;
   close(): Promise<void>;
 }
 
@@ -147,20 +147,13 @@ export type DesktopLocalHostRetirement =
   | { readonly kind: 'not_owned' }
   | { readonly kind: 'retired'; resume(): void };
 
-/**
- * Read-only answer to "would quitting interrupt active work right now". Quit
- * never drives retirement — the launch-owner guard closes an owned ephemeral
- * Host when the Desktop process exits — so the probe only feeds the
- * interruption-consent dialog.
- */
-export type DesktopLocalHostActivityProbe =
-  | { readonly kind: 'active_tasks' }
-  | { readonly kind: 'clear' }
-  | { readonly kind: 'not_owned' };
+type PreparedLocalHostRetirement =
+  | Exclude<DesktopLocalHostRetirement, { kind: 'retired' }>
+  | (Extract<DesktopLocalHostRetirement, { kind: 'retired' }> & { waitForExit(): Promise<void> });
 
 interface DesktopLocalHostRetirementTask {
   readonly mode: RuntimeHostRetirementMode;
-  readonly result: Promise<DesktopLocalHostRetirement>;
+  readonly result: Promise<PreparedLocalHostRetirement>;
 }
 
 export interface DesktopLocalHostRetirementFacts {
@@ -298,9 +291,9 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
   readonly #targets = new Map<string, DesktopRuntimeHostTargetGeneration>();
   readonly #targetMutations = new Map<string, Promise<void>>();
   readonly #baseInput: DesktopRuntimeHostCandidateStartInput;
-  readonly #pairingFinalizationShutdown = new AbortController();
+  readonly #shutdown = new AbortController();
   #defaultProfileId: string = LOCAL_RUNTIME_HOST_PROFILE.id;
-  #localHostRetirement: Extract<DesktopLocalHostRetirement, { kind: 'retired' }> | undefined;
+  #localHostRetirement: Extract<PreparedLocalHostRetirement, { kind: 'retired' }> | undefined;
   #localHostRetirementTask: DesktopLocalHostRetirementTask | undefined;
   #closed = false;
   #closeTask: Promise<void> | undefined;
@@ -411,7 +404,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       this.pairingFinalizationTimeoutMs,
     );
     const signal = AbortSignal.any([
-      this.#pairingFinalizationShutdown.signal,
+      this.#shutdown.signal,
       timeout.signal,
       ...(externalSignal ? [externalSignal] : []),
     ]);
@@ -466,6 +459,9 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
         }
       }
     } catch (error) {
+      if (this.#shutdown.signal.aborted) {
+        throw new RuntimeHostPairingFinalizationInterruptedError({ cause: error });
+      }
       if (!finalizationStarted && timeout.signal.aborted && completion === 'activation') {
         throw (target.state.readiness !== 'ready' && target.state.error)
           || new Error('Unable to connect to the sharing host before the deadline');
@@ -748,9 +744,33 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     this.onDefaultProfileChanged?.(profileId);
   }
 
-  retireOwnedLocalHost(
+  async retireOwnedLocalHost(
     mode: RuntimeHostRetirementMode,
   ): Promise<DesktopLocalHostRetirement> {
+    const result = await this.#prepareLocalHostRetirement(mode, 'replacement');
+    if (result.kind === 'retired') await result.waitForExit();
+    return result;
+  }
+
+  async prepareOwnedLocalHostQuit(
+    mode: RuntimeHostRetirementMode,
+  ): Promise<'ready' | 'active_tasks'> {
+    const candidate = this.#targets.get(LOCAL_RUNTIME_HOST_PROFILE.id)?.lifecycle?.current;
+    if (candidate?.hostOwnership !== 'owned_ephemeral') return 'ready';
+    try {
+      const result = await this.#prepareLocalHostRetirement(mode, 'quit');
+      return result.kind === 'active_tasks' ? 'active_tasks' : 'ready';
+    } catch {
+      // An unreachable Host must not prevent quitting. Its launch-owner guard
+      // remains armed and closes it when the Desktop process exits.
+      return 'ready';
+    }
+  }
+
+  #prepareLocalHostRetirement(
+    mode: RuntimeHostRetirementMode,
+    purpose: 'quit' | 'replacement',
+  ): Promise<PreparedLocalHostRetirement> {
     if (this.#localHostRetirement) return Promise.resolve(this.#localHostRetirement);
 
     const activeTask = this.#localHostRetirementTask;
@@ -761,14 +781,14 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       ) {
         return activeTask.result.then((result) =>
           result.kind === 'active_tasks'
-            ? this.retireOwnedLocalHost(mode)
+            ? this.#prepareLocalHostRetirement(mode, purpose)
             : result,
         );
       }
       return activeTask.result;
     }
 
-    const result = this.#retireOwnedLocalHost(mode).finally(() => {
+    const result = this.#retireOwnedLocalHost(mode, purpose).finally(() => {
       if (this.#localHostRetirementTask?.result === result) {
         this.#localHostRetirementTask = undefined;
       }
@@ -777,31 +797,10 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     return result;
   }
 
-  async probeOwnedLocalHostActivity(): Promise<DesktopLocalHostActivityProbe> {
-    const target = this.#targets.get(LOCAL_RUNTIME_HOST_PROFILE.id);
-    // During a reconnect gap `lifecycle.current` is undefined, so a busy Host
-    // reads as not_owned and quit will not ask. That is the accepted trade:
-    // quit never waits on the Host, and the launch-owner guard still closes
-    // the owned Host truthfully after process exit, interrupting or settling
-    // its work under the retirement contract.
-    const candidate = target?.lifecycle?.current;
-    if (!candidate || candidate.hostOwnership !== 'owned_ephemeral') {
-      return { kind: 'not_owned' };
-    }
-    try {
-      const diagnostics = await candidate.client.queryHostDiagnostics();
-      return { kind: diagnostics.upgradeBlockingActivity === true ? 'active_tasks' : 'clear' };
-    } catch {
-      // A Host that cannot answer a probe is still closed by its launch-owner
-      // guard when this process exits; diagnostics must never hold quit
-      // hostage.
-      return { kind: 'clear' };
-    }
-  }
-
   async #retireOwnedLocalHost(
     mode: RuntimeHostRetirementMode,
-  ): Promise<DesktopLocalHostRetirement> {
+    purpose: 'quit' | 'replacement',
+  ): Promise<PreparedLocalHostRetirement> {
     const target = this.#requireTarget(LOCAL_RUNTIME_HOST_PROFILE.id);
     const lifecycle = this.#requireLifecycle(target);
     const unavailable = this.#unavailableLocalHostRetirement(target);
@@ -827,6 +826,16 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       clearTimeout(admissionTimeout);
     }
     let hostPid = quiescence.current.hostPid;
+    const retirementError = (cause: unknown) => new DesktopLocalHostRetirementError(
+      {
+        hostId: quiescence.current.client.hostId,
+        hostEpoch: quiescence.current.client.hostEpoch,
+        lifecycleMode: 'ephemeral',
+        rootPath: this.#baseInput.rootPath,
+        ...(hostPid === undefined ? {} : { pid: hostPid }),
+      },
+      { cause },
+    );
     let launchBarrierPaused = false;
     const resume = () => {
       if (launchBarrierPaused) {
@@ -847,7 +856,10 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       // The adopted Host still owns the root here, so every other owned launch
       // can be settled without allowing it to become a late election winner.
       await this.#baseInput.candidateLaunchBarrier?.retireExcept(diagnostics.pid);
-      const result = await quiescence.current.client.prepareHostRetirement(mode);
+      const result = await quiescence.current.client.prepareHostRetirement(
+        mode,
+        purpose === 'quit' ? { timeoutMs: 2_000, allowCooperativeHandoff: false } : undefined,
+      );
       if (result.kind === 'active_tasks') {
         if (mode === 'interrupt_active_work') {
           throw new Error('Runtime Host refused authorized retirement');
@@ -855,28 +867,25 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
         resume();
         return result;
       }
-      await this.waitForHostExit(result.pid);
-      target.lastCandidate = undefined;
-      return this.#completeLocalHostRetirement(resume);
+      hostPid = result.pid;
+      return this.#completeLocalHostRetirement(resume, async () => {
+        try {
+          await this.waitForHostExit(result.pid);
+          target.lastCandidate = undefined;
+        } catch (error) {
+          throw retirementError(error);
+        }
+      });
     } catch (error) {
       resume();
-      throw new DesktopLocalHostRetirementError(
-        {
-          hostId: quiescence.current.client.hostId,
-          hostEpoch: quiescence.current.client.hostEpoch,
-          lifecycleMode: 'ephemeral',
-          rootPath: this.#baseInput.rootPath,
-          ...(hostPid === undefined ? {} : { pid: hostPid }),
-        },
-        { cause: error },
-      );
+      throw retirementError(error);
     }
   }
 
   #unavailableLocalHostRetirement(
     target: DesktopRuntimeHostTargetGeneration,
     cause: unknown = target.state.readiness === 'unavailable' ? target.state.error : undefined,
-  ): DesktopLocalHostRetirement | undefined {
+  ): Extract<DesktopLocalHostRetirement, { kind: 'not_owned' }> | undefined {
     if (target.state.readiness !== 'unavailable') return undefined;
     return this.#retirementWithoutCurrentHost(target, cause);
   }
@@ -884,7 +893,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
   #retirementWithoutCurrentHost(
     target: DesktopRuntimeHostTargetGeneration,
     cause: unknown,
-  ): DesktopLocalHostRetirement {
+  ): Extract<DesktopLocalHostRetirement, { kind: 'not_owned' }> {
     const failure = this.#localHostRetirementError(target, cause);
     if (!failure || target.lastCandidate?.ownedProcess?.state === 'exited') {
       return { kind: 'not_owned' };
@@ -914,10 +923,19 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
 
   #completeLocalHostRetirement(
     resume: () => void,
-  ): Extract<DesktopLocalHostRetirement, { kind: 'retired' }> {
+    waitForExit: () => Promise<void>,
+  ): Extract<PreparedLocalHostRetirement, { kind: 'retired' }> {
     let active = true;
+    let exitTask: Promise<void> | undefined;
     const retirement = {
       kind: 'retired' as const,
+      waitForExit: () => {
+        exitTask ??= waitForExit().catch((error: unknown) => {
+          retirement.resume();
+          throw error;
+        });
+        return exitTask;
+      },
       resume: () => {
         if (!active) return;
         active = false;
@@ -938,9 +956,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
 
   async #close(): Promise<void> {
     this.#closed = true;
-    this.#pairingFinalizationShutdown.abort(
-      new RuntimeHostPairingFinalizationInterruptedError(),
-    );
+    this.#shutdown.abort(new Error('Desktop Runtime Host manager is closed'));
     await Promise.allSettled([...this.#targetMutations.values()]);
     const results = await Promise.allSettled(
       [...this.#targets.values()].map((target) => this.#removeTarget(target)),
@@ -987,7 +1003,10 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
         retryInitialFailure: retryInitialFailure
           ? (error) => !(error instanceof RuntimeHostPeerError && error.code === 'peer_capacity_exceeded')
           : false,
-        ...(initialSignal ? { initialSignal } : {}),
+        initialSignal: AbortSignal.any([
+          this.#shutdown.signal,
+          ...(initialSignal ? [initialSignal] : []),
+        ]),
         onReconnectError: (error) => {
           console.warn('[runtime-host] reconnect attempt failed:', error);
           if (target.valid && target.state.readiness !== 'ready') {

--- a/apps/desktop/src/main/runtime-host-quit.ts
+++ b/apps/desktop/src/main/runtime-host-quit.ts
@@ -19,24 +19,21 @@
 
 import type { RuntimeHostDesktopManager } from './runtime-host-desktop-manager.js';
 
-type ActivityProbeOwner = Pick<RuntimeHostDesktopManager, 'probeOwnedLocalHostActivity'>;
+type QuitOwner = Pick<RuntimeHostDesktopManager, 'prepareOwnedLocalHostQuit'>;
 
 export interface RuntimeHostQuitPrompts {
   confirmInterrupt(): Promise<boolean>;
 }
 
-/**
- * Quit never drives retirement: the launch-owner guard closes an owned
- * ephemeral Host once the Desktop process exits. The probe only feeds the
- * interruption-consent dialog, and a Host that cannot answer it is still
- * closed by the guard — quit is never held hostage to the Host.
- */
+/** Stop Host admission before Desktop cleanup can race a new background job. */
 export async function prepareRuntimeHostQuit(
-  owner: ActivityProbeOwner | undefined,
+  owner: QuitOwner | undefined,
   prompts: RuntimeHostQuitPrompts,
 ): Promise<'ready' | 'cancelled'> {
   if (!owner) return 'ready';
-  const probe = await owner.probeOwnedLocalHostActivity();
-  if (probe.kind !== 'active_tasks') return 'ready';
-  return (await prompts.confirmInterrupt()) ? 'ready' : 'cancelled';
+  const result = await owner.prepareOwnedLocalHostQuit('refuse_active_work');
+  if (result === 'ready') return 'ready';
+  if (!await prompts.confirmInterrupt()) return 'cancelled';
+  await owner.prepareOwnedLocalHostQuit('interrupt_active_work');
+  return 'ready';
 }

--- a/packages/runtime-host/src/__tests__/daily-review-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/daily-review-coordinator.test.ts
@@ -44,6 +44,70 @@ const CONTEXT: ConnectionContext = {
   acquireResidency: () => ({ release: () => undefined }),
 };
 
+test('Daily Review shutdown during summary reads prevents model admission and publication', async () => {
+  const entered = deferred<void>();
+  const release = deferred<void>();
+  let modelCalls = 0;
+  await withCoordinator(
+    async ({ coordinator, store }) => {
+      const running = coordinator.handlers['daily-review.mutate'](
+        {
+          kind: 'run',
+          range: 1,
+          offsetDays: 0,
+          modelKeyOverride: '',
+          replaceExisting: true,
+        },
+        CONTEXT,
+      );
+      await entered.promise;
+      const closing = coordinator.close();
+      release.resolve();
+      const result = await running;
+      await closing;
+      assert.equal(modelCalls, 0);
+      assert.deepEqual(result, {
+        ok: false,
+        error: { code: 'host_draining', message: 'Runtime Host is draining' },
+      });
+      assert.equal(
+        await store.getArchive(dailyReviewArchiveId(localDayBoundsAt(Date.now(), 0), 1)),
+        null,
+      );
+    },
+    {
+      generate: async () => {
+        modelCalls++;
+        return { ok: false, errorClass: 'configuration' };
+      },
+    },
+    true,
+    {
+      list: async () => {
+        entered.resolve();
+        await release.promise;
+        return [
+          {
+            id: 'session',
+            name: 'Today',
+            lastMessageAt: Date.now(),
+            isFlagged: false,
+            isArchived: false,
+            labels: [],
+            hasUnread: false,
+            status: 'active',
+            backend: 'fake',
+            llmConnectionSlug: '',
+            connectionLocked: false,
+            model: '',
+            permissionMode: 'ask',
+          },
+        ];
+      },
+    },
+  );
+});
+
 test('Daily Review handoff fences an admitted timer tick and cancellation resumes a due review', async () => {
   let now = new Date(2026, 8, 9, 12).getTime();
   const timers = new Set<() => void>();

--- a/packages/runtime-host/src/__tests__/host-retirement.test.ts
+++ b/packages/runtime-host/src/__tests__/host-retirement.test.ts
@@ -65,6 +65,32 @@ test('retirement binds both interruption policy choices to the authenticated Hos
   ]);
 });
 
+test('quit can require interruption consent instead of waiting for cooperative handoff', async () => {
+  const connection = {
+    hostEpoch: 'authenticated-host',
+    cooperativeHandoff: true,
+    request: async (operation: string, input: unknown, timeoutMs: number) => {
+      assert.equal(operation, 'host.upgrade.prepare');
+      assert.deepEqual(input, {
+        expectedHostEpoch: 'authenticated-host',
+        allowInterruptActiveTasks: false,
+      });
+      assert.equal(timeoutMs, 2_000);
+      return { kind: 'active_tasks' };
+    },
+  } as unknown as RuntimeHostConnection;
+  assert.deepEqual(
+    await prepareConnectedRuntimeHostRetirement(
+      connection,
+      'refuse_active_work',
+      2_000,
+      undefined,
+      { allowCooperativeHandoff: false },
+    ),
+    { kind: 'active_tasks' },
+  );
+});
+
 test('cancelling preparation closes its connection and waits for the request to settle', async () => {
   const cancellation = new AbortController();
   let rejectRequest!: (error: Error) => void;

--- a/packages/runtime-host/src/client/host-retirement.ts
+++ b/packages/runtime-host/src/client/host-retirement.ts
@@ -35,6 +35,7 @@ export async function prepareConnectedRuntimeHostRetirement(
   mode: RuntimeHostRetirementMode,
   timeoutMs?: number,
   signal?: AbortSignal,
+  options?: { readonly allowCooperativeHandoff?: boolean },
 ): Promise<RuntimeHostRetirementPreparation> {
   signal?.throwIfAborted();
   // Retirement uses a dedicated lifecycle connection. Closing it cancels the
@@ -49,7 +50,9 @@ export async function prepareConnectedRuntimeHostRetirement(
       {
         expectedHostEpoch: connection.hostEpoch,
         allowInterruptActiveTasks: mode === 'interrupt_active_work',
-        ...(mode === 'refuse_active_work' && connection.cooperativeHandoff
+        ...(mode === 'refuse_active_work' &&
+        connection.cooperativeHandoff &&
+        options?.allowCooperativeHandoff !== false
           ? { allowCooperativeHandoff: true }
           : {}),
       },

--- a/packages/runtime-host/src/server/daily-review-coordinator.ts
+++ b/packages/runtime-host/src/server/daily-review-coordinator.ts
@@ -99,14 +99,16 @@ export class HostDailyReviewCoordinator {
       readonly promise: Promise<DailyReviewArchive>;
     }
   >();
-  readonly #abortControllers = new Set<AbortController>();
+  readonly #shutdown = new AbortController();
 
   #prepared = false;
   #started = false;
   #schedulerEnabled = false;
   #handoffHeld = false;
   #schedulerTask: Promise<void> | undefined;
-  #draining = false;
+  get #draining(): boolean {
+    return this.#shutdown.signal.aborted;
+  }
   #timer: unknown;
   #residency: RuntimeHostResidency | undefined;
   #closeTask: Promise<void> | undefined;
@@ -152,11 +154,8 @@ export class HostDailyReviewCoordinator {
 
   beginDrain(): void {
     if (this.#draining) return;
-    this.#draining = true;
+    this.#shutdown.abort(new DOMException('Runtime Host is draining', 'AbortError'));
     this.#stopScheduler();
-    for (const controller of this.#abortControllers) {
-      controller.abort(new DOMException('Runtime Host is draining', 'AbortError'));
-    }
   }
 
   holdForHandoff():
@@ -390,10 +389,13 @@ export class HostDailyReviewCoordinator {
       readonly replaceExisting: boolean;
     },
   ): Promise<DailyReviewArchive> {
+    const signal = this.#shutdown.signal;
+    signal.throwIfAborted();
     const summary = await this.#buildSummary(day, now);
     const existing = await this.#store.getArchive(archiveId);
     if (existing && !input.replaceExisting) return existing;
     const config = await this.#store.readConfig();
+    signal.throwIfAborted();
     const modelKey = modelKeyOverride || config.config.modelKey;
     const base = {
       id: archiveId,
@@ -413,57 +415,50 @@ export class HostDailyReviewCoordinator {
       });
     }
 
-    const controller = new AbortController();
-    this.#abortControllers.add(controller);
-    try {
-      const result = await this.#model.generate({
-        modelKey,
-        prompt: buildModelPrompt(summary, input.range),
-        abortSignal: controller.signal,
-      });
-      if (!result.ok) {
-        if (result.errorClass === 'aborted') {
-          throw (
-            controller.signal.reason ?? new DOMException('Daily Review was aborted', 'AbortError')
-          );
-        }
-        if (result.errorClass === 'persistence') {
-          this.#requestDrain();
-          throw new Error('Daily Review model accounting failed');
-        }
-        return this.#publish({
-          ...base,
-          status: result.errorClass === 'configuration' ? 'no_model' : 'failed',
-          sections: buildRuleBasedSections(summary, input.range),
-          errorMessage:
-            result.errorClass === 'configuration'
-              ? 'No executable analysis model is configured.'
-              : result.errorClass === 'timeout'
-                ? 'The analysis model timed out while generating this review.'
-                : 'The analysis model failed to generate this review.',
-        });
+    const result = await this.#model.generate({
+      modelKey,
+      prompt: buildModelPrompt(summary, input.range),
+      abortSignal: signal,
+    });
+    signal.throwIfAborted();
+    if (!result.ok) {
+      if (result.errorClass === 'aborted') {
+        throw signal.reason ?? new DOMException('Daily Review was aborted', 'AbortError');
       }
-      let sections: DailyReviewArchiveSectionContent;
-      try {
-        sections = parseSections(result.text);
-      } catch {
-        return this.#publish({
-          ...base,
-          modelKey: result.modelKey,
-          status: 'failed',
-          sections: buildRuleBasedSections(summary, input.range),
-          errorMessage: 'The analysis model returned an invalid review.',
-        });
+      if (result.errorClass === 'persistence') {
+        this.#requestDrain();
+        throw new Error('Daily Review model accounting failed');
       }
       return this.#publish({
         ...base,
-        modelKey: result.modelKey,
-        status: 'ok',
-        sections,
+        status: result.errorClass === 'configuration' ? 'no_model' : 'failed',
+        sections: buildRuleBasedSections(summary, input.range),
+        errorMessage:
+          result.errorClass === 'configuration'
+            ? 'No executable analysis model is configured.'
+            : result.errorClass === 'timeout'
+              ? 'The analysis model timed out while generating this review.'
+              : 'The analysis model failed to generate this review.',
       });
-    } finally {
-      this.#abortControllers.delete(controller);
     }
+    let sections: DailyReviewArchiveSectionContent;
+    try {
+      sections = parseSections(result.text);
+    } catch {
+      return this.#publish({
+        ...base,
+        modelKey: result.modelKey,
+        status: 'failed',
+        sections: buildRuleBasedSections(summary, input.range),
+        errorMessage: 'The analysis model returned an invalid review.',
+      });
+    }
+    return this.#publish({
+      ...base,
+      modelKey: result.modelKey,
+      status: 'ok',
+      sections,
+    });
   }
 
   async #publish(archive: DailyReviewArchive): Promise<DailyReviewArchive> {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Fix startup and shutdown races: a remote Host waiting at its compatibility prompt could block Desktop quit or profile disabling, freezing subsequent Host settings; an idle Host could admit background work after the quit check; Daily Review could start a model after shutdown began while its summary reads were pending.

- Cancel pending initial connections and pairing finalization before waiting for shutdown. Disabling a profile cancels its running and queued connection attempts before removal; re-enabling uses a fresh signal, so Host settings remain responsive.
- Replace the read-only quit probe with the existing Host retirement protocol, which atomically checks activity and stops admission. Busy Hosts require interruption consent; cancelled quit resumes the connection and launch barrier. Quit waits for preparation only, while replacement still waits for process exit through the shared retirement flow. Unreachable Hosts retain the launch-owner-guard fallback.
- Give Daily Review one lifetime cancellation signal covering preflight reads and model execution, preventing new model calls and archive publication after cancellation.
- Correct the WorkHub E2E recovery precondition: closing the rename dialog can restore keyboard focus to an action whose tooltip still covers the dock. Exercise that tooltip, then move hover and focus away before checking native-view recovery.

## Verification

- [CI run 34340837617](https://github.com/apache/maka/actions/runs/34340837617) passed on `46d348d2a`, including Desktop E2E, browser-view smoke, alignment audit and installed CLI release validation.

- **541 tests passed on the branch rebased onto `fcff80f58`:** 526 Desktop/CLI, profile, connection, Goal admission, scheduling, Daily Review, handoff and retirement tests; 15 selected Host kernel lifecycle tests.
- The original three regressions and both disable regressions were verified failing before their fixes and passing afterwards. The disable integration uses the production manager, profile service and persistent catalog; it verifies settings recovery and re-enabling. Queued starts are also covered. Evidence: pending remote startup now observes an aborted signal; the real Host connection test observes `beginDrain` before quit returns, preserves a cancelled quit, and holds Host cleanup pending without blocking Desktop cleanup; summary-read shutdown produces zero model calls and no archive.
- Passed full build, lint, format check, typecheck, Desktop/UI Knip, ASF header checks, protocol epoch guard and `git diff --check`. No wire protocol change.
- Desktop E2E: all 37 tests passed locally. The CI failure was reproduced with the action tooltip open. A preceding three-run repeat passed this recovery sequence every time, but one run failed later at the existing floating composer height assertion; the subsequent full suite and five additional diagnostic repeats passed that strict height equality. The height behavior and committed assertion are unchanged.
- Not run: the full repository test suite, manual Electron startup/quit, or a real external model request. Lifecycle tests use controlled production coordinators and a real local Host connection.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the races, implemented the fixes and tests, and ran verification. All three commits include `Generated-by: OpenAI Codex`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## Summary

修复启动及关闭竞态：远程 Host 停在兼容性提示时，可能阻塞桌面退出或禁用操作，并卡住后续 Host 设置；空闲检查后 Host 仍可能接收后台工作；Daily Review 在读取摘要期间收到关闭请求后仍可能启动模型。

- 管理器关闭时先取消初始连接和配对收尾，再等待目标操作结束。禁用配置时先取消该目标正在执行及排队的连接，再移除目标；重新启用使用新的取消信号，设置操作不再被阻塞。
- 退出复用现有 Host 停止协议，原子完成活动检查和停止准入。有活动时请求中断确认；取消退出会恢复连接及候选进程启动。退出只等待停止准备完成，升级继续通过同一流程等待旧进程退出。无法响应的 Host 保留启动者退出保护作为兜底。
- Daily Review 使用一个贯穿预读取和模型执行的生命周期取消信号，取消后不再发起模型调用或发布归档。
- 修正 WorkHub E2E 恢复断言的前置条件：关闭重命名弹窗后，焦点回到任务操作按钮，其 tooltip 仍可能遮挡工作台。测试显式覆盖该状态，再移开鼠标和焦点，确认原生视图恢复。

## Verification

- `46d348d2a` 的 [CI 34340837617](https://github.com/apache/maka/actions/runs/34340837617) 全部通过，包括桌面 E2E、浏览器视图检查、窗口对齐检查及已安装 CLI 发布包验证。

- **在已 rebase 到 `fcff80f58` 的分支上，541 项测试通过**：526 项桌面端、CLI、配置、连接、Goal 准入、调度、Daily Review、交接及停止测试，加上 15 项 Host 内核生命周期测试。
- 原有三个回归及新增两个禁用回归均已验证修复前失败、修复后通过。禁用集成测试使用生产管理器、配置服务和持久目录，验证设置恢复及重新启用；另覆盖仍在队列中的连接。证据：远程初始连接收到取消信号；真实 Host 连接测试确认退出返回前已调用 `beginDrain`、取消退出后仍可用，且 Host 清理未完成不会阻塞桌面清理；摘要读取期间关闭后模型调用数为零且无归档。
- 完整构建、lint、格式检查、类型检查、Desktop/UI Knip、ASF 文件头、协议 epoch 检查和 `git diff --check` 全部通过。未修改线协议。
- 桌面 E2E 全部 37 项本地通过。已在操作按钮 tooltip 打开的状态复现 CI 失败；此前三次重复运行均通过这段恢复检查，其中一次在后续既有浮窗输入区高度断言失败，之后完整套件及额外五次诊断重复运行均通过严格高度相等检查；未修改高度行为及提交中的原断言。
- 未运行全仓库测试、手动 Electron 启动/退出或真实外部模型请求；生命周期验证使用受控的生产协调器与真实本地 Host 连接。

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex 完成问题调查、实现、回归测试与验证；三个提交均包含 `Generated-by: OpenAI Codex`。

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

