### PR TITLE
docs(runtime): correct public imports and composition entry point

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -19,11 +19,18 @@
 
 # `@maka/runtime`
 
-`@maka/runtime` is Maka's pure-Node agent runtime. It owns model/backend execution, session sandbox-boundary control flow, event projection, context handling, recovery, and sandbox-aware workspace execution. Product shells compose it; they do not reimplement its loop.
+`@maka/runtime` is Maka's pure-Node agent runtime. It owns model/backend execution, session sandbox-boundary control flow, event projection, context handling, recovery, and sandbox-aware workspace execution. Runtime Host composes it; clients do not reimplement its loop.
 
 ## Public seam
 
-The package root barrel and the subpaths declared in `package.json` are supported public APIs. Do not import undeclared internal source paths from another package. The main integration points are:
+The subpaths declared in [`package.json`](./package.json) are supported public APIs. The package root (`@maka/runtime`) is not exported. Import through a declared subpath rather than an internal source path:
+
+```ts
+import { SessionManager } from '@maka/runtime/session-manager';
+import { AiSdkBackend } from '@maka/runtime/ai-sdk-backend';
+```
+
+The main integration points are:
 
 - `SessionManager` for session and turn orchestration.
 - `BackendRegistry` and `AgentBackend` for backend selection.
@@ -32,14 +39,14 @@ The package root barrel and the subpaths declared in `package.json` are supporte
 - `buildBuiltinTools()` and the workspace executor interfaces for tool composition.
 - `RuntimeKernel`, runtime events, projections, and recovery helpers for execution lifecycle.
 
-Desktop composition lives in `apps/desktop/src/main/main.ts`. Other clients execute Maka through Runtime Host rather than composing Runtime directly.
+The shared execution composition lives in [`packages/runtime-host/src/server/execution-composition.ts`](../runtime-host/src/server/execution-composition.ts). Desktop, TUI, and CLI execute Maka through Runtime Host.
 
 ## Extension rules
 
 - Add backend behavior behind `AgentBackend` and register it through the existing registry.
 - Add tools through the builtin/tool composition seams; keep filesystem and shell effects behind `WorkspaceExecutor`.
 - Put shared pure contracts in `packages/core` and interactive Runtime state in the SQLite control plane owned by `packages/storage`.
-- Expose supported package APIs through the root barrel or a declared `package.json` subpath rather than importing internal files from another package.
+- Expose supported package APIs through a declared `package.json` subpath rather than importing internal files from another package.
 - Keep provider credentials and Electron IPC outside this package. The product shell resolves credentials and passes only the dependencies required for execution.
 
 For the system-level model and code-reading map, start with the root `ARCHITECTURE.md`. Sandbox-specific contracts live in `src/sandbox/README.md`.


### PR DESCRIPTION
## Summary

The Runtime README described a supported package-root import even though `@maka/runtime` has no root export, and pointed contributors to Desktop main for Runtime composition.

This corrects both root-barrel references, adds explicit `SessionManager` and `AiSdkBackend` subpath import examples, and links the shared Runtime Host execution composition. The change is limited to `packages/runtime/README.md`; runtime behavior is unchanged.

Fixes #5141

## Verification

Verified on macOS 26.6.2 / Node.js v23.7.0, against base `f09119884` and this branch:

- Actual `import('@maka/runtime')` rejects with `ERR_PACKAGE_PATH_NOT_EXPORTED`, confirming the existing documentation defect.
- Both README example subpaths match the package export map and resolve to their declared targets; both named classes exist in the corresponding source modules.
- Both added relative links resolve to existing files.
- The linked Runtime Host composition constructs `SessionManager` and `BackendRegistry`.
- `git diff --check HEAD^ HEAD` passes.
- Inspected the actual GitHub Markdown rendering before and after the change.

The subpath checks cover resolution and source declarations, not execution of compiled Runtime modules. Full lint, formatter, typecheck, build, and workspace test suites were not run for this Markdown-only change.

<details>
<summary>Before and after screenshots — actual GitHub Markdown preview</summary>

**Before** — [base README](https://github.com/apache/maka/blob/f09119884e3e640f1c10755da19a583416aed19f/packages/runtime/README.md)

![Runtime README before correction](https://raw.githubusercontent.com/MasamiYui/maka/cd2821d9b4548d262c79926950af4fc897f17ca1/runtime-readme-before.png)

**After** — [updated README](https://github.com/MasamiYui/maka/blob/456002bdd8247951dfe6734df528456cc26ce71c/packages/runtime/README.md)

![Runtime README after correction](https://raw.githubusercontent.com/MasamiYui/maka/cd2821d9b4548d262c79926950af4fc897f17ca1/runtime-readme-after.png)

Screenshots are stored on a separate evidence branch in the fork and are not part of this PR's file changes.

</details>

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex inspected the package exports and composition, edited the README, ran the focused verification, and captured the screenshots. The commit includes `Generated-by: OpenAI Codex`.

Automated PR submission by OpenAI Codex on behalf of @MasamiYui, the human contributor of record.

## Checklist

- [ ] Tests cover the change and fail without it — N/A for runtime regression tests; this changes documentation only.
- [ ] Lint, format, typecheck and the affected suites pass locally — full suites not run; focused documentation checks are listed above.

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

