### PR TITLE
fix(runtime-host): preserve request acknowledgement headroom

### DIFF
--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -25,6 +25,7 @@ import { connect, createServer, type Server, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
 import {
   resolveRootControlNamespace,
   resolveStorageRoot,
@@ -240,10 +241,12 @@ test('transcript pages are serialized per connection before their responses are 
   }
 });
 
-test('the Client backpressures a healthy request burst at the Host connection limit', async () => {
+test('the Client leaves Host acknowledgement headroom while backpressuring a request burst', async () => {
   const requestCount = 96;
   const firstWaveEntered = deferred();
+  const acknowledgementHeadroomCrossed = deferred();
   const releaseFirstWave = deferred();
+  const clientRequestLimit = RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS - 1;
   let entered = 0;
   let active = 0;
   let maxActive = 0;
@@ -253,7 +256,8 @@ test('the Client backpressures a healthy request burst at the Host connection li
       entered += 1;
       active += 1;
       maxActive = Math.max(maxActive, active);
-      if (entered === RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS) firstWaveEntered.resolve();
+      if (entered === clientRequestLimit) firstWaveEntered.resolve();
+      if (entered > clientRequestLimit) acknowledgementHeadroomCrossed.resolve();
       await releaseFirstWave.promise;
       active -= 1;
       return {
@@ -268,7 +272,14 @@ test('the Client backpressures a healthy request burst at the Host connection li
       );
       try {
         await withTimeout(firstWaveEntered.promise, 1_000, 'first request wave was not admitted');
-        assert.equal(maxActive, RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS);
+        assert.equal(
+          await Promise.race([
+            acknowledgementHeadroomCrossed.promise.then(() => true),
+            delay(50, false),
+          ]),
+          false,
+        );
+        assert.equal(maxActive, clientRequestLimit);
         releaseFirstWave.resolve();
         const results = await Promise.all(requests);
         assert.equal(results.length, requestCount);

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -348,6 +348,13 @@ interface QueuedDomainFrame {
 
 type RequestTimeoutScope = 'request' | 'connection';
 
+// A Host response can reach the Client before the Host's transport write
+// promise resumes and retires that request. Leave one slot free so replacing
+// the observed response cannot transiently cross the Host's hard limit. The
+// Host serializes outbound writes, so at most one response occupies this
+// acknowledgement window.
+const CLIENT_MAX_IN_FLIGHT_DOMAIN_REQUESTS = RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS - 1;
+
 class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   readonly cooperativeHandoff?: true;
   readonly rootId: string;
@@ -547,7 +554,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   #drainDomainRequests(): void {
     while (
       !this.#terminalError &&
-      this.#inFlightDomainRequests < RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS
+      this.#inFlightDomainRequests < CLIENT_MAX_IN_FLIGHT_DOMAIN_REQUESTS
     ) {
       const queued = this.#queuedDomainFrames.shift();
       if (!queued) return;


### PR DESCRIPTION
## Summary

Prevent the official Runtime Host Client from transiently crossing the Host's 64-request hard limit while refilling a full request window.

A Host response can become readable by the Client before the Host's transport-write promise resumes and removes that request from its active map. At the previous 64-request Client ceiling, immediately replacing the observed response could therefore arrive while the Host still counted 64 requests. The Host correctly treated that apparent 65th request as an inbound-limit violation and tore down the connection.

Keep one Client domain slot as acknowledgement headroom. The Host's serial outbound writer permits at most one response in this scheduling window, so a 63-request Client ceiling closes the race without changing the protocol's 64-request Host limit, its liveness reserve, or real overflow enforcement.

This addresses the live Windows teardown evidence exposed by #5106 and the resulting `read_eof`, interrupted queries, capability-alignment failures, and transcript-consumer resets.

Fixes #5107

## Verification

- Red/green A/B: the regression test observes the acknowledgement headroom being crossed under the previous 64-slot Client policy and passes under the 63-slot policy
- `node --test packages/runtime-host/dist/__tests__/connection-session.test.js` — 21 passed
- `npm --workspace @maka/runtime-host run test:dist` — 1840 tests, 1828 passed, 12 skipped, 0 failed
- `npx biome check packages/runtime-host/src/client/connection.ts packages/runtime-host/src/__tests__/connection-session.test.ts`
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex correlated the live Windows teardown evidence with Client and Host request accounting, implemented the acknowledgement headroom, and added the regression coverage.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
