### PR TITLE
chore: remove unreferenced private methods

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1298,11 +1298,6 @@ export class McpClientManager {
     return { entry, config: entry.config };
   }
 
-  private requireOAuthStorage(): McpOAuthStorage {
-    if (!this.oauthStorage) throw new Error('MCP OAuth storage is not configured');
-    return this.oauthStorage;
-  }
-
   /**
    * Begins an interactive authorization round. Runs discovery (and, when
    * stored or configured credentials already satisfy the server, the silent

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -4300,22 +4300,6 @@ export class SessionManager {
     }
   }
 
-  private async requireTurnForAction(
-    sessionId: string,
-    turnId: string,
-    allowed: readonly TurnRecord['status'][],
-    action: string,
-  ): Promise<TurnRecord> {
-    const turn = (await this.getSessionView(sessionId)).turns.find(
-      (candidate) => candidate.turnId === turnId,
-    );
-    if (!turn) throw new Error(`Cannot ${action}: unknown turn ${turnId}`);
-    if (!allowed.includes(turn.status)) {
-      throw new Error(`Cannot ${action}: turn ${turnId} is ${turn.status}`);
-    }
-    return turn;
-  }
-
   /**
    * The Session as its ledger tells it.
    *

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -853,14 +853,6 @@ export class AgentGraphCoordinator {
     });
   }
 
-  async #readClientModelInput(
-    rootSessionId: string,
-    reconciliationFailures?: readonly AgentGraphClientReconciliationFailure[],
-  ): Promise<BuildAgentGraphClientReadModelInput> {
-    const graphId = await this.currentGraphId(rootSessionId);
-    return this.#readClientModelInputForGraph(rootSessionId, graphId, reconciliationFailures);
-  }
-
   async #readClientModelInputForGraph(
     rootSessionId: string,
     graphId: string,

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -4971,60 +4971,6 @@ export class SqliteSessionMetadataStore {
     }
   }
 
-  private replaceSessionMessageSync(
-    sessionId: string,
-    sequence: number,
-    message: StoredMessage,
-    json = JSON.stringify(message),
-  ): void {
-    const encoded = Buffer.from(json, 'utf8');
-    this.db
-      .prepare('DELETE FROM session_message_chunks WHERE session_id = ? AND sequence = ?')
-      .run(sessionId, sequence);
-    this.db
-      .prepare('DELETE FROM session_message_payloads WHERE session_id = ? AND sequence = ?')
-      .run(sessionId, sequence);
-    if (encoded.byteLength <= SQLITE_SESSION_MESSAGE_CHUNK_BYTES) {
-      this.db
-        .prepare(
-          'UPDATE session_messages SET record_json = ? WHERE session_id = ? AND sequence = ?',
-        )
-        .run(json, sessionId, sequence);
-      return;
-    }
-    this.db
-      .prepare('UPDATE session_messages SET record_json = ? WHERE session_id = ? AND sequence = ?')
-      .run(SQLITE_SESSION_MESSAGE_CHUNK_MARKER, sessionId, sequence);
-    this.db
-      .prepare(
-        'INSERT INTO session_message_payloads(session_id, sequence, record_bytes, sha256) VALUES (?, ?, ?, ?)',
-      )
-      .run(
-        sessionId,
-        sequence,
-        encoded.byteLength,
-        createHash('sha256').update(encoded).digest('hex'),
-      );
-    for (
-      let offset = 0;
-      offset < encoded.byteLength;
-      offset += SQLITE_SESSION_MESSAGE_CHUNK_BYTES
-    ) {
-      const chunk = encoded.subarray(offset, offset + SQLITE_SESSION_MESSAGE_CHUNK_BYTES);
-      this.db
-        .prepare(
-          'INSERT INTO session_message_chunks(session_id, sequence, chunk_index, data, sha256) VALUES (?, ?, ?, ?, ?)',
-        )
-        .run(
-          sessionId,
-          sequence,
-          offset / SQLITE_SESSION_MESSAGE_CHUNK_BYTES,
-          chunk,
-          createHash('sha256').update(chunk).digest('hex'),
-        );
-    }
-  }
-
   private readMessagesWith(
     sessionId: string,
     decode: (value: unknown) => StoredMessage,


### PR DESCRIPTION
## Summary

Four private methods with no callers left, each verified by a repo-wide search before removal:

- `replaceSessionMessageSync` on the SQLite session store — the surviving message-replace path goes through the async writer; this sync variant is unreferenced (~53 lines)
- `requireTurnForAction` on the Session manager — turn gating moved to the ledger-owned contracts
- `requireOAuthStorage` on the MCP manager — every caller reads the `oauthStorage` field directly
- `#readClientModelInput` on the stream graph coordinator — every call site resolves its own graph id and uses the `ForGraph` variant directly

All four are `private` (or `#`-private), so no external caller can exist.

## Verification

- Repo-wide `grep` for each name (excluding `dist/`) returns only the declaration
- `npm --workspace @maka/storage run typecheck`, `@maka/runtime`, `@maka/mcp` — all clean
- `test:dist` for the three workspaces: storage 1214 pass / 0 fail, runtime 3349 pass / 0 fail, mcp 186 pass / 0 fail
- `npx biome check` on the four changed files — clean

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: ZCode identified the candidates by search, verified zero references, and authored this description.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No