### PR TITLE
feat(cli): highlight Markdown code blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10519,6 +10519,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+      "integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/hono": {
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
@@ -17067,7 +17076,8 @@
         "@maka/mcp": "0.1.0",
         "@maka/runtime": "0.1.0",
         "@maka/runtime-host": "0.1.0",
-        "@maka/storage": "0.1.0"
+        "@maka/storage": "0.1.0",
+        "highlight.js": "11.12.0"
       },
       "bin": {
         "maka": "dist/cli.js"

--- a/packages/cli/THIRD_PARTY_NOTICES.txt
+++ b/packages/cli/THIRD_PARTY_NOTICES.txt
@@ -4469,6 +4469,44 @@ SOFTWARE.
 
 ================================================================================
 
+Package: highlight.js@11.12.0
+Declared license: BSD-3-Clause
+Selected license: BSD-3-Clause
+Repository: git://github.com/highlightjs/highlight.js.git
+
+--- LICENSE ---
+BSD 3-Clause License
+
+Copyright (c) 2006, Ivan Sagalaev.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+
 Package: html-escaper@3.0.3
 Declared license: MIT
 Selected license: MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
     "@maka/mcp": "0.1.0",
     "@maka/runtime": "0.1.0",
     "@maka/runtime-host": "0.1.0",
-    "@maka/storage": "0.1.0"
+    "@maka/storage": "0.1.0",
+    "highlight.js": "11.12.0"
   }
 }

--- a/packages/cli/src/__tests__/pi-transcript-highlight.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript-highlight.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { MakaTranscriptComponent } from '../pi-tui-layout.js';
+import { createMakaPiTranscriptState } from '../pi-transcript.js';
+import { markdownTheme } from '../pi-transcript-format.js';
+import { stripAnsi } from '../tui-ansi.js';
+import { highlightMarkdownCode } from '../tui-syntax-highlight.js';
+
+test('highlights tagged TypeScript code without changing its text', () => {
+  const highlightCode = markdownTheme.highlightCode;
+  assert.ok(highlightCode, 'the shared Markdown theme must provide the highlighting hook');
+  const code = ['const greeting: string = "你好";', 'console.log(greeting);'].join('\n');
+
+  const highlighted = highlightCode(code, 'typescript');
+
+  assert.equal(stripAnsi(highlighted.join('\n')), code);
+});
+
+test('classifies aliased language tokens without changing escaped source text', () => {
+  const code = 'const label = "你好<&>";';
+  const highlighted = highlightMarkdownCode(code, ' TS ', {
+    keyword: (text) => `<keyword>${text}</keyword>`,
+    string: (text) => `<string>${text}</string>`,
+  }).join('\n');
+
+  assert.match(highlighted, /<keyword>const<\/keyword>/u);
+  assert.match(highlighted, /<string>你好<\/string>/u);
+  assert.equal(highlighted.replace(/<\/?(?:keyword|string)>/gu, ''), code);
+});
+
+test('falls back to plain code for absent, unknown, or failed highlighting', () => {
+  const code = ['  first line', '', '最后一行  '].join('\n');
+
+  assert.deepEqual(highlightMarkdownCode(code), code.split('\n'));
+  assert.deepEqual(highlightMarkdownCode(code, 'made-up-language'), code.split('\n'));
+  assert.deepEqual(
+    highlightMarkdownCode('const value = 1;', 'typescript', {
+      keyword: () => {
+        throw new Error('theme failed');
+      },
+    }),
+    ['const value = 1;'],
+  );
+});
+
+test('renders the same streaming code through live and detailed transcript surfaces', () => {
+  const state = createMakaPiTranscriptState();
+  const source = 'const greeting = "你好"; // ' + 'long-code-'.repeat(8);
+  const entry = {
+    kind: 'assistant' as const,
+    messageId: 'assistant-code',
+    text: `\`\`\`ts\n${source}`,
+  };
+  state.entries.push(entry);
+  const transcript = new MakaTranscriptComponent(state, () => ({
+    title: 'Maka',
+    cwd: '/repo',
+    model: 'model',
+    connectionSlug: 'connection',
+    permissionMode: 'ask',
+  }));
+
+  const narrowLive = transcript.render(32).map(stripAnsi).join('\n');
+  const detailed = transcript.createDocumentRenderer()(80).lines.map(stripAnsi).join('\n');
+  assert.match(narrowLive, /const greeting = "你好";/u);
+  assert.match(detailed, /const greeting = "你好";/u);
+  assert.equal(entry.text, `\`\`\`ts\n${source}`);
+
+  // Closing the streamed fence and resizing must not change the source text.
+  entry.text += '\n```';
+  const wideLive = transcript.render(80).map(stripAnsi).join('\n');
+  assert.match(wideLive, /const greeting = "你好";/u);
+  assert.equal(entry.text, `\`\`\`ts\n${source}\n\`\`\``);
+});

--- a/packages/cli/src/pi-transcript-format.ts
+++ b/packages/cli/src/pi-transcript-format.ts
@@ -28,6 +28,7 @@ import { projectAgentSwarmResult } from '@maka/core/agent-swarm';
 import { ptyHumanTerminalText } from '@maka/core/pty-output-view';
 import { type ShellOutput } from '@maka/core/shell-run';
 import { ansi } from './tui-ansi.js';
+import { highlightMarkdownCode } from './tui-syntax-highlight.js';
 
 export function renderIndented(text: string, width: number, indent: number): string[] {
   const prefix = ' '.repeat(indent);
@@ -185,6 +186,7 @@ export const markdownTheme: MarkdownTheme = {
   code: ansi.yellow,
   codeBlock: (text) => text,
   codeBlockBorder: ansi.dim,
+  highlightCode: highlightMarkdownCode,
   quote: ansi.dim,
   quoteBorder: ansi.dim,
   hr: ansi.dim,

--- a/packages/cli/src/tui-syntax-highlight.ts
+++ b/packages/cli/src/tui-syntax-highlight.ts
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import hljs from 'highlight.js/lib/core';
+import bash from 'highlight.js/lib/languages/bash';
+import c from 'highlight.js/lib/languages/c';
+import cpp from 'highlight.js/lib/languages/cpp';
+import csharp from 'highlight.js/lib/languages/csharp';
+import css from 'highlight.js/lib/languages/css';
+import diff from 'highlight.js/lib/languages/diff';
+import go from 'highlight.js/lib/languages/go';
+import java from 'highlight.js/lib/languages/java';
+import javascript from 'highlight.js/lib/languages/javascript';
+import json from 'highlight.js/lib/languages/json';
+import markdown from 'highlight.js/lib/languages/markdown';
+import powershell from 'highlight.js/lib/languages/powershell';
+import python from 'highlight.js/lib/languages/python';
+import rust from 'highlight.js/lib/languages/rust';
+import sql from 'highlight.js/lib/languages/sql';
+import typescript from 'highlight.js/lib/languages/typescript';
+import xml from 'highlight.js/lib/languages/xml';
+import yaml from 'highlight.js/lib/languages/yaml';
+import { ansi } from './tui-ansi.js';
+
+type HighlightFormatter = (text: string) => string;
+
+export type TuiSyntaxHighlightTheme = Readonly<Partial<Record<string, HighlightFormatter>>>;
+
+const languages = {
+  bash,
+  c,
+  cpp,
+  csharp,
+  css,
+  diff,
+  go,
+  java,
+  javascript,
+  json,
+  markdown,
+  powershell,
+  python,
+  rust,
+  sql,
+  typescript,
+  xml,
+  yaml,
+};
+
+for (const [name, language] of Object.entries(languages)) {
+  hljs.registerLanguage(name, language);
+}
+
+/**
+ * Fence aliases are intentionally explicit. Unknown, blank, and plain-text
+ * tags stay unhighlighted instead of invoking unreliable auto-detection.
+ */
+const languageAliases: Readonly<Record<string, keyof typeof languages>> = {
+  sh: 'bash',
+  shell: 'bash',
+  zsh: 'bash',
+  'c++': 'cpp',
+  cs: 'csharp',
+  html: 'xml',
+  htm: 'xml',
+  svg: 'xml',
+  js: 'javascript',
+  jsx: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  md: 'markdown',
+  ps1: 'powershell',
+  py: 'python',
+  rs: 'rust',
+  ts: 'typescript',
+  tsx: 'typescript',
+  yml: 'yaml',
+};
+
+const defaultTheme: TuiSyntaxHighlightTheme = {
+  keyword: ansi.accent,
+  built_in: ansi.yellow,
+  literal: ansi.yellow,
+  number: ansi.yellow,
+  regexp: ansi.green,
+  string: ansi.green,
+  comment: ansi.dim,
+  doctag: ansi.dim,
+  meta: ansi.muted,
+  function: ansi.accent,
+  title: ansi.accent,
+  class: ansi.accent,
+  type: ansi.accent,
+  tag: ansi.accent,
+  name: ansi.accent,
+  attr: ansi.yellow,
+  attribute: ansi.yellow,
+  variable: ansi.yellow,
+  params: ansi.muted,
+  operator: ansi.yellow,
+  addition: ansi.green,
+  deletion: ansi.red,
+};
+
+/**
+ * Highlight a Markdown fence into independent terminal lines.
+ *
+ * The optional theme keeps token classification testable without assuming a
+ * TTY. Production uses Maka's capability-aware ANSI functions, so NO_COLOR and
+ * basic terminals inherit the same behavior as the rest of the TUI.
+ */
+export function highlightMarkdownCode(
+  code: string,
+  language?: string,
+  theme: TuiSyntaxHighlightTheme = defaultTheme,
+): string[] {
+  const normalizedLanguage = normalizeLanguage(language);
+  if (!normalizedLanguage) return code.split('\n');
+
+  try {
+    const html = hljs.highlight(code, {
+      language: normalizedLanguage,
+      ignoreIllegals: true,
+    }).value;
+    return renderHighlightedHtml(html, theme).split('\n');
+  } catch {
+    // Rendering a response must not fail because a grammar or theme failed.
+    return code.split('\n');
+  }
+}
+
+function normalizeLanguage(language: string | undefined): string | undefined {
+  const requested = language?.trim().toLowerCase();
+  if (!requested) return undefined;
+  const normalized = languageAliases[requested] ?? requested;
+  return Object.hasOwn(languages, normalized) ? normalized : undefined;
+}
+
+const HTML_TOKEN = /<span\b[^>]*>|<\/span>|&(?:amp|lt|gt|quot|apos|#(?:\d+|x[\da-f]+));/giu;
+
+function renderHighlightedHtml(html: string, theme: TuiSyntaxHighlightTheme): string {
+  const scopes: Array<string | undefined> = [];
+  let output = '';
+  let cursor = 0;
+
+  for (const match of html.matchAll(HTML_TOKEN)) {
+    const index = match.index;
+    appendStyled(html.slice(cursor, index));
+    const token = match[0];
+
+    if (token.startsWith('<span')) {
+      scopes.push(scopeFromSpan(token));
+    } else if (token === '</span>') {
+      scopes.pop();
+    } else {
+      appendStyled(decodeHtmlEntity(token));
+    }
+    cursor = index + token.length;
+  }
+  appendStyled(html.slice(cursor));
+  return output;
+
+  function appendStyled(text: string): void {
+    if (!text) return;
+    const formatter = activeFormatter(scopes, theme);
+    if (!formatter) {
+      output += text;
+      return;
+    }
+    // Keep every rendered line self-contained. A multi-line comment must not
+    // leave an ANSI style open across the array boundary consumed by pi-tui.
+    output += text
+      .split('\n')
+      .map((line) => (line ? formatter(line) : ''))
+      .join('\n');
+  }
+}
+
+function scopeFromSpan(tag: string): string | undefined {
+  const classes = /\bclass=(?:"([^"]*)"|'([^']*)')/u.exec(tag);
+  return (classes?.[1] ?? classes?.[2])
+    ?.split(/\s+/u)
+    .find((className) => className.startsWith('hljs-'))
+    ?.slice('hljs-'.length);
+}
+
+function activeFormatter(
+  scopes: readonly (string | undefined)[],
+  theme: TuiSyntaxHighlightTheme,
+): HighlightFormatter | undefined {
+  for (let index = scopes.length - 1; index >= 0; index -= 1) {
+    const scope = scopes[index];
+    if (!scope) continue;
+    const [prefix] = scope.split(/[.-]/u);
+    const formatter = theme[scope] ?? (prefix ? theme[prefix] : undefined);
+    if (formatter) return formatter;
+  }
+  return theme.default;
+}
+
+function decodeHtmlEntity(entity: string): string {
+  const body = entity.slice(1, -1);
+  switch (body) {
+    case 'amp':
+      return '&';
+    case 'lt':
+      return '<';
+    case 'gt':
+      return '>';
+    case 'quot':
+      return '"';
+    case 'apos':
+      return "'";
+    default: {
+      const radix = body.slice(0, 2).toLowerCase() === '#x' ? 16 : 10;
+      const digits = body.slice(radix === 16 ? 2 : 1);
+      const codePoint = Number.parseInt(digits, radix);
+      return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+        ? String.fromCodePoint(codePoint)
+        : entity;
+    }
+  }
+}

--- a/scripts/check-tui-copy.mjs
+++ b/scripts/check-tui-copy.mjs
@@ -58,6 +58,7 @@ export const EXCLUDED_TUI_FILES = [
   'packages/cli/src/tui-editor-render.ts',
   'packages/cli/src/tui-mcp-control.ts',
   'packages/cli/src/tui-mcp-remote-publication.ts',
+  'packages/cli/src/tui-syntax-highlight.ts',
 ];
 
 const CJK = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/u;

--- a/scripts/release-cli-file-policy.mjs
+++ b/scripts/release-cli-file-policy.mjs
@@ -211,6 +211,51 @@ export function releaseNpmEnvironment(environment, userConfigPath) {
   };
 }
 
+export const CLI_HIGHLIGHT_JS_LANGUAGE_MODULES = Object.freeze([
+  'bash',
+  'c',
+  'cpp',
+  'csharp',
+  'css',
+  'diff',
+  'go',
+  'java',
+  'javascript',
+  'json',
+  'markdown',
+  'powershell',
+  'python',
+  'rust',
+  'sql',
+  'typescript',
+  'xml',
+  'yaml',
+]);
+
+const HIGHLIGHT_JS_RUNTIME_DIRECTORIES = new Set(['es', 'es/languages', 'lib']);
+const HIGHLIGHT_JS_RUNTIME_FILES = new Set([
+  'LICENSE',
+  'package.json',
+  'es/core.js',
+  'es/package.json',
+  'lib/core.js',
+  ...CLI_HIGHLIGHT_JS_LANGUAGE_MODULES.map((language) => `es/languages/${language}.js`),
+]);
+
+/**
+ * Keep the CLI release's syntax highlighter dependency to its actual ESM
+ * runtime closure. npm publishes every highlight.js grammar and theme in one
+ * package, while Maka deliberately registers a bounded language set.
+ */
+export function isCliThirdPartyReleasePath(packageKey, relativePath) {
+  if (packageKey !== 'highlight.js@11.12.0') return true;
+  const portablePath = relativePath.split(/[\\/]/u).filter(Boolean).join('/');
+  return (
+    HIGHLIGHT_JS_RUNTIME_DIRECTORIES.has(portablePath) ||
+    HIGHLIGHT_JS_RUNTIME_FILES.has(portablePath)
+  );
+}
+
 export function isThirdPartyDevelopmentArtifact(relativePath) {
   const segments = relativePath.split(/[\\/]/).filter(Boolean);
   if (segments.some((segment) => DEVELOPMENT_DIRECTORIES.has(segment))) return true;

--- a/scripts/release-cli-file-policy.test.mjs
+++ b/scripts/release-cli-file-policy.test.mjs
@@ -31,7 +31,9 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, test } from 'node:test';
 import {
+  CLI_HIGHLIGHT_JS_LANGUAGE_MODULES,
   collectWorkspaceDependencyClosure,
+  isCliThirdPartyReleasePath,
   isCurrentDevelopmentJavaScript,
   isMakaDevelopmentArtifact,
   isThirdPartyDevelopmentArtifact,
@@ -206,6 +208,43 @@ describe('CLI release file policy', () => {
     ]) {
       assert.equal(isThirdPartyDevelopmentArtifact(path), false, path);
     }
+  });
+
+  test('keeps only the reviewed highlight.js runtime closure in CLI artifacts', () => {
+    for (const path of [
+      'package.json',
+      'LICENSE',
+      'es',
+      'es/core.js',
+      'es/package.json',
+      'es/languages',
+      'es/languages/typescript.js',
+      'lib',
+      'lib/core.js',
+    ]) {
+      assert.equal(isCliThirdPartyReleasePath('highlight.js@11.12.0', path), true, path);
+    }
+    for (const path of [
+      'README.md',
+      'es/index.js',
+      'es/languages/ada.js',
+      'lib/languages/typescript.js',
+      'styles/github.css',
+      'types/index.d.ts',
+    ]) {
+      assert.equal(isCliThirdPartyReleasePath('highlight.js@11.12.0', path), false, path);
+    }
+
+    assert.equal(isCliThirdPartyReleasePath('another-package@1.0.0', 'README.md'), true);
+
+    const highlighterSource = readFileSync(
+      resolve(import.meta.dirname, '../packages/cli/src/tui-syntax-highlight.ts'),
+      'utf8',
+    );
+    const importedLanguages = [
+      ...highlighterSource.matchAll(/from 'highlight\.js\/lib\/languages\/([^']+)'/gu),
+    ].map((match) => match[1]);
+    assert.deepEqual(importedLanguages.sort(), [...CLI_HIGHLIGHT_JS_LANGUAGE_MODULES].sort());
   });
 
   test('keeps the stricter Maka-owned package boundary', () => {

--- a/scripts/release-cli-package.mjs
+++ b/scripts/release-cli-package.mjs
@@ -41,6 +41,7 @@ import { validateCliReleaseArtifactMetrics } from './release-cli-artifact-policy
 import { assertProductNightlyVersion } from './release-version.mjs';
 import {
   isCurrentDevelopmentJavaScript,
+  isCliThirdPartyReleasePath,
   isMakaDevelopmentArtifact,
   isThirdPartyDevelopmentArtifact,
   orderWorkspaceBuilds,
@@ -452,9 +453,12 @@ function copyRuntimeDist(source, destination, packageName = 'maka-agent') {
 }
 
 function copyThirdPartyPackage(source, destination) {
-  if (!existsSync(join(source, 'package.json'))) {
+  const manifestPath = join(source, 'package.json');
+  if (!existsSync(manifestPath)) {
     throw new Error(`Installed dependency has no package.json: ${source}`);
   }
+  const manifest = readJson(manifestPath);
+  const packageKey = `${manifest.name}@${manifest.version}`;
   rmSync(destination, { recursive: true, force: true });
   cpSync(source, destination, {
     recursive: true,
@@ -464,7 +468,8 @@ function copyThirdPartyPackage(source, destination) {
       const relativePath = relative(source, path);
       return (
         !relativePath.split(sep).includes('node_modules') &&
-        !isThirdPartyDevelopmentArtifact(relativePath)
+        !isThirdPartyDevelopmentArtifact(relativePath) &&
+        isCliThirdPartyReleasePath(packageKey, relativePath)
       );
     },
   });


### PR DESCRIPTION
## Summary

Add language-aware syntax highlighting to fenced Markdown code in the CLI/TUI through pi-tui's existing theme hook. The implementation registers a bounded language set with explicit aliases, preserves source text, falls back to plain code for unknown or failing grammars, and uses Maka's capability-aware ANSI styling for no-color compatibility.

Fixes #5083

## Verification

- `npm run build` — passed.
- Focused highlighting plus transcript suites — 129 passed, 2 platform skips, 0 failed.
- Release file-policy and TUI-copy tests — 23 passed, 0 failed.
- `npm run lint`, `npm run format:check`, and `npm run typecheck` — passed.
- Knip checks for `apps/desktop` and `packages/ui` — passed.
- `npm run check:cli-third-party-notices` and `npm run check:asf-headers` — passed.
- The production CLI tarball builds at 33,207,106 bytes (347,326 bytes below the repository limit); its staged transcript module imports successfully and highlights TypeScript.
- `npm run release:cli:smoke` completed the offline install and installed-product checks, then encountered the existing Windows Runtime Host terminal-capture failure (`Terminal output did not contain a JSON object`) during the final managed-service lifecycle check.
- Real transcript output was checked in a browser-hosted terminal at narrow and wide widths; same-content before/after evidence for live and detailed surfaces is attached in a follow-up comment.
- Not claimed as a clean signal: the full CLI dist suite encounters pre-existing Windows symlink, fsync, and service-dependent failures outside this change; the affected transcript suites pass independently.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

OpenAI Codex — implementation, tests, validation, visual evidence, and automated PR submission at @yuzhiyang1's direction. @yuzhiyang1 decided to submit and remains the human contributor of record.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
