### PR TITLE
refactor(desktop): type the main-process copy tables as catalogs

### DIFF
--- a/apps/desktop/src/main/runtime-host-quit-copy.ts
+++ b/apps/desktop/src/main/runtime-host-quit-copy.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import type { UiLocale } from '@maka/core/ui-locale';
+import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
 import type { MessageBoxOptions } from 'electron';
 
 export interface RuntimeHostQuitDialog<Decision extends string> {
@@ -46,6 +46,14 @@ export function buildRuntimeHostActiveQuitDialog(
   };
 }
 
+interface RuntimeHostQuitCopy {
+  readonly activeTitle: string;
+  readonly activeMessage: string;
+  readonly activeDetail: string;
+  readonly stopAndQuit: string;
+  readonly keepRunning: string;
+}
+
 const COPY = {
   en: {
     activeTitle: 'Maka is still working',
@@ -71,4 +79,4 @@ const COPY = {
     stopAndQuit: '停止工作並結束',
     keepRunning: '繼續執行 Maka',
   },
-} as const;
+} satisfies UiCatalog<RuntimeHostQuitCopy>;

--- a/apps/desktop/src/main/runtime-host-wsl-handoff.ts
+++ b/apps/desktop/src/main/runtime-host-wsl-handoff.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import type { UiLocale } from '@maka/core/ui-locale';
+import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
 import type { EnvironmentRuntimeHostProfile, HostHandoffBlocker, HostHandoffPhase, RuntimeHostRemoteCompatibilityError } from '@maka/runtime-host/client';
 import { compareProductReleaseVersions } from '@maka/runtime-host/operator';
 import type { DesktopRuntimeHostManagedServiceBinding } from './runtime-host-managed-services.js';
@@ -110,6 +110,14 @@ export async function resolveDesktopWslHostHandoff(
 }
 
 
+interface WslHandoffGuidance {
+  readonly client: string;
+  readonly binding: string;
+  readonly source: string;
+  readonly target: string;
+  readonly development: string;
+}
+
 const GUIDANCE = {
   en: {
     client: 'Update Desktop to a build compatible with this Host. The Host will not be downgraded.',
@@ -132,4 +140,4 @@ const GUIDANCE = {
     target: '目前 Desktop 無法驗證合適的替換套件。請更新 Desktop，或透過開發環境明確管理選定的開發套件；現有 Host 會被保留。',
     development: '選定的開發構建',
   },
-} as const;
+} satisfies UiCatalog<WslHandoffGuidance>;

--- a/apps/desktop/src/main/startup-progress-window.ts
+++ b/apps/desktop/src/main/startup-progress-window.ts
@@ -19,7 +19,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { MAKA_WORDMARK_PATH } from '@maka/core/maka-wordmark';
-import type { UiLocale } from '@maka/core/ui-locale';
+import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
 import { formatHostHandoff, type HostHandoffView, type HostHandoffAction } from '@maka/runtime-host/client';
 import type { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
 
@@ -27,6 +27,17 @@ export type StartupPhase =
   | 'prepare' | 'storage' | 'connect' | 'package'
   | 'checking' | 'staging' | 'retiring' | 'replacing' | 'restart'
   | 'attention' | 'renderer';
+
+interface StartupProgressCopy {
+  readonly title: string;
+  readonly detail: string;
+  readonly slow: string;
+  readonly copy: string;
+  readonly copied: string;
+  readonly copyFailed: string;
+  readonly elapsed: string;
+  readonly phases: Record<StartupPhase, string>;
+}
 
 const COPY = {
   en: {
@@ -67,7 +78,7 @@ const COPY = {
       attention: '等待你的確認', renderer: '正在開啟工作區',
     },
   },
-} as const;
+} satisfies UiCatalog<StartupProgressCopy>;
 
 export interface StartupProgressWindow {
   update(phase: StartupPhase): void;

--- a/apps/desktop/src/main/windows-app-tray.ts
+++ b/apps/desktop/src/main/windows-app-tray.ts
@@ -18,6 +18,7 @@
  */
 
 import type { Menu, MenuItemConstructorOptions, Tray } from 'electron';
+import type { UiCatalog } from '@maka/core/ui-locale';
 import type { DesktopLocaleAuthority } from './desktop-locale-authority.js';
 
 type TraySurface = Pick<Tray, 'setToolTip' | 'setContextMenu' | 'on' | 'destroy' | 'isDestroyed'>;
@@ -33,11 +34,17 @@ interface WindowsAppTrayDeps {
   onError(error: unknown): void;
 }
 
+interface WindowsAppTrayCopy {
+  readonly open: string;
+  readonly workHub: string;
+  readonly quit: string;
+}
+
 const copy = {
   en: { open: 'Open Maka', workHub: 'Open WorkHub', quit: 'Quit Maka' },
   'zh-CN': { open: '打开 Maka', workHub: '打开 WorkHub', quit: '退出 Maka' },
   'zh-TW': { open: '開啟 Maka', workHub: '開啟 WorkHub', quit: '結束 Maka' },
-};
+} satisfies UiCatalog<WindowsAppTrayCopy>;
 
 /** Windows needs a visible way back after the last product window closes. */
 export function createWindowsAppTray(deps: WindowsAppTrayDeps) {


### PR DESCRIPTION
## Summary

Four trilingual copy tables in the main process were plain object literals, so nothing enforced that all three locales carry the same keys: a missing locale, or a key added to `zh-CN` but not `zh-TW`, was a runtime surprise rather than a compile error. `windows-app-tray.ts` was the loosest — no `as const`, no shape at all.

Each table now declares its shape and closes with `satisfies UiCatalog<T>`, the form already used by `notifications-policy.ts` and `client-settings-confirmation-copy.ts` in the same directory. Drift becomes a type error.

No copy changes: the diff adds type declarations and rewrites three import lines, and touches no string.

Refs #2672

## Verification

```
apps/desktop full dist suite        2463 pass / 5 fail
apps/desktop typecheck (4)          0 errors
check-locale-hygiene                passed
npm run format:check                clean
```

The five failures are `browser-message-box`, red on the unmodified base commit (7 tests, 5 fail) and unrelated to this diff.

No test accompanies the change because the guarantee is a compile-time one: deleting a locale from any of the four tables now fails `npm run typecheck`, which is what a test would have had to assert.

## Review focus

`packages/runtime-host/src/client/host-handoff-copy.ts` has the same problem in a worse form — `const zh = locale !== 'en'` with nested per-locale ternaries — and is deliberately **not** in this PR. Its copy is selected by `view.recoveryBlocker` and `view.reason` as well as locale, so converting it restructures the data model rather than adding a type, and it belongs in its own change with its own review of the three-locale output.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: **Claude Code** — located the untyped tables, wrote the shape declarations, and wrote this description. The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [ ] Tests cover the change and fail without it — the guarantee is compile-time; see Verification
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
