### PR TITLE
fix(runtime): project generic tool calls in session trace

### DIFF
--- a/packages/runtime/src/__tests__/session-trace-projection.test.ts
+++ b/packages/runtime/src/__tests__/session-trace-projection.test.ts
@@ -229,6 +229,133 @@ describe('session trace projection', () => {
     assert.equal(failure.message, 'turn ended after tool failure');
   });
 
+  test('projects a generic-lane function call as an in-flight tool step', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'call-1',
+          ts: 1_000,
+          content: {
+            kind: 'function_call',
+            id: 'tool-call-1',
+            name: 'AskUserQuestion',
+            args: { questions: [] },
+          },
+        }),
+      ],
+      modelCallAttempts: [],
+    });
+
+    assert.deepEqual(trace.turns[0]?.steps, [
+      {
+        kind: 'tool',
+        id: 'call-1',
+        turnId: 'turn-1',
+        runId: 'run-1',
+        startedAt: 1_000,
+        toolName: 'AskUserQuestion',
+        toolCallId: 'tool-call-1',
+        status: 'in_flight',
+      },
+    ]);
+  });
+
+  test('settles a generic-lane tool step from its matching response', () => {
+    for (const expected of [
+      { isError: undefined, status: 'completed' as const },
+      { isError: true, status: 'failed' as const },
+    ]) {
+      const trace = projectSessionTrace({
+        sessionId: 'session-1',
+        runtimeEvents: [
+          event({
+            id: 'call-1',
+            ts: 1_000,
+            content: {
+              kind: 'function_call',
+              id: 'tool-call-1',
+              name: 'AskUserQuestion',
+              args: { questions: [] },
+            },
+          }),
+          event({
+            id: 'response-1',
+            ts: 1_250,
+            role: 'tool',
+            author: 'tool',
+            content: {
+              kind: 'function_response',
+              id: 'tool-call-1',
+              name: 'AskUserQuestion',
+              result: 'answer',
+              ...(expected.isError ? { isError: true } : {}),
+            },
+          }),
+        ],
+        modelCallAttempts: [],
+      });
+
+      const tool = trace.turns[0]?.steps[0];
+      assert.equal(tool?.kind, 'tool');
+      if (tool?.kind !== 'tool') continue;
+      assert.equal(tool.status, expected.status);
+      assert.equal(tool.endedAt, 1_250);
+      assert.equal(tool.durationMs, 250);
+    }
+  });
+
+  test('prefers the durable dispatch step when a function call also has one', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'call-1',
+          ts: 900,
+          content: {
+            kind: 'function_call',
+            id: 'tool-call-1',
+            name: 'Bash',
+            args: { command: 'pwd' },
+          },
+        }),
+        event({
+          id: 'dispatch-1',
+          ts: 1_000,
+          actions: {
+            toolDispatch: {
+              protocol: 't1_after_preflight_v1',
+              operationId: 'op-1',
+              providerToolCallId: 'tool-call-1',
+              toolName: 'Bash',
+              canonicalArgsHash: 'hash',
+              recoveryMode: 'replay_safe',
+            },
+          },
+        }),
+        event({
+          id: 'response-1',
+          ts: 1_250,
+          role: 'tool',
+          author: 'tool',
+          content: {
+            kind: 'function_response',
+            id: 'tool-call-1',
+            name: 'Bash',
+            result: 'ok',
+          },
+        }),
+      ],
+      modelCallAttempts: [],
+    });
+
+    const tools = trace.turns[0]?.steps.filter((step) => step.kind === 'tool') ?? [];
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0]?.id, 'dispatch-1');
+    assert.equal(tools[0]?.operationId, 'op-1');
+    assert.equal(tools[0]?.status, 'completed');
+  });
+
   test('reports a backend that emits no canonical records instead of rendering an idle session', () => {
     // The pi backend emits `token_usage` and no `ModelCallAttempt` at all. An
     // empty timeline would be indistinguishable from a session that did nothing.

--- a/packages/runtime/src/session-trace-projection.ts
+++ b/packages/runtime/src/session-trace-projection.ts
@@ -283,6 +283,15 @@ function projectEventSteps(events: readonly RuntimeEvent[]): TraceStep[] {
   const steps: TraceStep[] = [];
   const toolStarts = new Map<string, { id: string; startedAt: number }>();
   const toolStepsByOperation = new Map<string, TraceStep & { kind: 'tool' }>();
+  // A normal tool execution carries both a model function_call and the richer
+  // durable dispatch fact. Only calls with no dispatch anywhere in this turn
+  // belong to the generic lane; otherwise the Inspector would show duplicates.
+  const dispatchedToolCallIds = new Set(
+    events.flatMap((event) => {
+      const dispatch = event.actions?.toolDispatch;
+      return dispatch ? [dispatch.providerToolCallId] : [];
+    }),
+  );
 
   for (const event of events) {
     // A written compaction boundary, which is not the same fact as the
@@ -311,6 +320,22 @@ function projectEventSteps(events: readonly RuntimeEvent[]): TraceStep[] {
           reasonCode: recovery.payload.reasonCode,
         };
       }
+      continue;
+    }
+
+    const genericCall = event.content?.kind === 'function_call' ? event.content : undefined;
+    if (genericCall && !dispatchedToolCallIds.has(genericCall.id)) {
+      toolStarts.set(genericCall.id, { id: event.id, startedAt: event.ts });
+      steps.push({
+        kind: 'tool',
+        id: event.id,
+        turnId: event.turnId,
+        runId: event.runId,
+        startedAt: event.ts,
+        toolName: genericCall.name,
+        toolCallId: genericCall.id,
+        status: 'in_flight',
+      });
       continue;
     }
 


### PR DESCRIPTION
## Summary

Project generic-lane `function_call` events as Session Inspector tool steps and settle them from matching `function_response` events. A precomputed dispatch witness keeps the richer durable `toolDispatch` lane authoritative and prevents duplicate steps.

Fixes #5092

## Verification

- `npm run build` — passed.
- Focused `session-trace-projection` suite — 18/18 passed.
- `npm run lint`, `npm run format:check`, and `npm run typecheck` — passed.
- Knip checks for `apps/desktop` and `packages/ui`, plus `npm run check:asf-headers` — passed.
- Not claimed as a clean signal: the full runtime dist suite encounters pre-existing Windows PTY, symlink, and path-dependent failures outside this change; the affected projection suite passes independently.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

OpenAI Codex — implementation, tests, validation, and automated PR submission at @yuzhiyang1's direction. @yuzhiyang1 decided to submit and remains the human contributor of record.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
