### PR TITLE
fix(runtime-host): normalize missing SQLite sessions

### DIFF
--- a/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
+++ b/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
@@ -159,6 +159,19 @@ test('projects the canonical root lifecycle and the attachment queue from real S
   });
 });
 
+test('returns null when SQLite no longer contains the requested Session', async () => {
+  await withStores(async (_root, stores) => {
+    const sessionId = 'missing-session';
+    const reader = new CanonicalSessionProjectionReader({
+      stores,
+      rootAdmissions: new RootAdmissionOwner(stores.agentRunStore),
+      messages: createMessages(sessionId, stores),
+    });
+
+    assert.equal(await reader.read(sessionId), null);
+  });
+});
+
 test('projects pending Interactions and preflights their combined snapshot capacity', async () => {
   await withStores(async (root, stores) => {
     const session = await stores.sessionStore.create(sessionInput(root));

--- a/packages/runtime-host/src/server/canonical-session-projection.ts
+++ b/packages/runtime-host/src/server/canonical-session-projection.ts
@@ -18,7 +18,7 @@
  */
 
 import type { SessionHeader } from '@maka/core/session';
-import type { ExecutionStoresWriter } from '@maka/storage/execution-stores';
+import { isSessionNotFoundError, type ExecutionStoresWriter } from '@maka/storage/execution-stores';
 import type {
   SessionContinuitySnapshot,
   SessionContinuityIdentity,
@@ -90,7 +90,7 @@ export class CanonicalSessionProjectionReader {
       header = record.header;
       metadataRevision = record.revision;
     } catch (error) {
-      if (isMissingFile(error)) return null;
+      if (isMissingFile(error) || isSessionNotFoundError(error)) return null;
       throw error;
     }
     if (header.id !== sessionId) {


### PR DESCRIPTION
## Summary

Normalize SQLite's typed missing-Session error at the canonical Session projection boundary. This lets `subscription.open` return its declared `not_found` outcome, so Desktop reconnect restoration can forget a stale observation as intended by #4764. Other Store failures still propagate.

Fixes #5095

## Verification

- Added a real SQLite-backed regression; it failed before the fix with `SessionNotFoundError` / `session_not_found` and passes after the fix.
- `npx biome check packages/runtime-host/src/server/canonical-session-projection.ts packages/runtime-host/src/__tests__/canonical-session-projection.test.ts`
- `npm --workspace @maka/runtime-host run build`
- `npm --workspace @maka/runtime-host run test:dist` — 1825 passed, 0 failed, 12 skipped
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the storage error mismatch, authored the focused fix and regression test, and ran verification under contributor direction.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
