### PR TITLE
perf(runtime): compile raw-text closing tags once in WebFetch

### DIFF
--- a/packages/runtime/src/__tests__/local-web-fetch.test.ts
+++ b/packages/runtime/src/__tests__/local-web-fetch.test.ts
@@ -83,6 +83,26 @@ test('local WebFetch rejects pathologically deep HTML before DOM parsing', async
   );
 });
 
+test('local WebFetch skips tag-like text inside script and style content', async () => {
+  // Raw-text elements are skipped to their real closing tag, so tag-shaped
+  // strings inside them must not count toward nesting. Six hundred fake
+  // `<div>`s in a style rule would trip the depth limit if the scanner
+  // believed them.
+  const html =
+    '<html><head><style>p::before { content: "</p>" } ' +
+    `${'<div>'.repeat(600)}</style>` +
+    '<script>const s = "</div>";</script></head><body><article>' +
+    '<h1>Raw text title</h1><p>A body long enough for extraction.</p>' +
+    '</article></body></html>';
+  const executor = createLocalWebFetchExecutor({
+    fetch: async () => new Response(html, { headers: { 'content-type': 'text/html' } }),
+  });
+
+  const result = await executor.fetch({ url: 'https://example.com/raw-text', sessionId: 's1' });
+
+  assert.match(result, /Raw text title/);
+});
+
 test('local WebFetch rejects explicit cloud metadata targets before connecting', async () => {
   let requests = 0;
   const executor = createLocalWebFetchExecutor({

--- a/packages/runtime/src/local-web-fetch.ts
+++ b/packages/runtime/src/local-web-fetch.ts
@@ -61,6 +61,13 @@ const VOID_HTML_ELEMENTS = new Set([
   'wbr',
 ]);
 const RAW_TEXT_HTML_ELEMENTS = new Set(['script', 'style', 'textarea', 'title']);
+/** Closing-tag matchers for the raw-text elements, compiled once: a page with
+ *  dozens of script/style tags would otherwise recompile the same four
+ *  regexes per element. Sharing an instance is safe because `lastIndex` is
+ *  assigned immediately before every exec. */
+const RAW_TEXT_CLOSING_TAGS = new Map(
+  [...RAW_TEXT_HTML_ELEMENTS].map((name) => [name, new RegExp(`</${name}\\s*>`, 'gi')]),
+);
 export const WEB_FETCH_RESPONSE_MAX_BYTES = 5 * 1024 * 1024;
 export const WEB_FETCH_TIMEOUT_MS = 30_000;
 
@@ -197,8 +204,8 @@ function assertSafeHtmlNesting(html: string): void {
       continue;
     }
     if (source.endsWith('/>') || VOID_HTML_ELEMENTS.has(name)) continue;
-    if (RAW_TEXT_HTML_ELEMENTS.has(name)) {
-      const closingTag = new RegExp(`</${name}\\s*>`, 'gi');
+    const closingTag = RAW_TEXT_CLOSING_TAGS.get(name);
+    if (closingTag) {
       closingTag.lastIndex = tags.lastIndex;
       const closingMatch = closingTag.exec(html);
       if (closingMatch) tags.lastIndex = closingTag.lastIndex;


### PR DESCRIPTION
## Summary

The HTML nesting scan built a fresh closing-tag RegExp for every `script`, `style`, `textarea`, and `title` element it met, so a script-heavy page recompiled one of four identical regexes per element. The raw-text element set is fixed, so the matchers are now derived once at module level.

Sharing a cached RegExp instance is safe here because the scan assigns `lastIndex` immediately before every `exec`, so no state leaks between uses.

Also adds a test for the raw-text skip path these lines implement, which was previously untested: tag-shaped strings inside script/style content must not count toward the nesting limit (600 fake `<div>`s inside a style rule would trip the depth limit if the scanner believed them).

## Verification

- `npm --workspace @maka/runtime run typecheck` — clean
- `npm --workspace @maka/runtime run test:dist` — 3350 pass / 0 fail, including the new test
- `npx biome check` on both changed files — clean

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: ZCode authored the change, the new test, and this description.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No