### PR TITLE
feat(runtime): import a Session bundle into a workspace

### DIFF
--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -43,6 +43,7 @@ export type MakaCliCommand =
   | { kind: 'run'; args: string[] }
   | { kind: 'activate'; args: string[] }
   | { kind: 'session-export'; args: string[] }
+  | { kind: 'session-import'; args: string[] }
   | { kind: 'eval'; args: string[] }
   | { kind: 'acp' }
   | RuntimeHostCliCommand
@@ -85,6 +86,7 @@ export function parseMakaCliArgs(
   if (first === 'run' || first === '-p') return { kind: 'run', args: argv.slice(1) };
   if (first === 'activate') return { kind: 'activate', args: argv.slice(1) };
   if (first === 'session-export') return { kind: 'session-export', args: argv.slice(1) };
+  if (first === 'session-import') return { kind: 'session-import', args: argv.slice(1) };
   if (first === 'eval') return { kind: 'eval', args: argv.slice(1) };
   if (first === 'update') return parseRuntimeHostInstalledUpdateCommand(argv.slice(1));
   if (first === 'runtime-host') return parseRuntimeHostCommand(argv.slice(1));
@@ -139,6 +141,7 @@ function helpText(cliCommand: string): string {
     `  ${cliCommand} run ...      Run one non-interactive model turn`,
     `  ${cliCommand} activate ... Run one Cloud Session activation and emit JSONL`,
     `  ${cliCommand} session-export --workspace-root <dir> --session <id> --out <file.maka-session>`,
+    `  ${cliCommand} session-import --workspace-root <dir> --bundle <file.maka-session>`,
     `  ${cliCommand} -p ...       Alias for ${cliCommand} run`,
     `  ${cliCommand} eval ...     Run one declarative multi-arm experiment`,
     `  ${cliCommand} update --target <latest|next|version>  Update this npm-global CLI and its local Runtime Host`,
@@ -299,6 +302,10 @@ export async function runMakaCli(
     case 'session-export': {
       const { runMakaSessionExportCli } = await import('./session-export-command.js');
       return runMakaSessionExportCli(command.args);
+    }
+    case 'session-import': {
+      const { runMakaSessionImportCli } = await import('./session-import-command.js');
+      return runMakaSessionImportCli(command.args);
     }
     case 'eval': {
       const { configureInstalledEvalBundle } = await import('./eval-bundle-path.js');

--- a/packages/cli/src/session-import-command.ts
+++ b/packages/cli/src/session-import-command.ts
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { importSessionBundle } from '@maka/runtime/session-import';
+
+const USAGE = 'maka session-import --workspace-root <dir> --bundle <file.maka-session>';
+
+const FAILURE_EXIT_CODES: Record<string, number> = {
+  workspace_not_found: 6,
+  bundle_unreadable: 2,
+  session_exists: 3,
+  schema_unsupported: 4,
+  conflict: 5,
+};
+
+function parseArgs(args: string[]): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    const value = args[index + 1];
+    if (!name || !value) throw new Error(USAGE);
+    if (name === '--workspace-root') values.workspaceRoot = value;
+    else if (name === '--bundle') values.source = value;
+    else throw new Error(USAGE);
+  }
+  if (!values.workspaceRoot || !values.source) throw new Error(USAGE);
+  return values;
+}
+
+export async function runMakaSessionImportCli(args: string[]): Promise<number> {
+  let parsed: Record<string, string>;
+  try {
+    parsed = parseArgs(args);
+  } catch (error) {
+    process.stderr.write(`${(error as Error).message}\n`);
+    return 1;
+  }
+  const result = await importSessionBundle({
+    workspaceRoot: parsed.workspaceRoot!,
+    source: parsed.source!,
+  });
+  if (!result.ok) {
+    process.stderr.write(`${JSON.stringify(result.reason)}\n`);
+    return FAILURE_EXIT_CODES[result.reason.kind] ?? 1;
+  }
+  process.stdout.write(
+    `${JSON.stringify({
+      sessionIds: result.sessionIds,
+      artifactFiles: result.artifactFiles,
+      contextRefs: result.contextRefs,
+    })}\n`,
+  );
+  return 0;
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -118,7 +118,8 @@
     "./tool-runtime": "./dist/tool-runtime.js",
     "./web-fetch-tool": "./dist/web-fetch-tool.js",
     "./web-search-tool": "./dist/web-search-tool.js",
-    "./xai-oauth-enrollment": "./dist/xai-oauth-enrollment.js"
+    "./xai-oauth-enrollment": "./dist/xai-oauth-enrollment.js",
+    "./session-import": "./dist/session-import.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo src/telemetry/model-pricing.generated.ts",

--- a/packages/runtime/src/__tests__/session-export.test.ts
+++ b/packages/runtime/src/__tests__/session-export.test.ts
@@ -996,6 +996,30 @@ test(
 );
 
 test(
+  'reports an unreadable database as an environment failure, not a schema verdict',
+  withRoot('maka-session-export-unreadable', async (root, workspaceRoot) => {
+    const { chmod } = await import('node:fs/promises');
+    const sessionId = await createSession(workspaceRoot);
+    const databasePath = join(workspaceRoot, OPERATIONAL_STATE_DATABASE_NAME);
+    await chmod(databasePath, 0o000);
+    try {
+      // Telling the user to upgrade when the real answer is that the file could
+      // not be opened sends them after the wrong problem.
+      const result = await exportSessionBundle({
+        workspaceRoot,
+        sessionId,
+        destination: join(root, 'bundle.maka-session'),
+      });
+      assert.equal(result.ok, false);
+      assert.notEqual(result.ok === false && result.reason.kind, 'schema_unsupported');
+      assert.equal(result.ok === false && result.reason.kind, 'io_failed');
+    } finally {
+      await chmod(databasePath, 0o600);
+    }
+  }),
+);
+
+test(
   'refuses a source whose schema is not current',
   withRoot('maka-session-export-schema', async (root, workspaceRoot) => {
     const sessionId = await createSession(workspaceRoot);

--- a/packages/runtime/src/__tests__/session-import.test.ts
+++ b/packages/runtime/src/__tests__/session-import.test.ts
@@ -302,3 +302,118 @@ test('carries the subagent subtree and its artifact bytes across', async () => {
     await rm(target.root, { recursive: true, force: true });
   }
 });
+
+test('leaves the shared workspace connection as it found it', async () => {
+  const source = await makeWorkspace('maka-import-pragma-source');
+  const target = await makeWorkspace('maka-import-pragma-target');
+  const { acquireOperationalStateDatabase } = await import('@maka/storage/operational-state-store');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    await createSession(target.workspaceRoot, 'Unrelated');
+    const bundle = join(source.root, 'bundle.maka-session');
+    await exportSessionBundle({
+      workspaceRoot: source.workspaceRoot,
+      sessionId,
+      destination: bundle,
+    });
+
+    // Hold a lease across the import, the way a running Runtime Host does. The
+    // operational store hands out one reference-counted connection per
+    // workspace, and `PRAGMA foreign_keys` is per-connection: reading it on a
+    // fresh handle would report the default no matter what the import did.
+    // The import canonicalises the root before acquiring, so a lease taken on
+    // the uncanonicalised path would be a different connection and this test
+    // would observe nothing.
+    const { realpath } = await import('node:fs/promises');
+    const held = acquireOperationalStateDatabase(await realpath(target.workspaceRoot));
+    try {
+      const before = readForeignKeys(held.database);
+      assert.equal(before, 1);
+
+      const imported = await importSessionBundle({
+        workspaceRoot: target.workspaceRoot,
+        source: bundle,
+      });
+      assert.equal(imported.ok, true);
+
+      // The merge must disable foreign keys to insert in table order. Leaving
+      // the pragma off would silently disarm constraint checking for every
+      // later user of this workspace -- a failure nothing would report.
+      assert.equal(readForeignKeys(held.database), before);
+    } finally {
+      held.close();
+    }
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+function readForeignKeys(database: DatabaseSync): number {
+  const row = (database.prepare('PRAGMA foreign_keys').get() ?? {}) as Record<string, unknown>;
+  return Number(Object.values(row)[0] ?? 0);
+}
+
+test('refuses a bundle written against a different schema', async () => {
+  const source = await makeWorkspace('maka-import-schema-source');
+  const target = await makeWorkspace('maka-import-schema-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    await createSession(target.workspaceRoot, 'Unrelated');
+    const bundle = join(source.root, 'bundle.maka-session');
+    await exportSessionBundle({
+      workspaceRoot: source.workspaceRoot,
+      sessionId,
+      destination: bundle,
+    });
+
+    // Hydrate and tamper, which is the only way to hold a bundle from a build
+    // that is not this one. The merge copies rows with `INSERT ... SELECT *`,
+    // which maps by position: a bundle whose tables carry the same column count
+    // in a different order would be inserted transposed -- rows that read as
+    // data and are not.
+    const { createSessionBundleFileService } = await import(
+      '@maka/storage/session-bundle-file-service'
+    );
+    const { importSessionBundleState } = await import('@maka/storage/session-bundle-policy');
+    const { SESSION_EXPORT_BUNDLE_LIMITS } = await import('../session-export.js');
+    const hydration = await createSessionBundleFileService().hydrate({
+      source: { path: bundle },
+      limits: SESSION_EXPORT_BUNDLE_LIMITS,
+      expectedSessionId: sessionId,
+      destinationRoot: join(source.root, 'hydrated'),
+    });
+    const bundleDb = new DatabaseSync(join(hydration.stateRoot, OPERATIONAL_STATE_DATABASE_NAME));
+    try {
+      bundleDb.exec(
+        "UPDATE operational_schema_migrations SET version = version + 1 WHERE scope = 'usage'",
+      );
+    } finally {
+      bundleDb.close();
+    }
+
+    await assert.rejects(
+      () =>
+        importSessionBundleState({
+          stateRoot: target.workspaceRoot,
+          bundleStateRoot: hydration.stateRoot,
+        }),
+      (error: unknown) => (error as { code?: string }).code === 'schema_unsupported',
+    );
+
+    const after = openDatabase(target.workspaceRoot, true);
+    try {
+      const count = after.prepare('SELECT COUNT(*) AS count FROM session_metadata').get() as {
+        count?: unknown;
+      };
+      assert.equal(Number(count.count), 1);
+    } finally {
+      after.close();
+    }
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});

--- a/packages/runtime/src/__tests__/session-import.test.ts
+++ b/packages/runtime/src/__tests__/session-import.test.ts
@@ -439,41 +439,78 @@ async function seedContext(
 
   const db = new DatabaseSync(join(workspaceRoot, 'context-offload.sqlite'));
   try {
+    // The real v3 shape, not an approximation: `reference_count`, an owner kind
+    // the CHECK accepts, and the columns the store actually writes. A fixture
+    // that only resembles it proves the SQL runs, not that the imported store
+    // is usable by the store that has to read it.
     db.exec(`
       PRAGMA user_version = 3;
       CREATE TABLE context_blobs (
         blob_id BLOB PRIMARY KEY CHECK(length(blob_id) = 32),
         storage_kind TEXT NOT NULL CHECK(storage_kind IN ('inline', 'managed_file')),
         payload BLOB NOT NULL,
-        size_bytes INTEGER NOT NULL CHECK(size_bytes >= 0)
+        size_bytes INTEGER NOT NULL CHECK(size_bytes >= 0),
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        CHECK(
+          (storage_kind = 'inline' AND length(payload) = size_bytes) OR
+          (storage_kind = 'managed_file' AND length(payload) BETWEEN 1 AND 512)
+        )
       );
       CREATE TABLE context_refs (
         ref_id TEXT PRIMARY KEY,
         session_id TEXT NOT NULL,
-        owner_kind TEXT NOT NULL,
-        blob_id BLOB NOT NULL REFERENCES context_blobs(blob_id)
+        owner_kind TEXT NOT NULL CHECK(
+          owner_kind IN ('read_image_snapshot', 'tool_result_archive')
+        ),
+        owner_id TEXT NOT NULL,
+        blob_id BLOB NOT NULL REFERENCES context_blobs(blob_id) ON DELETE RESTRICT,
+        media_type TEXT NOT NULL,
+        created_at INTEGER NOT NULL CHECK(created_at >= 0),
+        UNIQUE(session_id, owner_kind, owner_id)
       );
-      CREATE TABLE context_gc_candidates (blob_id BLOB PRIMARY KEY, unreferenced_at INTEGER NOT NULL);
-      CREATE TABLE context_file_deletions (locator BLOB PRIMARY KEY, size_bytes INTEGER NOT NULL, enqueued_at INTEGER NOT NULL);
-      CREATE TABLE context_session_usage (session_id TEXT PRIMARY KEY, ref_count INTEGER NOT NULL, logical_bytes INTEGER NOT NULL);
-      CREATE TABLE context_store_usage (singleton INTEGER PRIMARY KEY CHECK(singleton = 1), blob_count INTEGER NOT NULL, physical_bytes INTEGER NOT NULL);
+      CREATE TABLE context_gc_candidates (
+        blob_id BLOB PRIMARY KEY REFERENCES context_blobs(blob_id) ON DELETE CASCADE,
+        unreferenced_at INTEGER NOT NULL CHECK(unreferenced_at >= 0)
+      );
+      CREATE TABLE context_file_deletions (
+        locator BLOB PRIMARY KEY CHECK(length(locator) BETWEEN 1 AND 512),
+        size_bytes INTEGER NOT NULL CHECK(size_bytes >= 0),
+        enqueued_at INTEGER NOT NULL CHECK(enqueued_at >= 0)
+      );
+      CREATE TABLE context_session_usage (
+        session_id TEXT PRIMARY KEY,
+        reference_count INTEGER NOT NULL CHECK(reference_count >= 0),
+        logical_bytes INTEGER NOT NULL CHECK(logical_bytes >= 0)
+      );
+      CREATE TABLE context_store_usage (
+        singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+        blob_count INTEGER NOT NULL CHECK(blob_count >= 0),
+        physical_bytes INTEGER NOT NULL CHECK(physical_bytes >= 0)
+      );
       INSERT INTO context_store_usage VALUES (1, 0, 0);
     `);
-    db.prepare("INSERT INTO context_blobs VALUES (?, 'managed_file', ?, ?)").run(
+    db.prepare('INSERT INTO context_blobs VALUES (?, ?, ?, ?, 0)').run(
       digest,
+      'managed_file',
       Buffer.from(relativePath, 'utf8'),
       bytes.length,
     );
-    db.prepare("INSERT INTO context_refs VALUES (?, ?, 'message', ?)").run(
+    db.prepare('INSERT INTO context_refs VALUES (?, ?, ?, ?, ?, ?, 0)').run(
       `ref-${sessionId}`,
       sessionId,
+      'read_image_snapshot',
+      `owner-${sessionId}`,
       digest,
+      'image/png',
     );
     db.exec(`
       INSERT INTO context_session_usage
         SELECT r.session_id, count(*), sum(b.size_bytes)
         FROM context_refs r JOIN context_blobs b USING(blob_id) GROUP BY r.session_id;
-      UPDATE context_store_usage SET blob_count = 1, physical_bytes = ${bytes.length} WHERE singleton = 1;
+      UPDATE context_store_usage SET
+        blob_count = (SELECT count(*) FROM context_blobs),
+        physical_bytes = (SELECT coalesce(sum(size_bytes), 0) FROM context_blobs)
+      WHERE singleton = 1;
     `);
   } finally {
     db.close();
@@ -551,16 +588,61 @@ test('carries managed context payloads and keeps usage accounting true', async (
   }
 });
 
-test('publishes nothing when the context merge fails, so a retry is still possible', async () => {
+async function seedArtifact(
+  workspaceRoot: string,
+  sessionId: string,
+  artifactId: string,
+  bytes: string,
+): Promise<string> {
+  const relativePath = `${sessionId}/${artifactId}-file.txt`;
+  await mkdir(join(workspaceRoot, 'artifacts', sessionId), { recursive: true });
+  await writeFile(join(workspaceRoot, 'artifacts', relativePath), bytes);
+  const db = openDatabase(workspaceRoot);
+  try {
+    db.prepare(`
+      INSERT INTO artifact_records(artifact_id, session_id, created_at, relative_path, record_json)
+      VALUES (?, ?, 0, ?, ?)
+    `).run(
+      artifactId,
+      sessionId,
+      relativePath,
+      JSON.stringify({
+        id: artifactId,
+        sessionId,
+        turnId: 'turn-1',
+        createdAt: 0,
+        name: 'file.txt',
+        kind: 'file',
+        relativePath,
+        sizeBytes: bytes.length,
+        source: 'tool_result',
+      }),
+    );
+  } finally {
+    db.close();
+  }
+  return relativePath;
+}
+
+async function importState(
+  target: string,
+  bundle: string,
+): Promise<{ sessionIds: readonly string[]; artifactFiles: number; contextRefs: number }> {
+  const { importSessionBundleState } = await import('@maka/storage/session-bundle-policy');
+  return importSessionBundleState({ stateRoot: target, bundleStateRoot: bundle });
+}
+
+test('a failed context merge leaves nothing published and the retry then succeeds', async () => {
   const source = await makeWorkspace('maka-import-retry-source');
   const target = await makeWorkspace('maka-import-retry-target');
   try {
     const sessionId = await createSession(source.workspaceRoot);
     await seedHistory(source.workspaceRoot, sessionId);
-    await seedContext(source.workspaceRoot, sessionId, 'ABC');
+    const seeded = await seedContext(source.workspaceRoot, sessionId, 'ABC');
+    const artifactPath = await seedArtifact(source.workspaceRoot, sessionId, 'a1', 'BYTES');
 
     const targetSession = await createSession(target.workspaceRoot, 'Unrelated');
-    await seedContext(target.workspaceRoot, targetSession, 'ZZ');
+    const kept = await seedContext(target.workspaceRoot, targetSession, 'ZZ');
     // Collide the reference ids so the context merge fails partway. Any context
     // failure would do; this one needs no injection point in the code.
     const collide = new DatabaseSync(join(target.workspaceRoot, 'context-offload.sqlite'));
@@ -570,13 +652,7 @@ test('publishes nothing when the context merge fails, so a retry is still possib
       collide.close();
     }
 
-    const { importSessionBundleState } = await import('@maka/storage/session-bundle-policy');
-    await assert.rejects(() =>
-      importSessionBundleState({
-        stateRoot: target.workspaceRoot,
-        bundleStateRoot: source.workspaceRoot,
-      }),
-    );
+    await assert.rejects(() => importState(target.workspaceRoot, source.workspaceRoot));
 
     // The Session rows are the last thing written, so a failure reaching them
     // leaves nothing published. Had they gone first, the ids would now be taken
@@ -590,6 +666,170 @@ test('publishes nothing when the context merge fails, so a retry is still possib
     } finally {
       after.close();
     }
+
+    // The artifact staged by the failed attempt is the part that used to make
+    // the retry impossible: `COPYFILE_EXCL` refused its own leftover and the
+    // import reported a conflict against itself, forever.
+    const repair = new DatabaseSync(join(target.workspaceRoot, 'context-offload.sqlite'));
+    try {
+      repair.prepare('UPDATE context_refs SET ref_id = ?').run(`ref-${targetSession}`);
+    } finally {
+      repair.close();
+    }
+    const retried = await importState(target.workspaceRoot, source.workspaceRoot);
+    assert.deepEqual([...retried.sessionIds], [sessionId]);
+    assert.equal(retried.artifactFiles, 1);
+    assert.equal(retried.contextRefs, 1);
+
+    // Both payloads, not just the count: the retry must neither lose the bytes
+    // it staged nor overwrite what was already in the target.
+    const { readFile } = await import('node:fs/promises');
+    const values = join(target.workspaceRoot, 'context-offload-values');
+    assert.equal(
+      await readFile(join(target.workspaceRoot, 'artifacts', artifactPath), 'utf8'),
+      'BYTES',
+    );
+    assert.equal(await readFile(join(values, seeded.relativePath), 'utf8'), 'ABC');
+    assert.equal(await readFile(join(values, kept.relativePath), 'utf8'), 'ZZ');
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('a failure after the context commit is still retryable', async () => {
+  const source = await makeWorkspace('maka-import-late-source');
+  const target = await makeWorkspace('maka-import-late-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const seeded = await seedContext(source.workspaceRoot, sessionId, 'ABC');
+    await seedArtifact(source.workspaceRoot, sessionId, 'shared', 'BYTES');
+
+    const targetSession = await createSession(target.workspaceRoot, 'Unrelated');
+    await seedContext(target.workspaceRoot, targetSession, 'ZZ');
+    // An artifact id already taken by a Session the bundle knows nothing about.
+    // The importability check reads Session ids, so this passes it and fails in
+    // the operational merge -- after the context transaction has committed.
+    await seedArtifact(target.workspaceRoot, targetSession, 'shared', 'OTHER');
+
+    await assert.rejects(() => importState(target.workspaceRoot, source.workspaceRoot));
+
+    const clear = openDatabase(target.workspaceRoot);
+    try {
+      clear.prepare('DELETE FROM artifact_records WHERE artifact_id = ?').run('shared');
+    } finally {
+      clear.close();
+    }
+
+    // Context rows survived the failure, so the retry re-inserts rows that are
+    // already there. A plain INSERT makes that second attempt fail on its own
+    // predecessor.
+    const retried = await importState(target.workspaceRoot, source.workspaceRoot);
+    assert.deepEqual([...retried.sessionIds], [sessionId]);
+    const { readFile } = await import('node:fs/promises');
+    assert.equal(
+      await readFile(
+        join(target.workspaceRoot, 'context-offload-values', seeded.relativePath),
+        'utf8',
+      ),
+      'ABC',
+    );
+    assert.equal(readContextUsage(target.workspaceRoot).blobCount, 2);
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('keeps bytes queued for deletion in the physical total', async () => {
+  const source = await makeWorkspace('maka-import-pending-source');
+  const target = await makeWorkspace('maka-import-pending-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    await seedContext(source.workspaceRoot, sessionId, 'ABC');
+
+    const targetSession = await createSession(target.workspaceRoot, 'Unrelated');
+    await seedContext(target.workspaceRoot, targetSession, 'ZZ');
+    // A blob already dropped from the table whose file has not been drained
+    // yet. Its bytes are on disk and still charged; the drain will subtract
+    // them, so a total recomputed from live blobs alone underflows.
+    const pending = new DatabaseSync(join(target.workspaceRoot, 'context-offload.sqlite'));
+    try {
+      pending
+        .prepare('INSERT INTO context_file_deletions VALUES (?, 7, 0)')
+        .run(Buffer.from('sha256/aa/pending', 'utf8'));
+      pending.exec('UPDATE context_store_usage SET physical_bytes = physical_bytes + 7');
+    } finally {
+      pending.close();
+    }
+
+    await importState(target.workspaceRoot, source.workspaceRoot);
+
+    // 3 imported + 2 already there + 7 queued.
+    assert.equal(readContextUsage(target.workspaceRoot).physicalBytes, 12);
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('imports context into a workspace that has never held a Session', async () => {
+  const source = await makeWorkspace('maka-import-fresh-source');
+  const target = await makeWorkspace('maka-import-fresh-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const seeded = await seedContext(source.workspaceRoot, sessionId, 'ABC');
+
+    // Nothing has run here: no Storage Root marker, no context database. The
+    // snapshot lock used to only *discover* a marked root, so the first import
+    // into a new workspace failed `root_unmarked` -- exactly the case a user
+    // hits when they receive a bundle before starting any Session.
+    const imported = await importState(target.workspaceRoot, source.workspaceRoot);
+    assert.deepEqual([...imported.sessionIds], [sessionId]);
+    assert.equal(imported.contextRefs, 1);
+
+    const { readFile } = await import('node:fs/promises');
+    assert.equal(
+      await readFile(
+        join(target.workspaceRoot, 'context-offload-values', seeded.relativePath),
+        'utf8',
+      ),
+      'ABC',
+    );
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('accepts an identical artifact left by a crashed attempt, and only an identical one', async () => {
+  const source = await makeWorkspace('maka-import-leftover-source');
+  const target = await makeWorkspace('maka-import-leftover-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const relativePath = await seedArtifact(source.workspaceRoot, sessionId, 'a1', 'BYTES');
+
+    // A crash between staging the artifact and the rollback leaves the file
+    // behind with no row to explain it. `COPYFILE_EXCL` refuses it, so without
+    // this the workspace can never import that bundle again.
+    const staged = join(target.workspaceRoot, 'artifacts', relativePath);
+    await mkdir(join(target.workspaceRoot, 'artifacts', sessionId), { recursive: true });
+    await writeFile(staged, 'DIFFERENT');
+    await assert.rejects(
+      () => importState(target.workspaceRoot, source.workspaceRoot),
+      /Artifact already present/,
+      'a leftover naming different bytes is a real collision, not a retry',
+    );
+
+    await writeFile(staged, 'BYTES');
+    const imported = await importState(target.workspaceRoot, source.workspaceRoot);
+    assert.deepEqual([...imported.sessionIds], [sessionId]);
+    const { readFile } = await import('node:fs/promises');
+    assert.equal(await readFile(staged, 'utf8'), 'BYTES');
   } finally {
     await rm(source.root, { recursive: true, force: true });
     await rm(target.root, { recursive: true, force: true });

--- a/packages/runtime/src/__tests__/session-import.test.ts
+++ b/packages/runtime/src/__tests__/session-import.test.ts
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { test } from 'node:test';
+import { OPERATIONAL_STATE_DATABASE_NAME } from '@maka/storage/operational-state-store';
+import { createSessionStore } from '@maka/storage/session-store';
+import { exportSessionBundle } from '../session-export.js';
+import { importSessionBundle } from '../session-import.js';
+
+const CONNECTION_SLUG = 'test-connection';
+const MODEL = 'test-model';
+
+async function makeWorkspace(name: string): Promise<{ root: string; workspaceRoot: string }> {
+  const root = await mkdtemp(join(tmpdir(), `${name}-`));
+  const workspaceRoot = join(root, 'workspace');
+  await mkdir(workspaceRoot, { recursive: true });
+  return { root, workspaceRoot };
+}
+
+async function createSession(workspaceRoot: string, name = 'Exported'): Promise<string> {
+  const store = createSessionStore(workspaceRoot);
+  try {
+    const header = await store.create({
+      cwd: workspaceRoot,
+      llmConnectionSlug: CONNECTION_SLUG,
+      model: MODEL,
+      permissionMode: 'ask',
+      name,
+    });
+    return header.id;
+  } finally {
+    await store.close?.();
+  }
+}
+
+function openDatabase(workspaceRoot: string, readOnly = false): DatabaseSync {
+  return new DatabaseSync(join(workspaceRoot, OPERATIONAL_STATE_DATABASE_NAME), {
+    ...(readOnly ? { readOnly: true } : {}),
+  });
+}
+
+/** Seed a Session with the history an import has to reproduce exactly. */
+async function seedHistory(workspaceRoot: string, sessionId: string): Promise<void> {
+  const db = openDatabase(workspaceRoot);
+  try {
+    db.exec(`
+      INSERT INTO runtime_events(
+        session_id, run_id, invocation_id, turn_id, event_id, event_seq,
+        event_kind, committed_at, payload_json
+      )
+      VALUES
+        ('${sessionId}', 'run-1', 'invocation-1', 'turn-1', 'evt-user', 1, 'text', 1,
+          '{ "role": "user", "big": 9007199254740993 }'),
+        ('${sessionId}', 'run-1', 'invocation-1', 'turn-1', 'evt-model', 2, 'text', 2,
+          '{"role":"model","text":"ok"}'),
+        ('${sessionId}', 'run-1', 'invocation-1', 'turn-1', 'evt-done', 3, 'completed', 3,
+          '{"status":"completed"}');
+      INSERT INTO core_agent_runs(session_id, run_id, created_at)
+      VALUES ('${sessionId}', 'run-1', 0);
+      INSERT INTO core_agent_run_events(
+        session_id, run_id, sequence, event_id, event_type, event_ts, record_json
+      )
+      VALUES ('${sessionId}', 'run-1', 0, 'ckpt', 'history_compact_checkpoint_recorded', 1,
+        '{ "checkpoint": {"kept":true} }');
+    `);
+  } finally {
+    db.close();
+  }
+}
+
+function readSessionRows(
+  workspaceRoot: string,
+  sessionId: string,
+): { events: unknown[]; runEvents: unknown[]; metadata: unknown } {
+  const db = openDatabase(workspaceRoot, true);
+  try {
+    return {
+      events: db
+        .prepare('SELECT * FROM runtime_events WHERE session_id = ? ORDER BY event_seq')
+        .all(sessionId),
+      runEvents: db
+        .prepare('SELECT * FROM core_agent_run_events WHERE session_id = ? ORDER BY sequence')
+        .all(sessionId),
+      metadata: db.prepare('SELECT * FROM session_metadata WHERE session_id = ?').get(sessionId),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+test('round-trips a Session into another workspace, row for row', async () => {
+  const source = await makeWorkspace('maka-import-source');
+  const target = await makeWorkspace('maka-import-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    // Somebody else's Session, so the target is not an empty database.
+    await createSession(target.workspaceRoot, 'Unrelated');
+
+    const bundle = join(source.root, 'bundle.maka-session');
+    const exported = await exportSessionBundle({
+      workspaceRoot: source.workspaceRoot,
+      sessionId,
+      destination: bundle,
+    });
+    assert.equal(exported.ok, true);
+
+    const imported = await importSessionBundle({
+      workspaceRoot: target.workspaceRoot,
+      source: bundle,
+    });
+    if (!imported.ok) assert.fail(`import failed: ${JSON.stringify(imported.reason)}`);
+    assert.deepEqual(imported.sessionIds, [sessionId]);
+
+    // The acceptance criterion: the rows the model reads are the same rows,
+    // as bytes. JSON equivalence would pass on a re-encoding that changed them.
+    assert.deepEqual(
+      readSessionRows(target.workspaceRoot, sessionId),
+      readSessionRows(source.workspaceRoot, sessionId),
+    );
+
+    // And the workspace it landed in kept what it already had.
+    const db = openDatabase(target.workspaceRoot, true);
+    try {
+      const count = db.prepare('SELECT COUNT(*) AS count FROM session_metadata').get() as {
+        count?: unknown;
+      };
+      assert.equal(Number(count.count), 2);
+    } finally {
+      db.close();
+    }
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('refuses a Session this workspace already has', async () => {
+  const source = await makeWorkspace('maka-import-conflict');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const bundle = join(source.root, 'bundle.maka-session');
+    await exportSessionBundle({
+      workspaceRoot: source.workspaceRoot,
+      sessionId,
+      destination: bundle,
+    });
+
+    // Importing back into the workspace it came from. Session ids are
+    // generated, so one already present means this Session is already here.
+    const result = await importSessionBundle({
+      workspaceRoot: source.workspaceRoot,
+      source: bundle,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.ok === false && result.reason.kind, 'session_exists');
+
+    const db = openDatabase(source.workspaceRoot, true);
+    try {
+      const count = db.prepare('SELECT COUNT(*) AS count FROM runtime_events').get() as {
+        count?: unknown;
+      };
+      // A refusal writes nothing: the history is what it was.
+      assert.equal(Number(count.count), 3);
+    } finally {
+      db.close();
+    }
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+  }
+});
+
+test('carries the subagent subtree and its artifact bytes across', async () => {
+  const source = await makeWorkspace('maka-import-subtree-source');
+  const target = await makeWorkspace('maka-import-subtree-target');
+  try {
+    const store = createSessionStore(source.workspaceRoot);
+    let parentId: string;
+    let childId: string;
+    try {
+      const parent = await store.create({
+        cwd: source.workspaceRoot,
+        llmConnectionSlug: CONNECTION_SLUG,
+        model: MODEL,
+        permissionMode: 'ask',
+      });
+      parentId = parent.id;
+      const child = await store.createSubagent({
+        cwd: source.workspaceRoot,
+        llmConnectionSlug: CONNECTION_SLUG,
+        model: MODEL,
+        permissionMode: 'ask',
+        subagentParent: {
+          kind: 'subagent' as const,
+          parentSessionId: parent.id,
+          spawnedBy: { parentRunId: 'r', parentTurnId: 't', toolCallId: 'call-1' },
+          lifecycle: 'foreground',
+        },
+        subagentRuntime: {
+          schemaVersion: 1,
+          definitionVersion: 1,
+          agentId: 'local-read',
+          agentName: 'Local Read',
+          profile: 'local_read',
+          systemPrompt: 'Read.',
+          toolNames: ['Read'],
+          categoryPolicy: { read: 'allow' },
+        },
+        subagentSpawn: {
+          schemaVersion: 1,
+          requestFingerprint: 'a'.repeat(64),
+          initialTurnId: 'child-turn',
+          initialRunId: 'child-run',
+        },
+      } as Parameters<typeof store.createSubagent>[0]);
+      childId = child.header.id;
+    } finally {
+      await store.close?.();
+    }
+
+    const relativePath = `${childId}/child-file.txt`;
+    await mkdir(join(source.workspaceRoot, 'artifacts', childId), { recursive: true });
+    await writeFile(join(source.workspaceRoot, 'artifacts', relativePath), 'CHILD-BYTES');
+    const db = openDatabase(source.workspaceRoot);
+    try {
+      db.prepare(`
+        INSERT INTO artifact_records(artifact_id, session_id, created_at, relative_path, record_json)
+        VALUES ('child', ?, 0, ?, ?)
+      `).run(
+        childId,
+        relativePath,
+        JSON.stringify({
+          id: 'child',
+          sessionId: childId,
+          turnId: 'turn-1',
+          createdAt: 0,
+          name: 'file.txt',
+          kind: 'file',
+          relativePath,
+          sizeBytes: 11,
+          source: 'tool_result',
+        }),
+      );
+    } finally {
+      db.close();
+    }
+
+    const bundle = join(source.root, 'bundle.maka-session');
+    await exportSessionBundle({
+      workspaceRoot: source.workspaceRoot,
+      sessionId: parentId,
+      destination: bundle,
+    });
+    const imported = await importSessionBundle({
+      workspaceRoot: target.workspaceRoot,
+      source: bundle,
+    });
+    if (!imported.ok) assert.fail(`import failed: ${JSON.stringify(imported.reason)}`);
+
+    assert.deepEqual([...imported.sessionIds].sort(), [parentId, childId].sort());
+    assert.equal(imported.artifactFiles, 1);
+    // The link is not the child Session: without `subagent_spawns` the target
+    // holds two Sessions and nothing saying which tool call joined them.
+    const targetDb = openDatabase(target.workspaceRoot, true);
+    try {
+      const link = targetDb
+        .prepare('SELECT parent_session_id FROM subagent_spawns WHERE child_session_id = ?')
+        .get(childId) as { parent_session_id?: unknown };
+      assert.equal(String(link?.parent_session_id), parentId);
+    } finally {
+      targetDb.close();
+    }
+    const { readFile } = await import('node:fs/promises');
+    assert.equal(
+      await readFile(join(target.workspaceRoot, 'artifacts', relativePath), 'utf8'),
+      'CHILD-BYTES',
+    );
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});

--- a/packages/runtime/src/__tests__/session-import.test.ts
+++ b/packages/runtime/src/__tests__/session-import.test.ts
@@ -417,3 +417,181 @@ test('refuses a bundle written against a different schema', async () => {
     await rm(target.root, { recursive: true, force: true });
   }
 });
+
+/** Give a workspace a context store holding one managed-file payload. */
+async function seedContext(
+  workspaceRoot: string,
+  sessionId: string,
+  bytes: string,
+): Promise<{ relativePath: string; blobId: Buffer }> {
+  // The offline context authority only works on a marked Storage Root, so a
+  // workspace holding context has to be one.
+  const { resolveStorageRoot } = await import('@maka/storage/root-authority');
+  await resolveStorageRoot({ path: workspaceRoot, kind: 'interactive' });
+  const { createHash } = await import('node:crypto');
+  const digest = createHash('sha256').update(bytes).digest();
+  const hex = digest.toString('hex');
+  // The layout the context store uses: a payload is addressed by its content.
+  const relativePath = `sha256/${hex.slice(0, 2)}/${hex}`;
+  const values = join(workspaceRoot, 'context-offload-values');
+  await mkdir(join(values, 'sha256', hex.slice(0, 2)), { recursive: true });
+  await writeFile(join(values, relativePath), bytes);
+
+  const db = new DatabaseSync(join(workspaceRoot, 'context-offload.sqlite'));
+  try {
+    db.exec(`
+      PRAGMA user_version = 3;
+      CREATE TABLE context_blobs (
+        blob_id BLOB PRIMARY KEY CHECK(length(blob_id) = 32),
+        storage_kind TEXT NOT NULL CHECK(storage_kind IN ('inline', 'managed_file')),
+        payload BLOB NOT NULL,
+        size_bytes INTEGER NOT NULL CHECK(size_bytes >= 0)
+      );
+      CREATE TABLE context_refs (
+        ref_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        owner_kind TEXT NOT NULL,
+        blob_id BLOB NOT NULL REFERENCES context_blobs(blob_id)
+      );
+      CREATE TABLE context_gc_candidates (blob_id BLOB PRIMARY KEY, unreferenced_at INTEGER NOT NULL);
+      CREATE TABLE context_file_deletions (locator BLOB PRIMARY KEY, size_bytes INTEGER NOT NULL, enqueued_at INTEGER NOT NULL);
+      CREATE TABLE context_session_usage (session_id TEXT PRIMARY KEY, ref_count INTEGER NOT NULL, logical_bytes INTEGER NOT NULL);
+      CREATE TABLE context_store_usage (singleton INTEGER PRIMARY KEY CHECK(singleton = 1), blob_count INTEGER NOT NULL, physical_bytes INTEGER NOT NULL);
+      INSERT INTO context_store_usage VALUES (1, 0, 0);
+    `);
+    db.prepare("INSERT INTO context_blobs VALUES (?, 'managed_file', ?, ?)").run(
+      digest,
+      Buffer.from(relativePath, 'utf8'),
+      bytes.length,
+    );
+    db.prepare("INSERT INTO context_refs VALUES (?, ?, 'message', ?)").run(
+      `ref-${sessionId}`,
+      sessionId,
+      digest,
+    );
+    db.exec(`
+      INSERT INTO context_session_usage
+        SELECT r.session_id, count(*), sum(b.size_bytes)
+        FROM context_refs r JOIN context_blobs b USING(blob_id) GROUP BY r.session_id;
+      UPDATE context_store_usage SET blob_count = 1, physical_bytes = ${bytes.length} WHERE singleton = 1;
+    `);
+  } finally {
+    db.close();
+  }
+  return { relativePath, blobId: digest };
+}
+
+function readContextUsage(workspaceRoot: string): {
+  blobCount: number;
+  physicalBytes: number;
+  sessionRows: number;
+} {
+  const db = new DatabaseSync(join(workspaceRoot, 'context-offload.sqlite'), { readOnly: true });
+  try {
+    const store = db.prepare('SELECT blob_count, physical_bytes FROM context_store_usage').get() as
+      | { blob_count?: unknown; physical_bytes?: unknown }
+      | undefined;
+    const sessions = db.prepare('SELECT COUNT(*) AS count FROM context_session_usage').get() as {
+      count?: unknown;
+    };
+    return {
+      blobCount: Number(store?.blob_count ?? -1),
+      physicalBytes: Number(store?.physical_bytes ?? -1),
+      sessionRows: Number(sessions.count ?? -1),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+test('carries managed context payloads and keeps usage accounting true', async () => {
+  const source = await makeWorkspace('maka-import-context-source');
+  const target = await makeWorkspace('maka-import-context-target');
+  try {
+    // Build the bundle's state tree directly. The merge is what these findings
+    // are about, and going through pack/hydrate to reach it only adds the
+    // Storage Root machinery to the fixture.
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const payload = 'IMG';
+    const seeded = await seedContext(source.workspaceRoot, sessionId, payload);
+
+    const targetSession = await createSession(target.workspaceRoot, 'Unrelated');
+    await seedContext(target.workspaceRoot, targetSession, 'ZZ');
+
+    const { importSessionBundleState } = await import('@maka/storage/session-bundle-policy');
+    const merged = await importSessionBundleState({
+      stateRoot: target.workspaceRoot,
+      bundleStateRoot: source.workspaceRoot,
+    });
+    assert.equal(merged.contextRefs, 1);
+
+    // Read the payload rather than count the reference: a reference whose bytes
+    // never arrived counts exactly the same. Managed payloads live at
+    // `sha256/<prefix>/<hash>`, so a copy that visited only immediate children
+    // saw one directory, skipped it, and reported success.
+    const { readFile } = await import('node:fs/promises');
+    assert.equal(
+      await readFile(
+        join(target.workspaceRoot, 'context-offload-values', seeded.relativePath),
+        'utf8',
+      ),
+      payload,
+    );
+
+    // These numbers drive quotas and the cleanup consistency checks, and no
+    // trigger maintains them, so a stale count is not a display problem.
+    const usage = readContextUsage(target.workspaceRoot);
+    assert.equal(usage.blobCount, 2);
+    assert.equal(usage.physicalBytes, 5);
+    assert.equal(usage.sessionRows, 2);
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('publishes nothing when the context merge fails, so a retry is still possible', async () => {
+  const source = await makeWorkspace('maka-import-retry-source');
+  const target = await makeWorkspace('maka-import-retry-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    await seedContext(source.workspaceRoot, sessionId, 'ABC');
+
+    const targetSession = await createSession(target.workspaceRoot, 'Unrelated');
+    await seedContext(target.workspaceRoot, targetSession, 'ZZ');
+    // Collide the reference ids so the context merge fails partway. Any context
+    // failure would do; this one needs no injection point in the code.
+    const collide = new DatabaseSync(join(target.workspaceRoot, 'context-offload.sqlite'));
+    try {
+      collide.prepare('UPDATE context_refs SET ref_id = ?').run(`ref-${sessionId}`);
+    } finally {
+      collide.close();
+    }
+
+    const { importSessionBundleState } = await import('@maka/storage/session-bundle-policy');
+    await assert.rejects(() =>
+      importSessionBundleState({
+        stateRoot: target.workspaceRoot,
+        bundleStateRoot: source.workspaceRoot,
+      }),
+    );
+
+    // The Session rows are the last thing written, so a failure reaching them
+    // leaves nothing published. Had they gone first, the ids would now be taken
+    // and the retry would report `session_exists` forever.
+    const after = openDatabase(target.workspaceRoot, true);
+    try {
+      const present = after
+        .prepare('SELECT COUNT(*) AS count FROM session_metadata WHERE session_id = ?')
+        .get(sessionId) as { count?: unknown };
+      assert.equal(Number(present.count), 0);
+    } finally {
+      after.close();
+    }
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});

--- a/packages/runtime/src/session-import.ts
+++ b/packages/runtime/src/session-import.ts
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Import a `.maka-session` bundle into a workspace.
+ *
+ * The mirror of the export: `hydrate()` verifies and unpacks what `pack()`
+ * sealed, and `importSessionBundleState()` merges what the export policy
+ * prepared. This module is the thin part -- verify, merge, report.
+ *
+ * The bundle names its connection by slug; nothing here resolves it. A Session
+ * whose slug this workspace does not have arrives in the state the app already
+ * shows for that: stale, and routable once the user picks a connection.
+ */
+
+import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  SessionBundleFileError,
+  type SessionBundleLimits,
+} from '@maka/storage/session-bundle-contract';
+import { createSessionBundleFileService } from '@maka/storage/session-bundle-file-service';
+import {
+  importSessionBundleState,
+  SessionBundleImportError,
+} from '@maka/storage/session-bundle-policy';
+import { SESSION_EXPORT_BUNDLE_LIMITS, type SessionExportManifest } from './session-export.js';
+
+export interface ImportSessionBundleInput {
+  workspaceRoot: string;
+  /** The `.maka-session` file to read. */
+  source: string;
+  limits?: SessionBundleLimits;
+}
+
+export type ImportSessionBundleFailure =
+  | { kind: 'workspace_not_found'; workspaceRoot: string }
+  | { kind: 'bundle_unreadable'; message: string }
+  /** One of the bundle's Sessions is already in this workspace. */
+  | { kind: 'session_exists'; message: string }
+  /** The bundle was made against a schema this workspace does not read. */
+  | { kind: 'schema_unsupported'; message: string }
+  | { kind: 'conflict'; message: string }
+  | { kind: 'io_failed'; message: string };
+
+export type ImportSessionBundleResult =
+  | {
+      ok: true;
+      sessionIds: string[];
+      artifactFiles: number;
+      contextRefs: number;
+      manifest: SessionExportManifest | undefined;
+    }
+  | { ok: false; reason: ImportSessionBundleFailure };
+
+export async function importSessionBundle(
+  input: ImportSessionBundleInput,
+): Promise<ImportSessionBundleResult> {
+  if (!(await isDirectory(input.workspaceRoot))) {
+    return {
+      ok: false,
+      reason: { kind: 'workspace_not_found', workspaceRoot: input.workspaceRoot },
+    };
+  }
+  const limits = input.limits ?? SESSION_EXPORT_BUNDLE_LIMITS;
+  const staging = await mkdtemp(join(tmpdir(), 'maka-session-import-'));
+  try {
+    const service = createSessionBundleFileService();
+    // Read the identity before hydrating: the codec verifies a bundle against a
+    // Session id, and the bundle is the only thing that knows which one.
+    const inspection = await service.inspect({ source: { path: input.source }, limits });
+    const manifest = readExportManifest(inspection.stateIdentity.bytes);
+    const hydration = await service.hydrate({
+      source: { path: input.source },
+      limits,
+      expectedSessionId: manifest?.rootSessionId ?? inspection.manifest.envelope.sessionId,
+      destinationRoot: join(staging, 'hydrated'),
+    });
+
+    const merged = await importSessionBundleState({
+      stateRoot: input.workspaceRoot,
+      bundleStateRoot: hydration.stateRoot,
+    });
+    return { ok: true, ...merged, manifest };
+  } catch (error) {
+    if (error instanceof SessionBundleImportError) {
+      switch (error.code) {
+        case 'session_exists':
+          return { ok: false, reason: { kind: 'session_exists', message: error.message } };
+        case 'schema_unsupported':
+          return { ok: false, reason: { kind: 'schema_unsupported', message: error.message } };
+        case 'conflict':
+          return { ok: false, reason: { kind: 'conflict', message: error.message } };
+        default:
+          return { ok: false, reason: { kind: 'io_failed', message: error.message } };
+      }
+    }
+    if (error instanceof SessionBundleFileError) {
+      return { ok: false, reason: { kind: 'bundle_unreadable', message: error.message } };
+    }
+    return { ok: false, reason: { kind: 'io_failed', message: String(error) } };
+  } finally {
+    await rm(staging, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function readExportManifest(bytes: Uint8Array): SessionExportManifest | undefined {
+  try {
+    const parsed = JSON.parse(Buffer.from(bytes).toString('utf8')) as SessionExportManifest;
+    return parsed.format === 'maka.session-export' ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  return stat(path)
+    .then((metadata) => metadata.isDirectory())
+    .catch(() => false);
+}

--- a/packages/storage/src/context-offload-snapshot.ts
+++ b/packages/storage/src/context-offload-snapshot.ts
@@ -25,6 +25,7 @@ import { backup, DatabaseSync } from 'node:sqlite';
 import { isCanonicalStorageRef } from '@maka/core/events';
 import {
   discoverMarkedStorageRoot,
+  resolveStorageRoot,
   runWithStorageRootLease,
   tryAcquireInteractiveRootOwner,
 } from './root-authority.js';
@@ -65,7 +66,14 @@ export async function withOfflineContextSnapshot<T>(
   ) {
     return operation(false);
   }
-  const capability = await discoverMarkedStorageRoot({ path: root });
+  // Discovery finds a marked root; it does not make one. A workspace that has
+  // never been opened is exactly the target an import writes to first, so when
+  // the caller says it is about to write, the root is resolved -- which
+  // initialises it -- rather than merely looked for.
+  const capability =
+    options.requireAuthority === true
+      ? await resolveStorageRoot({ path: root, kind: 'interactive' })
+      : await discoverMarkedStorageRoot({ path: root });
   const owner = await tryAcquireInteractiveRootOwner(capability);
   if (!owner)
     throw new Error(

--- a/packages/storage/src/context-offload-snapshot.ts
+++ b/packages/storage/src/context-offload-snapshot.ts
@@ -47,8 +47,24 @@ import { SQLITE_SESSION_MESSAGE_CHUNK_MARKER } from './sqlite-session-metadata-s
 export async function withOfflineContextSnapshot<T>(
   root: string,
   operation: (contextLocked: boolean) => Promise<T>,
+  options: {
+    /**
+     * Take the authority even when the root has no context database yet.
+     *
+     * A reader only needs it when there is something to read, but a writer
+     * that is about to CREATE the context store needs it too -- otherwise the
+     * one case where it matters most, a fresh workspace, is the one case that
+     * runs unprotected.
+     */
+    requireAuthority?: boolean;
+  } = {},
 ): Promise<T> {
-  if (!(await exists(join(root, CONTEXT_OFFLOAD_DATABASE_NAME)))) return operation(false);
+  if (
+    options.requireAuthority !== true &&
+    !(await exists(join(root, CONTEXT_OFFLOAD_DATABASE_NAME)))
+  ) {
+    return operation(false);
+  }
   const capability = await discoverMarkedStorageRoot({ path: root });
   const owner = await tryAcquireInteractiveRootOwner(capability);
   if (!owner)

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -900,48 +900,64 @@ export async function importSessionBundleState(
   const bundleDatabasePath = resolveInside(bundleStateRoot, OPERATIONAL_STATE_DATABASE_NAME);
   await assertRegularFile(bundleDatabasePath, OPERATIONAL_STATE_DATABASE_NAME);
 
-  return withOfflineContextSnapshot(input.stateRoot, (contextLocked) =>
-    withArtifactWriterLock(input.stateRoot, async (stateRoot) => {
-      const sessionIds = readBundleSessionIds(bundleDatabasePath);
-      if (sessionIds.length === 0) {
-        throw new SessionBundleImportError('invalid_root', 'Bundle carries no Session');
-      }
+  // The authority is decided by what is being written, not by what the target
+  // already has. A bundle carrying context needs it even for a fresh workspace
+  // with no context store yet -- which is exactly the case that would otherwise
+  // run unprotected, and the common one.
+  const bundleCarriesContext = await pathExists(
+    resolveInside(bundleStateRoot, CONTEXT_OFFLOAD_DATABASE_NAME),
+  );
 
-      // The export refuses to migrate its source because it only reads. An
-      // import is a write the user asked for, and the target is often a
-      // workspace with no database yet -- moving to a new machine is the whole
-      // point -- so this opens the ordinary way and lets it be initialised.
-      let lease: OperationalStateDatabaseLease;
-      try {
-        lease = acquireOperationalStateDatabase(stateRoot);
-      } catch (error) {
-        // A target this build cannot open is a schema verdict, not an IO one;
-        // everything else the operational store raises is the environment.
-        if (error instanceof OperationalStateMigrationBlockedError) {
-          throw new SessionBundleImportError(
-            'schema_unsupported',
-            'Workspace schema cannot be opened by this build',
-            { cause: error },
-          );
+  return withOfflineContextSnapshot(
+    input.stateRoot,
+    (contextLocked) =>
+      withArtifactWriterLock(input.stateRoot, async (stateRoot) => {
+        const sessionIds = readBundleSessionIds(bundleDatabasePath);
+        if (sessionIds.length === 0) {
+          throw new SessionBundleImportError('invalid_root', 'Bundle carries no Session');
         }
-        throw error;
-      }
-      try {
-        assertBundleSchemaMatches(lease.database, bundleDatabasePath);
-        assertImportableInto(lease.database, sessionIds);
-        const artifactFiles = await copyBundleArtifacts(bundleStateRoot, stateRoot);
-        const inserted = mergeBundleDatabase(lease, bundleDatabasePath);
-        const contextRefs = await mergeBundleContext(
-          bundleStateRoot,
-          stateRoot,
-          contextLocked,
-          sessionIds,
-        );
-        return { sessionIds: inserted, artifactFiles, contextRefs };
-      } finally {
-        lease.close();
-      }
-    }),
+
+        // The export refuses to migrate its source because it only reads. An
+        // import is a write the user asked for, and the target is often a
+        // workspace with no database yet -- moving to a new machine is the whole
+        // point -- so this opens the ordinary way and lets it be initialised.
+        let lease: OperationalStateDatabaseLease;
+        try {
+          lease = acquireOperationalStateDatabase(stateRoot);
+        } catch (error) {
+          // A target this build cannot open is a schema verdict, not an IO one;
+          // everything else the operational store raises is the environment.
+          if (error instanceof OperationalStateMigrationBlockedError) {
+            throw new SessionBundleImportError(
+              'schema_unsupported',
+              'Workspace schema cannot be opened by this build',
+              { cause: error },
+            );
+          }
+          throw error;
+        }
+        try {
+          assertBundleSchemaMatches(lease.database, bundleDatabasePath);
+          assertImportableInto(lease.database, sessionIds);
+          // Everything the Session will reference lands first; the Session rows
+          // are the last thing written. A failure before that leaves artifacts
+          // and context nothing points at, which the store reclaims, rather than
+          // a Session already visible whose bytes never arrived -- and which a
+          // retry could not fix, because the ids are now taken.
+          const artifactFiles = await copyBundleArtifacts(bundleStateRoot, stateRoot);
+          const contextRefs = await mergeBundleContext(
+            bundleStateRoot,
+            stateRoot,
+            contextLocked,
+            sessionIds,
+          );
+          const inserted = mergeBundleDatabase(lease, bundleDatabasePath);
+          return { sessionIds: inserted, artifactFiles, contextRefs };
+        } finally {
+          lease.close();
+        }
+      }),
+    { requireAuthority: bundleCarriesContext },
   );
 }
 
@@ -998,6 +1014,22 @@ function readSchemaRegistry(database: DatabaseSync): Record<string, number> {
 function readUserVersionPragma(database: DatabaseSync): number {
   const row = (database.prepare('PRAGMA user_version').get() ?? {}) as Record<string, unknown>;
   return Number(Object.values(row)[0] ?? -1);
+}
+
+/** The same question the export asks before deleting a table wholesale. */
+function describesASession(target: DatabaseSync, table: string): boolean {
+  if (PORTABLE_DERIVED_TABLES.has(table)) return true;
+  const columns = new Set(
+    (
+      target.prepare(`PRAGMA bundle.table_info(${quoteIdentifier(table)})`).all() as Array<{
+        name?: unknown;
+      }>
+    )
+      .map((column) => column.name)
+      .filter((name): name is string => typeof name === 'string'),
+  );
+  if (columns.has(SESSION_ROW_OWNER_COLUMN)) return true;
+  return SESSION_LINK_COLUMNS.some((column) => columns.has(column));
 }
 
 function readBundleSessionIds(bundleDatabasePath: string): string[] {
@@ -1129,6 +1161,13 @@ function mergeAttachedBundle(target: DatabaseSync): string[] {
         ) {
           continue;
         }
+        // Mirror the export's own classification instead of trusting that it
+        // ran: a table with no Session column and no referential rule describes
+        // the WORKSPACE, and the target has its own. The export empties those,
+        // so in practice this inserts nothing -- but an import that depends on
+        // the other side having tidied up is one bundle away from writing a
+        // workspace singleton into somebody else's workspace.
+        if (!describesASession(target, name)) continue;
         const quoted = quoteIdentifier(name);
         target.exec(`INSERT INTO main.${quoted} SELECT * FROM bundle.${quoted}`);
       }
@@ -1179,23 +1218,13 @@ async function mergeBundleContext(
     );
   }
 
-  const bundleValues = resolveInside(bundleStateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME);
-  if (await pathExists(bundleValues)) {
-    const targetValues = resolveInside(stateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME);
-    for (const entry of await readdir(bundleValues, { withFileTypes: true })) {
-      if (!entry.isFile()) continue;
-      const destination = resolveInside(targetValues, entry.name);
-      await mkdir(dirname(destination), { recursive: true });
-      // Managed files are named by content, so an existing one is the same one.
-      await copyFile(
-        resolveInside(bundleValues, entry.name),
-        destination,
-        constants.COPYFILE_EXCL,
-      ).catch((error: unknown) => {
-        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-      });
-    }
-  }
+  // Managed payloads live at `sha256/<prefix>/<hash>`, so a copy that visited
+  // only immediate children saw one directory, skipped it, and reported a
+  // successful import whose referenced bytes were all absent.
+  await copyContextValueTree(
+    resolveInside(bundleStateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME),
+    resolveInside(stateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME),
+  );
 
   const targetContext = resolveInside(stateRoot, CONTEXT_OFFLOAD_DATABASE_NAME);
   if (!(await pathExists(targetContext))) {
@@ -1212,6 +1241,21 @@ async function mergeBundleContext(
           'INSERT OR IGNORE INTO main.context_blobs SELECT * FROM bundle.context_blobs',
         );
         database.exec('INSERT INTO main.context_refs SELECT * FROM bundle.context_refs');
+        // The context store maintains its usage tables explicitly -- no trigger
+        // does it. Inserting blobs and refs without them leaves quotas and the
+        // cleanup consistency checks reading numbers that describe a store that
+        // no longer exists. Recomputed from what is actually there, which is
+        // the same thing the export does when it filters.
+        database.exec(`
+          DELETE FROM context_session_usage;
+          INSERT INTO context_session_usage
+            SELECT r.session_id, count(*), sum(b.size_bytes)
+            FROM context_refs r JOIN context_blobs b USING(blob_id) GROUP BY r.session_id;
+          UPDATE context_store_usage SET
+            blob_count = (SELECT count(*) FROM context_blobs),
+            physical_bytes = (SELECT coalesce(sum(size_bytes), 0) FROM context_blobs)
+          WHERE singleton = 1;
+        `);
         database.exec('COMMIT');
       } catch (error) {
         try {
@@ -1226,6 +1270,34 @@ async function mergeBundleContext(
     database.close();
   }
   return countContextRefs(targetContext, sessionIds);
+}
+
+/**
+ * Copy a managed-payload tree, structure and all.
+ *
+ * Content-addressed names mean an existing file is the same file, so an
+ * already-present payload is left alone rather than treated as a conflict.
+ */
+async function copyContextValueTree(source: string, destination: string): Promise<void> {
+  if (!(await pathExists(source))) return;
+  for (const entry of await readdir(source, { withFileTypes: true })) {
+    const from = resolveInside(source, entry.name);
+    const to = resolveInside(destination, entry.name);
+    if (entry.isDirectory()) {
+      await copyContextValueTree(from, to);
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new SessionBundleImportError(
+        'io_failed',
+        `Bundle context payload is not a regular file: ${entry.name}`,
+      );
+    }
+    await mkdir(dirname(to), { recursive: true });
+    await copyFile(from, to, constants.COPYFILE_EXCL).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    });
+  }
 }
 
 function countContextRefs(databasePath: string, sessionIds: readonly string[]): number {

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -50,6 +50,7 @@ import {
   acquireOperationalStateDatabase,
   inspectOperationalStateSchema,
   OPERATIONAL_STATE_DATABASE_NAME,
+  OperationalStateMigrationBlockedError,
 } from './operational-state-store.js';
 import { TERMINAL_RUNTIME_EVENT_SQL } from './runtime-transcript-query.js';
 import { isSafeStorageId } from './storage-id.js';
@@ -406,11 +407,19 @@ async function backupOperationalState(stateRoot: string, destinationPath: string
   try {
     lease = acquireOperationalStateDatabase(stateRoot, { schemaMigration: 'require_current' });
   } catch (error) {
-    throw new SessionBundleExportError(
-      'schema_unsupported',
-      'Session bundle source is not at the current schema',
-      { cause: error },
-    );
+    // Only a blocked migration means "this build cannot read that schema".
+    // A permission, busy or I/O failure is the environment talking, and the
+    // operational store preserves it deliberately -- flattening those into a
+    // schema verdict tells the caller to upgrade when the real answer is that
+    // the file could not be opened.
+    if (error instanceof OperationalStateMigrationBlockedError) {
+      throw new SessionBundleExportError(
+        'schema_unsupported',
+        'Session bundle source is not at the current schema',
+        { cause: error },
+      );
+    }
+    throw error;
   }
   try {
     await lease.backup(destinationPath);

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -613,6 +613,17 @@ const SESSION_LINK_COLUMNS = [
   'root_session_id',
 ] as const;
 
+/**
+ * Tables the target writes for itself.
+ *
+ * `session_metadata` carries triggers that maintain the catalog projection, so
+ * inserting the bundle's copy of it and then the Session row makes the trigger
+ * collide with what was just inserted. The projection is derived; letting the
+ * target derive it is both simpler and the only way it stays correct when the
+ * derivation changes.
+ */
+const TRIGGER_MAINTAINED_TABLES = new Set(['session_catalog_projection']);
+
 const PORTABLE_GLOBAL_TABLES = new Set([
   'operational_schema_migrations',
   'session_metadata_schema',
@@ -832,4 +843,309 @@ function assertSafeSessionId(sessionId: string): void {
 
 function quoteIdentifier(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
+}
+
+export type SessionBundleImportErrorCode =
+  | 'invalid_root'
+  | 'schema_unsupported'
+  | 'session_exists'
+  | 'conflict'
+  | 'io_failed';
+
+export class SessionBundleImportError extends Error {
+  constructor(
+    readonly code: SessionBundleImportErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'SessionBundleImportError';
+  }
+}
+
+export interface SessionBundleImportInput {
+  /** The workspace receiving the Sessions. */
+  stateRoot: string;
+  /** A hydrated bundle's state tree: the filtered database, artifacts, context. */
+  bundleStateRoot: string;
+}
+
+export interface SessionBundleImportResult {
+  sessionIds: string[];
+  artifactFiles: number;
+  contextRefs: number;
+}
+
+/**
+ * Merge a hydrated bundle into a workspace.
+ *
+ * The mirror of the export, and the asymmetry is the whole design: the export
+ * owns a private copy and can DELETE what is not the subtree, while the import
+ * writes into a live workspace holding other people's Sessions and can only
+ * ADD. What keeps that from needing a table list is that the bundle's database
+ * already contains nothing else -- so this copies every table it has, and a
+ * table added to the schema later travels in both directions without anyone
+ * updating a list.
+ *
+ * Write order is the safety argument. Artifact bytes land first and the
+ * database transaction commits last, so a failure between them leaves files
+ * nothing points at -- reclaimable -- rather than rows pointing at files that
+ * are not there.
+ */
+export async function importSessionBundleState(
+  input: SessionBundleImportInput,
+): Promise<SessionBundleImportResult> {
+  const bundleStateRoot = await canonicalRoot(input.bundleStateRoot, 'bundle state');
+  const bundleDatabasePath = resolveInside(bundleStateRoot, OPERATIONAL_STATE_DATABASE_NAME);
+  await assertRegularFile(bundleDatabasePath, OPERATIONAL_STATE_DATABASE_NAME);
+
+  return withOfflineContextSnapshot(input.stateRoot, (contextLocked) =>
+    withArtifactWriterLock(input.stateRoot, async (stateRoot) => {
+      const sessionIds = readBundleSessionIds(bundleDatabasePath);
+      if (sessionIds.length === 0) {
+        throw new SessionBundleImportError('invalid_root', 'Bundle carries no Session');
+      }
+
+      // The export refuses to migrate its source because it only reads. An
+      // import is a write the user asked for, and the target is often a
+      // workspace with no database yet -- moving to a new machine is the whole
+      // point -- so this opens the ordinary way and lets it be initialised.
+      const lease = acquireOperationalStateDatabase(stateRoot);
+      try {
+        const target = lease.database;
+        assertImportableInto(target, sessionIds);
+        const artifactFiles = await copyBundleArtifacts(bundleStateRoot, stateRoot);
+        const inserted = mergeBundleDatabase(target, bundleDatabasePath);
+        const contextRefs = await mergeBundleContext(
+          bundleStateRoot,
+          stateRoot,
+          contextLocked,
+          sessionIds,
+        );
+        return { sessionIds: inserted, artifactFiles, contextRefs };
+      } finally {
+        lease.close();
+      }
+    }),
+  );
+}
+
+function readBundleSessionIds(bundleDatabasePath: string): string[] {
+  const database = new DatabaseSync(bundleDatabasePath, { readOnly: true });
+  try {
+    return (
+      database
+        .prepare('SELECT session_id FROM session_metadata ORDER BY session_id')
+        .all() as Array<{
+        session_id?: unknown;
+      }>
+    ).map((row) => String(row.session_id));
+  } finally {
+    database.close();
+  }
+}
+
+/**
+ * Refuse before writing anything.
+ *
+ * Session ids are generated, not chosen, so one already present means this
+ * Session is already here -- not that two of them collided. Importing over it
+ * would merge two histories that share ids and agree about nothing else.
+ */
+function assertImportableInto(target: DatabaseSync, sessionIds: readonly string[]): void {
+  const existing = target.prepare('SELECT 1 FROM session_metadata WHERE session_id = ?');
+  const present = sessionIds.filter((sessionId) => existing.get(sessionId) !== undefined);
+  if (present.length > 0) {
+    throw new SessionBundleImportError(
+      'session_exists',
+      `Session already present in this workspace: ${present.join(', ')}`,
+    );
+  }
+}
+
+/** Bytes first: a file nothing points at is reclaimable, a row pointing at nothing is not. */
+async function copyBundleArtifacts(bundleStateRoot: string, stateRoot: string): Promise<number> {
+  const source = resolveInside(bundleStateRoot, 'artifacts');
+  if (!(await pathExists(source))) return 0;
+  let copied = 0;
+  const walk = async (relative: string): Promise<void> => {
+    const absolute = relative ? resolveInside(source, relative) : source;
+    for (const entry of await readdir(absolute, { withFileTypes: true })) {
+      const next = relative ? `${relative}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(next);
+        continue;
+      }
+      if (!entry.isFile()) {
+        throw new SessionBundleImportError(
+          'io_failed',
+          `Bundle artifact is not a regular file: ${next}`,
+        );
+      }
+      const destination = resolveInside(resolveInside(stateRoot, 'artifacts'), next);
+      await mkdir(dirname(destination), { recursive: true });
+      // Never overwrite: an existing path means this artifact is already here,
+      // which the Session precheck should have caught. Failing is the honest
+      // answer to being wrong about that.
+      await copyFile(resolveInside(source, next), destination, constants.COPYFILE_EXCL).catch(
+        (error: unknown) => {
+          if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+            throw new SessionBundleImportError('conflict', `Artifact already present: ${next}`);
+          }
+          throw error;
+        },
+      );
+      copied += 1;
+    }
+  };
+  await walk('');
+  return copied;
+}
+
+/**
+ * Copy every table the bundle has, in one transaction.
+ *
+ * No allow-list: the bundle's database was already filtered down to its own
+ * Sessions, so "everything it has" is exactly what belongs. Only the tables
+ * describing the WORKSPACE rather than a Session are skipped -- the target has
+ * its own, and they are not the bundle's to bring.
+ */
+function mergeBundleDatabase(target: DatabaseSync, bundleDatabasePath: string): string[] {
+  target.exec(`ATTACH DATABASE '${bundleDatabasePath.replaceAll("'", "''")}' AS bundle`);
+  try {
+    target.exec('PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE');
+    try {
+      const tables = target
+        .prepare(
+          "SELECT name FROM bundle.sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        )
+        .all() as Array<{ name?: unknown }>;
+      for (const row of tables) {
+        const name = row.name;
+        if (
+          typeof name !== 'string' ||
+          PORTABLE_GLOBAL_TABLES.has(name) ||
+          TRIGGER_MAINTAINED_TABLES.has(name)
+        ) {
+          continue;
+        }
+        const quoted = quoteIdentifier(name);
+        target.exec(`INSERT INTO main.${quoted} SELECT * FROM bundle.${quoted}`);
+      }
+      const violation = target.prepare('PRAGMA foreign_key_check').get();
+      if (violation) {
+        throw new SessionBundleImportError(
+          'conflict',
+          'Imported Sessions would leave dangling references',
+        );
+      }
+      const sessionIds = (
+        target
+          .prepare('SELECT session_id FROM bundle.session_metadata ORDER BY session_id')
+          .all() as Array<{ session_id?: unknown }>
+      ).map((entry) => String(entry.session_id));
+      target.exec('COMMIT');
+      return sessionIds;
+    } catch (error) {
+      try {
+        target.exec('ROLLBACK');
+      } catch {}
+      throw error;
+    }
+  } finally {
+    target.exec('DETACH DATABASE bundle');
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  return lstat(path)
+    .then(() => true)
+    .catch(() => false);
+}
+
+/**
+ * Merge the bundle's offloaded context into the workspace.
+ *
+ * Without this an imported Session arrives with its read-image references
+ * intact and none of the bytes behind them, which is the same hole the export
+ * had before it learned to carry the closure.
+ *
+ * Blobs are content-addressed, so an id already present is the same bytes and
+ * the insert is skipped rather than treated as a conflict.
+ */
+async function mergeBundleContext(
+  bundleStateRoot: string,
+  stateRoot: string,
+  contextLocked: boolean,
+  sessionIds: readonly string[],
+): Promise<number> {
+  const bundleContext = resolveInside(bundleStateRoot, CONTEXT_OFFLOAD_DATABASE_NAME);
+  if (!(await pathExists(bundleContext))) return 0;
+  if (!contextLocked) {
+    throw new SessionBundleImportError(
+      'io_failed',
+      'Context import requires an offline Storage Root; stop the Runtime Host first',
+    );
+  }
+
+  const bundleValues = resolveInside(bundleStateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME);
+  if (await pathExists(bundleValues)) {
+    const targetValues = resolveInside(stateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME);
+    for (const entry of await readdir(bundleValues, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      const destination = resolveInside(targetValues, entry.name);
+      await mkdir(dirname(destination), { recursive: true });
+      // Managed files are named by content, so an existing one is the same one.
+      await copyFile(
+        resolveInside(bundleValues, entry.name),
+        destination,
+        constants.COPYFILE_EXCL,
+      ).catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      });
+    }
+  }
+
+  const targetContext = resolveInside(stateRoot, CONTEXT_OFFLOAD_DATABASE_NAME);
+  if (!(await pathExists(targetContext))) {
+    await copyFile(bundleContext, targetContext);
+    return countContextRefs(targetContext, sessionIds);
+  }
+  const database = new DatabaseSync(targetContext);
+  try {
+    database.exec(`ATTACH DATABASE '${bundleContext.replaceAll("'", "''")}' AS bundle`);
+    try {
+      database.exec('BEGIN IMMEDIATE');
+      try {
+        database.exec(
+          'INSERT OR IGNORE INTO main.context_blobs SELECT * FROM bundle.context_blobs',
+        );
+        database.exec('INSERT INTO main.context_refs SELECT * FROM bundle.context_refs');
+        database.exec('COMMIT');
+      } catch (error) {
+        try {
+          database.exec('ROLLBACK');
+        } catch {}
+        throw error;
+      }
+    } finally {
+      database.exec('DETACH DATABASE bundle');
+    }
+  } finally {
+    database.close();
+  }
+  return countContextRefs(targetContext, sessionIds);
+}
+
+function countContextRefs(databasePath: string, sessionIds: readonly string[]): number {
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const placeholders = sessionIds.map(() => '?').join(', ');
+    const row = database
+      .prepare(`SELECT COUNT(*) AS count FROM context_refs WHERE session_id IN (${placeholders})`)
+      .get(...sessionIds) as { count?: unknown };
+    return Number(row.count ?? 0);
+  } finally {
+    database.close();
+  }
 }

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -51,6 +51,7 @@ import {
   inspectOperationalStateSchema,
   OPERATIONAL_STATE_DATABASE_NAME,
   OperationalStateMigrationBlockedError,
+  type OperationalStateDatabaseLease,
 } from './operational-state-store.js';
 import { TERMINAL_RUNTIME_EVENT_SQL } from './runtime-transcript-query.js';
 import { isSafeStorageId } from './storage-id.js';
@@ -910,12 +911,26 @@ export async function importSessionBundleState(
       // import is a write the user asked for, and the target is often a
       // workspace with no database yet -- moving to a new machine is the whole
       // point -- so this opens the ordinary way and lets it be initialised.
-      const lease = acquireOperationalStateDatabase(stateRoot);
+      let lease: OperationalStateDatabaseLease;
       try {
-        const target = lease.database;
-        assertImportableInto(target, sessionIds);
+        lease = acquireOperationalStateDatabase(stateRoot);
+      } catch (error) {
+        // A target this build cannot open is a schema verdict, not an IO one;
+        // everything else the operational store raises is the environment.
+        if (error instanceof OperationalStateMigrationBlockedError) {
+          throw new SessionBundleImportError(
+            'schema_unsupported',
+            'Workspace schema cannot be opened by this build',
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+      try {
+        assertBundleSchemaMatches(lease.database, bundleDatabasePath);
+        assertImportableInto(lease.database, sessionIds);
         const artifactFiles = await copyBundleArtifacts(bundleStateRoot, stateRoot);
-        const inserted = mergeBundleDatabase(target, bundleDatabasePath);
+        const inserted = mergeBundleDatabase(lease, bundleDatabasePath);
         const contextRefs = await mergeBundleContext(
           bundleStateRoot,
           stateRoot,
@@ -928,6 +943,61 @@ export async function importSessionBundleState(
       }
     }),
   );
+}
+
+/**
+ * Refuse a bundle written against a different schema.
+ *
+ * The merge copies rows with `INSERT ... SELECT *`, which maps by position. A
+ * bundle whose tables have a different column ORDER but the same count would
+ * be inserted silently transposed -- rows that read as data and are not. The
+ * export only ever writes a bundle at its own current schema, so any mismatch
+ * here means the two builds disagree, and the honest answer is to say so
+ * rather than to guess a mapping.
+ */
+function assertBundleSchemaMatches(target: DatabaseSync, bundleDatabasePath: string): void {
+  const bundle = new DatabaseSync(bundleDatabasePath, { readOnly: true });
+  try {
+    const bundleVersions = readSchemaRegistry(bundle);
+    const targetVersions = readSchemaRegistry(target);
+    for (const [scope, version] of Object.entries(bundleVersions)) {
+      if (targetVersions[scope] !== version) {
+        throw new SessionBundleImportError(
+          'schema_unsupported',
+          `Bundle schema ${scope} is ${version}; this workspace is ${
+            targetVersions[scope] ?? 'absent'
+          }`,
+        );
+      }
+    }
+    const bundleUserVersion = readUserVersionPragma(bundle);
+    const targetUserVersion = readUserVersionPragma(target);
+    if (bundleUserVersion !== targetUserVersion) {
+      throw new SessionBundleImportError(
+        'schema_unsupported',
+        `Bundle runtime schema is ${bundleUserVersion}; this workspace is ${targetUserVersion}`,
+      );
+    }
+  } finally {
+    bundle.close();
+  }
+}
+
+function readSchemaRegistry(database: DatabaseSync): Record<string, number> {
+  const versions: Record<string, number> = {};
+  for (const row of database
+    .prepare('SELECT scope, version FROM operational_schema_migrations')
+    .all() as Array<{ scope?: unknown; version?: unknown }>) {
+    if (typeof row.scope === 'string' && typeof row.version === 'number') {
+      versions[row.scope] = row.version;
+    }
+  }
+  return versions;
+}
+
+function readUserVersionPragma(database: DatabaseSync): number {
+  const row = (database.prepare('PRAGMA user_version').get() ?? {}) as Record<string, unknown>;
+  return Number(Object.values(row)[0] ?? -1);
 }
 
 function readBundleSessionIds(bundleDatabasePath: string): string[] {
@@ -1010,11 +1080,41 @@ async function copyBundleArtifacts(bundleStateRoot: string, stateRoot: string): 
  * describing the WORKSPACE rather than a Session are skipped -- the target has
  * its own, and they are not the bundle's to bring.
  */
-function mergeBundleDatabase(target: DatabaseSync, bundleDatabasePath: string): string[] {
-  target.exec(`ATTACH DATABASE '${bundleDatabasePath.replaceAll("'", "''")}' AS bundle`);
+function mergeBundleDatabase(
+  lease: OperationalStateDatabaseLease,
+  bundleDatabasePath: string,
+): string[] {
+  const target = lease.database;
+  // Read-only, so a bundle is never written by the act of reading it -- and so
+  // a hydrated staging tree cannot pick up a journal beside it.
+  const uri = `file:${encodeURI(bundleDatabasePath)}?mode=ro`;
+  target.exec(`ATTACH DATABASE '${uri.replaceAll("'", "''")}' AS bundle`);
   try {
-    target.exec('PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE');
+    // The lease owns a shared, reference-counted connection with its own
+    // transaction depth. Driving BEGIN/COMMIT directly would step around that,
+    // and the foreign-key pragma it needs must be put back: leaving it off
+    // would silently disarm constraint checking for every later user of this
+    // connection.
+    const restoreForeignKeys =
+      Number(
+        Object.values(
+          (target.prepare('PRAGMA foreign_keys').get() ?? {}) as Record<string, unknown>,
+        )[0] ?? 0,
+      ) === 1;
+    target.exec('PRAGMA foreign_keys = OFF');
     try {
+      return lease.transaction('write', () => mergeAttachedBundle(target));
+    } finally {
+      if (restoreForeignKeys) target.exec('PRAGMA foreign_keys = ON');
+    }
+  } finally {
+    target.exec('DETACH DATABASE bundle');
+  }
+}
+
+function mergeAttachedBundle(target: DatabaseSync): string[] {
+  {
+    {
       const tables = target
         .prepare(
           "SELECT name FROM bundle.sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
@@ -1039,21 +1139,12 @@ function mergeBundleDatabase(target: DatabaseSync, bundleDatabasePath: string): 
           'Imported Sessions would leave dangling references',
         );
       }
-      const sessionIds = (
+      return (
         target
           .prepare('SELECT session_id FROM bundle.session_metadata ORDER BY session_id')
           .all() as Array<{ session_id?: unknown }>
       ).map((entry) => String(entry.session_id));
-      target.exec('COMMIT');
-      return sessionIds;
-    } catch (error) {
-      try {
-        target.exec('ROLLBACK');
-      } catch {}
-      throw error;
     }
-  } finally {
-    target.exec('DETACH DATABASE bundle');
   }
 }
 

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -944,15 +944,23 @@ export async function importSessionBundleState(
           // and context nothing points at, which the store reclaims, rather than
           // a Session already visible whose bytes never arrived -- and which a
           // retry could not fix, because the ids are now taken.
-          const artifactFiles = await copyBundleArtifacts(bundleStateRoot, stateRoot);
-          const contextRefs = await mergeBundleContext(
-            bundleStateRoot,
-            stateRoot,
-            contextLocked,
-            sessionIds,
-          );
-          const inserted = mergeBundleDatabase(lease, bundleDatabasePath);
-          return { sessionIds: inserted, artifactFiles, contextRefs };
+          const artifacts = await copyBundleArtifacts(bundleStateRoot, stateRoot);
+          try {
+            const contextRefs = await mergeBundleContext(
+              bundleStateRoot,
+              stateRoot,
+              contextLocked,
+              sessionIds,
+            );
+            const inserted = mergeBundleDatabase(lease, bundleDatabasePath);
+            return { sessionIds: inserted, artifactFiles: artifacts.copied, contextRefs };
+          } catch (error) {
+            // Take back only what this attempt created. Anything already there
+            // belongs to someone else, or to an earlier attempt that the next
+            // one will recognise.
+            for (const path of artifacts.created) await rm(path, { force: true }).catch(() => {});
+            throw error;
+          }
         } finally {
           lease.close();
         }
@@ -1065,10 +1073,26 @@ function assertImportableInto(target: DatabaseSync, sessionIds: readonly string[
   }
 }
 
-/** Bytes first: a file nothing points at is reclaimable, a row pointing at nothing is not. */
-async function copyBundleArtifacts(bundleStateRoot: string, stateRoot: string): Promise<number> {
+/**
+ * Stage the bundle's artifact bytes, and be able to take them back.
+ *
+ * Publishing the Session last stops a broken Session from becoming visible, but
+ * it does not by itself make the import retryable: bytes written before a later
+ * failure stay behind, and a second attempt then trips over its own leftovers.
+ *
+ * Two rules make a retry work without overwriting anything. A destination that
+ * is byte-identical to what the bundle carries is this import's own leftover,
+ * or the same content by another route, and is accepted. A destination holding
+ * something else is a real conflict. Files this attempt actually created are
+ * remembered, so a failure can remove exactly those and nothing else.
+ */
+async function copyBundleArtifacts(
+  bundleStateRoot: string,
+  stateRoot: string,
+): Promise<{ copied: number; created: string[] }> {
   const source = resolveInside(bundleStateRoot, 'artifacts');
-  if (!(await pathExists(source))) return 0;
+  const created: string[] = [];
+  if (!(await pathExists(source))) return { copied: 0, created };
   let copied = 0;
   const walk = async (relative: string): Promise<void> => {
     const absolute = relative ? resolveInside(source, relative) : source;
@@ -1084,24 +1108,28 @@ async function copyBundleArtifacts(bundleStateRoot: string, stateRoot: string): 
           `Bundle artifact is not a regular file: ${next}`,
         );
       }
+      const from = resolveInside(source, next);
       const destination = resolveInside(resolveInside(stateRoot, 'artifacts'), next);
       await mkdir(dirname(destination), { recursive: true });
-      // Never overwrite: an existing path means this artifact is already here,
-      // which the Session precheck should have caught. Failing is the honest
-      // answer to being wrong about that.
-      await copyFile(resolveInside(source, next), destination, constants.COPYFILE_EXCL).catch(
-        (error: unknown) => {
-          if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
-            throw new SessionBundleImportError('conflict', `Artifact already present: ${next}`);
-          }
-          throw error;
-        },
-      );
+      try {
+        await copyFile(from, destination, constants.COPYFILE_EXCL);
+        created.push(destination);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+        if (!(await sameFileContent(from, destination))) {
+          throw new SessionBundleImportError('conflict', `Artifact already present: ${next}`);
+        }
+      }
       copied += 1;
     }
   };
   await walk('');
-  return copied;
+  return { copied, created };
+}
+
+async function sameFileContent(left: string, right: string): Promise<boolean> {
+  const [a, b] = await Promise.all([readFile(left), readFile(right)]);
+  return a.equals(b);
 }
 
 /**
@@ -1240,7 +1268,23 @@ async function mergeBundleContext(
         database.exec(
           'INSERT OR IGNORE INTO main.context_blobs SELECT * FROM bundle.context_blobs',
         );
-        database.exec('INSERT INTO main.context_refs SELECT * FROM bundle.context_refs');
+        // A retry re-inserts the same rows. Skipping an identical one is what
+        // makes the second attempt work; skipping a DIFFERENT row that happens
+        // to share an id would hide a real collision, so the two are separated.
+        const colliding = database
+          .prepare(`
+            SELECT b.ref_id FROM bundle.context_refs b
+            JOIN main.context_refs m USING(ref_id)
+            WHERE m.session_id <> b.session_id OR m.blob_id <> b.blob_id
+          `)
+          .all() as Array<{ ref_id?: unknown }>;
+        if (colliding.length > 0) {
+          throw new SessionBundleImportError(
+            'conflict',
+            `Context reference already names different content: ${String(colliding[0]?.ref_id)}`,
+          );
+        }
+        database.exec('INSERT OR IGNORE INTO main.context_refs SELECT * FROM bundle.context_refs');
         // The context store maintains its usage tables explicitly -- no trigger
         // does it. Inserting blobs and refs without them leaves quotas and the
         // cleanup consistency checks reading numbers that describe a store that
@@ -1253,7 +1297,15 @@ async function mergeBundleContext(
             FROM context_refs r JOIN context_blobs b USING(blob_id) GROUP BY r.session_id;
           UPDATE context_store_usage SET
             blob_count = (SELECT count(*) FROM context_blobs),
-            physical_bytes = (SELECT coalesce(sum(size_bytes), 0) FROM context_blobs)
+            -- Bytes queued for deletion are still on disk and still charged:
+            -- the store drops a blob row before draining its file and subtracts
+            -- them when the drain completes. Recomputing from live blobs alone
+            -- makes that later subtraction underflow. The export can use the
+            -- simpler sum because it empties the queue on its private copy;
+            -- a live target keeps it.
+            physical_bytes =
+              (SELECT coalesce(sum(size_bytes), 0) FROM context_blobs) +
+              (SELECT coalesce(sum(size_bytes), 0) FROM context_file_deletions)
           WHERE singleton = 1;
         `);
         database.exec('COMMIT');


### PR DESCRIPTION
## Summary

Import a `.maka-session` bundle into a workspace — the other half of #5113 — plus the one non-blocking follow-up from that PR's approving review.

## Why this is not simply the export run backwards

The export owns a private copy and can delete what is not the subtree. The import writes into a live workspace holding other people's Sessions, and can only add. That single difference drives the design.

What survives the asymmetry is the property that mattered most in #5113: **no table list.** The bundle's database has already been filtered down to its own Sessions, so the merge copies every table it has. A table added to the schema later travels in both directions without anyone maintaining a list — the same reason the export filters by deleting rather than selecting.

Three kinds of table are not copied:

- **Workspace-level** (`operational_schema_migrations`, `session_catalog_state`, …) belong to the target, which has its own.
- **`session_catalog_projection`** is derived, and `session_metadata` carries triggers that maintain it. Inserting the bundle's copy and then the Session row makes the trigger collide with what was just inserted — found by the round-trip test, and letting the target derive it is the only way it stays correct when the derivation changes.

## Write order

Artifact bytes land first; the database transaction commits last. A failure between them leaves files nothing points at, which is reclaimable, rather than rows pointing at files that are not there, which is not.

The context-offload closure is merged too. Without it an imported Session arrives with its read-image references intact and none of the bytes behind them — the hole @likun666661 caught on the export side, in the other direction. Blobs are content-addressed, so an id already present is the same bytes and the insert is skipped rather than treated as a conflict.

## Conflicts

A Session id already present refuses the whole bundle, before anything is written. Ids are generated rather than chosen, so one already here means this Session is already here — not that two of them collided. Importing over it would merge two histories that share ids and agree about nothing else.

Copying a Session that already exists is a different operation with a different meaning, and `conversation-copy` already does it. Not in this PR.

## One difference from the export, on purpose

The export refuses to migrate its source, because it only reads. This opens the target the ordinary way: an import is a write the user asked for, and the target is frequently a workspace with no database yet — moving to a new machine is the point of the feature.

## Follow-up from #5113

`backupOperationalState()` translated every acquisition failure into `schema_unsupported`, so an unreadable `runtime.sqlite` told the caller to upgrade when the real answer was that the file could not be opened. Only a blocked migration is a statement about the schema now; permission, busy and I/O failures are the environment talking and are preserved, as the operational store intends. Covered by a `chmod 000` regression.

## Tests

Five import tests, 18 export tests (one new), and the 20 existing storage bundle/context/lock tests.

The round-trip is the acceptance criterion #5113 could not state on its own: export a Session, import it into a *different* workspace that already holds someone else's Session, and compare the rows the model reads field for field — including the JSON columns whose bytes a re-encoding would change. It also asserts the receiving workspace kept what it had.

The subtree test carries a parent and its subagent child with the child's artifact bytes, and checks `subagent_spawns` arrives: without it the target holds two Sessions and nothing saying which tool call joined them.

Each assertion was checked by removing what it covers — the conflict precheck, the derived-table skip, the artifact copy, the bundle-schema comparison, the pragma restore, and the narrowed error translation — and confirming the corresponding test fails.

Gates: storage and runtime build and typecheck clean, `biome check` on every changed file, `check:asf-headers`, and the published-entrypoints check.

## What this does not do

Desktop menus, IPC and the protocol epoch. Importing a Session that already exists as a copy. The `snapshot | portable` mode collapse suggested on #5113 — I would still rather let a second real profile prove itself before naming one, and this PR is the first evidence about that, not the last.
