### PR TITLE
fix(desktop): keep expanded tool calls in flow

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -173,17 +173,15 @@
   contain-intrinsic-block-size: auto 32px;
 }
 
-/* Expanded activity headers stay reachable while their own detail is being
-   read. Native sticky positioning keeps the header in the transcript flow,
-   so it leaves naturally at the card boundary and does not disturb ChatLayout
-   scroll anchoring while reasoning or tool output continues to stream. */
-.maka-turn :is(.maka-deep-thinking, .maka-tool-activity-card) {
+/* An expanded reasoning header stays reachable while its own detail is being
+   read. Tool-call disclosures remain in normal flow: pinning both the group
+   header and an expanded call row creates a floating two-tier stack that
+   visually detaches from the transcript around adjacent messages. */
+.maka-turn .maka-deep-thinking {
   --maka-activity-sticky-top: var(--space-2);
-  --maka-activity-header-height: var(--h-control-sm);
 }
 
-.maka-turn .maka-activity-card-header[aria-expanded="true"],
-.maka-turn .maka-tool-activity-card [role="button"][aria-expanded="true"] {
+.maka-turn .maka-activity-card-header[aria-expanded="true"] {
   position: sticky;
   top: var(--maka-activity-sticky-top);
   z-index: var(--z-sticky);
@@ -192,23 +190,11 @@
   box-shadow: 0 var(--border-width-hairline) 0 var(--border-soft);
 }
 
-/* A call detail inside an expanded tool group forms a second, bounded sticky
-   tier. The group remains available to collapse the whole run; the lower row
-   collapses only the detail currently being read.
-   Stock ChatToolCalls uses role=button on call rows (no data-slot patch). */
-.maka-turn
-  .maka-tool-activity-card
-  > [role="button"][aria-expanded="true"]
-  ~ div
-  [role="button"][aria-expanded="true"] {
-  top: calc(var(--maka-activity-sticky-top) + var(--maka-activity-header-height));
-}
-
 /* Astryx clips the animated group body with overflow:hidden. `clip` preserves
-   that visual boundary without becoming a scroll ancestor that captures the
-   nested sticky row. The inner wrapper is also a grid item: without an explicit
-   zero minimum its long, nowrap call preview becomes the track's minimum size
-   and stretches every expanded row past the turn instead of ellipsizing it. */
+   that visual boundary. The inner wrapper is also a grid item: without an
+   explicit zero minimum its long, nowrap call preview becomes the track's
+   minimum size and stretches every expanded row past the turn instead of
+   ellipsizing it. */
 .maka-turn .maka-tool-activity-card > [role="button"] + div > div {
   min-width: 0;
   overflow: clip;

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -177,27 +177,20 @@
    read. Tool-call disclosures remain in normal flow: pinning both the group
    header and an expanded call row creates a floating two-tier stack that
    visually detaches from the transcript around adjacent messages. */
-.maka-turn .maka-deep-thinking {
-  --maka-activity-sticky-top: var(--space-2);
-}
-
-.maka-turn .maka-activity-card-header[aria-expanded="true"] {
+.maka-turn .maka-deep-thinking .maka-activity-card-header[aria-expanded="true"] {
   position: sticky;
-  top: var(--maka-activity-sticky-top);
+  top: var(--space-2);
   z-index: var(--z-sticky);
   background: var(--surface-raised);
   border-radius: var(--radius-element);
   box-shadow: 0 var(--border-width-hairline) 0 var(--border-soft);
 }
 
-/* Astryx clips the animated group body with overflow:hidden. `clip` preserves
-   that visual boundary. The inner wrapper is also a grid item: without an
-   explicit zero minimum its long, nowrap call preview becomes the track's
-   minimum size and stretches every expanded row past the turn instead of
-   ellipsizing it. */
+/* The inner wrapper is a grid item: without an explicit zero minimum its long,
+   nowrap call preview becomes the track's minimum size and stretches every
+   expanded row past the turn instead of ellipsizing it. */
 .maka-turn .maka-tool-activity-card > [role="button"] + div > div {
   min-width: 0;
-  overflow: clip;
 }
 
 /* Cursor for tool/reasoning disclosure triggers is owned by

--- a/packages/ui/stories/tool-activity.stories.tsx
+++ b/packages/ui/stories/tool-activity.stories.tsx
@@ -19,7 +19,7 @@
 
 import { useEffect, useRef } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { ToolCallDetail, ToolTrow } from '../src/tool-activity.js';
 import type { ToolActivityItem } from '../src/materialize.js';
 import {
@@ -276,6 +276,8 @@ export const LongIntentGroupNarrow: Story = {
     );
     expect(disclosure).not.toBeNull();
     await userEvent.click(disclosure!);
+    await waitFor(() => expect(disclosure).toHaveAttribute('aria-expanded', 'true'));
+    expect(getComputedStyle(disclosure!).position).toBe('static');
     const rows = Array.from(group!.querySelectorAll<HTMLElement>('[role="button"]'));
     expect(Math.max(...rows.map((row) => row.getBoundingClientRect().width))).toBeLessThanOrEqual(
       turn.clientWidth + 8,

--- a/packages/ui/stories/tool-activity.stories.tsx
+++ b/packages/ui/stories/tool-activity.stories.tsx
@@ -278,6 +278,13 @@ export const LongIntentGroupNarrow: Story = {
     await userEvent.click(disclosure!);
     await waitFor(() => expect(disclosure).toHaveAttribute('aria-expanded', 'true'));
     expect(getComputedStyle(disclosure!).position).toBe('static');
+    const callRow = group!.querySelector<HTMLElement>(
+      ':scope > [role="button"] + div [role="button"][aria-expanded="false"]',
+    );
+    expect(callRow).not.toBeNull();
+    await userEvent.click(callRow!);
+    await waitFor(() => expect(callRow).toHaveAttribute('aria-expanded', 'true'));
+    expect(getComputedStyle(callRow!).position).toBe('static');
     const rows = Array.from(group!.querySelectorAll<HTMLElement>('[role="button"]'));
     expect(Math.max(...rows.map((row) => row.getBoundingClientRect().width))).toBeLessThanOrEqual(
       turn.clientWidth + 8,


### PR DESCRIPTION
## Summary

Keep expanded tool-call group and row disclosures in the transcript's normal document flow instead of pinning them over adjacent conversation content. The reasoning disclosure retains its existing sticky header behavior.

The existing narrow grouped-tool Storybook interaction now expands both the group and one call row, then asserts that both disclosures compute to `position: static`, covering the regression at the real presentation seam.

Fixes #5157
Refs #4773

## Verification

- `npm run format:check`
- `npm run lint`
- `npm --workspace @maka/desktop run typecheck:stories`
- `npm --workspace @maka/desktop run build-storybook`
- Storybook `Product/Tool Activity/Long Intent Group Narrow`: the regression assertions fail on `main` with `position: sticky` and pass here with `position: static`
- Headless browser check: the expanded group header and call row both report `position: static; top: auto; z-index: auto`

Both captures use Storybook `Product/Tool Activity/Long Intent Group Narrow`, a 720 × 140 CSS-pixel viewport at 2× device scale, the first call row expanded, and the document scrolled to the bottom.

| Before (`main`) | After (this branch) |
| --- | --- |
| The group header and expanded call row remain pinned (`position: sticky`), obscuring the transcript flow. | The same header and row scroll together in normal flow (`position: static`). |
| ![Before on main: expanded group header and call row remain pinned](https://github.com/liuxiaocs7/maka/releases/download/pr-5158-evidence/before.png) | ![After on this branch: expanded group header and call row remain in flow](https://github.com/liuxiaocs7/maka/releases/download/pr-5158-evidence/after.png) |

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the CSS interaction, implemented the scoped selector change, added the Storybook regression assertion, and drafted this issue and pull request under human direction.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

