### PR TITLE
fix(desktop): add explicit managed WSL Host handoff

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -2053,3 +2053,53 @@ function testPeerReachability(peerId: string) {
     signature: Buffer.from('signature').toString('base64url'),
   };
 }
+
+test('managed WSL handoff uses its verified adapter and reconnects without local process ownership', { timeout: 5_000 }, async () => {
+  const local = candidateHarness({ hostId: 'local-host' });
+  const remote = candidateHarness({ hostId: 'wsl-host', ownership: 'external' });
+  let replaced = false;
+  const target = {
+    profile: {
+      id: 'ubuntu', name: 'Ubuntu', kind: 'environment' as const,
+      rootId: 'a'.repeat(64), provider: { kind: 'wsl' as const, distribution: 'Ubuntu' },
+      operator: { kind: 'node' as const, platform: 'posix' as const, nodePath: '/usr/bin/node', modulePath: '/operator.mjs' },
+    },
+  };
+  const manager = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (input) => {
+      if (!input.profileTarget) return ready(local.candidate);
+      if (replaced) return ready(remote.candidate);
+      throw new RuntimeHostRemoteCompatibilityError('ubuntu', {
+        kind: 'incompatible', hostEpoch: 'old-wsl', compatibilityEpoch: 1,
+        protocolMin: 0, protocolMax: 0, compositionId: 'interactive',
+        compositionRevision: 'old', state: 'ready', replacement: 'blocked_by_residency',
+      });
+    },
+    handoffSurface: decideHandoff((view) => {
+      assert.equal(view.reason, 'replacement_required');
+      return 'replace';
+    }),
+    resolveWslHostHandoff: async (profile, error) => {
+      assert.equal(profile.id, 'ubuntu');
+      assert.equal(error.hostEpoch, 'old-wsl');
+      return {
+        identity: 'deployment/old-wsl', target: { name: 'Ubuntu', location: 'remote' },
+        reason: 'upgrade', mayExitNaturally: false, manualRecheck: true,
+        replacement: {
+          kind: 'replace', canReplaceIdle: true, canInterrupt: true, requiresExplicitSelection: true,
+          execute: async (policy, _progress, consent) => {
+            assert.equal(policy, 'refuse_active_work'); assert.equal(consent, 'explicit');
+            replaced = true; return { kind: 'completed' };
+          },
+        },
+      };
+    },
+    resolveLocalHostReplacement: async () => assert.fail('WSL must not use local ownership'),
+    forceTerminateObservedHost: async () => assert.fail('WSL must not terminate a raw PID'),
+  });
+  try {
+    await manager.enable(target);
+    assert.equal(replaced, true);
+    assert.ok(manager.entries().some((entry) => entry.target.profile.id === 'ubuntu' && entry.readiness === 'ready'));
+  } finally { await manager.close(); }
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-profile-service.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-profile-service.test.ts
@@ -332,7 +332,7 @@ test("keeps Local enabled while a new remote Host connects", async () => {
   );
 });
 
-test("reuses the existing WSL profile when the same managed Host is added again", async () => {
+test("reuses the existing WSL profile when the same managed Host is added again", { timeout: 5_000 }, async () => {
   const root = await clientRoot();
   const catalog = createClientRuntimeHostProfileCatalog(root);
   const managedServices = createDesktopRuntimeHostManagedServiceStore(root);
@@ -357,6 +357,8 @@ test("reuses the existing WSL profile when the same managed Host is added again"
     states: () => [connectingLocal()],
     enable: async (target) => {
       enabled.push(target.profile.id);
+      const binding = await service.resolveManagedService(target.profile.id);
+      assert.equal(binding?.deployment.deploymentId, '11111111-1111-4111-8111-111111111111');
     },
     disable: async () => undefined,
     setDefault: () => undefined,

--- a/apps/desktop/src/main/__tests__/runtime-host-wsl-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-wsl-controller.test.ts
@@ -229,6 +229,7 @@ test('WSL update cancellation closes retirement input without killing the transa
     expectedTarget: { serviceId: 'a'.repeat(64), rootId: 'a'.repeat(64), rootPath: '/state', deploymentId: '00000000-0000-4000-8000-000000000001' },
     expectedConfigFingerprint: `sha256:${'b'.repeat(64)}`,
     expectedHost: { hostEpoch: 'old-host', pid: 42 },
+    expectedSourceVersion: '0.2.0',
     allowInterruptActiveTasks: false, signal: abort.signal,
   }, () => {}, {
     wslExecutable: 'wsl.exe',

--- a/apps/desktop/src/main/__tests__/runtime-host-wsl-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-wsl-controller.test.ts
@@ -33,6 +33,7 @@ import {
 import {
   runDesktopRuntimeHostWslManagement,
   runDesktopRuntimeHostWslSetup,
+  runDesktopRuntimeHostWslUpdate,
 } from '../runtime-host-wsl-controller.js';
 
 const OPERATOR = {
@@ -213,4 +214,72 @@ test('released WSL onboarding cannot authorize replacement or interruption', asy
     },
   }), /Use the update workflow/u);
   assert.doesNotMatch(command, /--update-existing|--allow-interrupt-active-tasks/u);
+  assert.match(command, /--reuse-existing-environment/u);
+});
+
+
+test('WSL update cancellation closes retirement input without killing the transaction', async () => {
+  const abort = new AbortController();
+  let finish!: () => void;
+  let stdin!: PassThrough;
+  let killed = false;
+  let launch: readonly string[] = [];
+  const running = runDesktopRuntimeHostWslUpdate({
+    distribution: 'Ubuntu', setupPackage: { kind: 'npm', specifier: 'maka-agent@0.3.0' },
+    expectedTarget: { serviceId: 'a'.repeat(64), rootId: 'a'.repeat(64), rootPath: '/state', deploymentId: '00000000-0000-4000-8000-000000000001' },
+    expectedConfigFingerprint: `sha256:${'b'.repeat(64)}`,
+    expectedHost: { hostEpoch: 'old-host', pid: 42 },
+    allowInterruptActiveTasks: false, signal: abort.signal,
+  }, () => {}, {
+    wslExecutable: 'wsl.exe',
+    processFactory: (_executable, args) => {
+      launch = args;
+      const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+      stdin = new PassThrough();
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      Object.assign(child, { stdin, stdout, stderr, kill: () => { killed = true; return true; } });
+      finish = () => {
+        stdout.end(); stderr.end(); child.emit('close', 1, null);
+      };
+      return child;
+    },
+  });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(stdin.writableEnded, false);
+  assert.match(launch.at(-1)!, /--expected-config-fingerprint/u);
+  assert.match(launch.at(-1)!, /--expected-host-json/u);
+  assert.doesNotMatch(launch.at(-1)!, /--allow-interrupt-active-tasks/u);
+  let settled = false;
+  const outcome = running.finally(() => { settled = true; });
+  const rejected = assert.rejects(outcome, /abort/iu);
+  abort.abort();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(stdin.writableEnded, true);
+  assert.equal(killed, false);
+  assert.equal(settled, false);
+  finish();
+  await rejected;
+});
+
+
+test('released WSL discovery accepts an existing binding without a credential or package mutation', async () => {
+  const existing = {
+    schemaVersion: 1 as const, sequence: 0, kind: 'existing_environment' as const,
+    version: '0.3.0', serviceId: 'a'.repeat(64), rootId: 'a'.repeat(64), rootPath: '/state',
+    deploymentId: '00000000-0000-4000-8000-000000000001', operator: OPERATOR,
+  };
+  const result = await runDesktopRuntimeHostWslSetup({
+    distribution: 'Ubuntu', setupPackage: { kind: 'npm', specifier: 'maka-agent@0.2.0' }, principalId: 'desktop:client',
+  }, () => {}, undefined, {
+    wslExecutable: 'wsl.exe',
+    processFactory: () => {
+      const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+      const stdout = new PassThrough(); const stderr = new PassThrough();
+      Object.assign(child, { stdin: new PassThrough(), stdout, stderr, kill: () => true });
+      process.nextTick(() => { stdout.end(encodeRuntimeHostSetupFrame(existing)); stderr.end(); child.emit('close', 0, null); });
+      return child;
+    },
+  });
+  assert.deepEqual(result, existing);
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-wsl-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-wsl-handoff.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RuntimeHostRemoteCompatibilityError, type EnvironmentRuntimeHostProfile } from '@maka/runtime-host/client';
+import { RUNTIME_HOST_COMPATIBILITY_EPOCH, RUNTIME_HOST_PROTOCOL_VERSION, INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID } from '@maka/runtime-host/protocol';
+import { resolveDesktopWslHostHandoff } from '../runtime-host-wsl-handoff.js';
+
+const profile: EnvironmentRuntimeHostProfile = {
+  id: 'ubuntu', name: 'Ubuntu', kind: 'environment', rootId: 'a'.repeat(64),
+  provider: { kind: 'wsl', distribution: 'Ubuntu' },
+  operator: { kind: 'node', platform: 'posix', nodePath: '/usr/bin/node', modulePath: '/operator.mjs' },
+};
+const binding = {
+  profile, state: 'active' as const,
+  deployment: { id: profile.rootId, rootPath: '/state', deploymentId: '00000000-0000-4000-8000-000000000001' },
+};
+function incompatible(epoch = RUNTIME_HOST_COMPATIBILITY_EPOCH - 1) {
+  return new RuntimeHostRemoteCompatibilityError(profile.id, {
+    kind: 'incompatible', state: 'ready', replacement: 'blocked_by_residency', protocolMin: RUNTIME_HOST_PROTOCOL_VERSION, protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+    compatibilityEpoch: epoch, compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+    compositionRevision: 'test', hostEpoch: 'old-host',
+  });
+}
+const service = {
+  platform: 'linux', arch: 'x64', osRelease: '6.6', state: 'running' as const,
+  pid: 42, lastExitCode: null, installedVersion: '0.2.0',
+  lifecycle: { mode: 'on_demand' as const, availability: 'activation' as const },
+  projectDirectoryRoots: [], configurationFingerprint: `sha256:${'b'.repeat(64)}`,
+};
+
+test('newer WSL Host offers no downgrade and never resolves an update package', async () => {
+  const blocker = await resolveDesktopWslHostHandoff(profile, incompatible(RUNTIME_HOST_COMPATIBILITY_EPOCH + 1), new AbortController().signal, {
+    resolveBinding: async () => assert.fail('newer Host must not be managed'),
+    resolvePackage: async () => assert.fail('must not stage a downgrade'),
+  });
+  assert.equal(blocker.replacement, undefined);
+  assert.match(blocker.operatorStep!, /Update Desktop/u);
+  assert.equal(blocker.manualRecheck, true);
+});
+
+test('unbound WSL connection has no mutation authority', async () => {
+  const blocker = await resolveDesktopWslHostHandoff(profile, incompatible(), new AbortController().signal, {
+    resolveBinding: async () => undefined,
+    resolvePackage: async () => assert.fail('unbound target cannot select a package'),
+  });
+  assert.equal(blocker.replacement, undefined);
+});
+
+test('WSL handoff carries exact source identity and separately forwards interruption consent', async () => {
+  let changed = false;
+  const policies: boolean[] = [];
+  const blocker = await resolveDesktopWslHostHandoff(profile, incompatible(), new AbortController().signal, {
+    resolveBinding: async () => changed ? undefined : binding,
+    resolvePackage: async () => ({ kind: 'npm', specifier: 'maka-agent@0.3.0' }),
+    status: async () => ({ schemaVersion: 1, kind: 'result', action: 'status', service }),
+    update: async (input) => {
+      assert.deepEqual(input.expectedHost, { hostEpoch: 'old-host', pid: 42 });
+      assert.equal(input.expectedConfigFingerprint, service.configurationFingerprint);
+      assert.equal(input.expectedTarget.deploymentId, binding.deployment.deploymentId);
+      policies.push(input.allowInterruptActiveTasks);
+      return { schemaVersion: 1, kind: 'result', action: 'update', service,
+        update: input.allowInterruptActiveTasks
+          ? { kind: 'updated', previousVersion: '0.2.0', targetVersion: '0.3.0' }
+          : { kind: 'active_tasks', currentVersion: '0.2.0', targetVersion: '0.3.0' },
+      };
+    },
+  });
+  assert.equal(blocker.replacement?.requiresExplicitSelection, true);
+  assert.deepEqual(await blocker.replacement!.execute('refuse_active_work', () => {}, 'explicit'), { kind: 'active_work' });
+  assert.deepEqual(await blocker.replacement!.execute('interrupt_active_work', () => {}, 'explicit'), { kind: 'completed' });
+  changed = true;
+  assert.deepEqual(await blocker.replacement!.execute('interrupt_active_work', () => {}, 'explicit'), { kind: 'changed' });
+  assert.deepEqual(policies, [false, true]);
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-wsl-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-wsl-handoff.test.ts
@@ -90,3 +90,22 @@ test('WSL handoff carries exact source identity and separately forwards interrup
   assert.deepEqual(await blocker.replacement!.execute('interrupt_active_work', () => {}, 'explicit'), { kind: 'changed' });
   assert.deepEqual(policies, [false, true]);
 });
+
+
+test('legacy operator without a configuration fingerprint remains fenced by source version and Host identity', async () => {
+  const { configurationFingerprint: _fingerprint, ...legacyService } = service;
+  const blocker = await resolveDesktopWslHostHandoff(profile, incompatible(), new AbortController().signal, {
+    resolveBinding: async () => binding,
+    resolvePackage: async () => ({ kind: 'development_archive', path: '/selected.tgz', integrity: 'sha512-selected' }),
+    status: async () => ({ schemaVersion: 1, kind: 'result', action: 'status', service: legacyService }),
+    update: async (input) => {
+      assert.equal(input.expectedConfigFingerprint, undefined);
+      assert.equal(input.expectedSourceVersion, legacyService.installedVersion);
+      assert.deepEqual(input.expectedHost, { hostEpoch: 'old-host', pid: 42 });
+      assert.equal(input.expectedTarget.deploymentId, binding.deployment.deploymentId);
+      return { schemaVersion: 1, kind: 'error', action: 'update', error: { code: 'target_mismatch', message: 'Source changed under deployment lock' } };
+    },
+  });
+  assert.ok(blocker.replacement);
+  assert.deepEqual(await blocker.replacement.execute('refuse_active_work', () => {}, 'explicit'), { kind: 'changed' });
+});

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { resolveDesktopWslHostHandoff } from './runtime-host-wsl-handoff.js';
 import {
   app,
   type BrowserWindow,
@@ -1366,6 +1367,11 @@ const startLocalRuntimeHostManager = () => startRuntimeHostDesktopManager(
     },
     recoverLocalHost: (signal) => localRuntimeHostRemoteAccess.recoverBeforeLocalHostStart(signal),
     resolveStartupRepair: (error, signal) => localRuntimeHostRemoteAccess.resolveStartupRepair(error, signal),
+    resolveWslHostHandoff: async (profile, error, signal) => resolveDesktopWslHostHandoff(profile, error, signal, {
+      locale: await desktopLocale.resolve(),
+      resolveBinding: (profileId) => runtimeHostProfileService.resolveManagedService(profileId),
+      resolvePackage: (packageSignal) => runtimeHostSetupPackage.resolve('none', packageSignal),
+    }),
     resolveLocalHostReplacement: (registration, signal) =>
       localRuntimeHostRemoteAccess.resolveConflictingHostReplacement(registration, signal),
     onFatalError: (error, target) => {

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -265,6 +265,7 @@ export async function startRuntimeHostDesktopManager(
     ) => Promise<RuntimeHostLocalReplacement | undefined>;
     recoverLocalHost?: (signal: AbortSignal) => Promise<boolean>;
     resolveStartupRepair?: (error: Error, signal: AbortSignal) => Promise<HostHandoffBlocker | undefined>;
+    resolveWslHostHandoff?: (profile: Extract<ResolvedRuntimeHostProfile['profile'], { kind: 'environment' }>, error: RuntimeHostRemoteCompatibilityError, signal: AbortSignal) => Promise<HostHandoffBlocker>;
     reconnectBackoff?: RuntimeHostReconnectBackoff;
     pairingFinalizationTimeoutMs?: number;
     onTargetStateChanged?: (state: RuntimeHostDesktopTargetState) => void;
@@ -283,6 +284,7 @@ export async function startRuntimeHostDesktopManager(
     options.resolveLocalHostReplacement,
     options.recoverLocalHost,
     options.resolveStartupRepair,
+    options.resolveWslHostHandoff,
     options.reconnectBackoff,
     options.pairingFinalizationTimeoutMs ?? DEFAULT_PAIRING_FINALIZATION_TIMEOUT_MS,
     options.onTargetStateChanged,
@@ -334,6 +336,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
     private readonly resolveStartupRepair:
       | ((error: Error, signal: AbortSignal) => Promise<HostHandoffBlocker | undefined>)
       | undefined,
+    private readonly resolveWslHostHandoff: ((profile: Extract<ResolvedRuntimeHostProfile['profile'], { kind: 'environment' }>, error: RuntimeHostRemoteCompatibilityError, signal: AbortSignal) => Promise<HostHandoffBlocker>) | undefined,
     private readonly reconnectBackoff: RuntimeHostReconnectBackoff | undefined,
     private readonly pairingFinalizationTimeoutMs: number,
     private readonly onTargetStateChanged:
@@ -1157,12 +1160,25 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       } catch (error) {
         signal.throwIfAborted();
         if (target.input.profileTarget && error instanceof RuntimeHostRemoteCompatibilityError) {
+          if (target.target.profile.kind === 'environment' && this.resolveWslHostHandoff) {
+            try {
+              return { kind: 'blocked', blocker: await this.resolveWslHostHandoff(target.target.profile, error, signal) };
+            } catch (managementError) {
+              signal.throwIfAborted();
+              return { kind: 'blocked', blocker: {
+                identity: JSON.stringify([target.epoch, error.hostEpoch, 'management-unavailable']),
+                target: { name: target.target.profile.name, location: 'remote', rootId: target.target.profile.rootId, hostEpoch: error.hostEpoch },
+                reason: 'unavailable', mayExitNaturally: false, manualRecheck: true,
+                diagnostic: managementError instanceof Error ? managementError.message : String(managementError),
+              } };
+            }
+          }
           return { kind: 'blocked', blocker: {
             identity: JSON.stringify([target.epoch, error.hostEpoch, error.details]),
             target: { name: target.target.profile.name, location: 'remote',
               ...(target.target.profile.kind === 'local' ? {} : { rootId: target.target.profile.rootId }),
               hostEpoch: error.hostEpoch },
-            reason: 'upgrade', mayExitNaturally: false, diagnostic: error.message,
+            reason: 'upgrade', mayExitNaturally: false, manualRecheck: true, diagnostic: error.message,
           } };
         }
         if (await tryRecoverLocalHost()) continue;

--- a/apps/desktop/src/main/runtime-host-local-operator.ts
+++ b/apps/desktop/src/main/runtime-host-local-operator.ts
@@ -866,6 +866,7 @@ function runSetupProcess(input: {
     onFrame(frame) {
       if (frame.kind === 'progress') input.onProgress(frame);
       else if (frame.kind === 'error') failure = new Error(frame.error.message);
+      else if (frame.kind === 'existing_environment') failure = new Error('Local setup returned an environment binding');
       else if (complete) failure = new Error('Local Maka setup returned multiple results');
       else complete = frame;
     },

--- a/apps/desktop/src/main/runtime-host-profile-service.ts
+++ b/apps/desktop/src/main/runtime-host-profile-service.ts
@@ -925,18 +925,18 @@ export function createDesktopRuntimeHostProfileService(input: {
         }
       });
     },
-    resolveManagedService(profileId) {
-      return mutate(async () => {
-        const profile = (await catalog.read()).profiles.find(
-          (candidate) => candidate.id === profileId,
-        );
-        if (!profile) return undefined;
-        const binding = findDesktopRuntimeHostManagedServiceBinding(
-          await managedServices.read(),
-          profile,
-        );
-        return binding;
-      });
+    async resolveManagedService(profileId) {
+      // Connection may be waiting for handoff while the profile mutation queue
+      // is held. Read the persisted binding without re-entering that queue;
+      // mutation adapters revalidate the snapshot before acting on it.
+      const profile = (await catalog.read()).profiles.find(
+        (candidate) => candidate.id === profileId,
+      );
+      if (!profile) return undefined;
+      return findDesktopRuntimeHostManagedServiceBinding(
+        await managedServices.read(),
+        profile,
+      );
     },
     resolveCollaborationConnectionTarget(profile) {
       return mutate(async () => {

--- a/apps/desktop/src/main/runtime-host-ssh-terminal.ts
+++ b/apps/desktop/src/main/runtime-host-ssh-terminal.ts
@@ -762,7 +762,7 @@ export function createDesktopRuntimeHostSshTerminal(input: {
               complete = frame;
               onComplete?.(frame);
               if (setupTerminal) completePresentation(setupTerminal);
-            } else setupFailure = new Error(frame.error.message);
+            } else setupFailure = new Error(frame.kind === 'error' ? frame.error.message : 'SSH setup returned a local environment binding');
           },
           onError: (error) => {
             setupFailure = error;

--- a/apps/desktop/src/main/runtime-host-wsl-controller.ts
+++ b/apps/desktop/src/main/runtime-host-wsl-controller.ts
@@ -219,7 +219,8 @@ export async function runDesktopRuntimeHostWslUpdate(
     readonly distribution: string;
     readonly setupPackage: DesktopRuntimeHostSetupPackage;
     readonly expectedTarget: DesktopRuntimeHostWslManagementInput['expectedTarget'];
-    readonly expectedConfigFingerprint: string;
+    readonly expectedConfigFingerprint?: string;
+    readonly expectedSourceVersion: string;
     readonly expectedHost: { readonly hostEpoch: string; readonly pid: number };
     readonly allowInterruptActiveTasks: boolean;
     readonly signal?: AbortSignal;
@@ -246,7 +247,8 @@ export async function runDesktopRuntimeHostWslUpdate(
     '--expected-root-id', target.rootId,
     '--expected-root-path', target.rootPath,
     '--expected-deployment-id', target.deploymentId,
-    '--expected-config-fingerprint', input.expectedConfigFingerprint,
+    '--expected-source-version', input.expectedSourceVersion,
+    ...(input.expectedConfigFingerprint ? ['--expected-config-fingerprint', input.expectedConfigFingerprint] : []),
     '--expected-host-json', JSON.stringify(input.expectedHost),
     ...(input.allowInterruptActiveTasks ? ['--allow-interrupt-active-tasks'] : []),
   ];

--- a/apps/desktop/src/main/runtime-host-wsl-controller.ts
+++ b/apps/desktop/src/main/runtime-host-wsl-controller.ts
@@ -28,6 +28,7 @@ import {
   decodeRuntimeHostSetupFrame,
   decodeRuntimeHostServiceManagementFrame,
   RUNTIME_HOST_OPERATOR_PROJECT_DIRECTORY_CONFIGURATION_REQUEST_ENV,
+  RUNTIME_HOST_OPERATOR_RETIREMENT_CANCELLATION_ENV,
   RUNTIME_HOST_SERVICE_MANAGEMENT_FRAME_PREFIX,
   RUNTIME_HOST_SETUP_FRAME_PREFIX,
   RUNTIME_HOST_SETUP_SOURCE_PACKAGE_INTEGRITY_ENV,
@@ -47,7 +48,7 @@ const WSL_SETUP_TIMEOUT_MS = 10 * 60_000;
 const WSL_SETUP_OUTPUT_MAX_BYTES = 64 * 1024;
 const WSL_SETUP_STDERR_MAX_BYTES = 8 * 1024;
 
-type RuntimeHostSetupCompleteFrame = Extract<RuntimeHostSetupFrame, { kind: 'complete' }>;
+type RuntimeHostSetupCompleteFrame = Extract<RuntimeHostSetupFrame, { kind: 'complete' | 'existing_environment' }>;
 type RuntimeHostWslSetupCompleteFrame = Omit<RuntimeHostSetupCompleteFrame, 'operator'> & {
   readonly operator: RuntimeHostNodeOperatorCommand<'posix'>;
 };
@@ -212,6 +213,62 @@ export async function runDesktopRuntimeHostWslSetup(
   });
 }
 
+/** Runs the explicitly selected successor, which owns the existing durable update transaction. */
+export async function runDesktopRuntimeHostWslUpdate(
+  input: {
+    readonly distribution: string;
+    readonly setupPackage: DesktopRuntimeHostSetupPackage;
+    readonly expectedTarget: DesktopRuntimeHostWslManagementInput['expectedTarget'];
+    readonly expectedConfigFingerprint: string;
+    readonly expectedHost: { readonly hostEpoch: string; readonly pid: number };
+    readonly allowInterruptActiveTasks: boolean;
+    readonly signal?: AbortSignal;
+  },
+  onProgress: (phase: string) => void,
+  overrides: {
+    readonly processFactory?: RuntimeHostWslProcessFactory;
+    readonly wslExecutable?: string;
+  } = {},
+): Promise<RuntimeHostManagementTerminalFrame> {
+  input.signal?.throwIfAborted();
+  const distribution = normalizeRuntimeHostWslDistribution(input.distribution);
+  const processFactory = overrides.processFactory ?? spawnWsl;
+  const executable = overrides.wslExecutable ?? resolveSystemRuntimeHostWslExecutable();
+  const setupPackage = await resolveWslPackageSpecifier(input.setupPackage, distribution, executable, processFactory);
+  input.signal?.throwIfAborted();
+  const target = input.expectedTarget;
+  if (!target.deploymentId) throw new Error('WSL update requires a bound deployment identity');
+  const args = [
+    'npx', '--yes', '--package', setupPackage.specifier,
+    'maka', 'runtime-host', 'service', 'update', '--framed',
+    '--managed-root-id', target.rootId,
+    '--expected-service-id', target.serviceId,
+    '--expected-root-id', target.rootId,
+    '--expected-root-path', target.rootPath,
+    '--expected-deployment-id', target.deploymentId,
+    '--expected-config-fingerprint', input.expectedConfigFingerprint,
+    '--expected-host-json', JSON.stringify(input.expectedHost),
+    ...(input.allowInterruptActiveTasks ? ['--allow-interrupt-active-tasks'] : []),
+  ];
+  const environment = `${RUNTIME_HOST_OPERATOR_RETIREMENT_CANCELLATION_ENV}=1 ` +
+    (setupPackage.integrity ? `${RUNTIME_HOST_SETUP_SOURCE_PACKAGE_INTEGRITY_ENV}=${quotePosix(setupPackage.integrity)} ` : '');
+  const command = `maka_prefix=$(mktemp -d) || exit 1; trap 'rm -rf -- "$maka_prefix"' EXIT; cd "$maka_prefix" || exit 1; ${environment}${args.map(quotePosix).join(' ')}`;
+  const child = processFactory(executable, ['--distribution', distribution, '--exec', '/bin/sh', '-lc', `exec /bin/sh -c ${quotePosix(command)}`]);
+  const terminal = await runWslFramedProcess({
+    child, signal: input.signal, retirementCancellation: true,
+    prefix: RUNTIME_HOST_SERVICE_MANAGEMENT_FRAME_PREFIX,
+    decode: decodeRuntimeHostServiceManagementFrame,
+    label: 'WSL Runtime Host update',
+    onFrame: (frame) => {
+      if (frame.action !== 'update') throw new Error('WSL returned an unrelated update result');
+      if (frame.kind === 'progress') { onProgress(frame.phase); return undefined; }
+      if (frame.kind === 'result' && frame.update.kind !== 'active_tasks') onProgress('verifying');
+      return frame;
+    },
+  });
+  return terminal;
+}
+
 async function resolveWslPackageSpecifier(
   setupPackage: DesktopRuntimeHostSetupPackage,
   distribution: string,
@@ -259,7 +316,7 @@ function runtimeHostWslSetupCommand(
     '--repair-root-after-remount',
     // Source development explicitly selects a new archive; released onboarding
     // must never replace an existing shared deployment as a side effect of Connect.
-    ...(development ? ['--update-existing'] : []),
+    ...(development ? ['--update-existing'] : ['--reuse-existing-environment']),
     ...(input.projectDirectoryRoots === undefined
       ? []
       : input.projectDirectoryRoots.length === 0
@@ -328,11 +385,15 @@ async function runWslFramedProcess<Frame, Result>(input: {
   readonly label: string;
   readonly onFrame: (frame: Frame) => Result | undefined;
   readonly onResult?: (result: Result) => void;
+  readonly retirementCancellation?: boolean;
 }): Promise<Result> {
-  const abort = () => input.child.kill();
+  // EOF cancels only retirement admission. The updater must settle its durable
+  // transaction after cutover, even when the user closes the handoff window.
+  const abort = () => input.retirementCancellation ? input.child.stdin.end() : input.child.kill();
   input.signal?.addEventListener('abort', abort, { once: true });
   if (input.signal?.aborted) abort();
-  input.child.stdin.end();
+  if (!input.retirementCancellation) input.child.stdin.end();
+  input.child.stdin.on('error', () => undefined);
   let result: Result | undefined;
   let failure: Error | undefined;
   const filter = createRuntimeHostFramedOutputFilter({

--- a/apps/desktop/src/main/runtime-host-wsl-handoff.ts
+++ b/apps/desktop/src/main/runtime-host-wsl-handoff.ts
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { UiLocale } from '@maka/core/ui-locale';
+import type { EnvironmentRuntimeHostProfile, HostHandoffBlocker, HostHandoffPhase, RuntimeHostRemoteCompatibilityError } from '@maka/runtime-host/client';
+import { compareProductReleaseVersions } from '@maka/runtime-host/operator';
+import type { DesktopRuntimeHostManagedServiceBinding } from './runtime-host-managed-services.js';
+import { runtimeHostSetupPackageVersion, type DesktopRuntimeHostSetupPackage } from './runtime-host-setup-package.js';
+import { runDesktopRuntimeHostWslManagement, runDesktopRuntimeHostWslUpdate } from './runtime-host-wsl-controller.js';
+
+/** A WSL route is a capability only after its persisted management binding is validated. */
+export async function resolveDesktopWslHostHandoff(
+  profile: EnvironmentRuntimeHostProfile,
+  error: RuntimeHostRemoteCompatibilityError,
+  signal: AbortSignal,
+  deps: {
+    readonly locale?: UiLocale;
+    resolveBinding(profileId: string): Promise<DesktopRuntimeHostManagedServiceBinding | undefined>;
+    resolvePackage(signal: AbortSignal): Promise<DesktopRuntimeHostSetupPackage>;
+    status?: typeof runDesktopRuntimeHostWslManagement;
+    update?: typeof runDesktopRuntimeHostWslUpdate;
+  },
+): Promise<HostHandoffBlocker> {
+  const guidance = GUIDANCE[deps.locale ?? 'en'];
+  const base: HostHandoffBlocker = {
+    identity: JSON.stringify([profile, error.hostEpoch, error.details]),
+    target: { name: profile.name, location: 'remote', rootId: profile.rootId, hostEpoch: error.hostEpoch },
+    reason: 'upgrade', mayExitNaturally: false, manualRecheck: true,
+    diagnostic: error.message,
+  };
+  // Host compatibility is not a release ordering, but a newer contract must
+  // never be replaced by this older Client's package to make Connect succeed.
+  if (error.details.host.compatibilityEpoch > error.details.client.compatibilityEpoch) {
+    return { ...base, operatorStep: guidance.client };
+  }
+  const binding = await deps.resolveBinding(profile.id);
+  if (!binding || binding.state !== 'active' || binding.profile.kind !== 'environment' ||
+      JSON.stringify(binding.profile) !== JSON.stringify(profile) || !binding.deployment.deploymentId) {
+    return { ...base, operatorStep: guidance.binding };
+  }
+  const expectedTarget = {
+    serviceId: binding.deployment.id, rootPath: binding.deployment.rootPath,
+    rootId: profile.rootId, deploymentId: binding.deployment.deploymentId,
+  };
+  const status = await (deps.status ?? runDesktopRuntimeHostWslManagement)({
+    distribution: profile.provider.distribution, operator: profile.operator,
+    action: 'status', expectedTarget, signal,
+  });
+  if (status.kind !== 'result' || status.action !== 'status' || status.service.lifecycle?.mode !== 'on_demand' ||
+      !status.service.pid || !status.service.installedVersion || !status.service.configurationFingerprint) {
+    return { ...base, operatorStep: guidance.source };
+  }
+  const setupPackage = await deps.resolvePackage(signal);
+  const targetVersion = runtimeHostSetupPackageVersion(setupPackage);
+  if (targetVersion && (/(?:-|\.)dev-[0-9a-f]{12}$/u.test(status.service.installedVersion) || compareProductReleaseVersions(targetVersion, status.service.installedVersion) <= 0)) {
+    return { ...base, operatorStep: guidance.target };
+  }
+  const currentVersion = status.service.installedVersion;
+  const expectedConfigFingerprint = status.service.configurationFingerprint;
+  const expectedHost = { hostEpoch: error.hostEpoch, pid: status.service.pid };
+  const identity = JSON.stringify([base.identity, binding.deployment, expectedHost, expectedConfigFingerprint, setupPackage]);
+  return {
+    ...base, identity,
+    packageChange: { current: currentVersion, target: targetVersion ?? (setupPackage.kind === 'development_archive' ? setupPackage.integrity : setupPackage.specifier) },
+    replacement: {
+      kind: 'replace', canReplaceIdle: true, canInterrupt: true, requiresExplicitSelection: true,
+      execute: async (policy, progress, _consent, retirementSignal) => {
+        const fresh = await deps.resolveBinding(profile.id);
+        if (JSON.stringify(fresh) !== JSON.stringify(binding)) return { kind: 'changed' };
+        const result = await (deps.update ?? runDesktopRuntimeHostWslUpdate)({
+          distribution: profile.provider.distribution, setupPackage, expectedTarget,
+          expectedConfigFingerprint, expectedHost,
+          allowInterruptActiveTasks: policy === 'interrupt_active_work', signal: retirementSignal,
+        }, (phase) => {
+          const phases: readonly string[] = ['checking', 'staging', 'retiring', 'replacing', 'verifying'];
+          if (phases.includes(phase)) progress(phase as HostHandoffPhase);
+        });
+        if (result.kind === 'error') {
+          if (result.error.code === 'target_mismatch') return { kind: 'changed' };
+          if (result.error.code === 'active_tasks') return { kind: 'active_work' };
+          return { kind: 'recovery_required', diagnostic: result.error.message };
+        }
+        if (result.action !== 'update') return { kind: 'recovery_required', diagnostic: 'WSL returned an unrelated update result' };
+        return { kind: result.update.kind === 'active_tasks' ? 'active_work' : 'completed' };
+      },
+    },
+  };
+}
+
+
+const GUIDANCE = {
+  en: {
+    client: 'Update Desktop to a build compatible with this Host. The Host will not be downgraded.',
+    binding: 'The WSL management binding is unavailable. Restore it through Runtime Host settings before updating.',
+    source: 'The installed WSL operator could not verify the running on-demand Host. Recheck its service status in Runtime Host settings.',
+    target: 'This Desktop cannot verify a suitable replacement package. Update Desktop or manage the selected development artifact explicitly; the existing Host will be preserved.',
+  },
+  'zh-CN': {
+    client: '请更新 Desktop，使它与此 Host 兼容。不会降级现有 Host。',
+    binding: 'WSL 管理绑定不可用。请先在 Runtime Host 设置中恢复管理入口，再进行更新。',
+    source: '已安装的 WSL 管理程序无法验证正在运行的按需 Host。请在 Runtime Host 设置中检查服务状态。',
+    target: '当前 Desktop 无法验证合适的替换包。请更新 Desktop，或通过开发环境明确管理选定的开发包；现有 Host 会被保留。',
+  },
+  'zh-TW': {
+    client: '請更新 Desktop，使它與此 Host 相容。不會降級現有 Host。',
+    binding: 'WSL 管理綁定不可用。請先在 Runtime Host 設定中恢復管理入口，再進行更新。',
+    source: '已安裝的 WSL 管理程式無法驗證正在執行的按需 Host。請在 Runtime Host 設定中檢查服務狀態。',
+    target: '目前 Desktop 無法驗證合適的替換套件。請更新 Desktop，或透過開發環境明確管理選定的開發套件；現有 Host 會被保留。',
+  },
+} as const;

--- a/apps/desktop/src/main/runtime-host-wsl-handoff.ts
+++ b/apps/desktop/src/main/runtime-host-wsl-handoff.ts
@@ -63,7 +63,7 @@ export async function resolveDesktopWslHostHandoff(
     action: 'status', expectedTarget, signal,
   });
   if (status.kind !== 'result' || status.action !== 'status' || status.service.lifecycle?.mode !== 'on_demand' ||
-      !status.service.pid || !status.service.installedVersion || !status.service.configurationFingerprint) {
+      !status.service.pid || !status.service.installedVersion) {
     return { ...base, operatorStep: guidance.source };
   }
   const setupPackage = await deps.resolvePackage(signal);
@@ -72,9 +72,11 @@ export async function resolveDesktopWslHostHandoff(
     return { ...base, operatorStep: guidance.target };
   }
   const currentVersion = status.service.installedVersion;
+  // Legacy operators omit the fingerprint. The transaction still fences the source
+  // package version, deployment identity and exact Host generation under its lease.
   const expectedConfigFingerprint = status.service.configurationFingerprint;
   const expectedHost = { hostEpoch: error.hostEpoch, pid: status.service.pid };
-  const identity = JSON.stringify([base.identity, binding.deployment, expectedHost, expectedConfigFingerprint, setupPackage]);
+  const identity = JSON.stringify([base.identity, binding.deployment, expectedHost, currentVersion, expectedConfigFingerprint, setupPackage]);
   return {
     ...base, identity,
     packageChange: { current: currentVersion, target: targetVersion ?? (setupPackage.kind === 'development_archive' ? setupPackage.integrity : setupPackage.specifier) },
@@ -85,7 +87,7 @@ export async function resolveDesktopWslHostHandoff(
         if (JSON.stringify(fresh) !== JSON.stringify(binding)) return { kind: 'changed' };
         const result = await (deps.update ?? runDesktopRuntimeHostWslUpdate)({
           distribution: profile.provider.distribution, setupPackage, expectedTarget,
-          expectedConfigFingerprint, expectedHost,
+          expectedConfigFingerprint, expectedHost, expectedSourceVersion: currentVersion,
           allowInterruptActiveTasks: policy === 'interrupt_active_work', signal: retirementSignal,
         }, (phase) => {
           const phases: readonly string[] = ['checking', 'staging', 'retiring', 'replacing', 'verifying'];

--- a/apps/desktop/src/main/startup-progress-window.ts
+++ b/apps/desktop/src/main/startup-progress-window.ts
@@ -146,7 +146,7 @@ export function createStartupProgressWindow(input: {
   win.webContents.on('will-navigate', (event, url) => {
     event.preventDefault();
     if (url.startsWith('maka-startup://handoff/')) {
-      const match = /^maka-startup:\/\/handoff\/([a-z0-9-]+)\/(cancel|retry|interrupt)$/.exec(url);
+      const match = /^maka-startup:\/\/handoff\/([a-z0-9-]+)\/(cancel|retry|replace|interrupt)$/.exec(url);
       if (match && handoff?.view.revision === match[1] && handoff.view.actions.includes(match[2] as HostHandoffAction)) {
         handoff.submit(match[1], match[2] as HostHandoffAction);
       }
@@ -227,10 +227,11 @@ footer { display: flex; justify-content: space-between; align-items: center; mar
 #elapsed { opacity: .55; font-variant-numeric: tabular-nums; }
 button { font: inherit; color: inherit; background: transparent; border: 1px solid ${dark ? '#48494f' : '#dedee3'}; border-radius: 7px; padding: 6px 10px; cursor: pointer; }
 button:hover { background: ${dark ? '#303137' : '#f4f4f6'}; } button:focus-visible { outline: 2px solid #788aff; outline-offset: 3px; }
-#handoff-detail { white-space: pre-line; margin-top: 18px; } #actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px; }
+#handoff-detail { white-space: pre-line; overflow-wrap: anywhere; margin-top: 18px; } #actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px; }
 #actions .destructive { border-color: ${dark ? '#c77976' : '#bc443d'}; color: ${dark ? '#ffada7' : '#a42c25'}; }
 #handoff-diagnostic { white-space: pre-wrap; overflow-wrap: anywhere; max-height: 70px; overflow: auto; font: 11px/1.4 monospace; opacity: .6; }
 body[data-handoff] #slow, body[data-handoff] .status { display: none; }
+body[data-handoff="attention"] #elapsed { display: none; }
 @keyframes spin { to { transform: rotate(360deg); } } @media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
 </style></head><body>
 <svg viewBox="0 0 460 120" role="img" aria-label="Maka"><g transform="translate(0,120) scale(0.1,-0.1)"><path d="${MAKA_WORDMARK_PATH}"/></g></svg>

--- a/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
@@ -465,7 +465,7 @@ test('replacement reactivates a proven previous authority after a pre-commit fai
   }
 });
 
-test('failed on-demand candidate activation restores the known-good package authority', async (t) => {
+test('failed on-demand candidate activation retains the successor authority', async (t) => {
   const stateRoot = await mkdtemp(join(tmpdir(), 'maka-lifecycle-on-demand-update-'));
   const capability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
   const authorityDirectory = dirname(
@@ -508,14 +508,14 @@ test('failed on-demand candidate activation restores the known-good package auth
         },
       },
     }),
-    { code: 'transition_failed' },
+    { code: 'recovery_failed' },
   );
 
-  const restored = await readRuntimeHostManagedDeploymentAuthorityRecord(capability);
-  assert.equal(restored?.state, 'active');
-  assert.equal(restored?.configRevision, 3);
-  assert.deepEqual(restored?.launch, current.launch);
-  assert.deepEqual(operatorProjection.launch, current.launch);
+  const retained = await readRuntimeHostManagedDeploymentAuthorityRecord(capability);
+  assert.equal(retained?.state, 'active');
+  assert.equal(retained?.configRevision, 2);
+  assert.deepEqual(retained?.launch, desired.launch);
+  assert.deepEqual(operatorProjection.launch, desired.launch);
 });
 
 test('revalidates product invariants after Host retirement and restores the prior lifecycle', async (t) => {
@@ -1015,7 +1015,6 @@ test('failed on-demand update activation retains the committed package without r
       operation: 'update',
       current,
       desired,
-      retainDesiredOnActivationFailure: true,
       activateDesired: async () => {
         throw new Error('Successor opened storage but readiness failed');
       },

--- a/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-lifecycle-transaction.test.ts
@@ -952,3 +952,83 @@ function config(
       : { trigger: 'activation' },
   };
 }
+
+test('on-demand source retirement fences identity, preserves active work, and acquires the released root', async (t) => {
+  const stateRoot = await mkdtemp(join(tmpdir(), 'maka-source-retirement-'));
+  t.after(() => rm(stateRoot, { recursive: true, force: true }));
+  const capability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+  let owner = await tryAcquireStateRootOwner(capability);
+  assert.ok(owner);
+  t.after(async () => owner?.close());
+  let epoch = 'host-b';
+  let calls = 0;
+  let refuse = true;
+  const input = {
+    rootPath: capability.canonicalPath,
+    rootId: capability.rootId,
+    expectedOwner: { hostEpoch: 'host-a', pid: 42 },
+    connectExisting: (async () => ({
+      kind: 'incompatible',
+      registration: {
+        rootId: capability.rootId,
+        hostEpoch: epoch,
+        pid: 42,
+        lifecycleMode: 'ephemeral',
+      },
+    })) as unknown as typeof connectExistingRuntimeHost,
+    prepareSourceRetirement: async () => {
+      calls += 1;
+      if (refuse) return 'active_work' as const;
+      await owner?.close();
+      owner = undefined;
+      return 'prepared' as const;
+    },
+  };
+  await assert.rejects(retireRuntimeHostLifecycleOwner(input), { code: 'owner_changed' });
+  assert.equal(calls, 0);
+  epoch = 'host-a';
+  assert.deepEqual(await retireRuntimeHostLifecycleOwner(input), { kind: 'active_tasks' });
+  assert.equal(await tryAcquireStateRootOwner(capability), undefined);
+  refuse = false;
+  const result = await retireRuntimeHostLifecycleOwner(input);
+  assert.equal(result.kind, 'retired');
+  if (result.kind === 'retired') await result.owner.close();
+  await assert.rejects(retireRuntimeHostLifecycleOwner(input), { code: 'owner_changed' });
+  assert.equal(calls, 2);
+});
+
+test('failed on-demand update activation retains the committed package without reactivating old code', async (t) => {
+  const stateRoot = await mkdtemp(join(tmpdir(), 'maka-update-retained-'));
+  const capability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+  t.after(() => rm(stateRoot, { recursive: true, force: true }));
+  t.after(() =>
+    rm(dirname(resolveRuntimeHostManagedDeploymentConfigPath(capability.rootId)), {
+      recursive: true,
+      force: true,
+    }),
+  );
+  const current = config(capability.canonicalPath, capability.rootId, 1, 'on_demand');
+  const desired = config(capability.canonicalPath, capability.rootId, 2, 'on_demand');
+  await claimRuntimeHostManagedDeployment(capability, current);
+  await assert.rejects(
+    replaceRuntimeHostLifecycle({
+      operation: 'update',
+      current,
+      desired,
+      retainDesiredOnActivationFailure: true,
+      activateDesired: async () => {
+        throw new Error('Successor opened storage but readiness failed');
+      },
+      activatePrevious: async () => assert.fail('must not reactivate old package'),
+      deps: {
+        convergeOperator: async () => undefined,
+        verifyOperator: async () => undefined,
+        resolveProvider: () => {
+          throw new Error('on-demand has no supervisor');
+        },
+      },
+    }),
+    { code: 'recovery_failed' },
+  );
+  assert.deepEqual(await readRuntimeHostManagedDeploymentAuthorityRecord(capability), desired);
+});

--- a/packages/cli/src/__tests__/runtime-host-managed-source-handoff.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-managed-source-handoff.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import { connectExistingRuntimeHost } from '@maka/runtime-host/client';
+import {
+  RuntimeHostKernel,
+  defineInteractiveRuntimeHostComposition,
+  createUnavailableDomainOperationHandlers,
+} from '@maka/runtime-host/server';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '@maka/runtime-host/protocol';
+import { launchRuntimeHostLocalSourceRetirement } from '../runtime-host-local-source-retirement.js';
+import { retireRuntimeHostLifecycleOwner } from '../runtime-host-lifecycle-transaction.js';
+import { withRuntimeHostManagedServiceDeploymentLock } from '../runtime-host-service-manager.js';
+
+for (const policy of ['refuse_active_work', 'interrupt_active_work'] as const)
+  test(`managed source handoff preserves connection/work admission before ${policy}`, {
+    timeout: 15_000,
+  }, async (t) => {
+    const directory = await mkdtemp(join(tmpdir(), 'maka-managed-source-handoff-'));
+    t.after(() => rm(directory, { recursive: true, force: true }));
+    const capability = await resolveStorageRoot({
+      path: join(directory, 'state'),
+      kind: 'interactive',
+    });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    let releaseWork = () => {};
+    const host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 60_000,
+      composition: defineInteractiveRuntimeHostComposition(async (context) => {
+        const work = context.acquireResidency('background-work');
+        releaseWork = () => work.release();
+        return {
+          handlers: createUnavailableDomainOperationHandlers(),
+          beginDrain() {
+            releaseWork();
+          },
+          async recover() {},
+          async close() {},
+        };
+      }),
+    });
+    t.after(() => host.close());
+    const idleSurface = await connectExistingRuntimeHost({
+      rootPath: capability.canonicalPath,
+      protocol: { min: RUNTIME_HOST_PROTOCOL_VERSION, max: RUNTIME_HOST_PROTOCOL_VERSION },
+    });
+    assert.equal(idleSurface.kind, 'connected');
+    if (idleSurface.kind !== 'connected') return;
+    t.after(() => idleSurface.connection.close());
+    const incompatibleConnect: typeof connectExistingRuntimeHost = (input) =>
+      connectExistingRuntimeHost({
+        ...input,
+        protocol: {
+          min: RUNTIME_HOST_PROTOCOL_VERSION + 1,
+          max: RUNTIME_HOST_PROTOCOL_VERSION + 1,
+        },
+      });
+    const observed = await incompatibleConnect({
+      rootPath: capability.canonicalPath,
+      protocol: { min: 0, max: 0 },
+    });
+    assert.equal(observed.kind, 'incompatible');
+    await withRuntimeHostManagedServiceDeploymentLock(join(directory, 'control'), async (lease) => {
+      assert.ok(lease !== undefined);
+      const retire = (activeWorkPolicy: 'refuse_active_work' | 'interrupt_active_work') =>
+        retireRuntimeHostLifecycleOwner({
+          rootPath: capability.canonicalPath,
+          rootId: capability.rootId,
+          expectedOwner: { hostEpoch: host.hostEpoch, pid: process.pid },
+          connectExisting: incompatibleConnect,
+          prepareSourceRetirement: (signal) =>
+            launchRuntimeHostLocalSourceRetirement({
+              sourceCliPath: fileURLToPath(new URL('../cli.js', import.meta.url)),
+              sourceNodePath: process.execPath,
+              rootPath: capability.canonicalPath,
+              expectedRootId: capability.rootId,
+              expectedHostEpoch: host.hostEpoch,
+              activeWorkPolicy,
+              inheritableAuthorityLeaseFd: lease,
+              signal,
+            }),
+        });
+      // Legacy admission conservatively counts another connection as in use;
+      // neither the parent nor the source helper may override that with a snapshot.
+      assert.deepEqual(await retire('refuse_active_work'), { kind: 'active_tasks' });
+      assert.equal(host.state, 'ready');
+      await idleSurface.connection.close();
+      assert.deepEqual(await retire('refuse_active_work'), { kind: 'active_tasks' });
+      if (policy === 'refuse_active_work') releaseWork();
+      const result = await retire(policy);
+      assert.equal(result.kind, 'retired');
+      if (result.kind === 'retired') await result.owner.close();
+    });
+    await host.closed;
+  });

--- a/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
@@ -530,7 +530,6 @@ describe('canonical WSL update fences', () => {
         canonical: {
           ...canonical,
           replaceLifecycle: async (input) => {
-            assert.equal(input.retainDesiredOnActivationFailure, true);
             assert.equal(await input.prepareSourceRetirement?.(), 'active_work');
             return { kind: 'active_tasks' };
           },

--- a/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
@@ -478,6 +478,7 @@ describe('canonical WSL update fences', () => {
 
   for (const selection of [
     { version: '1.0.0' },
+    { version: '3.0.0', expectedSourceVersion: '1.9.0' },
     { version: '3.0.0', expectedConfigFingerprint: `sha256:${'f'.repeat(64)}` },
   ])
     it(`rejects a downgrade or stale consent before staging: ${selection.version}`, async () => {

--- a/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-selected-update.test.ts
@@ -431,3 +431,127 @@ function updateSelection(
     },
   };
 }
+
+describe('canonical WSL update fences', () => {
+  const current = {
+    configRevision: 7,
+    deploymentRoot: '/managed',
+    root: { id: TARGET.rootId, path: TARGET.rootPath },
+    lifecycle: { mode: 'on_demand', availability: 'activation' },
+    launch: {
+      nodePath: '/source/node',
+      package: { kind: 'npm_registry', version: '2.0.0', integrity: INTEGRITY },
+    },
+  };
+  const status = {
+    schemaVersion: 1,
+    action: 'status',
+    service: {
+      manager: 'on_demand',
+      installed: true,
+      enabled: true,
+      active: true,
+      state: 'running',
+      pid: 42,
+      lastExitCode: 0,
+      installedVersion: '2.0.0',
+      config: {
+        schemaVersion: 1,
+        managedDeploymentRoot: '/managed',
+        rootPath: TARGET.rootPath,
+        projectDirectoryRoots: [],
+        websocket: { host: '127.0.0.1', port: 7400, path: '/runtime-host' },
+        launch: { nodePath: '/source/node', cliPath: '/managed/current/dist/cli.js' },
+      },
+    },
+  };
+  const canonical = {
+    createLifecycleDeps: () => ({}) as never,
+    assertOperatorDeployment: async () => {},
+    recoverDeployment: async () => ({ kind: 'active', config: current }) as never,
+    convergeControlProjection: async () => {},
+    verifyProjection: async () => {},
+    assertOperatorConfig: () => {},
+    manageLifecycle: async () => status as never,
+    replaceLifecycle: async () => assert.fail('rejected selections must not retire a Host'),
+  };
+
+  for (const selection of [
+    { version: '1.0.0' },
+    { version: '3.0.0', expectedConfigFingerprint: `sha256:${'f'.repeat(64)}` },
+  ])
+    it(`rejects a downgrade or stale consent before staging: ${selection.version}`, async () => {
+      let output = '';
+      const code = await runManagedRuntimeHostUpdateCli(
+        {
+          ...OPTIONS,
+          ...selection,
+          sourcePackageRoot: '/candidate',
+          managedRootId: TARGET.rootId,
+        },
+        {
+          canonical,
+          withDeploymentLock: async (_root, operation) => operation(88),
+          prepareDeployment: async () => assert.fail('rejection must precede staging'),
+          writeOutput: (value) => {
+            output += value;
+          },
+        },
+      );
+      assert.equal(code, 1);
+      const terminal = decodeRuntimeHostServiceManagementFrame(output.trim());
+      assert.equal(terminal?.kind === 'error' ? terminal.error.code : undefined, 'target_mismatch');
+    });
+
+  it('runs the source package under the inherited lease and preserves a refused Host', async () => {
+    let retired = false;
+    let output = '';
+    const code = await runManagedRuntimeHostUpdateCli(
+      {
+        ...OPTIONS,
+        version: '2.0.0',
+        sourcePackageRoot: '/candidate',
+        managedRootId: TARGET.rootId,
+        expectedHost: { hostEpoch: 'observed-host', pid: 42 },
+      },
+      {
+        withDeploymentLock: async (_root, operation) => operation(88),
+        prepareDeployment: async () => assert.fail('same exact package does not need staging'),
+        retireSource: async (input) => {
+          assert.equal(input.sourceNodePath, '/source/node');
+          assert.match(input.sourceCliPath, /\/versions\/registry-[a-f0-9]+\/dist\/cli\.js$/u);
+          assert.equal(input.inheritableAuthorityLeaseFd, 88);
+          assert.equal(input.expectedHostEpoch, 'observed-host');
+          assert.equal(input.activeWorkPolicy, 'refuse_active_work');
+          retired = true;
+          return 'active_work';
+        },
+        canonical: {
+          ...canonical,
+          replaceLifecycle: async (input) => {
+            assert.equal(input.retainDesiredOnActivationFailure, true);
+            assert.equal(await input.prepareSourceRetirement?.(), 'active_work');
+            return { kind: 'active_tasks' };
+          },
+        },
+        writeOutput: (value) => {
+          output += value;
+        },
+      },
+    );
+    assert.equal(code, 1);
+    assert.equal(retired, true);
+    const frames = output.trim().split('\n').map(decodeRuntimeHostServiceManagementFrame);
+    const terminal = frames.at(-1);
+    assert.equal(
+      terminal?.kind === 'result' && terminal.action === 'update'
+        ? terminal.update.kind
+        : undefined,
+      'active_tasks',
+    );
+    assert.equal(
+      frames.some((frame) => frame?.kind === 'progress' && frame.phase === 'replacing'),
+      false,
+    );
+  });
+});

--- a/packages/cli/src/__tests__/runtime-host-setup.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-setup.test.ts
@@ -201,7 +201,10 @@ test('on-demand setup installs one exact deployment without a service backend', 
     },
     writeOutput: (value) => outputs.push(value),
   } satisfies NonNullable<Parameters<typeof runRuntimeHostSetupCli>[1]>;
-  assert.equal(await runRuntimeHostSetupCli(options, overrides), 0);
+  assert.equal(
+    await runRuntimeHostSetupCli({ ...options, reuseExistingEnvironment: true }, overrides),
+    0,
+  );
   assert.equal(pairingAttempts, 3);
   const complete = outputs
     .map(decodeRuntimeHostSetupFrame)
@@ -280,6 +283,46 @@ test('on-demand setup installs one exact deployment without a service backend', 
     'unsupported_lifecycle_configuration',
   );
 
+  // Discovery reuses canonical identity even when a newer/older Desktop selects
+  // another package, and never opens storage, activates, pairs, or changes settings.
+  const discoveryOwner = await tryAcquireStateRootOwner(
+    await resolveStorageRoot({ path: stateRoot, kind: 'interactive' }),
+  );
+  assert.ok(discoveryOwner);
+  t.after(() => discoveryOwner.close());
+  for (const version of ['1.2.2', '1.2.3', '1.2.4']) {
+    const discovery: string[] = [];
+    assert.equal(
+      await runRuntimeHostSetupCli(
+        { ...options, version, reuseExistingEnvironment: true },
+        {
+          ...overrides,
+          resolveRegistryCandidate: async () => assert.fail('discovery must not resolve a package'),
+          prepareDeployment: async () => assert.fail('discovery must not stage a package'),
+          replaceLifecycle: async () => assert.fail('discovery must not retire a Host'),
+          activateManaged: async () => assert.fail('discovery must not activate'),
+          replaceCredential: async () => assert.fail('local environment discovery must not pair'),
+          writeOutput: (value) => discovery.push(value),
+        },
+      ),
+      0,
+    );
+    const binding = discovery
+      .map(decodeRuntimeHostSetupFrame)
+      .find((frame) => frame?.kind === 'existing_environment');
+    assert.equal(binding?.kind, 'existing_environment');
+    assert.equal(
+      binding && 'deploymentId' in binding ? binding.deploymentId : undefined,
+      complete.deploymentId,
+    );
+    assert.deepEqual(
+      JSON.parse(await readFile(resolveRuntimeHostManagedDeploymentConfigPath(rootId), 'utf8')),
+      persisted,
+    );
+  }
+
+  await discoveryOwner.close();
+
   const replacementIntegrity = `sha512-${Buffer.alloc(64, 9).toString('base64')}`;
   const replacementOptions = { ...options, version: '1.2.4' } as const;
   const replacementPackage = {
@@ -319,6 +362,7 @@ test('on-demand setup installs one exact deployment without a service backend', 
         replaceLifecycle: async (input) => {
           // Model the source Host refusing retirement while a TUI owns work.
           assert.equal(input.allowInterruptActiveTasks, false);
+          assert.equal(input.retainDesiredOnActivationFailure, true);
           return { kind: 'active_tasks' };
         },
         writeOutput: (value) => busyOutputs.push(value),

--- a/packages/cli/src/__tests__/runtime-host-setup.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-setup.test.ts
@@ -362,7 +362,6 @@ test('on-demand setup installs one exact deployment without a service backend', 
         replaceLifecycle: async (input) => {
           // Model the source Host refusing retirement while a TUI owns work.
           assert.equal(input.allowInterruptActiveTasks, false);
-          assert.equal(input.retainDesiredOnActivationFailure, true);
           return { kind: 'active_tasks' };
         },
         writeOutput: (value) => busyOutputs.push(value),

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -465,6 +465,7 @@ export async function runMakaCli(
         bindPairingToClient: command.bindPairingToClient,
         ...(command.repairRootAfterRemount ? { repairRootAfterRemount: true } : {}),
         updateExisting: command.updateExisting,
+        reuseExistingEnvironment: command.reuseExistingEnvironment,
         allowInterruptActiveTasks: command.allowInterruptActiveTasks,
         ...(command.rootPath ? { rootPath: command.rootPath } : {}),
         ...(command.projectDirectoryRoots
@@ -575,6 +576,9 @@ export async function runMakaCli(
           selector: command.selector,
           expectedTarget: command.expectedTarget,
           ...(command.expectedHost ? { expectedHost: command.expectedHost } : {}),
+          ...(command.expectedConfigFingerprint
+            ? { expectedConfigFingerprint: command.expectedConfigFingerprint }
+            : {}),
           ...(command.managedRootId ? { managedRootId: command.managedRootId } : {}),
           ...(command.operatorDeploymentId
             ? { operatorDeploymentId: command.operatorDeploymentId }
@@ -593,6 +597,9 @@ export async function runMakaCli(
         version,
         expectedTarget: command.expectedTarget,
         ...(command.expectedHost ? { expectedHost: command.expectedHost } : {}),
+        ...(command.expectedConfigFingerprint
+          ? { expectedConfigFingerprint: command.expectedConfigFingerprint }
+          : {}),
         ...(command.managedRootId ? { managedRootId: command.managedRootId } : {}),
         ...(command.operatorDeploymentId
           ? { operatorDeploymentId: command.operatorDeploymentId }

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -575,6 +575,9 @@ export async function runMakaCli(
           defaultRootPath: serviceDataRoots.workspaceRoot,
           selector: command.selector,
           expectedTarget: command.expectedTarget,
+          ...(command.expectedSourceVersion
+            ? { expectedSourceVersion: command.expectedSourceVersion }
+            : {}),
           ...(command.expectedHost ? { expectedHost: command.expectedHost } : {}),
           ...(command.expectedConfigFingerprint
             ? { expectedConfigFingerprint: command.expectedConfigFingerprint }
@@ -596,6 +599,9 @@ export async function runMakaCli(
         ...(sourcePackageIntegrity ? { sourcePackageIntegrity } : {}),
         version,
         expectedTarget: command.expectedTarget,
+        ...(command.expectedSourceVersion
+          ? { expectedSourceVersion: command.expectedSourceVersion }
+          : {}),
         ...(command.expectedHost ? { expectedHost: command.expectedHost } : {}),
         ...(command.expectedConfigFingerprint
           ? { expectedConfigFingerprint: command.expectedConfigFingerprint }

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -241,6 +241,7 @@ export type RuntimeHostCliCommand =
       expectedTarget: RuntimeHostManagedServiceTarget;
       expectedHost?: RuntimeHostExpectedHost;
       expectedConfigFingerprint?: string;
+      expectedSourceVersion?: string;
       selector?: RuntimeHostUpdateSelector;
       allowManualUpdate?: true;
       allowInterruptActiveTasks?: true;
@@ -881,6 +882,7 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
   let updateTarget: string | undefined;
   let expectedHost: RuntimeHostExpectedHost | undefined;
   let expectedConfigFingerprint: string | undefined;
+  let expectedSourceVersion: string | undefined;
   const flagOptions: Readonly<Record<string, () => void | RuntimeHostCliError>> =
     action === 'uninstall'
       ? {
@@ -932,6 +934,17 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
             '--target': (value: string) => {
               if (updateTarget !== undefined) return error('Duplicate --target');
               updateTarget = value;
+            },
+          }
+        : {}),
+      ...(action === 'update'
+        ? {
+            '--expected-source-version': (value: string) => {
+              if (expectedSourceVersion !== undefined)
+                return error('Duplicate --expected-source-version');
+              if (!isProductReleaseVersion(value))
+                return error('--expected-source-version must be an exact package version');
+              expectedSourceVersion = value;
             },
           }
         : {}),
@@ -1028,8 +1041,11 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
     };
   }
   if (action === 'update') {
-    if (expectedHost && !options.managedRootId) {
-      return error('--expected-host-json requires --managed-root-id');
+    if (
+      (expectedHost || expectedSourceVersion || expectedConfigFingerprint) &&
+      !options.managedRootId
+    ) {
+      return error('Observed Host and deployment fences require --managed-root-id');
     }
     const selector =
       updateTarget === undefined ? undefined : parseUpdateSelector(updateTarget, 'update');
@@ -1056,6 +1072,7 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
       expectedTarget: options.expectedTarget!,
       ...(expectedHost ? { expectedHost } : {}),
       ...(expectedConfigFingerprint ? { expectedConfigFingerprint } : {}),
+      ...(expectedSourceVersion ? { expectedSourceVersion } : {}),
       ...(selector ? { selector } : {}),
       ...(allowManualUpdate ? { allowManualUpdate: true } : {}),
       ...(allowInterruptActiveTasks ? { allowInterruptActiveTasks: true } : {}),

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -142,6 +142,7 @@ export type RuntimeHostCliCommand =
       bindPairingToClient?: true;
       repairRootAfterRemount?: true;
       updateExisting?: true;
+      reuseExistingEnvironment?: true;
       allowInterruptActiveTasks?: true;
       clientDataRoot?: string;
       rootPath?: string;
@@ -239,6 +240,7 @@ export type RuntimeHostCliCommand =
       operatorDeploymentId?: string;
       expectedTarget: RuntimeHostManagedServiceTarget;
       expectedHost?: RuntimeHostExpectedHost;
+      expectedConfigFingerprint?: string;
       selector?: RuntimeHostUpdateSelector;
       allowManualUpdate?: true;
       allowInterruptActiveTasks?: true;
@@ -703,6 +705,7 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
   let bindPairingToClient = false;
   let repairRootAfterRemount = false;
   let updateExisting = false;
+  let reuseExistingEnvironment = false;
   let allowInterruptActiveTasks = false;
   let clientDataRoot: string | undefined;
   let enableDirectPeer = false;
@@ -756,6 +759,10 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
         if (allowInterruptActiveTasks) return error('Duplicate --allow-interrupt-active-tasks');
         allowInterruptActiveTasks = true;
       },
+      '--reuse-existing-environment': () => {
+        if (reuseExistingEnvironment) return error('Duplicate --reuse-existing-environment');
+        reuseExistingEnvironment = true;
+      },
       '--update-existing': () => {
         if (updateExisting) return error('Duplicate --update-existing');
         updateExisting = true;
@@ -763,6 +770,18 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
     },
   });
   if ('kind' in options) return options;
+  if (
+    reuseExistingEnvironment &&
+    ((lifecycle as string) !== 'on_demand' ||
+      updateExisting ||
+      enableDirectPeer ||
+      deferPairingCommit ||
+      bindPairingToClient)
+  ) {
+    return error(
+      '--reuse-existing-environment requires on-demand local setup without update or remote pairing options',
+    );
+  }
   if (allowInterruptActiveTasks && !updateExisting) {
     return error('--allow-interrupt-active-tasks requires --update-existing');
   }
@@ -786,6 +805,7 @@ function parseSetupCommand(argv: string[]): RuntimeHostCliCommand {
     ...(bindPairingToClient ? { bindPairingToClient: true } : {}),
     ...(repairRootAfterRemount ? { repairRootAfterRemount: true } : {}),
     ...(updateExisting ? { updateExisting: true } : {}),
+    ...(reuseExistingEnvironment ? { reuseExistingEnvironment: true } : {}),
     ...(allowInterruptActiveTasks ? { allowInterruptActiveTasks: true } : {}),
     ...(clientDataRoot ? { clientDataRoot } : {}),
     ...(enableDirectPeer ? { directPeer: { coordinationRelays } } : {}),
@@ -925,7 +945,7 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
             },
           }
         : {}),
-      ...(action === 'configure'
+      ...(action === 'configure' || action === 'update'
         ? {
             '--expected-config-fingerprint': (value: string) => {
               if (expectedConfigFingerprint !== undefined) {
@@ -1035,6 +1055,7 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
         : {}),
       expectedTarget: options.expectedTarget!,
       ...(expectedHost ? { expectedHost } : {}),
+      ...(expectedConfigFingerprint ? { expectedConfigFingerprint } : {}),
       ...(selector ? { selector } : {}),
       ...(allowManualUpdate ? { allowManualUpdate: true } : {}),
       ...(allowInterruptActiveTasks ? { allowInterruptActiveTasks: true } : {}),

--- a/packages/cli/src/runtime-host-handoff-surface.ts
+++ b/packages/cli/src/runtime-host-handoff-surface.ts
@@ -75,7 +75,7 @@ export function createCliHostHandoffSurface(
         if (view.actions.length === 0) return;
         const options = copy.actions.map(
           ({ action, label }) =>
-            `${action === 'interrupt' ? 'stop' : action === 'retry' ? 'r' : 'Enter'}: ${label}`,
+            `${action === 'interrupt' ? 'stop' : action === 'retry' ? 'r' : action === 'replace' ? 'update' : 'Enter'}: ${label}`,
         );
         // Create the reader only after the explanation is visible, with the
         // final action prompt already installed. Never draw readline's default >.
@@ -96,13 +96,15 @@ export function createCliHostHandoffSurface(
           if (readline !== reader || current?.revision !== view.revision) return;
           const answer = line.trim().toLowerCase();
           const action =
-            answer === 'r'
-              ? 'retry'
-              : answer === 'stop'
-                ? 'interrupt'
-                : answer === ''
-                  ? 'cancel'
-                  : undefined;
+            answer === 'update'
+              ? 'replace'
+              : answer === 'r'
+                ? 'retry'
+                : answer === 'stop'
+                  ? 'interrupt'
+                  : answer === ''
+                    ? 'cancel'
+                    : undefined;
           if (!action || !view.actions.includes(action)) {
             reader.prompt();
             return;

--- a/packages/cli/src/runtime-host-lifecycle-transaction.ts
+++ b/packages/cli/src/runtime-host-lifecycle-transaction.ts
@@ -544,8 +544,6 @@ export async function replaceRuntimeHostLifecycle(input: {
   readonly prepareSourceRetirement?: Parameters<
     typeof retireRuntimeHostLifecycleOwner
   >[0]['prepareSourceRetirement'];
-  /** Package updates must not reactivate old code after the successor may have opened storage. */
-  readonly retainDesiredOnActivationFailure?: boolean;
   readonly retirementSupervisor?: {
     status(): Promise<{ readonly active: boolean; readonly pid: number | null }>;
     retire(): Promise<void>;
@@ -597,7 +595,10 @@ export async function replaceRuntimeHostLifecycle(input: {
       await verifyRuntimeHostLifecycleReady(desired, input.deps);
     }
   } catch (activationError) {
-    if (input.retainDesiredOnActivationFailure) {
+    // An on-demand update may have allowed its successor to open the State Root
+    // before readiness failed. Keep that successor authoritative; configuring an
+    // existing package and supervised updates retain their rollback behavior.
+    if (input.operation === 'update' && desired.lifecycle.mode === 'on_demand') {
       throw new RuntimeHostLifecycleTransactionError(
         'recovery_failed',
         'The updated Runtime Host could not become ready. Its deployment is retained; retry activation or repair it without restoring older code.',

--- a/packages/cli/src/runtime-host-lifecycle-transaction.ts
+++ b/packages/cli/src/runtime-host-lifecycle-transaction.ts
@@ -321,7 +321,7 @@ export async function retireRuntimeHostLifecycleOwner(input: {
   readonly connectExisting?: typeof connectExistingRuntimeHost;
   readonly allowInterruptActiveTasks?: boolean;
   /**
-   * Freshness fence evaluated before a canonical supervised-deployment retirement is admitted.
+   * Freshness fence evaluated before a canonical deployment retirement is admitted.
    * The deployment lock and provider identity remain the mutation authority after admission.
    */
   readonly expectedOwner?: { readonly hostEpoch: string; readonly pid: number };
@@ -332,6 +332,10 @@ export async function retireRuntimeHostLifecycleOwner(input: {
     }>;
     retire(): Promise<void>;
   };
+  /** Selected source package speaks the running Host protocol under the caller's deployment lease. */
+  readonly prepareSourceRetirement?: (
+    signal?: AbortSignal,
+  ) => Promise<'prepared' | 'active_work' | 'operator_required'>;
   readonly timeoutMs?: number;
   readonly retireIdleSupervisor?: boolean;
 }): Promise<RuntimeHostLifecycleRetirement> {
@@ -345,12 +349,6 @@ async function retireRuntimeHostLifecycleOwnerWithSignal(
   signal?: AbortSignal,
 ): Promise<RuntimeHostLifecycleRetirement> {
   signal?.throwIfAborted();
-  if (input.expectedOwner && !input.supervisor) {
-    throw new RuntimeHostLifecycleTransactionError(
-      'owner_changed',
-      'A Runtime Host identity fence requires a supervised deployment',
-    );
-  }
   const capability = await resolveExistingStorageRoot({
     path: input.rootPath,
     kind: 'interactive',
@@ -359,6 +357,12 @@ async function retireRuntimeHostLifecycleOwnerWithSignal(
   const idleOwner = await tryAcquireStateRootOwner(capability);
   if (idleOwner) {
     try {
+      if (input.expectedOwner && !input.supervisor) {
+        throw new RuntimeHostLifecycleTransactionError(
+          'owner_changed',
+          'The observed Runtime Host has exited',
+        );
+      }
       if (input.expectedOwner && input.supervisor) {
         const status = await input.supervisor.status();
         assertExpectedSupervisorOwner(input.expectedOwner, status);
@@ -383,6 +387,25 @@ async function retireRuntimeHostLifecycleOwnerWithSignal(
     'registration' in connected ? connected.registration : undefined,
   );
   if (connected.kind !== 'connected') {
+    if (
+      connected.kind === 'incompatible' &&
+      connected.registration?.rootId === input.rootId &&
+      connected.registration.lifecycleMode === 'ephemeral' &&
+      input.expectedOwner &&
+      !input.supervisor &&
+      input.prepareSourceRetirement
+    ) {
+      signal?.throwIfAborted();
+      const prepared = await input.prepareSourceRetirement(signal);
+      if (prepared === 'active_work') return { kind: 'active_tasks' };
+      if (prepared === 'prepared') {
+        return waitForRuntimeHostLifecycleOwner(capability, input.timeoutMs ?? 45_000);
+      }
+      throw new RuntimeHostLifecycleTransactionError(
+        'transition_failed',
+        'The installed source package cannot retire this Runtime Host',
+      );
+    }
     if (input.supervisor) {
       const status = await input.supervisor.status();
       assertExpectedSupervisorOwner(input.expectedOwner, status);
@@ -518,6 +541,11 @@ export async function replaceRuntimeHostLifecycle(input: {
   readonly allowInterruptActiveTasks?: boolean;
   readonly expectedOwner?: { readonly hostEpoch: string; readonly pid: number };
   readonly deps: RuntimeHostLifecycleTransactionDeps;
+  readonly prepareSourceRetirement?: Parameters<
+    typeof retireRuntimeHostLifecycleOwner
+  >[0]['prepareSourceRetirement'];
+  /** Package updates must not reactivate old code after the successor may have opened storage. */
+  readonly retainDesiredOnActivationFailure?: boolean;
   readonly retirementSupervisor?: {
     status(): Promise<{ readonly active: boolean; readonly pid: number | null }>;
     retire(): Promise<void>;
@@ -539,6 +567,10 @@ export async function replaceRuntimeHostLifecycle(input: {
   const retirement = await retireRuntimeHostLifecycleOwner({
     rootPath: desired.root.path,
     rootId: desired.root.id,
+    ...(input.deps.connectExisting ? { connectExisting: input.deps.connectExisting } : {}),
+    ...(input.prepareSourceRetirement
+      ? { prepareSourceRetirement: input.prepareSourceRetirement }
+      : {}),
     ...(input.retirementSupervisor
       ? { supervisor: input.retirementSupervisor }
       : currentProvider
@@ -565,6 +597,13 @@ export async function replaceRuntimeHostLifecycle(input: {
       await verifyRuntimeHostLifecycleReady(desired, input.deps);
     }
   } catch (activationError) {
+    if (input.retainDesiredOnActivationFailure) {
+      throw new RuntimeHostLifecycleTransactionError(
+        'recovery_failed',
+        'The updated Runtime Host could not become ready. Its deployment is retained; retry activation or repair it without restoring older code.',
+        { cause: activationError },
+      );
+    }
     const rollback = current
       ? ({
           ...current,

--- a/packages/cli/src/runtime-host-local-source-retirement.ts
+++ b/packages/cli/src/runtime-host-local-source-retirement.ts
@@ -82,6 +82,7 @@ export async function runRuntimeHostLocalSourceRetirement(
 
 export function launchRuntimeHostLocalSourceRetirement(input: {
   readonly sourceCliPath: string;
+  readonly sourceNodePath?: string;
   readonly rootPath: string;
   readonly expectedRootId: string;
   readonly expectedHostEpoch: string;
@@ -105,7 +106,7 @@ export function launchRuntimeHostLocalSourceRetirement(input: {
       : []),
   ];
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, args, {
+    const child = spawn(input.sourceNodePath ?? process.execPath, args, {
       // fd 4 inherits the existing owner-authority lease. The source helper
       // holds it only while the authenticated retirement request is in flight.
       stdio: ['ignore', 'ignore', 'inherit', 'ignore', input.inheritableAuthorityLeaseFd],

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -370,7 +370,7 @@ export async function withRuntimeHostManagedServiceLifecycleLock<T>(
 
 export async function withRuntimeHostManagedServiceDeploymentLock<T>(
   clientDataRoot: string,
-  operation: () => Promise<T>,
+  operation: (inheritableLeaseFd?: number) => Promise<T>,
   timeoutMs = SERVICE_OPERATION_LOCK_TIMEOUT_MS,
 ): Promise<T> {
   await mkdir(clientDataRoot, { recursive: true, mode: 0o700 });

--- a/packages/cli/src/runtime-host-setup-command.ts
+++ b/packages/cli/src/runtime-host-setup-command.ts
@@ -34,6 +34,7 @@ import {
   encodeRuntimeHostSetupFrame,
   isSha512PackageIntegrity,
   resolveRuntimeHostManagedDeployment,
+  resolveRuntimeHostManagedDeploymentAuthority,
   runtimeHostManagedOperatorCommand,
   RUNTIME_HOST_SETUP_ERROR_CODE_MAX_BYTES,
   RUNTIME_HOST_SETUP_ERROR_MESSAGE_MAX_BYTES,
@@ -140,6 +141,7 @@ export interface RuntimeHostSetupCliOptions {
   readonly bindPairingToClient?: boolean;
   readonly repairRootAfterRemount?: true;
   readonly updateExisting?: boolean;
+  readonly reuseExistingEnvironment?: boolean;
   readonly allowInterruptActiveTasks?: boolean;
   readonly rootPath?: string;
   readonly projectDirectoryRoots?: readonly {
@@ -284,7 +286,7 @@ export async function runRuntimeHostSetupCli(
               () =>
                 withRuntimeHostManagedServiceLifecycleLock(
                   controlRoot,
-                  () => runRuntimeHostSetupLocked(options, deps, emit),
+                  () => runRuntimeHostSetupLocked(options, deps, emit, rootId),
                   SETUP_LOCK_TIMEOUT_MS,
                 ),
               SETUP_LOCK_TIMEOUT_MS,
@@ -334,7 +336,37 @@ async function runRuntimeHostSetupLocked(
   options: RuntimeHostSetupCliOptions,
   deps: RuntimeHostSetupDeps,
   emit: SetupEmitter,
+  rootId: string,
 ): Promise<void> {
+  if (options.reuseExistingEnvironment) {
+    if (options.lifecycle !== 'on_demand' || options.updateExisting) {
+      throw new RuntimeHostSetupError(
+        'invalid_setup',
+        'Environment discovery cannot replace a deployment',
+      );
+    }
+    const existing = await resolveRuntimeHostManagedDeploymentAuthority(rootId);
+    if (existing) {
+      const { config, capability } = await resolveRuntimeHostManagedDeployment(rootId);
+      assertCanonicalSetupTarget(options.expectedTarget, rootId, capability.canonicalPath);
+      assertExpectedDeploymentGeneration(options.expectedTarget, config);
+      // The binding comes from canonical authority. The installed operator validates
+      // its own projection when connected; discovery must not rewrite an older launcher.
+      emit({
+        kind: 'existing_environment',
+        version: config.launch.package.version,
+        serviceId: rootId,
+        deploymentId: config.deploymentId,
+        rootId,
+        rootPath: capability.canonicalPath,
+        operator: runtimeHostManagedOperatorCommand(
+          config,
+          process.platform === 'win32' ? 'win32' : 'posix',
+        ),
+      });
+      return;
+    }
+  }
   if (options.lifecycle === 'on_demand') {
     await runRuntimeHostOnDemandSetupLocked(options, deps, emit);
     return;
@@ -874,6 +906,7 @@ async function runRuntimeHostOnDemandSetupLocked(
                 : 'install',
           ...(current ? { current } : {}),
           desired: desiredConfig,
+          retainDesiredOnActivationFailure: Boolean(current && packageChanged),
           ...(legacyToMigrate && legacyBackend ? { retirementSupervisor: legacyBackend } : {}),
           ...(legacyToMigrate && legacyBackend
             ? { activatePrevious: () => legacyBackend.start() }
@@ -1260,6 +1293,10 @@ type SetupEmitter = (
   frame:
     | Omit<Extract<RuntimeHostSetupFrame, { kind: 'progress' }>, 'schemaVersion' | 'sequence'>
     | Omit<Extract<RuntimeHostSetupFrame, { kind: 'complete' }>, 'schemaVersion' | 'sequence'>
+    | Omit<
+        Extract<RuntimeHostSetupFrame, { kind: 'existing_environment' }>,
+        'schemaVersion' | 'sequence'
+      >
     | Omit<Extract<RuntimeHostSetupFrame, { kind: 'error' }>, 'schemaVersion' | 'sequence'>,
 ) => void;
 
@@ -1277,7 +1314,7 @@ function createEmitter(json: boolean, deps: RuntimeHostSetupDeps): SetupEmitter 
     }
     if (frame.kind === 'progress') {
       deps.writeOutput(`${humanPhase(frame.phase)}\n`);
-    } else if (frame.kind === 'complete') {
+    } else if (frame.kind === 'complete' || frame.kind === 'existing_environment') {
       deps.writeOutput(`${JSON.stringify(frame, null, 2)}\n`);
     } else {
       deps.writeError(`${frame.error.message}\n`);

--- a/packages/cli/src/runtime-host-setup-command.ts
+++ b/packages/cli/src/runtime-host-setup-command.ts
@@ -906,7 +906,6 @@ async function runRuntimeHostOnDemandSetupLocked(
                 : 'install',
           ...(current ? { current } : {}),
           desired: desiredConfig,
-          retainDesiredOnActivationFailure: Boolean(current && packageChanged),
           ...(legacyToMigrate && legacyBackend ? { retirementSupervisor: legacyBackend } : {}),
           ...(legacyToMigrate && legacyBackend
             ? { activatePrevious: () => legacyBackend.start() }

--- a/packages/cli/src/runtime-host-update-command.ts
+++ b/packages/cli/src/runtime-host-update-command.ts
@@ -808,7 +808,6 @@ async function runCanonicalRuntimeHostUpdate(
           ...(options.expectedHost ? { expectedOwner: options.expectedHost } : {}),
           ...(desired.lifecycle.mode === 'on_demand'
             ? {
-                retainDesiredOnActivationFailure: true,
                 ...(options.expectedHost
                   ? {
                       prepareSourceRetirement: (signal?: AbortSignal) => {

--- a/packages/cli/src/runtime-host-update-command.ts
+++ b/packages/cli/src/runtime-host-update-command.ts
@@ -107,6 +107,7 @@ export interface RuntimeHostUpdateCliOptions {
   readonly expectedTarget: RuntimeHostManagedServiceTarget;
   readonly expectedHost?: RuntimeHostExpectedHost;
   readonly expectedConfigFingerprint?: string;
+  readonly expectedSourceVersion?: string;
   readonly managedRootId?: string;
   readonly operatorDeploymentId?: string;
   readonly registrySelection?: {
@@ -660,6 +661,15 @@ async function runCanonicalRuntimeHostUpdate(
           );
         }
         const current = recovered.config;
+        if (
+          options.expectedSourceVersion &&
+          current.launch.package.version !== options.expectedSourceVersion
+        ) {
+          throw new RuntimeHostServiceManagerError(
+            'target_mismatch',
+            'The installed Runtime Host package changed; check it again before updating',
+          );
+        }
         await deps.canonical.convergeControlProjection(current, lifecycleDeps);
         await deps.canonical.verifyProjection(current, lifecycleDeps);
         deps.canonical.assertOperatorConfig(

--- a/packages/cli/src/runtime-host-update-command.ts
+++ b/packages/cli/src/runtime-host-update-command.ts
@@ -22,6 +22,7 @@ import { dirname, join, resolve } from 'node:path';
 import { truncateUtf8 } from '@maka/core/diagnostic-log';
 import { activateRuntimeHostManagedDeployment } from '@maka/runtime-host/client';
 import {
+  compareProductReleaseVersions,
   createRuntimeHostLegacyPosixOperatorCommand,
   decodeRuntimeHostServiceManagementFrame,
   encodeRuntimeHostServiceManagementFrame,
@@ -38,6 +39,7 @@ import {
   RuntimeHostManagedDeploymentError as RuntimeHostDeploymentAuthorityError,
 } from '@maka/runtime-host/operator';
 import {
+  isRuntimeHostDevelopmentPackageVersion,
   assertRuntimeHostManagedOperatorConfig,
   assertRuntimeHostManagedOperatorDeployment,
   convergeRuntimeHostManagedOperator,
@@ -51,6 +53,7 @@ import {
   type RuntimeHostManagedPackageDeployment,
 } from './runtime-host-managed-deployment.js';
 import {
+  runtimeHostManagedServiceConfigFingerprint,
   manageRuntimeHostService,
   replaceRuntimeHostManagedService,
   resolveRuntimeHostManagedServiceId,
@@ -87,6 +90,7 @@ import {
   verifyRuntimeHostLifecycleProjection,
   type RuntimeHostLifecycleTransactionDeps,
 } from './runtime-host-lifecycle-transaction.js';
+import { launchRuntimeHostLocalSourceRetirement } from './runtime-host-local-source-retirement.js';
 import { manageRuntimeHostManagedLifecycle } from './runtime-host-managed-lifecycle-manager.js';
 
 const OPERATOR_TIMEOUT_MS = 2 * 60_000;
@@ -102,6 +106,7 @@ export interface RuntimeHostUpdateCliOptions {
   readonly version: string;
   readonly expectedTarget: RuntimeHostManagedServiceTarget;
   readonly expectedHost?: RuntimeHostExpectedHost;
+  readonly expectedConfigFingerprint?: string;
   readonly managedRootId?: string;
   readonly operatorDeploymentId?: string;
   readonly registrySelection?: {
@@ -128,6 +133,7 @@ interface RuntimeHostUpdateCliDeps {
   readonly prepareDeployment: typeof prepareRuntimeHostManagedPackageDeployment;
   readonly prunePackages: typeof pruneRuntimeHostManagedPackages;
   readonly activateDesired: typeof activateRuntimeHostManagedDeployment;
+  readonly retireSource: typeof launchRuntimeHostLocalSourceRetirement;
   readonly withLifecycleLock: typeof withRuntimeHostManagedServiceLifecycleLock;
   readonly withDeploymentLock: typeof withRuntimeHostManagedServiceDeploymentLock;
   readonly withLegacyOperatorLeases: typeof withRuntimeHostManagedServiceLegacyOperatorLeases;
@@ -219,6 +225,7 @@ export async function runManagedRuntimeHostUpdateCli(
     openDeployment: openRuntimeHostManagedPackageDeployment,
     prepareDeployment: prepareRuntimeHostManagedPackageDeployment,
     prunePackages: pruneRuntimeHostManagedPackages,
+    retireSource: launchRuntimeHostLocalSourceRetirement,
     activateDesired: (input) =>
       activateRuntimeHostManagedDeployment(input, {
         reconcileActivation: async () => undefined,
@@ -626,7 +633,7 @@ async function runCanonicalRuntimeHostUpdate(
   try {
     return await deps.withDeploymentLock(
       resolveRuntimeHostManagedControlRoot(options.managedRootId),
-      async () => {
+      async (inheritableAuthorityLeaseFd) => {
         await deps.canonical.assertOperatorDeployment(
           options.managedRootId,
           options.operatorDeploymentId,
@@ -672,6 +679,35 @@ async function runCanonicalRuntimeHostUpdate(
           },
           { resolveProvider: resolveRuntimeHostLifecycleProvider },
         );
+        if (
+          options.expectedConfigFingerprint &&
+          (!currentStatus.service.config ||
+            runtimeHostManagedServiceConfigFingerprint(currentStatus.service.config) !==
+              options.expectedConfigFingerprint)
+        ) {
+          throw new RuntimeHostServiceManagerError(
+            'target_mismatch',
+            'The managed Runtime Host configuration changed; check it again before updating',
+          );
+        }
+        const developmentArtifact =
+          isRuntimeHostDevelopmentPackageVersion(options.version) ||
+          isRuntimeHostDevelopmentPackageVersion(current.launch.package.version);
+        if (developmentArtifact && !options.sourcePackageIntegrity) {
+          throw new RuntimeHostServiceManagerError(
+            'target_mismatch',
+            'Development deployments require an explicitly selected source artifact; source hashes do not establish release order',
+          );
+        }
+        if (
+          !developmentArtifact &&
+          compareProductReleaseVersions(options.version, current.launch.package.version) < 0
+        ) {
+          throw new RuntimeHostServiceManagerError(
+            'target_mismatch',
+            'This update would downgrade the shared Runtime Host. Update the Client instead.',
+          );
+        }
         const targetIntegrity =
           options.sourcePackageIntegrity ??
           options.registrySelection?.integrity ??
@@ -751,15 +787,42 @@ async function runCanonicalRuntimeHostUpdate(
           },
         };
         emit(progress('retiring', current.launch.package.version, options.version));
-        emit(progress('replacing', current.launch.package.version, options.version));
         const replacement = await deps.canonical.replaceLifecycle({
           operation: 'update',
+          validateRetiredState: async () => {
+            emit(progress('replacing', current.launch.package.version, options.version));
+          },
           current,
           desired,
           allowInterruptActiveTasks: options.allowInterruptActiveTasks ?? false,
           ...(options.expectedHost ? { expectedOwner: options.expectedHost } : {}),
           ...(desired.lifecycle.mode === 'on_demand'
             ? {
+                retainDesiredOnActivationFailure: true,
+                ...(options.expectedHost
+                  ? {
+                      prepareSourceRetirement: (signal?: AbortSignal) => {
+                        if (inheritableAuthorityLeaseFd === undefined) {
+                          throw new RuntimeHostServiceManagerError(
+                            'target_mismatch',
+                            'Source-package retirement requires the deployment authority lease',
+                          );
+                        }
+                        return deps.retireSource({
+                          sourceCliPath: currentCliPath,
+                          sourceNodePath: current.launch.nodePath,
+                          rootPath: current.root.path,
+                          expectedRootId: current.root.id,
+                          expectedHostEpoch: options.expectedHost!.hostEpoch,
+                          activeWorkPolicy: options.allowInterruptActiveTasks
+                            ? 'interrupt_active_work'
+                            : 'refuse_active_work',
+                          inheritableAuthorityLeaseFd,
+                          ...(signal ? { signal } : {}),
+                        });
+                      },
+                    }
+                  : {}),
                 activateDesired: async () => {
                   await deps.activateDesired({ rootId: options.managedRootId });
                 },

--- a/packages/runtime-host/src/__tests__/host-handoff.test.ts
+++ b/packages/runtime-host/src/__tests__/host-handoff.test.ts
@@ -528,3 +528,53 @@ test('cancellation does not abandon an in-flight deployment transaction', async 
   await assert.rejects(running, /cancelled/);
   assert.equal(settled, true);
 });
+
+test('managed handoff rechecks without mutation and requests interruption only after safe admission refuses', async () => {
+  const ui = surfaceHarness();
+  const policies: string[] = [];
+  let observations = 0;
+  let ready = false;
+  const running = runHostHandoff({
+    openSurface: ui.openSurface,
+    pollIntervalMs: 1,
+    observe: async () => {
+      observations += 1;
+      if (ready) return { kind: 'ready', value: resource('connected') };
+      return blocked({
+        ...base,
+        manualRecheck: true,
+        activity: idle,
+        packageChange: { current: '0.2.0', target: '0.3.0' },
+        replacement: {
+          kind: 'replace',
+          canReplaceIdle: true,
+          canInterrupt: true,
+          requiresExplicitSelection: true,
+          execute: async (policy, _progress, consent) => {
+            assert.equal(consent, 'explicit');
+            policies.push(policy);
+            if (policy === 'refuse_active_work') return { kind: 'active_work' };
+            ready = true;
+            return { kind: 'completed' };
+          },
+        },
+      });
+    },
+  });
+  const initial = await ui.view();
+  assert.equal(initial.reason, 'replacement_required');
+  assert.match(formatHostHandoff(initial, 'zh-CN').detail, /0\.2\.0 → 0\.3\.0/u);
+  assert.deepEqual(initial.actions, ['cancel', 'retry', 'replace']);
+  await new Promise((resolve) => setTimeout(resolve, 15));
+  assert.equal(observations, 1);
+  ui.choose(initial, 'retry');
+  const checked = await ui.view((view) => view.revision !== initial.revision);
+  assert.deepEqual(policies, []);
+  ui.choose(checked, 'replace');
+  const busy = await ui.view((view) => view.state === 'attention' && view.reason === 'busy');
+  assert.deepEqual(policies, ['refuse_active_work']);
+  assert.ok(busy.actions.includes('interrupt'));
+  ui.choose(busy, 'interrupt');
+  assert.equal((await running).value, 'connected');
+  assert.deepEqual(policies, ['refuse_active_work', 'interrupt_active_work']);
+});

--- a/packages/runtime-host/src/client/host-handoff-copy.ts
+++ b/packages/runtime-host/src/client/host-handoff-copy.ts
@@ -34,6 +34,7 @@ export function formatHostHandoff(
   const tw = locale === 'zh-TW';
   const titles = tw
     ? {
+        replacement_required: '需要切換 WSL 背景服務',
         busy: '背景服務仍在使用中',
         activity_unknown: '需要確認是否停止背景服務',
         operator_required: '背景服務需要手動更新',
@@ -42,6 +43,7 @@ export function formatHostHandoff(
       }
     : zh
       ? {
+          replacement_required: '需要切换 WSL 后台服务',
           busy: '后台服务仍在使用中',
           activity_unknown: '需要确认是否停止后台服务',
           operator_required: '后台服务需要手动更新',
@@ -49,6 +51,7 @@ export function formatHostHandoff(
           retry_required: '暂时无法完成交接',
         }
       : {
+          replacement_required: 'Switch the WSL background service',
           busy: 'Your background service is still in use',
           activity_unknown: 'Confirm before stopping the service',
           operator_required: 'The background service needs a manual update',
@@ -57,6 +60,8 @@ export function formatHostHandoff(
         };
   const descriptions = tw
     ? {
+        replacement_required:
+          '目前尚未更新。選擇繼續後，將透過已安裝的管理程式安全停止舊服務並啟動選定版本；有進行中的工作時會另行確認。',
         busy: '其他連線或正在執行的工作阻止了自動交接。停止並繼續可能中斷這些工作。',
         activity_unknown:
           '背景服務與目前用戶端不相容，且無法確認有哪些工作仍在執行。停止並繼續會重新啟動服務，可能中斷其他視窗或裝置上的工作。',
@@ -66,6 +71,8 @@ export function formatHostHandoff(
       }
     : zh
       ? {
+          replacement_required:
+            '当前尚未更新。选择继续后，将通过已安装的管理程序安全停止旧服务并启动选定版本；有活动工作时会另行确认。',
           busy: '其它连接或正在执行的工作阻止了自动交接。停止并继续可能中断这些工作。',
           activity_unknown:
             '后台服务与当前客户端不兼容，且无法确认有哪些工作仍在运行。停止并继续会重新启动服务，可能中断其他窗口或设备上的工作。',
@@ -74,6 +81,8 @@ export function formatHostHandoff(
           retry_required: '服务状态发生了变化，或交接尚未完成。可以安全重试，不会默认中断工作。',
         }
       : {
+          replacement_required:
+            'No update is running. Continue to retire the old service through its installed operator and start the selected version. Interrupting active work requires a separate confirmation.',
           busy: 'Other connections or work in progress prevent an automatic handoff. Stopping the service may interrupt that work.',
           activity_unknown:
             'The background service is incompatible with this client, and its active work is unknown. Stop and continue restarts it and may interrupt work in other windows or devices.',
@@ -115,6 +124,28 @@ export function formatHostHandoff(
         };
     descriptions.operator_required = guidance[view.recoveryBlocker];
   }
+  if (view.manualRecheck && view.reason === 'busy') {
+    descriptions.busy = zh
+      ? tw
+        ? '舊服務拒絕安全停止；這可能是其他連線或背景工作所致。關閉其他用戶端後可再次嘗試安全停止，或明確選擇中斷工作並繼續。'
+        : '旧服务拒绝安全停止；这可能是其他连接或后台工作所致。关闭其他客户端后可再次尝试安全停止，或明确选择中断工作并继续。'
+      : 'The old service refused safe retirement. Other connections or background work may be keeping it in use. Close other clients and try stopping safely again, or explicitly interrupt work and continue.';
+  }
+  if (view.manualRecheck && view.reason === 'operator_required') {
+    titles.operator_required = zh
+      ? tw
+        ? '無法連線到背景服務'
+        : '无法连接后台服务'
+      : 'Cannot connect to the background service';
+    descriptions.operator_required = zh
+      ? tw
+        ? '目前版本無法連線，且尚未執行更新。請查看診斷或更新用戶端，完成後重新檢查。'
+        : '当前版本无法连接，且尚未执行更新。请查看诊断或更新客户端，完成后重新检查。'
+      : 'These builds cannot connect and no update is running. Check the diagnostic or update the client, then recheck.';
+  }
+  const packageChange = view.packageChange
+    ? `${view.target.name}: ${view.packageChange.current} → ${view.packageChange.target}`
+    : '';
   const activity = view.activity;
   const background = activity?.drainResidencies;
   const backgroundFacts = !activity
@@ -137,17 +168,23 @@ export function formatHostHandoff(
         ? `${activity.connections} 个连接 · ${activity.activeOperations} 个进行中的操作`
         : `${activity.connections} connections · ${activity.activeOperations} operations in progress`
     : '';
-  const waiting = view.mayExitNaturally
-    ? tw
-      ? 'Maka 會持續檢查，並在可以安全繼續時自動繼續。'
-      : zh
-        ? 'Maka 会持续检查，并在可以安全继续时自动继续。'
-        : 'Maka keeps checking and continues automatically when it is safe.'
-    : tw
-      ? 'Maka 會持續檢查。若狀態沒有改變，等待或重試不會解決此問題。'
-      : zh
-        ? 'Maka 会持续检查。若状态没有变化，等待或重试不会解决此问题。'
-        : 'Maka keeps checking. Waiting or retrying will not resolve this unless the service state changes.';
+  const waiting = view.manualRecheck
+    ? zh
+      ? tw
+        ? '重新檢查只會重試連線，不會更新服務。'
+        : '重新检查只会重试连接，不会更新服务。'
+      : 'Recheck retries the connection without updating the service.'
+    : view.mayExitNaturally
+      ? tw
+        ? 'Maka 會持續檢查，並在可以安全繼續時自動繼續。'
+        : zh
+          ? 'Maka 会持续检查，并在可以安全继续时自动继续。'
+          : 'Maka keeps checking and continues automatically when it is safe.'
+      : tw
+        ? 'Maka 會持續檢查。若狀態沒有改變，等待或重試不會解決此問題。'
+        : zh
+          ? 'Maka 会持续检查。若状态没有变化，等待或重试不会解决此问题。'
+          : 'Maka keeps checking. Waiting or retrying will not resolve this unless the service state changes.';
   const repairNotice =
     view.operation === 'repair'
       ? tw
@@ -159,19 +196,34 @@ export function formatHostHandoff(
   const labels = tw
     ? {
         cancel: '取消',
-        retry: '安全重試',
-        interrupt: view.operation === 'repair' ? '中斷並修復' : '停止並繼續',
+        retry: view.manualRecheck ? '重新檢查' : '安全重試',
+        replace: '停止舊服務並繼續',
+        interrupt: view.manualRecheck
+          ? '中斷工作並繼續'
+          : view.operation === 'repair'
+            ? '中斷並修復'
+            : '停止並繼續',
       }
     : zh
       ? {
           cancel: '取消',
-          retry: '安全重试',
-          interrupt: view.operation === 'repair' ? '中断并修复' : '停止并继续',
+          retry: view.manualRecheck ? '重新检查' : '安全重试',
+          replace: '停止旧服务并继续',
+          interrupt: view.manualRecheck
+            ? '中断工作并继续'
+            : view.operation === 'repair'
+              ? '中断并修复'
+              : '停止并继续',
         }
       : {
           cancel: 'Cancel',
-          retry: 'Retry safely',
-          interrupt: view.operation === 'repair' ? 'Interrupt and repair' : 'Stop and continue',
+          retry: view.manualRecheck ? 'Recheck' : 'Retry safely',
+          replace: 'Stop old service and continue',
+          interrupt: view.manualRecheck
+            ? 'Interrupt work and continue'
+            : view.operation === 'repair'
+              ? 'Interrupt and repair'
+              : 'Stop and continue',
         };
   const phases = tw
     ? {
@@ -217,7 +269,7 @@ export function formatHostHandoff(
           : zh
             ? '正在完成交接或安全收尾，请稍候。'
             : 'Finishing the handoff or its safe recovery. Please wait.'
-        : [facts, backgroundFacts, waiting, repairNotice, view.operatorStep]
+        : [packageChange, facts, backgroundFacts, waiting, repairNotice, view.operatorStep]
             .filter(Boolean)
             .join('\n'),
     actions: view.actions.map((action) => ({ action, label: labels[action] })),

--- a/packages/runtime-host/src/client/host-handoff.ts
+++ b/packages/runtime-host/src/client/host-handoff.ts
@@ -24,7 +24,7 @@ import { RuntimeHostPermanentReconnectError } from './reconnect-lifecycle.js';
 import { formatHostHandoff } from './host-handoff-copy.js';
 import { redactSecrets } from '@maka/core/redaction';
 
-export type HostHandoffAction = 'cancel' | 'retry' | 'interrupt';
+export type HostHandoffAction = 'cancel' | 'retry' | 'replace' | 'interrupt';
 export type HostHandoffPhase =
   | 'checking'
   | 'staging'
@@ -47,6 +47,8 @@ export interface HostHandoffTarget {
 export interface HostHandoffReplacement {
   readonly kind: 'replace' | 'repair';
   readonly canReplaceIdle: boolean;
+  /** Managed environments require package-change consent before any replacement. */
+  readonly requiresExplicitSelection?: boolean;
   readonly canInterrupt: boolean;
   execute(
     policy: RuntimeHostRetirementMode,
@@ -69,6 +71,8 @@ export interface HostHandoffBlocker {
   readonly reason: 'upgrade' | 'repair' | 'unavailable';
   readonly activity?: HostActivitySnapshot;
   readonly mayExitNaturally: boolean;
+  readonly manualRecheck?: boolean;
+  readonly packageChange?: { readonly current: string; readonly target: string };
   readonly replacement?: HostHandoffReplacement;
   readonly recoveryBlocker?: HostHandoffRecoveryBlocker;
   readonly operatorStep?: string;
@@ -85,6 +89,7 @@ export interface HostHandoffView {
   readonly target: HostHandoffTarget;
   readonly state: 'attention' | 'progress';
   readonly reason:
+    | 'replacement_required'
     | 'busy'
     | 'activity_unknown'
     | 'operator_required'
@@ -92,6 +97,8 @@ export interface HostHandoffView {
     | 'retry_required';
   readonly activity?: HostActivitySnapshot;
   readonly mayExitNaturally: boolean;
+  readonly manualRecheck?: boolean;
+  readonly packageChange?: { readonly current: string; readonly target: string };
   readonly operation?: 'replace' | 'repair';
   readonly phase?: HostHandoffPhase;
   readonly actions: readonly HostHandoffAction[];
@@ -149,6 +156,8 @@ export async function runHostHandoff<T extends { close(): Promise<void> }>(input
   // (or a broken successor) into an automatic replacement storm.
   const attempted = new Set<string>();
   let automaticAttempts = 0;
+  let refusedWork: string | undefined;
+  let replacementCompleted = false;
   let recovery: { identity: string; diagnostic: string } | undefined;
   const publish = (next: HostHandoffView) => {
     view = next;
@@ -189,7 +198,10 @@ export async function runHostHandoff<T extends { close(): Promise<void> }>(input
             target: view.target,
             reason: 'unavailable',
             mayExitNaturally: false,
-            diagnostic: boundedDiagnostic(error),
+            ...(view.manualRecheck ? { manualRecheck: true } : {}),
+            diagnostic: replacementCompleted
+              ? `Host replacement completed, but reconnection failed: ${boundedDiagnostic(error)}`
+              : boundedDiagnostic(error),
           },
         };
       }
@@ -210,13 +222,21 @@ export async function runHostHandoff<T extends { close(): Promise<void> }>(input
       if ((choice as { action: HostHandoffAction } | undefined)?.action === 'cancel') {
         throw new HostHandoffCancelledError();
       }
-      const blocker = observed.blocker;
+      const blocker: HostHandoffBlocker = observed.blocker;
       if (recovery?.identity !== blocker.identity) recovery = undefined;
+      if (refusedWork !== blocker.identity) refusedWork = undefined;
       const nextSignature = blockerSignature(blocker);
       if (signature !== nextSignature) {
         signature = nextSignature;
         choice = undefined;
-        publish(projectBlocker(blocker, randomUUID(), recovery?.diagnostic));
+        publish(
+          projectBlocker(
+            blocker,
+            randomUUID(),
+            recovery?.diagnostic,
+            refusedWork === blocker.identity,
+          ),
+        );
       }
       const current = view!;
       const selected = choice as { revision: string; action: HostHandoffAction } | undefined;
@@ -231,13 +251,20 @@ export async function runHostHandoff<T extends { close(): Promise<void> }>(input
         !recovery &&
         automaticAttempts < 3 &&
         !attempted.has(nextSignature) &&
+        !blocker.replacement?.requiresExplicitSelection &&
         blocker.replacement?.canReplaceIdle &&
         blocker.activity &&
         (isHostActivityIdle(blocker.activity) || cooperative);
       const interrupt = selected?.revision === current.revision && selected.action === 'interrupt';
+      const replace = selected?.revision === current.revision && selected.action === 'replace';
       const retry = selected?.revision === current.revision && selected.action === 'retry';
       if (
-        (automatic || interrupt || (retry && blocker.replacement?.canReplaceIdle)) &&
+        (automatic ||
+          interrupt ||
+          replace ||
+          (retry &&
+            !blocker.replacement?.requiresExplicitSelection &&
+            blocker.replacement?.canReplaceIdle)) &&
         blocker.replacement
       ) {
         if (automatic) {
@@ -273,6 +300,8 @@ export async function runHostHandoff<T extends { close(): Promise<void> }>(input
         } finally {
           attemptAbort = undefined;
         }
+        replacementCompleted = result.kind === 'completed';
+        refusedWork = result.kind === 'active_work' ? blocker.identity : undefined;
         recovery =
           result.kind === 'recovery_required'
             ? { identity: blocker.identity, diagnostic: result.diagnostic.slice(0, 8_192) }
@@ -289,7 +318,12 @@ export async function runHostHandoff<T extends { close(): Promise<void> }>(input
         signature = undefined;
         continue;
       }
-      const attention = projectBlocker(blocker, current.revision, recovery?.diagnostic);
+      const attention = projectBlocker(
+        blocker,
+        current.revision,
+        recovery?.diagnostic,
+        refusedWork === blocker.identity,
+      );
       if (!input.openSurface) throw new HostHandoffRequiredError(attention);
       surface ??= input.openSurface(submit);
       publish(attention);
@@ -302,7 +336,7 @@ export async function runHostHandoff<T extends { close(): Promise<void> }>(input
           else resolve();
         };
         const abort = () => finish(input.signal?.reason);
-        const timer = setTimeout(finish, interval);
+        const timer = blocker.manualRecheck ? undefined : setTimeout(finish, interval);
         wake = () => finish();
         input.signal?.addEventListener('abort', abort, { once: true });
         if (input.signal?.aborted) abort();
@@ -318,6 +352,7 @@ function projectBlocker(
   blocker: HostHandoffBlocker,
   revision: string,
   recovery?: string,
+  activeWorkRefused = false,
 ): HostHandoffView {
   const replacement = blocker.replacement;
   return {
@@ -331,15 +366,30 @@ function projectBlocker(
           ? 'repair_required'
           : !replacement
             ? 'operator_required'
-            : !blocker.activity
-              ? 'activity_unknown'
-              : isHostActivityIdle(blocker.activity)
-                ? 'retry_required'
-                : 'busy',
+            : replacement.requiresExplicitSelection
+              ? activeWorkRefused
+                ? 'busy'
+                : 'replacement_required'
+              : !blocker.activity
+                ? 'activity_unknown'
+                : isHostActivityIdle(blocker.activity)
+                  ? 'retry_required'
+                  : 'busy',
     ...(blocker.activity ? { activity: blocker.activity } : {}),
     mayExitNaturally: blocker.mayExitNaturally,
+    ...(blocker.manualRecheck ? { manualRecheck: true } : {}),
+    ...(blocker.packageChange ? { packageChange: blocker.packageChange } : {}),
     ...(replacement ? { operation: replacement.kind } : {}),
-    actions: replacement?.canInterrupt ? ['cancel', 'retry', 'interrupt'] : ['cancel', 'retry'],
+    actions: replacement?.requiresExplicitSelection
+      ? [
+          'cancel',
+          'retry',
+          'replace',
+          ...(activeWorkRefused && replacement.canInterrupt ? ['interrupt' as const] : []),
+        ]
+      : replacement?.canInterrupt
+        ? ['cancel', 'retry', 'interrupt']
+        : ['cancel', 'retry'],
     defaultAction: 'cancel',
     ...(blocker.recoveryBlocker ? { recoveryBlocker: blocker.recoveryBlocker } : {}),
     ...(blocker.operatorStep ? { operatorStep: blocker.operatorStep } : {}),
@@ -360,6 +410,9 @@ function blockerSignature(blocker: HostHandoffBlocker): string {
     blocker.replacement?.kind,
     blocker.replacement?.canReplaceIdle,
     blocker.replacement?.canInterrupt,
+    blocker.replacement?.requiresExplicitSelection,
+    blocker.manualRecheck,
+    blocker.packageChange,
     blocker.operatorStep,
     blocker.recoveryBlocker,
     blocker.diagnostic,

--- a/packages/runtime-host/src/operator/setup-frame.ts
+++ b/packages/runtime-host/src/operator/setup-frame.ts
@@ -47,6 +47,28 @@ const frameBase = {
   schemaVersion: z.literal(1),
   sequence: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
 } as const;
+const environmentBindingFields = {
+  version: boundedString(128),
+  serviceId: z.string().regex(/^[a-f0-9]{64}$/u),
+  deploymentId: z.string().uuid(),
+  operator: z.unknown().transform((value, context) => {
+    try {
+      const command = decodeRuntimeHostOperatorCommand(value);
+      if (command.kind !== 'node') {
+        throw new Error('Runtime Host setup operator must be a Node command');
+      }
+      return command;
+    } catch (error) {
+      context.addIssue({
+        code: 'custom',
+        message: error instanceof Error ? error.message : 'Runtime Host operator is invalid',
+      });
+      return z.NEVER;
+    }
+  }),
+  rootPath: boundedString(4 * 1024).refine((value) => !/[\u0000-\u001f\u007f]/u.test(value)),
+  rootId: z.string().regex(/^[a-f0-9]{64}$/u),
+} as const;
 const SETUP_FRAME_SCHEMA = z.discriminatedUnion('kind', [
   z
     .object({
@@ -59,26 +81,7 @@ const SETUP_FRAME_SCHEMA = z.discriminatedUnion('kind', [
     .object({
       ...frameBase,
       kind: z.literal('complete'),
-      version: boundedString(128),
-      serviceId: z.string().regex(/^[a-f0-9]{64}$/u),
-      deploymentId: z.string().uuid(),
-      operator: z.unknown().transform((value, context) => {
-        try {
-          const command = decodeRuntimeHostOperatorCommand(value);
-          if (command.kind !== 'node') {
-            throw new Error('Runtime Host setup operator must be a Node command');
-          }
-          return command;
-        } catch (error) {
-          context.addIssue({
-            code: 'custom',
-            message: error instanceof Error ? error.message : 'Runtime Host operator is invalid',
-          });
-          return z.NEVER;
-        }
-      }),
-      rootPath: boundedString(4 * 1024).refine((value) => !/[\u0000-\u001f\u007f]/u.test(value)),
-      rootId: z.string().regex(/^[a-f0-9]{64}$/u),
+      ...environmentBindingFields,
       endpoint: boundedString(SETUP_FIELD_MAX_BYTES).refine(
         (value) => parseRuntimeHostSetupEndpoint(value) !== undefined,
       ),
@@ -92,6 +95,13 @@ const SETUP_FRAME_SCHEMA = z.discriminatedUnion('kind', [
         })
         .strict()
         .optional(),
+    })
+    .strict(),
+  z
+    .object({
+      ...frameBase,
+      kind: z.literal('existing_environment'),
+      ...environmentBindingFields,
     })
     .strict(),
   z


### PR DESCRIPTION
## Summary

An incompatible managed WSL Host currently produces an indefinite manual-update window. Add an explicit handoff through the validated WSL deployment binding, with package identities, read-only Recheck, and separate interruption consent. Released onboarding discovers and reuses an existing environment before staging or changing any package.

The canonical update transaction verifies the observed source version and Host identity under its existing deployment lease, plus the configuration fingerprint when the source operator provides one. The installed epoch 121 operator lacks that fingerprint; its path remains fenced by source version, deployment/Root identity and exact Host generation. Its selected source-package retirement helper speaks the old Host's protocol; the State Root writer fence still controls cutover. Post-commit activation failure retains the new deployment instead of automatically reopening storage with older code.

Refs #5143 and #5144. Depends on #5160. This PR targets its branch so only the handoff changes appear in the diff; retarget to `main` after #5160 merges.

## Verification

- Broader Runtime Host/CLI run: 93 passing tests. After the legacy-status compatibility fix, all six affected backend suites passed again (56 tests), including real IPC/source-helper processes and writer locks.
- Broader Desktop run: 150 passing tests. After the legacy-status compatibility fix, six affected Desktop suites passed again (111 tests), including the WSL manager route, discovery, command framing, cancellation and profile-queue reentrancy.
- Full Desktop build, workspace typecheck, lint, format and `check:stale` passed.
- Isolated experiment over `ssh wsl`: the modified retirement code with the installed epoch 133 client rejected the existing source package's epoch 121 Host handshake, then used that exact source package's CLI helper to retire temporary Hosts under the deployment lease. Safe refusal, retry after work completion and explicit interruption passed. The normal deployment JSON was byte-identical afterward; its State Root was not used by the experiment.
- Rendered startup-window fixtures in Simplified Chinese: no timer in blocker state, current/target package identities visible, Cancel default, distinct safe and interruption actions, no horizontal overflow. The rendered-fixture output is included below.
- Full isolated WSL update: staged the new development archive, observed safe refusal with the actual epoch 121 source Host, explicitly authorized interruption, committed/activated epoch 139 and connected using the target client. The old client correctly reported incompatibility. Generation-bound retire/uninstall cleaned the fixture, and the normal deployment JSON remained byte-identical. Sanitized experiment output is included below.
- Not claimed: a packaged Windows Desktop end-to-end journey through the actual Windows transport and interactive GUI. Backend replacement was exercised on WSL; the UI evidence is rendered-template fixtures.


<details>
<summary>Rendered UI fixture and actual WSL experiment output</summary>

The UI checks render the actual startup-window template; they are not a packaged Windows GUI test.

```text
before {"horizontalOverflow":false,"elapsedVisible":true,"buttons":["取消","安全重试"]}
after {"horizontalOverflow":false,"elapsedVisible":false,"buttons":["取消","重新检查","停止旧服务并继续"]}
busy {"horizontalOverflow":false,"elapsedVisible":false,"buttons":["取消","重新检查","停止旧服务并继续","中断工作并继续"]}
newer {"horizontalOverflow":false,"elapsedVisible":false,"buttons":["取消","重新检查"]}
```

Actual isolated WSL update (normal deployment unchanged):

```text
{"stage":"safe_admission","result":"active_tasks","oldEpoch":121,"newEpoch":139}
{"stage":"replacement","result":"updated_and_connected","version":"0.2.0-dev-f4a1d7df24af","oldClient":"incompatible","phases":["checking","staging","retiring","replacing"]}
{"cleanup":{"retire":0,"uninstall":0}}
LIVE_DEPLOYMENT_UNCHANGED
```

</details>

## Legacy source admission

The existing source Host contract reports `active_tasks` for another live connection as well as background work. Even an idle TUI may trigger that conservative refusal. The UI states this limitation and offers closing other clients and trying safe retirement again, or separately authorizing interruption. It never turns a diagnostics snapshot into permission to force retirement. This boundary was experimentally confirmed; it is not a claim that the old protocol distinguishes every idle-client case.

Source hashes are not release ordering. Ordered releases cannot downgrade; an older client contract gets client-update guidance. Development artifacts remain explicit and identity-fenced. Connect-only SSH gains no replacement authority.

## Remaining review

- [ ] Confirm the legacy-admission UX against #5143's idle-TUI acceptance wording.
- [ ] Exercise the packaged Windows Desktop journey before merge.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated source and installed artifacts, implemented changes and tests, ran isolated WSL and local experiments, and drafted these review materials.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
