### PR TITLE
fix(desktop): separate WSL setup replacement and interruption consent

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-wsl-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-wsl-controller.test.ts
@@ -181,5 +181,36 @@ test('WSL setup forwards the development archive and its exact evidence', async 
   const setupCommand = launches[1]?.at(-1) ?? '';
   assert.match(setupCommand, new RegExp(`${RUNTIME_HOST_SETUP_SOURCE_PACKAGE_INTEGRITY_ENV}=`, 'u'));
   assert.ok(setupCommand.includes(integrity));
+  assert.match(setupCommand, /--update-existing/u);
+  assert.doesNotMatch(setupCommand, /--allow-interrupt-active-tasks/u);
   assert.match(setupCommand, /--package.*\/mnt\/c\/maka-development\.tgz/u);
+});
+
+
+test('released WSL onboarding cannot authorize replacement or interruption', async () => {
+  let command = '';
+  await assert.rejects(runDesktopRuntimeHostWslSetup({
+    distribution: 'Ubuntu',
+    setupPackage: { kind: 'npm', specifier: 'maka-agent@0.2.0' },
+    principalId: 'desktop:client',
+  }, () => undefined, undefined, {
+    wslExecutable: 'wsl.exe',
+    processFactory: (_executable, args) => {
+      command = args.at(-1) ?? '';
+      const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      Object.assign(child, { stdin: new PassThrough(), stdout, stderr, kill: () => true });
+      process.nextTick(() => {
+        stdout.end(encodeRuntimeHostSetupFrame({
+          schemaVersion: 1, sequence: 0, kind: 'error',
+          error: { code: 'version_change_requires_update', message: 'Use the update workflow' },
+        }));
+        stderr.end();
+        child.emit('close', 1, null);
+      });
+      return child;
+    },
+  }), /Use the update workflow/u);
+  assert.doesNotMatch(command, /--update-existing|--allow-interrupt-active-tasks/u);
 });

--- a/apps/desktop/src/main/runtime-host-wsl-controller.ts
+++ b/apps/desktop/src/main/runtime-host-wsl-controller.ts
@@ -182,7 +182,7 @@ export async function runDesktopRuntimeHostWslSetup(
     executable,
     processFactory,
   );
-  const command = runtimeHostWslSetupCommand(setupPackage, input);
+  const command = runtimeHostWslSetupCommand(setupPackage, input, input.setupPackage.kind === 'development_archive');
   const child = processFactory(executable, ['--distribution', distribution, '--exec', '/bin/sh', '-lc', command]);
   return runWslFramedProcess({
     child,
@@ -241,6 +241,7 @@ async function resolveWslPackageSpecifier(
 function runtimeHostWslSetupCommand(
   setupPackage: { readonly specifier: string; readonly integrity?: string },
   input: Pick<DesktopRuntimeHostWslSetupInput, 'principalId' | 'projectDirectoryRoots'>,
+  development: boolean,
 ): string {
   if (!/^[A-Za-z0-9_.:-]{1,128}$/u.test(input.principalId)) {
     throw new Error('Runtime Host setup principal is invalid');
@@ -256,7 +257,9 @@ function runtimeHostWslSetupCommand(
     '--lifecycle',
     'on-demand',
     '--repair-root-after-remount',
-    '--update-existing',
+    // Source development explicitly selects a new archive; released onboarding
+    // must never replace an existing shared deployment as a side effect of Connect.
+    ...(development ? ['--update-existing'] : []),
     ...(input.projectDirectoryRoots === undefined
       ? []
       : input.projectDirectoryRoots.length === 0

--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -497,6 +497,36 @@ describe('managed Runtime Host service', () => {
       },
     );
     assert.equal(parseRuntimeHostCommand(['service', 'status', '--root', '/tmp']).kind, 'error');
+    const setupUpdateArgs = [
+      'setup',
+      '--principal',
+      'desktop.client-1',
+      '--preset',
+      'desktop-client',
+    ];
+    assert.equal(
+      parseRuntimeHostCommand([...setupUpdateArgs, '--allow-interrupt-active-tasks']).kind,
+      'error',
+    );
+    const explicitSetupUpdate = parseRuntimeHostCommand([
+      ...setupUpdateArgs,
+      '--update-existing',
+      '--allow-interrupt-active-tasks',
+    ]);
+    assert.equal(explicitSetupUpdate.kind, 'runtime-host-setup');
+    if (explicitSetupUpdate.kind === 'runtime-host-setup') {
+      assert.equal(explicitSetupUpdate.allowInterruptActiveTasks, true);
+    }
+    assert.equal(
+      parseRuntimeHostCommand([
+        ...setupUpdateArgs,
+        '--update-existing',
+        '--allow-interrupt-active-tasks',
+        '--allow-interrupt-active-tasks',
+      ]).kind,
+      'error',
+    );
+
     assert.equal(
       parseRuntimeHostCommand([
         'setup',

--- a/packages/cli/src/__tests__/runtime-host-setup.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-setup.test.ts
@@ -306,6 +306,36 @@ test('on-demand setup installs one exact deployment without a service backend', 
     'version_change_requires_update',
   );
 
+  const beforeBusyUpdate = await readFile(
+    resolveRuntimeHostManagedDeploymentConfigPath(rootId),
+    'utf8',
+  );
+  const busyOutputs: string[] = [];
+  assert.equal(
+    await runRuntimeHostSetupCli(
+      { ...replacementOptions, updateExisting: true },
+      {
+        ...replacementPackage,
+        replaceLifecycle: async (input) => {
+          // Model the source Host refusing retirement while a TUI owns work.
+          assert.equal(input.allowInterruptActiveTasks, false);
+          return { kind: 'active_tasks' };
+        },
+        writeOutput: (value) => busyOutputs.push(value),
+      },
+    ),
+    1,
+  );
+  assert.equal(
+    await readFile(resolveRuntimeHostManagedDeploymentConfigPath(rootId), 'utf8'),
+    beforeBusyUpdate,
+  );
+  assert.ok(
+    busyOutputs
+      .map(decodeRuntimeHostSetupFrame)
+      .some((frame) => frame?.kind === 'error' && frame.error.code === 'active_tasks'),
+  );
+
   const replacementOutputs: string[] = [];
   let replacementAllowedInterrupt: boolean | undefined;
   assert.equal(
@@ -329,7 +359,7 @@ test('on-demand setup installs one exact deployment without a service backend', 
   ) as RuntimeHostManagedDeploymentConfig;
   assert.equal(replaced.launch.package.version, '1.2.4');
   assert.equal(replaced.launch.package.integrity, replacementIntegrity);
-  assert.equal(replacementAllowedInterrupt, true);
+  assert.equal(replacementAllowedInterrupt, false);
   assert.equal(
     replacementOutputs.map(decodeRuntimeHostSetupFrame).some((frame) => frame?.kind === 'complete'),
     true,

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -465,6 +465,7 @@ export async function runMakaCli(
         bindPairingToClient: command.bindPairingToClient,
         ...(command.repairRootAfterRemount ? { repairRootAfterRemount: true } : {}),
         updateExisting: command.updateExisting,
+        allowInterruptActiveTasks: command.allowInterruptActiveTasks,
         ...(command.rootPath ? { rootPath: command.rootPath } : {}),
         ...(command.projectDirectoryRoots
           ? { projectDirectoryRoots: command.projectDirectoryRoots }

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -142,6 +142,7 @@ export type RuntimeHostCliCommand =
       bindPairingToClient?: true;
       repairRootAfterRemount?: true;
       updateExisting?: true;
+      allowInterruptActiveTasks?: true;
       clientDataRoot?: string;
       rootPath?: string;
       projectDirectoryRoots?: { label: string; path: string }[];
@@ -702,6 +703,7 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
   let bindPairingToClient = false;
   let repairRootAfterRemount = false;
   let updateExisting = false;
+  let allowInterruptActiveTasks = false;
   let clientDataRoot: string | undefined;
   let enableDirectPeer = false;
   const coordinationRelays: string[] = [];
@@ -750,6 +752,10 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
         if (repairRootAfterRemount) return error('Duplicate --repair-root-after-remount');
         repairRootAfterRemount = true;
       },
+      '--allow-interrupt-active-tasks': () => {
+        if (allowInterruptActiveTasks) return error('Duplicate --allow-interrupt-active-tasks');
+        allowInterruptActiveTasks = true;
+      },
       '--update-existing': () => {
         if (updateExisting) return error('Duplicate --update-existing');
         updateExisting = true;
@@ -757,6 +763,9 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
     },
   });
   if ('kind' in options) return options;
+  if (allowInterruptActiveTasks && !updateExisting) {
+    return error('--allow-interrupt-active-tasks requires --update-existing');
+  }
   if (!principalId || !/^[A-Za-z0-9_.:-]{1,128}$/u.test(principalId)) {
     return error('runtime-host setup requires a valid --principal');
   }
@@ -777,6 +786,7 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
     ...(bindPairingToClient ? { bindPairingToClient: true } : {}),
     ...(repairRootAfterRemount ? { repairRootAfterRemount: true } : {}),
     ...(updateExisting ? { updateExisting: true } : {}),
+    ...(allowInterruptActiveTasks ? { allowInterruptActiveTasks: true } : {}),
     ...(clientDataRoot ? { clientDataRoot } : {}),
     ...(enableDirectPeer ? { directPeer: { coordinationRelays } } : {}),
   };

--- a/packages/cli/src/runtime-host-setup-command.ts
+++ b/packages/cli/src/runtime-host-setup-command.ts
@@ -140,6 +140,7 @@ export interface RuntimeHostSetupCliOptions {
   readonly bindPairingToClient?: boolean;
   readonly repairRootAfterRemount?: true;
   readonly updateExisting?: boolean;
+  readonly allowInterruptActiveTasks?: boolean;
   readonly rootPath?: string;
   readonly projectDirectoryRoots?: readonly {
     readonly label: string;
@@ -502,7 +503,7 @@ async function runRuntimeHostSupervisedSetupLocked(
                   .then(() => undefined),
             }
           : {}),
-        allowInterruptActiveTasks: Boolean(current && packageChanged && options.updateExisting),
+        allowInterruptActiveTasks: options.allowInterruptActiveTasks === true,
         deps: lifecycleDeps,
       });
       if (replacement.kind === 'active_tasks') {
@@ -880,7 +881,7 @@ async function runRuntimeHostOnDemandSetupLocked(
           activateDesired: async () => {
             await deps.activateDesired({ rootId: capability.rootId });
           },
-          allowInterruptActiveTasks: Boolean(current && packageChanged && options.updateExisting),
+          allowInterruptActiveTasks: options.allowInterruptActiveTasks === true,
           deps: lifecycleDeps,
         });
         if (replacement.kind === 'active_tasks') {


### PR DESCRIPTION
## Summary

Released Desktop WSL onboarding currently authorizes replacing a shared deployment, and setup interprets replacement consent as permission to interrupt active work. Remove the released onboarding replacement flag and require a separate explicit interruption flag in setup. Source archive setup keeps its explicit replacement route with safe admission by default.

Refs #5144. This first PR provides the authorization guard; the dependent #5143 work completes discovery/reuse and the explicit WSL maintenance journey.

## Verification

- CLI setup, command parsing and lifecycle transaction suites: 42 passing tests.
- Desktop WSL controller, onboarding and SSH terminal suites: 36 passing tests.
- Workspace typecheck, lint and format checks passed.
- Generated released WSL command contains neither `--update-existing` nor `--allow-interrupt-active-tasks`; development setup contains only the former.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the issue, implemented the changes and tests, and drafted these review materials.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
