### PR TITLE
fix(runtime): route DingTalk 1:1 replies by staff id

### DIFF
--- a/packages/runtime/src/bots/__tests__/dingtalk-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/dingtalk-bridge.test.ts
@@ -37,27 +37,55 @@ describe('decideDingTalkClose (PR-BOT-DINGTALK-OPERATIONAL-0)', () => {
   });
 });
 
+// Realistic identifier shapes. Both conversation kinds begin with `cid`,
+// which is the whole point: any implementation that infers the route from
+// DingTalk's own id format instead of the stamped prefix fails these.
+const SINGLE_CONVERSATION_ID = 'cidEXAMPLEsingle0Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8=';
+const GROUP_CONVERSATION_ID = 'cidEXAMPLEgroup9Zy8Xw7Vu6Ts5Rq4Po3Nm2Lk1J=';
+const SENDER_ID = '$:LWCP_v1:$0Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv';
+const SENDER_STAFF_ID = '01234567890123456789';
+
 describe('pickDingTalkSendRoute', () => {
-  it('routes group and direct targets while rejecting empty ids', () => {
-    assert.deepEqual(pickDingTalkSendRoute(' cidp-abc ', 'app-key-1', 'hello'), {
-      path: '/v1.0/robot/groupMessages/send',
-      body: {
-        robotCode: 'app-key-1',
-        openConversationId: 'cidp-abc',
-        msgKey: 'sampleText',
-        msgParam: '{"content":"hello"}',
-      },
-    });
-    assert.deepEqual(pickDingTalkSendRoute(' user-99 ', 'app-key-1', 'hi'), {
+  it('routes a stamped single chat to the 1:1 endpoint by staff id', () => {
+    assert.deepEqual(pickDingTalkSendRoute(` oto:${SENDER_STAFF_ID} `, 'app-key-1', 'hi'), {
       path: '/v1.0/robot/oToMessages/batchSend',
       body: {
         robotCode: 'app-key-1',
-        userIds: ['user-99'],
+        userIds: [SENDER_STAFF_ID],
         msgKey: 'sampleText',
         msgParam: '{"content":"hi"}',
       },
     });
+  });
+
+  it('routes a stamped group chat to the group endpoint', () => {
+    assert.deepEqual(
+      pickDingTalkSendRoute(` group:${GROUP_CONVERSATION_ID} `, 'app-key-1', 'hello'),
+      {
+        path: '/v1.0/robot/groupMessages/send',
+        body: {
+          robotCode: 'app-key-1',
+          openConversationId: GROUP_CONVERSATION_ID,
+          msgKey: 'sampleText',
+          msgParam: '{"content":"hello"}',
+        },
+      },
+    );
+  });
+
+  it('keeps unprefixed ids on the group endpoint for pre-existing delivery targets', () => {
+    // Scheduled-task delivery targets persisted before the prefix existed,
+    // and ids typed by hand into the scheduled task form.
+    const route = pickDingTalkSendRoute(GROUP_CONVERSATION_ID, 'app-key-1', 'hello');
+    assert.equal(route?.path, '/v1.0/robot/groupMessages/send');
+    assert.equal(route?.body.openConversationId, GROUP_CONVERSATION_ID);
+  });
+
+  it('rejects empty and prefix-only ids', () => {
     assert.equal(pickDingTalkSendRoute('   ', 'app-key-1', 'hi'), null);
+    assert.equal(pickDingTalkSendRoute('oto:', 'app-key-1', 'hi'), null);
+    assert.equal(pickDingTalkSendRoute('oto:   ', 'app-key-1', 'hi'), null);
+    assert.equal(pickDingTalkSendRoute('group:', 'app-key-1', 'hi'), null);
   });
 });
 
@@ -93,12 +121,13 @@ describe('classifyDingTalkSendResponse', () => {
 });
 
 describe('dingTalkPayloadToEvent', () => {
-  it('maps direct and group messages with stable identity fallbacks', () => {
+  it('addresses a single chat by staff id, not by conversation id', () => {
     const event = dingTalkPayloadToEvent(
       {
-        senderId: 'user-1',
+        senderId: SENDER_ID,
+        senderStaffId: SENDER_STAFF_ID,
         senderNick: 'Alice',
-        conversationId: 'cidp-single',
+        conversationId: SINGLE_CONVERSATION_ID,
         conversationType: '1',
         text: { content: 'hello' },
         robotCode: 'app-key-1',
@@ -107,23 +136,81 @@ describe('dingTalkPayloadToEvent', () => {
     );
     assert.ok(event);
     assert.equal(event!.platform, 'dingtalk');
-    assert.equal(event!.userId, 'user-1');
+    assert.equal(event!.userId, SENDER_ID);
     assert.equal(event!.userName, 'Alice');
-    assert.equal(event!.chatId, 'cidp-single');
+    assert.equal(event!.chatId, `oto:${SENDER_STAFF_ID}`);
     assert.equal(event!.isGroup, false);
     assert.equal(event!.text, 'hello');
-    assert.equal(event!.sourceMessageId, 'cidp-single:1700000000000');
+    assert.equal(event!.sourceMessageId, `${SINGLE_CONVERSATION_ID}:1700000000000`);
+  });
+
+  it('addresses a group chat by conversation id', () => {
     const groupEvent = dingTalkPayloadToEvent(
       {
-        senderId: 'user-2',
-        conversationId: 'cidp-group',
+        senderId: SENDER_ID,
+        senderStaffId: SENDER_STAFF_ID,
+        conversationId: GROUP_CONVERSATION_ID,
         conversationType: '2',
         text: { content: 'hi' },
       },
       1,
     );
+    assert.ok(groupEvent);
     assert.equal(groupEvent!.isGroup, true);
-    assert.equal(groupEvent!.userName, 'user-2');
+    assert.equal(groupEvent!.chatId, `group:${GROUP_CONVERSATION_ID}`);
+    assert.equal(groupEvent!.userName, SENDER_ID);
+  });
+
+  it('round-trips a single chat from receive to the 1:1 send body', () => {
+    // The regression this guards: a 1:1 conversationId also starts with
+    // `cid`, so routing on the raw id sends direct replies to the group
+    // endpoint and DingTalk answers 400 resource.not.found.
+    const event = dingTalkPayloadToEvent(
+      {
+        senderId: SENDER_ID,
+        senderStaffId: SENDER_STAFF_ID,
+        conversationId: SINGLE_CONVERSATION_ID,
+        conversationType: '1',
+        text: { content: 'ping' },
+      },
+      1,
+    );
+    const route = pickDingTalkSendRoute(event!.chatId, 'app-key-1', 'pong');
+    assert.equal(route?.path, '/v1.0/robot/oToMessages/batchSend');
+    assert.deepEqual(route?.body.userIds, [SENDER_STAFF_ID]);
+  });
+
+  it('round-trips a group chat from receive to the group send body', () => {
+    const event = dingTalkPayloadToEvent(
+      {
+        senderId: SENDER_ID,
+        senderStaffId: SENDER_STAFF_ID,
+        conversationId: GROUP_CONVERSATION_ID,
+        conversationType: '2',
+        text: { content: 'ping' },
+      },
+      1,
+    );
+    const route = pickDingTalkSendRoute(event!.chatId, 'app-key-1', 'pong');
+    assert.equal(route?.path, '/v1.0/robot/groupMessages/send');
+    assert.equal(route?.body.openConversationId, GROUP_CONVERSATION_ID);
+  });
+
+  it('still delivers a single chat that carries no staff id', () => {
+    // Nothing to address a 1:1 reply to, but receiving must not depend on
+    // being able to reply.
+    const event = dingTalkPayloadToEvent(
+      {
+        senderId: SENDER_ID,
+        conversationId: SINGLE_CONVERSATION_ID,
+        conversationType: '1',
+        text: { content: 'hello' },
+      },
+      1,
+    );
+    assert.ok(event);
+    assert.equal(event!.isGroup, false);
+    assert.equal(event!.chatId, SINGLE_CONVERSATION_ID);
   });
 
   it('drops payloads missing text or routing identity', () => {

--- a/packages/runtime/src/bots/__tests__/dingtalk-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/dingtalk-bridge.test.ts
@@ -73,12 +73,21 @@ describe('pickDingTalkSendRoute', () => {
     );
   });
 
-  it('keeps unprefixed ids on the group endpoint for pre-existing delivery targets', () => {
-    // Scheduled-task delivery targets persisted before the prefix existed,
-    // and ids typed by hand into the scheduled task form.
+  // Unstamped ids are scheduled-task delivery targets persisted before the
+  // prefix existed, plus ids typed by hand into the scheduled task form.
+  // Both outcomes of the pre-stamping discriminator have to survive.
+  it('keeps an unprefixed conversation id on the group endpoint', () => {
     const route = pickDingTalkSendRoute(GROUP_CONVERSATION_ID, 'app-key-1', 'hello');
     assert.equal(route?.path, '/v1.0/robot/groupMessages/send');
     assert.equal(route?.body.openConversationId, GROUP_CONVERSATION_ID);
+  });
+
+  it('keeps an unprefixed staff id on the 1:1 endpoint', () => {
+    // A bare staff id delivered successfully before stamping existed, so
+    // routing it to the group endpoint would break a working target.
+    const route = pickDingTalkSendRoute(SENDER_STAFF_ID, 'app-key-1', 'hi');
+    assert.equal(route?.path, '/v1.0/robot/oToMessages/batchSend');
+    assert.deepEqual(route?.body.userIds, [SENDER_STAFF_ID]);
   });
 
   it('rejects empty and prefix-only ids', () => {

--- a/packages/runtime/src/bots/dingtalk-bridge.ts
+++ b/packages/runtime/src/bots/dingtalk-bridge.ts
@@ -56,6 +56,23 @@ const SEND_RETRY_DELAY_MAX_MS = 30_000;
 
 const DINGTALK_TOPIC_BOT_MESSAGES = '/v1.0/im/bot/messages/get';
 
+const DINGTALK_GROUP_SEND_PATH = '/v1.0/robot/groupMessages/send';
+const DINGTALK_SINGLE_SEND_PATH = '/v1.0/robot/oToMessages/batchSend';
+
+/**
+ * Route markers stamped onto `chatId` when a message is received, so the
+ * send side can pick an endpoint without re-deriving the conversation
+ * kind. Same approach as `qq-bridge.ts`, and for the same reason: the
+ * conversation kind is known exactly at receive time (DingTalk sends
+ * `conversationType`) and cannot be recovered later from the id alone.
+ *
+ * Guessing from DingTalk's own id shapes does not work — 1:1 and group
+ * `conversationId` values both begin with `cid`, so a prefix test sends
+ * every direct reply to the group endpoint.
+ */
+const DINGTALK_GROUP_CHAT_PREFIX = 'group:';
+const DINGTALK_SINGLE_CHAT_PREFIX = 'oto:';
+
 interface DingTalkConnectionOpenResponse {
   endpoint: string;
   ticket: string;
@@ -70,6 +87,12 @@ interface DingTalkStreamFrame {
 
 interface DingTalkBotMessagePayload {
   senderId?: string;
+  /**
+   * The org-scoped staff id of the sender. This is the only identifier
+   * `/v1.0/robot/oToMessages/batchSend` accepts in `userIds`: `senderId`
+   * (a `$:LWCP_v1:$…` handle) is rejected with `staffId.notExisted`.
+   */
+  senderStaffId?: string;
   senderNick?: string;
   conversationId?: string;
   conversationType?: '1' | '2'; // 1 = single chat, 2 = group
@@ -127,6 +150,16 @@ export function buildDingTalkSingleSendBody(
   };
 }
 
+/**
+ * Pure helper: route a send to the right DingTalk REST endpoint based on
+ * the chatId prefix that `dingTalkPayloadToEvent` stamps.
+ *
+ * An unprefixed id is treated as a group `openConversationId`. Those are
+ * chatIds recorded before this bridge stamped a prefix — persisted
+ * scheduled-task delivery targets and hand-typed ids in the scheduled
+ * task form — and group delivery is what they resolved to at the time,
+ * so keeping that mapping preserves their behavior.
+ */
 export function pickDingTalkSendRoute(
   chatId: string,
   robotCode: string,
@@ -137,12 +170,21 @@ export function pickDingTalkSendRoute(
 } | null {
   const targetId = chatId.trim();
   if (!targetId) return null;
-  const isGroup = targetId.startsWith('cid');
+  if (targetId.startsWith(DINGTALK_SINGLE_CHAT_PREFIX)) {
+    const staffId = targetId.slice(DINGTALK_SINGLE_CHAT_PREFIX.length).trim();
+    if (!staffId) return null;
+    return {
+      path: DINGTALK_SINGLE_SEND_PATH,
+      body: buildDingTalkSingleSendBody(staffId, robotCode, text),
+    };
+  }
+  const openConversationId = targetId.startsWith(DINGTALK_GROUP_CHAT_PREFIX)
+    ? targetId.slice(DINGTALK_GROUP_CHAT_PREFIX.length).trim()
+    : targetId;
+  if (!openConversationId) return null;
   return {
-    path: isGroup ? '/v1.0/robot/groupMessages/send' : '/v1.0/robot/oToMessages/batchSend',
-    body: isGroup
-      ? buildDingTalkGroupSendBody(targetId, robotCode, text)
-      : buildDingTalkSingleSendBody(targetId, robotCode, text),
+    path: DINGTALK_GROUP_SEND_PATH,
+    body: buildDingTalkGroupSendBody(openConversationId, robotCode, text),
   };
 }
 
@@ -210,21 +252,34 @@ export function dingTalkPayloadToEvent(
   if (!payload || typeof payload !== 'object') return null;
   const content = payload.text?.content;
   if (typeof content !== 'string' || content.length === 0) return null;
-  const chatId = payload.conversationId;
+  const conversationId = payload.conversationId;
   const userId = payload.senderId;
-  if (typeof chatId !== 'string' || chatId.length === 0) return null;
+  if (typeof conversationId !== 'string' || conversationId.length === 0) return null;
   if (typeof userId !== 'string' || userId.length === 0) return null;
+  const isGroup = payload.conversationType === '2';
+  const staffId = typeof payload.senderStaffId === 'string' ? payload.senderStaffId.trim() : '';
+  // Stamp the route while the conversation kind is still known. A 1:1
+  // reply must address the sender's staff id, not the conversation, so
+  // that is what the chatId carries. When the payload omits
+  // `senderStaffId` there is no address to reply to, so fall back to the
+  // bare conversationId: the message is still delivered upward and keeps
+  // a stable per-conversation key, and the send simply routes as before.
+  const chatId = isGroup
+    ? `${DINGTALK_GROUP_CHAT_PREFIX}${conversationId}`
+    : staffId
+      ? `${DINGTALK_SINGLE_CHAT_PREFIX}${staffId}`
+      : conversationId;
   return {
     platform: 'dingtalk',
     userId,
     userName: payload.senderNick ?? userId,
     chatId,
-    isGroup: payload.conversationType === '2',
+    isGroup,
     text: content,
     // DingTalk Stream callbacks do not carry the original message id;
     // use a synthetic key so downstream contracts that key off
     // `sourceMessageId` still get a unique value.
-    sourceMessageId: `${chatId}:${receivedAt}`,
+    sourceMessageId: `${conversationId}:${receivedAt}`,
     receivedAt,
   };
 }
@@ -374,14 +429,11 @@ export class DingTalkBotBridge extends WsBridgeBase implements SendCapable {
   }
 
   /**
-   * DingTalk REST send. We treat any chatId with a `cidp` prefix as a
-   * group conversation; pure-numeric or other prefixes route to the
-   * single-user batch API. The caller (main.ts) already knows whether
-   * the bot conversation is a group via the BotMessageEvent.isGroup
-   * flag, but the bridge's `sendMessage` only sees the chatId — so we
-   * make a conservative split based on the `conversationType` hint
-   * baked into the chatId structure: group conversation IDs start with
-   * `cid` per DingTalk's open platform docs.
+   * DingTalk REST send. `sendMessage` only sees the chatId, so the
+   * conversation kind travels inside it: `dingTalkPayloadToEvent`
+   * stamps `group:` or `oto:` at receive time, where DingTalk's
+   * `conversationType` is still available, and
+   * `pickDingTalkSendRoute` decodes it here.
    */
   async sendMessage(
     chatId: string,

--- a/packages/runtime/src/bots/dingtalk-bridge.ts
+++ b/packages/runtime/src/bots/dingtalk-bridge.ts
@@ -73,6 +73,13 @@ const DINGTALK_SINGLE_SEND_PATH = '/v1.0/robot/oToMessages/batchSend';
 const DINGTALK_GROUP_CHAT_PREFIX = 'group:';
 const DINGTALK_SINGLE_CHAT_PREFIX = 'oto:';
 
+/**
+ * The discriminator this bridge used before chatIds carried a stamp.
+ * Retained only to route ids that predate stamping — see the unstamped
+ * branch of `pickDingTalkSendRoute`.
+ */
+const DINGTALK_LEGACY_GROUP_ID_PREFIX = 'cid';
+
 interface DingTalkConnectionOpenResponse {
   endpoint: string;
   ticket: string;
@@ -154,11 +161,13 @@ export function buildDingTalkSingleSendBody(
  * Pure helper: route a send to the right DingTalk REST endpoint based on
  * the chatId prefix that `dingTalkPayloadToEvent` stamps.
  *
- * An unprefixed id is treated as a group `openConversationId`. Those are
- * chatIds recorded before this bridge stamped a prefix — persisted
- * scheduled-task delivery targets and hand-typed ids in the scheduled
- * task form — and group delivery is what they resolved to at the time,
- * so keeping that mapping preserves their behavior.
+ * Unstamped ids are chatIds recorded before this bridge stamped a prefix
+ * — persisted scheduled-task delivery targets and ids typed by hand into
+ * the scheduled task form. They keep the pre-stamping discriminator, so
+ * both of its outcomes survive: a `cid…` conversation id still goes to
+ * the group endpoint, and a bare staff id still goes to the 1:1 endpoint,
+ * which is where it was delivering successfully. That guess was only ever
+ * wrong for a 1:1 *conversation* id, and the stamped path now covers it.
  */
 export function pickDingTalkSendRoute(
   chatId: string,
@@ -178,14 +187,23 @@ export function pickDingTalkSendRoute(
       body: buildDingTalkSingleSendBody(staffId, robotCode, text),
     };
   }
-  const openConversationId = targetId.startsWith(DINGTALK_GROUP_CHAT_PREFIX)
-    ? targetId.slice(DINGTALK_GROUP_CHAT_PREFIX.length).trim()
-    : targetId;
-  if (!openConversationId) return null;
-  return {
-    path: DINGTALK_GROUP_SEND_PATH,
-    body: buildDingTalkGroupSendBody(openConversationId, robotCode, text),
-  };
+  if (targetId.startsWith(DINGTALK_GROUP_CHAT_PREFIX)) {
+    const openConversationId = targetId.slice(DINGTALK_GROUP_CHAT_PREFIX.length).trim();
+    if (!openConversationId) return null;
+    return {
+      path: DINGTALK_GROUP_SEND_PATH,
+      body: buildDingTalkGroupSendBody(openConversationId, robotCode, text),
+    };
+  }
+  return targetId.startsWith(DINGTALK_LEGACY_GROUP_ID_PREFIX)
+    ? {
+        path: DINGTALK_GROUP_SEND_PATH,
+        body: buildDingTalkGroupSendBody(targetId, robotCode, text),
+      }
+    : {
+        path: DINGTALK_SINGLE_SEND_PATH,
+        body: buildDingTalkSingleSendBody(targetId, robotCode, text),
+      };
 }
 
 /**
@@ -260,10 +278,14 @@ export function dingTalkPayloadToEvent(
   const staffId = typeof payload.senderStaffId === 'string' ? payload.senderStaffId.trim() : '';
   // Stamp the route while the conversation kind is still known. A 1:1
   // reply must address the sender's staff id, not the conversation, so
-  // that is what the chatId carries. When the payload omits
-  // `senderStaffId` there is no address to reply to, so fall back to the
-  // bare conversationId: the message is still delivered upward and keeps
-  // a stable per-conversation key, and the send simply routes as before.
+  // that is what the chatId carries.
+  //
+  // When the payload omits `senderStaffId` there is nothing a 1:1 reply
+  // can be addressed to. Fall back to the bare conversationId so the
+  // message still reaches the agent under a stable per-conversation key,
+  // but a reply to it will take the unstamped `cid…` branch and fail at
+  // the group endpoint — the same dead end as before this change, not a
+  // working path.
   const chatId = isGroup
     ? `${DINGTALK_GROUP_CHAT_PREFIX}${conversationId}`
     : staffId


### PR DESCRIPTION
## Summary

DingTalk direct messages were received but could never be answered. The channel looked healthy throughout — connected, `operational`, ingesting text — so from the user's side the bot simply went quiet.

Two defects stacked, and fixing only the first would not have helped:

1. **The route was guessed from the id, and the guess was wrong.** `pickDingTalkSendRoute` picked the group endpoint whenever the chatId began with `cid`. A 1:1 `conversationId` also begins with `cid`, so every direct reply went to `/v1.0/robot/groupMessages/send`.
2. **There was no usable 1:1 address in the event.** The single-chat endpoint addresses recipients by `senderStaffId`, which `DingTalkBotMessagePayload` never declared — so it was dropped at parse time. Neither `conversationId` nor `senderId` is accepted there.

The fix stamps the route into the chatId at receive time, where DingTalk's `conversationType` still says what the conversation is, and decodes it at send time. That is the convention [`qq-bridge.ts`](https://github.com/apache/maka/blob/09c73430c/packages/runtime/src/bots/qq-bridge.ts#L233-L236) already follows — *"based on the chatId prefix that the receive-side helpers stamp"* — and DingTalk was the one bridge inferring from the platform's native id format instead. Group chats now carry `group:<openConversationId>`, single chats `oto:<senderStaffId>`.

The alternative — adding `isGroup` to `BotSendOptions`, which `BotReplyStreamOptions` already declares — would leave defect 2 unfixed, since `senderStaffId` would still never be captured.

Fixes #5111

### Compatibility

Unstamped chatIds keep the pre-stamping discriminator, so both of its outcomes survive: `cid…` conversation ids still route to the group endpoint, and bare staff ids still route to the 1:1 endpoint. The old guess was only ever wrong for a 1:1 *conversation* id, which the stamped path now handles.

This matters because a chatId is not always freshly received:

- scheduled-task bot delivery persists `{platform, chatId}` into `workflow_scheduled_tasks.record_json` (and fire claims), migrated verbatim from the legacy `workflow_plan_reminders` table, with no format validation;
- the scheduled task form takes the chatId as **free text**, and DingTalk is in `BOT_DELIVERY_PROVIDERS`.

Making unstamped ids unroutable would have silently broken existing DingTalk reminders at fire time. Existing targets of both shapes keep working unchanged.

An earlier revision of this branch collapsed all unstamped ids onto the group endpoint, which would have broken a working bare-staff-id target; caught in review and fixed in `ed622ec`, with a test that pins it.

The `${platform}:${chatId}` conversation map is process-local and rebuilt each launch, so the group chatId format change costs at most one lost session binding across a restart.

## Verification

**Unit — the tests fail without the fix.** Reverting only `dingtalk-bridge.ts` to `upstream/main` and keeping the new tests:

```
# tests 14
# pass 8
# fail 6
not ok - routes a stamped single chat to the 1:1 endpoint by staff id
not ok - routes a stamped group chat to the group endpoint
not ok - rejects empty and prefix-only ids
not ok - addresses a single chat by staff id, not by conversation id
not ok - addresses a group chat by conversation id
not ok - round-trips a single chat from receive to the 1:1 send body
```

With the fix: `# tests 15  # pass 15  # fail 0`. Full bot suite: `# tests 108  # pass 108  # fail 0`.

The review fix is pinned the same way: `keeps an unprefixed staff id on the 1:1 endpoint` is the single failure when run against the revision it corrects.

The old fixtures passed because they were invented — `cidp-abc` for a group, `user-99` for a single chat. No real 1:1 conversation id looks like `user-99`; real ones start with `cid` and took the group branch. The replacements use realistic shapes where **both** kinds begin with `cid`, so any implementation that infers the route from the id fails them, plus round-trip cases from payload through to send body.

**Live account — the patched path, end to end.** A probe mirroring the patched `dingTalkPayloadToEvent` and `pickDingTalkSendRoute` line-for-line connected over DingTalk Stream and **auto-replied** to incoming direct messages: no human copied an id between steps, so receive → stamp → decode → send is exercised as one chain. Two direct messages, two successful replies, both confirmed received in the DingTalk client. Identifiers masked.

Direct message — the path that was broken:

```
[probe] senderStaffId present in payload: true
[probe] mapped event: isGroup=false chatId=oto:…80 <24 chars> text="hi"
[probe] route chosen: POST /v1.0/robot/oToMessages/batchSend
[probe] ✅ REPLY DELIVERED — HTTP 200, processQueryKey present: true
```

Line by line: `senderStaffId` **is** present in the callback payload, so the old interface was discarding it; the stamped chatId identifies the conversation as 1:1; the route resolves to the single-chat endpoint, where the old code would have chosen the group endpoint; and the send returns 200.

Group message — the path that had to keep working. The bot was installed into a group and @-mentioned:

```
[probe] mapped event: isGroup=true chatId=grou…== <33 chars> text=" hi"
[probe] route chosen: POST /v1.0/robot/groupMessages/send
[probe] ✅ REPLY DELIVERED — HTTP 200, processQueryKey present: true
```

Two messages per conversation kind, four replies, all delivered and confirmed received in the DingTalk client.

**Live account — three-way controlled experiment** (how the diagnosis was pinned down before the patch). Same conversation, same `robotCode`, same token, same text; only the target id varied.

| # | Target passed as `chatId` | Route | Result |
|---|---|---|---|
| A | `conversationId` (`cid…=`) — what the bridge stamped **before** this PR | group | ❌ 400 `resource.not.found` — "robot 不存在；请确认 robotCode 是否正确" |
| B | `senderId` (`$:LWCP_v1:$…`) | 1:1 | ❌ 400 `staffId.notExisted` |
| C | `senderStaffId` — what this PR stamps | 1:1 | ✅ delivered, receipt confirmed in the DingTalk client |

Row A is what shipped; row C is what this PR does.

Row A's error is misleading: it blames `robotCode`, but `robotCode` is correct — the raw callback payload's `robotCode` matched the app's AppKey exactly, confirming the existing derivation from `appId`. The group endpoint rejects a 1:1 conversation and reports it as a missing robot.

**Checks run:** `biome check` on both changed files, `tsc` build of `@maka/runtime`, ASF header audit, protocol epoch guard, `git diff --check`.

**Not run:** the full repo suite (`npm test`) — this touches one bridge's pure helpers and the bot suite passes in full. The husky pre-commit wrapper could not spawn `biome.cmd` in this Windows environment, so its checks were run directly instead; the commit is `--no-verify` for that reason alone.

## Scope

Both conversation kinds are exercised against a live account. Not covered: non-text message types, and orgs where the callback payload omits `senderStaffId` (external contacts) — that case falls back to the bare conversationId, which keeps the message flowing upward and routes the send exactly as it did before this PR.

## Follow-ups (not in this PR)

- The scheduled task form's chatId field is free text with the placeholder `例如 Telegram chat_id` and no per-platform guidance. Targeting a DingTalk 1:1 reminder now requires typing `oto:<staffId>`, which nothing in the product teaches. QQ has had the same undocumented requirement (`channel:` / `group:` / `c2c:`) since it landed.
- `qq-bridge.ts` looks to have a defect of the same family: guild DMs are stamped `` `dm:${channelLike.chatId}` `` producing `dm:channel:<id>`, but `pickQQSendRoute` has no `dm:` branch and falls through to `return null`, so those replies never send. Untested against a live account; I have not filed it.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Opus 5) — diagnosis via live-account probes, the patch, and the tests. Reviewed and verified by the author against a real DingTalk app. Commit carries a `Generated-by` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
