### PR TITLE
fix(desktop): apply the chosen app icon on the Windows taskbar

### DIFF
--- a/apps/desktop/src/main/__tests__/app-icon.test.ts
+++ b/apps/desktop/src/main/__tests__/app-icon.test.ts
@@ -25,8 +25,10 @@ import { APP_ICONS } from '@maka/core/settings';
 import {
   appIconAssetSegments,
   appIconLoadOrder,
+  encodeWindowsIco,
   pickReadableAppIconPath,
   resolveAppIconPath,
+  WINDOWS_TASKBAR_ICON_SIZES,
 } from '../app-icon.js';
 import { isAppIcon, toAppIconChoice, type AppIconChoice } from '@maka/core/settings';
 import { desktopAssetRoot } from '../desktop-assets.js';
@@ -130,5 +132,37 @@ test('a persisted custom id whose file disappeared falls back to the brand mark'
   assert.equal(
     pickReadableAppIconPath(gone, toPath, () => true),
     join('/user-data', 'app-icons', `${'d'.repeat(32)}.png`),
+  );
+});
+
+test('the Windows ICO carries every taskbar size as a PNG frame', () => {
+  const frames = WINDOWS_TASKBAR_ICON_SIZES.map((size) => ({
+    size,
+    png: Buffer.from(`png-${size}`),
+  }));
+  const encoded = encodeWindowsIco(frames);
+  assert.equal(encoded.readUInt16LE(0), 0);
+  assert.equal(encoded.readUInt16LE(2), 1);
+  assert.equal(encoded.readUInt16LE(4), frames.length);
+
+  let cursor = 6;
+  for (const frame of frames) {
+    const storedSize = frame.size >= 256 ? 0 : frame.size;
+    assert.equal(encoded.readUInt8(cursor), storedSize);
+    assert.equal(encoded.readUInt8(cursor + 1), storedSize);
+    assert.equal(encoded.readUInt16LE(cursor + 4), 1);
+    assert.equal(encoded.readUInt16LE(cursor + 6), 32);
+    assert.equal(encoded.readUInt32LE(cursor + 8), frame.png.byteLength);
+    const offset = encoded.readUInt32LE(cursor + 12);
+    assert.equal(
+      encoded.subarray(offset, offset + frame.png.byteLength).toString(),
+      frame.png.toString(),
+    );
+    cursor += 16;
+  }
+  assert.deepEqual(
+    [...WINDOWS_TASKBAR_ICON_SIZES],
+    [16, 24, 32, 48, 64, 256],
+    'Windows needs a 16px and 32px frame; dropping either leaves the taskbar on the packaged sky icon',
   );
 });

--- a/apps/desktop/src/main/app-icon-surface.ts
+++ b/apps/desktop/src/main/app-icon-surface.ts
@@ -32,7 +32,13 @@ import {
   listCustomAppIconIds,
   resolveCustomAppIconPath,
 } from './custom-app-icon-store.js';
-import { appIconLoadOrder, pickReadableAppIconPath, resolveAppIconPath } from './app-icon.js';
+import {
+  appIconLoadOrder,
+  encodeWindowsIco,
+  pickReadableAppIconPath,
+  resolveAppIconPath,
+  WINDOWS_TASKBAR_ICON_SIZES,
+} from './app-icon.js';
 import { desktopAssetRoot } from './desktop-assets.js';
 
 /**
@@ -69,6 +75,16 @@ export function readableAppIconPath(value: unknown): string {
 }
 
 /**
+ * Same artwork as `readableAppIconPath`, already in the form `setIcon` and
+ * the window constructor can hand Windows. A path to the 1024px PNG master
+ * is enough on macOS and Linux; Windows needs the rebuilt ICO.
+ */
+export function readableAppIconImage(value: unknown): Electron.NativeImage {
+  const image = nativeImage.createFromPath(readableAppIconPath(value));
+  return image.isEmpty() ? image : nativeAppIcon(image);
+}
+
+/**
  * Where this process reads icon artwork from. Exported so the window `icon`
  * option resolves the same root the dock does — one of them guessing wrong
  * would ship a build whose windows and dock disagree.
@@ -97,6 +113,8 @@ let shippedPreviews: readonly AppIconPreview[] | undefined;
  * per-window icons are ignored. Windows and Linux draw it per window instead,
  * which is why every open window is updated: the `icon` option in
  * `createWindow` only covers windows opened *after* the choice was persisted.
+ * Windows additionally needs the rebuilt ICO from `nativeAppIcon`; the PNG
+ * master is a valid NativeImage but does not replace the packaged .exe tile.
  */
 export function applyAppIcon(value: unknown, onIconError: (error: unknown) => void): void {
   const icon = toAppIconChoice(value);
@@ -106,11 +124,12 @@ export function applyAppIcon(value: unknown, onIconError: (error: unknown) => vo
       onIconError(new Error(`no readable artwork for app icon "${icon}"`));
       return;
     }
+    const surface = nativeAppIcon(image);
     if (app.dock) {
-      app.dock.setIcon(image);
+      app.dock.setIcon(surface);
       return;
     }
-    for (const window of BrowserWindow.getAllWindows()) window.setIcon(image);
+    for (const window of BrowserWindow.getAllWindows()) window.setIcon(surface);
   } catch (error) {
     onIconError(error);
   }
@@ -171,4 +190,22 @@ function loadAppIcon(icon: AppIconChoice): Electron.NativeImage | undefined {
     if (!image.isEmpty()) return image;
   }
   return undefined;
+}
+
+/**
+ * Windows `setIcon` consumes an HICON. The 1024px PNG master is a valid
+ * NativeImage, but Chromium does not always promote it into the small/large
+ * sizes the taskbar asks for, so the running window keeps the packaged
+ * `sky` tile. Rebuild as a multi-size ICO on win32 only; macOS and Linux
+ * already accept the PNG master.
+ */
+function nativeAppIcon(image: Electron.NativeImage): Electron.NativeImage {
+  if (process.platform !== 'win32') return image;
+  const frames = WINDOWS_TASKBAR_ICON_SIZES.flatMap((size) => {
+    const png = image.resize({ width: size, height: size, quality: 'better' }).toPNG();
+    return png.byteLength > 0 ? [{ size, png }] : [];
+  });
+  if (frames.length === 0) return image;
+  const ico = nativeImage.createFromBuffer(encodeWindowsIco(frames));
+  return ico.isEmpty() ? image : ico;
 }

--- a/apps/desktop/src/main/app-icon.ts
+++ b/apps/desktop/src/main/app-icon.ts
@@ -51,9 +51,8 @@ export function appIconLoadOrder(icon: AppIconChoice): readonly AppIconChoice[] 
  *
  * A path being well-formed says nothing about the file existing: a persisted
  * custom id whose file was deleted resolves to a perfectly valid path that
- * decodes to nothing. Windows and Linux hand that path straight to a new
- * window, so window creation has to walk the same fallback the dock does
- * instead of trusting the first candidate.
+ * decodes to nothing. Window creation has to walk the same fallback the dock
+ * does instead of trusting the first candidate.
  */
 export function pickReadableAppIconPath(
   icon: AppIconChoice,
@@ -65,4 +64,54 @@ export function pickReadableAppIconPath(
     if (isReadable(path)) return path;
   }
   return toPath('default');
+}
+
+/**
+ * Sizes Windows asks for when a running window replaces the .exe resource.
+ *
+ * A 1024px PNG handed to `BrowserWindow.setIcon` is a valid NativeImage, but
+ * `WM_SETICON` wants a small (16) and large (32) HICON. Chromium then leaves
+ * the taskbar on the packaged icon — currently `sky` — so Settings can show
+ * the classic mascot selected while the taskbar still draws the geometric mark.
+ */
+export const WINDOWS_TASKBAR_ICON_SIZES = [16, 24, 32, 48, 64, 256] as const;
+
+export interface WindowsIcoFrame {
+  readonly size: number;
+  readonly png: Uint8Array;
+}
+
+/**
+ * PNG-in-ICO container. Electron's in-memory NativeImage does not always
+ * survive `setIcon` on Windows when it still contains the 1024px master;
+ * an ICO with the sizes above does.
+ */
+export function encodeWindowsIco(frames: readonly WindowsIcoFrame[]): Buffer {
+  const headerSize = 6 + 16 * frames.length;
+  let imageOffset = headerSize;
+  const entries = frames.map((frame) => {
+    const entry = { ...frame, offset: imageOffset };
+    imageOffset += frame.png.byteLength;
+    return entry;
+  });
+  const encoded = Buffer.alloc(imageOffset);
+  encoded.writeUInt16LE(0, 0);
+  encoded.writeUInt16LE(1, 2);
+  encoded.writeUInt16LE(frames.length, 4);
+  let cursor = 6;
+  for (const entry of entries) {
+    encoded.writeUInt8(entry.size >= 256 ? 0 : entry.size, cursor);
+    encoded.writeUInt8(entry.size >= 256 ? 0 : entry.size, cursor + 1);
+    encoded.writeUInt8(0, cursor + 2);
+    encoded.writeUInt8(0, cursor + 3);
+    encoded.writeUInt16LE(1, cursor + 4);
+    encoded.writeUInt16LE(32, cursor + 6);
+    encoded.writeUInt32LE(entry.png.byteLength, cursor + 8);
+    encoded.writeUInt32LE(entry.offset, cursor + 12);
+    cursor += 16;
+  }
+  for (const entry of entries) {
+    Buffer.from(entry.png).copy(encoded, entry.offset);
+  }
+  return encoded;
 }

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -21,7 +21,7 @@ import { app, BrowserWindow, dialog, nativeTheme, screen, shell, webFrameMain } 
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { appIconForTheme, type AppSettings } from '@maka/core/settings';
-import { readableAppIconPath } from './app-icon-surface.js';
+import { readableAppIconImage } from './app-icon-surface.js';
 import { isExternalUrl } from './external-link-guard.js';
 import { readSavedBounds, writeSavedBounds, SAFE_MIN_HEIGHT, SAFE_MIN_WIDTH, type SavedBounds } from './window-state.js';
 import { BrowserViewController } from './browser/controller.js';
@@ -326,11 +326,10 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       ...(bounds.x !== undefined && bounds.y !== undefined ? { x: bounds.x, y: bounds.y } : {}),
       title: 'Maka',
       // PR-GRAY-CARD-LIFT-0 (WAWQAQ msg `0eb99429` 2026-06-20): the
-      // app icon ships as a 1024px PNG under apps/desktop/assets/. BrowserWindow
-      // accepts a PNG path directly on macOS for the dock / window title bar;
-      // .icns / .ico packaging will come with the installer build pass. The
-      // asset path resolves from the built dist/main/main.js (two levels up to
-      // apps/desktop, then assets).
+      // app icon ships as a 1024px PNG under apps/desktop/assets/. macOS and
+      // Linux accept that path as the window icon. Windows does not: the
+      // taskbar wants a small/large HICON, so `readableAppIconImage` rebuilds
+      // a multi-size ICO there instead of handing Chromium the PNG master.
       //
       // Windows and Linux draw this icon per window, so a window opened after
       // the user switched icons must be born with the chosen one — waiting for
@@ -339,7 +338,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       // Windows and Linux draw the icon per window, so a window opened while
       // dark is in effect must be born with the dark tile — otherwise it keeps
       // the light one until something else triggers a re-apply.
-      icon: readableAppIconPath(
+      icon: readableAppIconImage(
         appIconForTheme(persistedAppearance ?? {}, isDark),
       ),
       // PR-WINDOW-TITLEBAR-0: hide the native title bar so the renderer

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -65,6 +65,12 @@ installMainProcessLogCapture(mainProcessLogBuffer, () => recoveryJournal?.markDi
 // socket/pipe namespace, and single-instance lock) without touching any
 // path logic. See https://github.com/maka-agent/maka-agent/issues/2252.
 app.setName(app.isPackaged ? 'Maka' : 'Maka Dev');
+if (process.platform === 'win32') {
+  // Without a stable AppUserModelID, Windows groups the running window with
+  // the .exe shortcut and ignores `setIcon`. The picker then shows the classic
+  // mascot while the taskbar keeps the packaged `sky` tile.
+  app.setAppUserModelId(app.isPackaged ? 'com.maka.desktop' : 'com.maka.desktop.dev');
+}
 
 // Electron otherwise quits implicitly when the last BrowserWindow closes.
 // Startup and fatal-recovery surfaces can be the only window, so keep process

--- a/apps/desktop/src/main/startup-presentation.ts
+++ b/apps/desktop/src/main/startup-presentation.ts
@@ -20,7 +20,7 @@
 import { app, BrowserWindow, clipboard, nativeTheme } from 'electron';
 import { resolveSystemUiLocale, type UiLocale } from '@maka/core/ui-locale';
 import type { HostHandoffView, OpenHostHandoffSurface } from '@maka/runtime-host/client';
-import { readableAppIconPath } from './app-icon-surface.js';
+import { readableAppIconImage } from './app-icon-surface.js';
 import { installApplicationMenu } from './application-menu.js';
 import { installDesktopStartupBranding } from './desktop-shell-presentation.js';
 import { isIsolatedE2e } from './startup-context.js';
@@ -55,7 +55,7 @@ export function showDesktopStartupProgress(
     progress = createStartupProgressWindow({
       locale: resolveSystemUiLocale(app.getPreferredSystemLanguages()),
       dark: nativeTheme.shouldUseDarkColors,
-      icon: readableAppIconPath('default'),
+      icon: readableAppIconImage('default'),
       createWindow: (options) => new BrowserWindow(options),
       copyDiagnostics: (phase, handoff) => handoff
         ? clipboard.writeText(JSON.stringify(handoff, null, 2)) : copyDiagnostics(phase),
@@ -91,7 +91,7 @@ export function createDesktopHostHandoffSurface(resolveLocale: () => Promise<UiL
       } else {
         ownWindow = true;
         window = createStartupProgressWindow({
-          locale, dark: nativeTheme.shouldUseDarkColors, icon: readableAppIconPath('default'),
+          locale, dark: nativeTheme.shouldUseDarkColors, icon: readableAppIconImage('default'),
           createWindow: (options) => new BrowserWindow(options),
           copyDiagnostics: () => clipboard.writeText(JSON.stringify(latest, null, 2)),
           onError: (error) => console.error('[runtime-host] handoff presentation failed:', error),

--- a/apps/desktop/src/main/startup-progress-window.ts
+++ b/apps/desktop/src/main/startup-progress-window.ts
@@ -21,7 +21,7 @@ import { randomUUID } from 'node:crypto';
 import { MAKA_WORDMARK_PATH } from '@maka/core/maka-wordmark';
 import type { UiLocale } from '@maka/core/ui-locale';
 import { formatHostHandoff, type HostHandoffView, type HostHandoffAction } from '@maka/runtime-host/client';
-import type { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
+import type { BrowserWindow, BrowserWindowConstructorOptions, NativeImage } from 'electron';
 
 export type StartupPhase =
   | 'prepare' | 'storage' | 'connect' | 'package'
@@ -82,7 +82,7 @@ export interface StartupProgressWindow {
 export function createStartupProgressWindow(input: {
   locale: UiLocale;
   dark: boolean;
-  icon: string;
+  icon: string | NativeImage;
   createWindow(options: BrowserWindowConstructorOptions): BrowserWindow;
   copyDiagnostics(phase: StartupPhase, handoff?: HostHandoffView): void | Promise<void>;
   onError(error: unknown): void;


### PR DESCRIPTION
## Summary

Settings can show the classic mascot selected while the Windows taskbar keeps the packaged `sky` tile. The picker write succeeds; the OS surface does not.

Windows `WM_SETICON` wants a small (16) and large (32) HICON, and Chromium groups the running window with the `.exe` shortcut unless a stable AppUserModelID is set. Handing `BrowserWindow.setIcon` the 1024px PNG master is a valid NativeImage, but it does not replace that packaged resource.

- rebuild the running icon as a multi-size ICO (`16/24/32/48/64/256`) before `setIcon` and window creation
- stamp `com.maka.desktop` / `com.maka.desktop.dev` before `ready`
- leave the packaged `.exe` icon as `sky`; Finder/shortcut still cannot follow a live choice

Refs #3431 #3941

## Verification

- `npx biome check --write` on the seven changed files — no fixes applied
- `npm --workspace @maka/desktop run build:main` — pass
- `node --test --test-force-exit apps/desktop/dist/main/__tests__/app-icon.test.js apps/desktop/dist/main/__tests__/client-settings-effects.test.js` — 12 pass, including the new ICO-frame contract
- `node --test --test-force-exit apps/desktop/dist/main/__tests__/startup-progress-window.test.js` — 7 pass

Not run: packaged Windows installer (`electron-builder`) and a live taskbar capture against a signed `.exe`. The husky pre-commit Biome stdin hook failed to spawn `biome.cmd` on this Windows shell (`EINVAL`); Biome was run directly on the files instead.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Grok — located the Windows `setIcon` / AppUserModelID gap, wrote the ICO rebuild, tests, and this PR under my direction.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No