### PR TITLE
fix(desktop): hand the Windows taskbar the rebuilt ICO as a file path

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -43,7 +43,7 @@
     "package:linux-deb-arm64": "electron-builder --config electron-builder.config.mjs --linux deb --arm64 --publish never",
     "typecheck": "tsc -p tsconfig.preload.json --noEmit && tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit && tsc -p tsconfig.storybook.json --noEmit",
     "typecheck:stories": "tsc -p tsconfig.storybook.json --noEmit",
-    "test:dist": "node --test --test-force-exit \"dist/main/**/*.test.js\" scripts/dev-app-runtime.test.mjs scripts/vite-workspace-packages.test.mjs",
+    "test:dist": "node --test --test-force-exit --experimental-test-module-mocks \"dist/main/**/*.test.js\" scripts/dev-app-runtime.test.mjs scripts/vite-workspace-packages.test.mjs",
     "e2e": "npm run build:with-deps && playwright test --config e2e/playwright.config.ts",
     "build:with-deps": "npm run build:workspace-deps && npm run build",
     "smoke:real-window": "npm run build:with-deps && node ../../scripts/desktop-real-window-smoke.mjs",

--- a/apps/desktop/src/main/__tests__/app-icon-apply.test.ts
+++ b/apps/desktop/src/main/__tests__/app-icon-apply.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mock, test } from 'node:test';
+import { desktopAssetRoot } from '../desktop-assets.js';
+import { pngOfSize } from './app-icon-test-fixture.js';
+
+/**
+ * What the fake Electron hands the module under test.
+ *
+ * `applyAppIcon` imports Electron at load time, and a plain `node --test`
+ * process cannot resolve that: the package's real entry point exports a path
+ * to the binary, not `app`, so the import fails before any assertion runs.
+ * The call chain is therefore exercised against these fakes — with the
+ * platform pinned, because the same code has to behave differently on Windows
+ * and on the per-window platforms, and CI does not run Windows.
+ */
+const electron = {
+  userDataRoot: '',
+  reads: (_path: string) => true,
+  icons: [] as string[],
+};
+
+mock.module('electron', {
+  namedExports: {
+    app: {
+      getPath: () => electron.userDataRoot,
+      isPackaged: false,
+      dock: undefined,
+    },
+    BrowserWindow: {
+      getAllWindows: () => [{ setIcon: (icon: string) => electron.icons.push(icon) }],
+    },
+    nativeImage: {
+      createFromPath: (path: string) => ({
+        isEmpty: () => !electron.reads(path),
+        resize: ({ width }: { width: number }) => ({ toPNG: () => pngOfSize(width) }),
+      }),
+      createFromBuffer: () => ({ isEmpty: () => true }),
+    },
+  },
+});
+
+/** The 1024px master a window falls back to when nothing else can be used. */
+const DEFAULT_MASTER = join(
+  desktopAssetRoot({ isPackaged: false, resourcesPath: process.resourcesPath }),
+  'assets',
+  'icon.png',
+);
+
+async function withPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T>): Promise<T> {
+  const original = process.platform;
+  // `process.platform` is configurable, so pinning it keeps these assertions
+  // about the platform's branch rather than about the machine running them.
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  }
+}
+
+async function withTempUserData(run: (root: string) => Promise<void>): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), 'maka-app-icon-'));
+  electron.userDataRoot = root;
+  try {
+    await run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** Runs one icon change against the real module and reports what reached the window. */
+async function applyIcon(
+  value: unknown,
+): Promise<{ readonly icons: readonly string[]; readonly errors: readonly unknown[] }> {
+  const { applyAppIcon } = await import('../app-icon-surface.js');
+  electron.icons = [];
+  const errors: unknown[] = [];
+  applyAppIcon(value, (error) => errors.push(error));
+  return { icons: electron.icons, errors };
+}
+
+test('the taskbar gets the rebuilt ICO path, so the picker and the taskbar agree', async () => {
+  await withTempUserData(async (root) => {
+    electron.reads = () => true;
+    const { icons, errors } = await withPlatform('win32', () => applyIcon('default'));
+
+    const cached = join(root, 'app-icon-cache', 'taskbar.ico');
+    assert.deepEqual(icons, [cached]);
+    assert.deepEqual(errors, []);
+
+    // And the file Windows is pointed at holds every size it asks for: a path
+    // to a PNG master leaves the taskbar on the packaged `.exe` tile.
+    const ico = readFileSync(cached);
+    assert.equal(ico.readUInt16LE(2), 1, 'not an ICO');
+    assert.equal(ico.readUInt16LE(4), 6, 'the small/large HICON sizes are missing');
+  });
+});
+
+test('a cache that cannot be written leaves the window on the PNG master', async (t) => {
+  const reported = t.mock.method(console, 'error', () => undefined);
+  await withTempUserData(async (root) => {
+    electron.reads = () => true;
+    // A file where the cache directory has to go, so the write cannot happen.
+    writeFileSync(join(root, 'app-icon-cache'), 'in the way');
+
+    const { icons, errors } = await withPlatform('win32', () => applyIcon('default'));
+
+    // The fallback is a readable PNG — never the ICO path that decodes to
+    // nothing — and the failure is not swallowed into silence.
+    assert.deepEqual(icons, [DEFAULT_MASTER]);
+    assert.deepEqual(errors, []);
+    assert.equal(reported.mock.callCount(), 1);
+  });
+});
+
+for (const platform of ['win32', 'linux'] as const) {
+  test(`artwork that is gone on ${platform} reports instead of blanking the running icon`, async () => {
+    await withTempUserData(async () => {
+      electron.reads = () => false;
+      const { icons, errors } = await withPlatform(platform, () => applyIcon('default'));
+
+      // `setIcon` with a path that decodes to nothing blanks the icon the
+      // window already has, which is worse than leaving it as it is.
+      assert.deepEqual(icons, []);
+      assert.equal(errors.length, 1);
+      assert.match(String(errors[0]), /no readable artwork for app icon "default"/);
+    });
+  });
+}

--- a/apps/desktop/src/main/__tests__/app-icon-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/app-icon-cache.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { windowsTaskbarIconCachePath, writeWindowsTaskbarIconCache } from '../app-icon-cache.js';
+
+test('the rebuilt taskbar icon lands where Windows is told to look', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-app-icon-'));
+  try {
+    // The encoded ICO, whatever it holds: this is about the path handed to
+    // Electron and the bytes reaching that path, not about the container.
+    const bytes = Buffer.from([0, 1, 2, 3]);
+    const path = writeWindowsTaskbarIconCache(root, bytes);
+    assert.equal(path, join(root, 'app-icon-cache', 'taskbar.ico'));
+    assert.equal(path, windowsTaskbarIconCachePath(root));
+    assert.ok(path, 'a writable cache has to name the file it wrote');
+    assert.deepEqual(await readFile(path), bytes);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('an unwritable cache reports back instead of naming a broken file', async (t) => {
+  const reported = t.mock.method(console, 'error', () => undefined);
+  const root = await mkdtemp(join(tmpdir(), 'maka-app-icon-'));
+  try {
+    // A file where the cache directory has to go, so `mkdir` cannot make it.
+    await writeFile(join(root, 'app-icon-cache'), 'in the way');
+
+    // null and not a path: the caller's fallback is the PNG master, and a
+    // taskbar on the packaged tile beats an icon that decodes to nothing.
+    assert.equal(writeWindowsTaskbarIconCache(root, Buffer.from([0])), null);
+    assert.equal(
+      reported.mock.callCount(),
+      1,
+      'a cache failure has to be reported, not swallowed into a silent null',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/src/main/__tests__/app-icon-test-fixture.ts
+++ b/apps/desktop/src/main/__tests__/app-icon-test-fixture.ts
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { deflateSync } from 'node:zlib';
+
+/**
+ * CRC-32 over one chunk's type and data, as PNG defines it.
+ *
+ * The frames below are built rather than faked with a string, because a test
+ * that only walks the ICO container cannot say whether the bytes Windows would
+ * decode are an image.
+ */
+const CRC_TABLE = new Uint32Array(256).map((_, index) => {
+  let value = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  return value >>> 0;
+});
+
+function crc32(bytes: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const body = Buffer.concat([Buffer.from(type, 'latin1'), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(body), 0);
+  return Buffer.concat([length, body, crc]);
+}
+
+/**
+ * An 8-bit RGBA PNG of one flat colour, `size` by `size`.
+ *
+ * Real bytes, at the size the caller declares: that is what the Windows loader
+ * reads, and a frame whose own header disagrees with its ICO directory entry
+ * is invisible to a test that only walks the container.
+ */
+export function pngOfSize(size: number): Buffer {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(size, 0);
+  header.writeUInt32BE(size, 4);
+  header.writeUInt8(8, 8); // bit depth
+  header.writeUInt8(6, 9); // colour type: RGBA, the 32bpp the entries declare
+  // Bytes 10..12 stay 0: the one compression, filter and interlace method.
+  const row = Buffer.alloc(1 + size * 4); // filter byte, then RGBA pixels
+  const pixels = Buffer.concat(Array.from({ length: size }, () => row));
+  return Buffer.concat([
+    Buffer.from('89504e470d0a1a0a', 'hex'),
+    pngChunk('IHDR', header),
+    pngChunk('IDAT', deflateSync(pixels)),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}

--- a/apps/desktop/src/main/__tests__/app-icon.test.ts
+++ b/apps/desktop/src/main/__tests__/app-icon.test.ts
@@ -21,7 +21,6 @@ import assert from 'node:assert/strict';
 import { open } from 'node:fs/promises';
 import { join, sep } from 'node:path';
 import { test } from 'node:test';
-import { deflateSync } from 'node:zlib';
 import { APP_ICONS } from '@maka/core/settings';
 import {
   appIconAssetSegments,
@@ -32,6 +31,7 @@ import {
   resolveAppIconPath,
   WINDOWS_TASKBAR_ICON_SIZES,
 } from '../app-icon.js';
+import { pngOfSize } from './app-icon-test-fixture.js';
 import { isAppIcon, toAppIconChoice, type AppIconChoice } from '@maka/core/settings';
 import { desktopAssetRoot } from '../desktop-assets.js';
 
@@ -157,58 +157,6 @@ test('artwork that is gone resolves to nothing rather than to a dead path', () =
     readable,
   );
 });
-
-/**
- * CRC-32 over one chunk's type and data, as PNG defines it. The frames below
- * are built here rather than faked with a string, because a container test
- * cannot say whether the bytes Windows would decode are actually an image.
- */
-const CRC_TABLE = new Uint32Array(256).map((_, index) => {
-  let value = index;
-  for (let bit = 0; bit < 8; bit += 1) {
-    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
-  }
-  return value >>> 0;
-});
-
-function crc32(bytes: Buffer): number {
-  let crc = 0xffffffff;
-  for (const byte of bytes) crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
-  return (crc ^ 0xffffffff) >>> 0;
-}
-
-function pngChunk(type: string, data: Buffer): Buffer {
-  const length = Buffer.alloc(4);
-  length.writeUInt32BE(data.length, 0);
-  const body = Buffer.concat([Buffer.from(type, 'latin1'), data]);
-  const crc = Buffer.alloc(4);
-  crc.writeUInt32BE(crc32(body), 0);
-  return Buffer.concat([length, body, crc]);
-}
-
-/**
- * An 8-bit RGBA PNG of one flat colour, `size` by `size`.
- *
- * Real bytes, at the size the directory entry declares: that is what the
- * Windows loader reads, and a frame whose own header disagrees with its entry
- * is invisible to a test that only walks the container.
- */
-function pngOfSize(size: number): Buffer {
-  const header = Buffer.alloc(13);
-  header.writeUInt32BE(size, 0);
-  header.writeUInt32BE(size, 4);
-  header.writeUInt8(8, 8); // bit depth
-  header.writeUInt8(6, 9); // colour type: RGBA, the 32bpp the entries declare
-  // Bytes 10..12 stay 0: the one compression, filter and interlace method.
-  const row = Buffer.alloc(1 + size * 4); // filter byte, then RGBA pixels
-  const pixels = Buffer.concat(Array.from({ length: size }, () => row));
-  return Buffer.concat([
-    Buffer.from('89504e470d0a1a0a', 'hex'),
-    pngChunk('IHDR', header),
-    pngChunk('IDAT', deflateSync(pixels)),
-    pngChunk('IEND', Buffer.alloc(0)),
-  ]);
-}
 
 test('the Windows ICO carries every taskbar size as a PNG frame', () => {
   const frames = WINDOWS_TASKBAR_ICON_SIZES.map((size) => ({ size, png: pngOfSize(size) }));

--- a/apps/desktop/src/main/__tests__/app-icon.test.ts
+++ b/apps/desktop/src/main/__tests__/app-icon.test.ts
@@ -25,8 +25,10 @@ import { APP_ICONS } from '@maka/core/settings';
 import {
   appIconAssetSegments,
   appIconLoadOrder,
+  encodeWindowsIco,
   pickReadableAppIconPath,
   resolveAppIconPath,
+  WINDOWS_TASKBAR_ICON_SIZES,
 } from '../app-icon.js';
 import { isAppIcon, toAppIconChoice, type AppIconChoice } from '@maka/core/settings';
 import { desktopAssetRoot } from '../desktop-assets.js';
@@ -130,5 +132,38 @@ test('a persisted custom id whose file disappeared falls back to the brand mark'
   assert.equal(
     pickReadableAppIconPath(gone, toPath, () => true),
     join('/user-data', 'app-icons', `${'d'.repeat(32)}.png`),
+  );
+});
+
+test('the Windows ICO carries every taskbar size as a PNG frame', () => {
+  const frames = WINDOWS_TASKBAR_ICON_SIZES.map((size) => ({
+    size,
+    png: Buffer.from(`png-${size}`),
+  }));
+  const encoded = encodeWindowsIco(frames);
+  assert.equal(encoded.readUInt16LE(0), 0);
+  assert.equal(encoded.readUInt16LE(2), 1);
+  assert.equal(encoded.readUInt16LE(4), frames.length);
+
+  let cursor = 6;
+  for (const frame of frames) {
+    // 256 is stored as 0: the size field is one byte wide.
+    const storedSize = frame.size >= 256 ? 0 : frame.size;
+    assert.equal(encoded.readUInt8(cursor), storedSize);
+    assert.equal(encoded.readUInt8(cursor + 1), storedSize);
+    assert.equal(encoded.readUInt16LE(cursor + 4), 1);
+    assert.equal(encoded.readUInt16LE(cursor + 6), 32);
+    assert.equal(encoded.readUInt32LE(cursor + 8), frame.png.byteLength);
+    const offset = encoded.readUInt32LE(cursor + 12);
+    assert.equal(
+      encoded.subarray(offset, offset + frame.png.byteLength).toString(),
+      frame.png.toString(),
+    );
+    cursor += 16;
+  }
+  assert.deepEqual(
+    [...WINDOWS_TASKBAR_ICON_SIZES],
+    [16, 24, 32, 48, 64, 256],
+    'Windows needs a 16px and 32px frame; dropping either leaves the taskbar on the packaged sky icon',
   );
 });

--- a/apps/desktop/src/main/__tests__/app-icon.test.ts
+++ b/apps/desktop/src/main/__tests__/app-icon.test.ts
@@ -21,11 +21,13 @@ import assert from 'node:assert/strict';
 import { open } from 'node:fs/promises';
 import { join, sep } from 'node:path';
 import { test } from 'node:test';
+import { deflateSync } from 'node:zlib';
 import { APP_ICONS } from '@maka/core/settings';
 import {
   appIconAssetSegments,
   appIconLoadOrder,
   encodeWindowsIco,
+  firstReadableAppIconPath,
   pickReadableAppIconPath,
   resolveAppIconPath,
   WINDOWS_TASKBAR_ICON_SIZES,
@@ -135,11 +137,81 @@ test('a persisted custom id whose file disappeared falls back to the brand mark'
   );
 });
 
+test('artwork that is gone resolves to nothing rather than to a dead path', () => {
+  // The contract the icon *replacement* path depends on: `undefined` is what
+  // leaves a window's existing icon alone, where a path that decodes to
+  // nothing would blank it.
+  const gone = `custom:${'e'.repeat(32)}` as const;
+  const toPath = (choice: AppIconChoice) => join('/user-data', 'app-icons', `${choice.slice(7)}.png`);
+
+  assert.equal(
+    firstReadableAppIconPath(gone, toPath, () => false),
+    undefined,
+    'no candidate reads, so there is no path to hand Windows or Linux',
+  );
+
+  // And a readable candidate still wins, so the answer is not just "none".
+  const readable = toPath(gone);
+  assert.equal(
+    firstReadableAppIconPath(gone, toPath, (path) => path === readable),
+    readable,
+  );
+});
+
+/**
+ * CRC-32 over one chunk's type and data, as PNG defines it. The frames below
+ * are built here rather than faked with a string, because a container test
+ * cannot say whether the bytes Windows would decode are actually an image.
+ */
+const CRC_TABLE = new Uint32Array(256).map((_, index) => {
+  let value = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  return value >>> 0;
+});
+
+function crc32(bytes: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const body = Buffer.concat([Buffer.from(type, 'latin1'), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(body), 0);
+  return Buffer.concat([length, body, crc]);
+}
+
+/**
+ * An 8-bit RGBA PNG of one flat colour, `size` by `size`.
+ *
+ * Real bytes, at the size the directory entry declares: that is what the
+ * Windows loader reads, and a frame whose own header disagrees with its entry
+ * is invisible to a test that only walks the container.
+ */
+function pngOfSize(size: number): Buffer {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(size, 0);
+  header.writeUInt32BE(size, 4);
+  header.writeUInt8(8, 8); // bit depth
+  header.writeUInt8(6, 9); // colour type: RGBA, the 32bpp the entries declare
+  // Bytes 10..12 stay 0: the one compression, filter and interlace method.
+  const row = Buffer.alloc(1 + size * 4); // filter byte, then RGBA pixels
+  const pixels = Buffer.concat(Array.from({ length: size }, () => row));
+  return Buffer.concat([
+    Buffer.from('89504e470d0a1a0a', 'hex'),
+    pngChunk('IHDR', header),
+    pngChunk('IDAT', deflateSync(pixels)),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
 test('the Windows ICO carries every taskbar size as a PNG frame', () => {
-  const frames = WINDOWS_TASKBAR_ICON_SIZES.map((size) => ({
-    size,
-    png: Buffer.from(`png-${size}`),
-  }));
+  const frames = WINDOWS_TASKBAR_ICON_SIZES.map((size) => ({ size, png: pngOfSize(size) }));
   const encoded = encodeWindowsIco(frames);
   assert.equal(encoded.readUInt16LE(0), 0);
   assert.equal(encoded.readUInt16LE(2), 1);
@@ -155,12 +227,24 @@ test('the Windows ICO carries every taskbar size as a PNG frame', () => {
     assert.equal(encoded.readUInt16LE(cursor + 6), 32);
     assert.equal(encoded.readUInt32LE(cursor + 8), frame.png.byteLength);
     const offset = encoded.readUInt32LE(cursor + 12);
-    assert.equal(
-      encoded.subarray(offset, offset + frame.png.byteLength).toString(),
-      frame.png.toString(),
-    );
+    const payload = encoded.subarray(offset, offset + frame.png.byteLength);
+    // The entry has to land on this frame's own bytes — an offset that is
+    // merely in range leaves Windows decoding a neighbour's data.
+    assert.deepEqual(Buffer.from(payload), frame.png);
+    // ...and those bytes have to be a PNG of the size the entry promises.
+    assert.equal(payload.subarray(0, 8).toString('hex'), '89504e470d0a1a0a');
+    assert.equal(payload.readUInt32BE(16), frame.size, 'the frame is not the size the entry declares');
+    assert.equal(payload.readUInt32BE(20), frame.size, 'the frame is not the size the entry declares');
     cursor += 16;
   }
+
+  // Header plus frames and nothing more: an offset past the end of the file
+  // would still be readable as a number here.
+  assert.equal(
+    encoded.byteLength,
+    6 + 16 * frames.length + frames.reduce((total, frame) => total + frame.png.byteLength, 0),
+  );
+
   assert.deepEqual(
     [...WINDOWS_TASKBAR_ICON_SIZES],
     [16, 24, 32, 48, 64, 256],

--- a/apps/desktop/src/main/app-icon-cache.ts
+++ b/apps/desktop/src/main/app-icon-cache.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/**
+ * Where the rebuilt Windows taskbar icon is cached, under the user data
+ * directory the app owns.
+ *
+ * A `.ico` cannot travel as bytes: `nativeImage` decodes PNG/JPG only, so
+ * `createFromBuffer` of an ICO returns an EMPTY image. The artwork is written
+ * to this file instead and Windows is handed the path — which makes this name
+ * part of the fix rather than an implementation detail, so it stays put.
+ *
+ * The root is a parameter, not `app.getPath('userData')`, so the cache can be
+ * exercised without an Electron process.
+ */
+export function windowsTaskbarIconCachePath(userDataRoot: string): string {
+  return join(userDataRoot, 'app-icon-cache', 'taskbar.ico');
+}
+
+/**
+ * Writes the rebuilt ICO and returns the path to hand Windows, or `null` when
+ * the cache cannot be written.
+ *
+ * `null` rather than a throw: the caller's fallback is the PNG master, and a
+ * taskbar that keeps showing the packaged tile is a smaller loss than an icon
+ * that decodes to nothing. The failure is reported here because a silent
+ * `null` would leave "the taskbar is wrong" with no evidence of why.
+ */
+export function writeWindowsTaskbarIconCache(
+  userDataRoot: string,
+  bytes: Uint8Array,
+): string | null {
+  const path = windowsTaskbarIconCachePath(userDataRoot);
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, bytes);
+    return path;
+  } catch (error) {
+    console.error('[icon] failed to cache the Windows taskbar icon:', error);
+    return null;
+  }
+}

--- a/apps/desktop/src/main/app-icon-surface.ts
+++ b/apps/desktop/src/main/app-icon-surface.ts
@@ -18,6 +18,7 @@
  */
 
 import { app, BrowserWindow, nativeImage } from 'electron';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   APP_ICONS,
@@ -32,7 +33,13 @@ import {
   listCustomAppIconIds,
   resolveCustomAppIconPath,
 } from './custom-app-icon-store.js';
-import { appIconLoadOrder, pickReadableAppIconPath, resolveAppIconPath } from './app-icon.js';
+import {
+  appIconLoadOrder,
+  encodeWindowsIco,
+  pickReadableAppIconPath,
+  resolveAppIconPath,
+  WINDOWS_TASKBAR_ICON_SIZES,
+} from './app-icon.js';
 import { desktopAssetRoot } from './desktop-assets.js';
 
 /**
@@ -59,13 +66,58 @@ export function appIconPath(value: unknown): string {
  * The path a window should be born with: the same fallback `applyAppIcon`
  * walks, so a window created after the artwork went missing gets the brand
  * mark rather than a path that decodes to nothing.
+ *
+ * On Windows this resolves to the rebuilt multi-size ICO file (see
+ * `windowsTaskbarIconFile`) because the taskbar needs the small/large HICON
+ * a PNG NativeImage does not provide. macOS and Linux take the 1024px PNG
+ * master path directly.
  */
 export function readableAppIconPath(value: unknown): string {
+  if (process.platform === 'win32') {
+    const icoPath = windowsTaskbarIconFile(value);
+    if (icoPath !== null) return icoPath;
+  }
   return pickReadableAppIconPath(
     toAppIconChoice(value),
     appIconPath,
     (path) => !nativeImage.createFromPath(path).isEmpty(),
   );
+}
+
+/**
+ * The Windows taskbar icon, as the `.ico` file path Electron wants.
+ *
+ * `BrowserWindow`'s `icon` option and `setIcon` take either a NativeImage or
+ * a file path, and on Windows a path to an `.ico` is what reaches the small
+ * and large HICONs `WM_SETICON` asks for. A NativeImage built from the 1024px
+ * PNG master does not: Chromium keeps the packaged `.exe` tile, so the picker
+ * and the taskbar disagree.
+ *
+ * The rebuilt ICO cannot be handed to Windows as bytes either — `nativeImage`
+ * only decodes PNG/JPG, so `createFromBuffer` of an ICO returns an EMPTY
+ * image. So the artwork is written to the app-owned cache and its path is
+ * returned. Every failure — unreadable art, an encode or write error — returns
+ * null so the caller falls back to the PNG master rather than to a path that
+ * decodes to nothing.
+ */
+export function windowsTaskbarIconFile(value: unknown): string | null {
+  const image = loadAppIcon(toAppIconChoice(value));
+  if (!image) return null;
+  const frames = WINDOWS_TASKBAR_ICON_SIZES.flatMap((size) => {
+    const png = image.resize({ width: size, height: size, quality: 'better' }).toPNG();
+    return png.byteLength > 0 ? [{ size, png: Buffer.from(png) }] : [];
+  });
+  if (frames.length === 0) return null;
+  try {
+    const directory = join(app.getPath('userData'), 'app-icon-cache');
+    mkdirSync(directory, { recursive: true });
+    const path = join(directory, 'taskbar.ico');
+    writeFileSync(path, encodeWindowsIco(frames));
+    return path;
+  } catch (error) {
+    console.error('[icon] failed to cache the Windows taskbar icon:', error);
+    return null;
+  }
 }
 
 /**
@@ -97,20 +149,24 @@ let shippedPreviews: readonly AppIconPreview[] | undefined;
  * per-window icons are ignored. Windows and Linux draw it per window instead,
  * which is why every open window is updated: the `icon` option in
  * `createWindow` only covers windows opened *after* the choice was persisted.
+ *
+ * Windows is handed a path to the rebuilt `.ico` (see `readableAppIconPath`):
+ * a PNG NativeImage leaves the taskbar on the packaged `.exe` tile.
  */
 export function applyAppIcon(value: unknown, onIconError: (error: unknown) => void): void {
   const icon = toAppIconChoice(value);
   try {
-    const image = loadAppIcon(icon);
-    if (!image) {
-      onIconError(new Error(`no readable artwork for app icon "${icon}"`));
-      return;
-    }
     if (app.dock) {
+      const image = loadAppIcon(icon);
+      if (!image) {
+        onIconError(new Error(`no readable artwork for app icon "${icon}"`));
+        return;
+      }
       app.dock.setIcon(image);
       return;
     }
-    for (const window of BrowserWindow.getAllWindows()) window.setIcon(image);
+    const surface = readableAppIconPath(icon);
+    for (const window of BrowserWindow.getAllWindows()) window.setIcon(surface);
   } catch (error) {
     onIconError(error);
   }

--- a/apps/desktop/src/main/app-icon-surface.ts
+++ b/apps/desktop/src/main/app-icon-surface.ts
@@ -18,7 +18,6 @@
  */
 
 import { app, BrowserWindow, nativeImage } from 'electron';
-import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   APP_ICONS,
@@ -36,10 +35,11 @@ import {
 import {
   appIconLoadOrder,
   encodeWindowsIco,
-  pickReadableAppIconPath,
+  firstReadableAppIconPath,
   resolveAppIconPath,
   WINDOWS_TASKBAR_ICON_SIZES,
 } from './app-icon.js';
+import { writeWindowsTaskbarIconCache } from './app-icon-cache.js';
 import { desktopAssetRoot } from './desktop-assets.js';
 
 /**
@@ -63,25 +63,42 @@ export function appIconPath(value: unknown): string {
 }
 
 /**
+ * The path a window's icon surface should be set from, or `null` when no
+ * artwork reads.
+ *
+ * On Windows this is the rebuilt multi-size ICO file (see
+ * `windowsTaskbarIconFile`) because the taskbar needs the small/large HICON a
+ * PNG NativeImage does not provide. macOS and Linux take the first 1024px PNG
+ * master that actually reads.
+ *
+ * `null` is the answer a caller *replacing* an icon needs: `setIcon` with a
+ * path that decodes to nothing blanks the icon a window already has, so
+ * "nothing reads" has to be sayable rather than turned into a path.
+ */
+export function appIconSurfacePath(value: unknown): string | null {
+  const icon = toAppIconChoice(value);
+  if (process.platform === 'win32') {
+    const icoPath = windowsTaskbarIconFile(icon);
+    if (icoPath !== null) return icoPath;
+  }
+  return firstReadableAppIconPath(icon, appIconPath, readsAsArtwork) ?? null;
+}
+
+/**
  * The path a window should be born with: the same fallback `applyAppIcon`
  * walks, so a window created after the artwork went missing gets the brand
  * mark rather than a path that decodes to nothing.
  *
- * On Windows this resolves to the rebuilt multi-size ICO file (see
- * `windowsTaskbarIconFile`) because the taskbar needs the small/large HICON
- * a PNG NativeImage does not provide. macOS and Linux take the 1024px PNG
- * master path directly.
+ * The `string` form of `appIconSurfacePath`, for the callers that have to name
+ * a path: a window being created cannot report an error.
  */
 export function readableAppIconPath(value: unknown): string {
-  if (process.platform === 'win32') {
-    const icoPath = windowsTaskbarIconFile(value);
-    if (icoPath !== null) return icoPath;
-  }
-  return pickReadableAppIconPath(
-    toAppIconChoice(value),
-    appIconPath,
-    (path) => !nativeImage.createFromPath(path).isEmpty(),
-  );
+  return appIconSurfacePath(value) ?? appIconPath('default');
+}
+
+/** `nativeImage` reports a missing or undecodable file as an EMPTY image. */
+function readsAsArtwork(path: string): boolean {
+  return !nativeImage.createFromPath(path).isEmpty();
 }
 
 /**
@@ -108,16 +125,7 @@ export function windowsTaskbarIconFile(value: unknown): string | null {
     return png.byteLength > 0 ? [{ size, png: Buffer.from(png) }] : [];
   });
   if (frames.length === 0) return null;
-  try {
-    const directory = join(app.getPath('userData'), 'app-icon-cache');
-    mkdirSync(directory, { recursive: true });
-    const path = join(directory, 'taskbar.ico');
-    writeFileSync(path, encodeWindowsIco(frames));
-    return path;
-  } catch (error) {
-    console.error('[icon] failed to cache the Windows taskbar icon:', error);
-    return null;
-  }
+  return writeWindowsTaskbarIconCache(app.getPath('userData'), encodeWindowsIco(frames));
 }
 
 /**
@@ -150,8 +158,12 @@ let shippedPreviews: readonly AppIconPreview[] | undefined;
  * which is why every open window is updated: the `icon` option in
  * `createWindow` only covers windows opened *after* the choice was persisted.
  *
- * Windows is handed a path to the rebuilt `.ico` (see `readableAppIconPath`):
+ * Windows is handed a path to the rebuilt `.ico` (see `appIconSurfacePath`):
  * a PNG NativeImage leaves the taskbar on the packaged `.exe` tile.
+ *
+ * Nothing readable means nothing is set. `setIcon` with a path that decodes to
+ * nothing blanks the icon the window already has, so a missing set of artwork
+ * has to leave the running icon alone and say so instead.
  */
 export function applyAppIcon(value: unknown, onIconError: (error: unknown) => void): void {
   const icon = toAppIconChoice(value);
@@ -165,7 +177,11 @@ export function applyAppIcon(value: unknown, onIconError: (error: unknown) => vo
       app.dock.setIcon(image);
       return;
     }
-    const surface = readableAppIconPath(icon);
+    const surface = appIconSurfacePath(icon);
+    if (surface === null) {
+      onIconError(new Error(`no readable artwork for app icon "${icon}"`));
+      return;
+    }
     for (const window of BrowserWindow.getAllWindows()) window.setIcon(surface);
   } catch (error) {
     onIconError(error);

--- a/apps/desktop/src/main/app-icon.ts
+++ b/apps/desktop/src/main/app-icon.ts
@@ -66,3 +66,60 @@ export function pickReadableAppIconPath(
   }
   return toPath('default');
 }
+
+/**
+ * Sizes Windows asks for when a running window replaces the .exe resource.
+ *
+ * A 1024px PNG handed to `BrowserWindow.setIcon` is a valid NativeImage, but
+ * `WM_SETICON` wants a small (16) and large (32) HICON, and Chromium does not
+ * promote a single-frame PNG into those sizes. The taskbar then keeps the
+ * packaged `.exe` tile — currently `sky` — so Settings can show the classic
+ * mascot selected while the taskbar still draws the geometric mark.
+ */
+export const WINDOWS_TASKBAR_ICON_SIZES = [16, 24, 32, 48, 64, 256] as const;
+
+export interface WindowsIcoFrame {
+  readonly size: number;
+  readonly png: Uint8Array;
+}
+
+/**
+ * PNG-in-ICO container.
+ *
+ * `nativeImage` only decodes PNG/JPG, so an ICO handed to
+ * `nativeImage.createFromBuffer` comes back EMPTY; the ICO has to reach
+ * Windows as a *file path* instead (see `windowsTaskbarIconFile`). This
+ * builds that file: one directory entry per size, each carrying a PNG frame,
+ * which is what the Windows icon loader reads.
+ */
+export function encodeWindowsIco(frames: readonly WindowsIcoFrame[]): Buffer {
+  const headerSize = 6 + 16 * frames.length;
+  let imageOffset = headerSize;
+  const entries = frames.map((frame) => {
+    const entry = { ...frame, offset: imageOffset };
+    imageOffset += frame.png.byteLength;
+    return entry;
+  });
+  const encoded = Buffer.alloc(imageOffset);
+  encoded.writeUInt16LE(0, 0);
+  encoded.writeUInt16LE(1, 2);
+  encoded.writeUInt16LE(frames.length, 4);
+  let cursor = 6;
+  for (const entry of entries) {
+    // 256 is stored as 0: the field is one byte, and 0 is the width/height the
+    // format reserves for 256px. Golden rule for this and the next byte.
+    encoded.writeUInt8(entry.size >= 256 ? 0 : entry.size, cursor);
+    encoded.writeUInt8(entry.size >= 256 ? 0 : entry.size, cursor + 1);
+    encoded.writeUInt8(0, cursor + 2);
+    encoded.writeUInt8(0, cursor + 3);
+    encoded.writeUInt16LE(1, cursor + 4);
+    encoded.writeUInt16LE(32, cursor + 6);
+    encoded.writeUInt32LE(entry.png.byteLength, cursor + 8);
+    encoded.writeUInt32LE(entry.offset, cursor + 12);
+    cursor += 16;
+  }
+  for (const entry of entries) {
+    Buffer.from(entry.png).copy(encoded, entry.offset);
+  }
+  return encoded;
+}

--- a/apps/desktop/src/main/app-icon.ts
+++ b/apps/desktop/src/main/app-icon.ts
@@ -47,24 +47,42 @@ export function appIconLoadOrder(icon: AppIconChoice): readonly AppIconChoice[] 
 }
 
 /**
- * First path in the fallback order whose artwork actually reads.
+ * First path in the fallback order whose artwork actually reads, or
+ * `undefined` when every candidate is gone.
  *
  * A path being well-formed says nothing about the file existing: a persisted
  * custom id whose file was deleted resolves to a perfectly valid path that
  * decodes to nothing. Windows and Linux hand that path straight to a new
  * window, so window creation has to walk the same fallback the dock does
  * instead of trusting the first candidate.
+ *
+ * `undefined` is the answer a caller *replacing* artwork needs: `setIcon` with
+ * an unreadable path blanks the icon a window already has, so "nothing reads"
+ * has to be sayable rather than answered with a path that decodes to nothing.
+ */
+export function firstReadableAppIconPath(
+  icon: AppIconChoice,
+  toPath: (choice: AppIconChoice) => string,
+  isReadable: (path: string) => boolean,
+): string | undefined {
+  for (const candidate of appIconLoadOrder(icon)) {
+    const path = toPath(candidate);
+    if (isReadable(path)) return path;
+  }
+  return undefined;
+}
+
+/**
+ * The same walk for a caller that has to name a path even when nothing reads:
+ * a window being created cannot report an error and has no previous icon to
+ * leave alone, so the brand mark is named instead.
  */
 export function pickReadableAppIconPath(
   icon: AppIconChoice,
   toPath: (choice: AppIconChoice) => string,
   isReadable: (path: string) => boolean,
 ): string {
-  for (const candidate of appIconLoadOrder(icon)) {
-    const path = toPath(candidate);
-    if (isReadable(path)) return path;
-  }
-  return toPath('default');
+  return firstReadableAppIconPath(icon, toPath, isReadable) ?? toPath('default');
 }
 
 /**


### PR DESCRIPTION
## Summary

Settings -> Appearance can show a chosen app icon while the Windows taskbar keeps the packaged `sky` tile. `BrowserWindow.setIcon` and the window `icon` option take a NativeImage or a file path; a NativeImage built from the 1024px PNG master is valid, but it does not give `WM_SETICON` the small (16) and large (32) HICONs it asks for, so the taskbar stays on the icon the `.exe` carries.

Hand Windows a path to a rebuilt multi-size ICO instead:

- `encodeWindowsIco` packs 16/24/32/48/64/256 PNG frames into a PNG-in-ICO container (pure function, unit-tested).
- `windowsTaskbarIconFile` writes that ICO to `userData/app-icon-cache/taskbar.ico` and returns the path.
- `readableAppIconPath` resolves to the ICO path on win32 and keeps returning the 1024px PNG master path on macOS and Linux, so no caller changes.

The ICO cannot travel as bytes: `nativeImage` only decodes PNG/JPG, so `createFromBuffer` of an ICO returns an EMPTY image (verified against Electron 43.4.1). Every failure -- unreadable art, an encode or write error -- falls back to the PNG master rather than to a path that decodes to nothing.

## Verification

- `npm --workspace @maka/desktop run build:main` -- pass
- `node --test dist/main/__tests__/app-icon.test.js dist/main/__tests__/client-settings-effects.test.js dist/main/__tests__/startup-progress-window.test.js` -- 20 pass, including the new ICO-frame contract
- `npm --workspace @maka/desktop run typecheck` -- pass
- `npx biome check` on the changed files -- clean
- **Manual, Windows 11, dev build (`npm run dev`)**: switching the icon under Settings -> Appearance updates the taskbar icon, and the run writes `%APPDATA%/Maka Dev/app-icon-cache/taskbar.ico`. The file loads in the Windows icon loader with 16/24/32/48/64/256 frames present.

Not run: a packaged Windows installer, and a live capture against a signed `.exe`. The husky pre-commit Biome stdin hook cannot spawn `biome.cmd` on this Windows shell (`EINVAL`); Biome was run directly on the changed files instead.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: DeepSeek Harness -- located the `setIcon` / HICON gap, wrote the ICO rebuild, the cache write, the tests and this PR text under my direction.

### Screenshots

Before / after of the taskbar tile, plus the picker, to follow -- Windows UI changes are reviewed as diffs otherwise, and the taskbar is the surface this PR is about. (Will attach from my Windows 11 machine.)

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes -- described under Summary above
- [ ] No
