### PR TITLE
refactor(cli): give each command its own help screen

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -46,17 +46,17 @@ describe('Maka CLI args', () => {
     const help = parseMakaCliArgs(['--help'], '0.1.0');
     assert.equal(help.kind, 'help');
     if (help.kind !== 'help') return;
-    assert.match(help.text, /^  maka              Start the TUI$/m);
+    assert.match(help.text, /^ {2}maka {2,}Start the TUI$/m);
     assert.doesNotMatch(help.text, /maka-agent/);
-    assert.match(help.text, /^  maka run /m);
-    assert.match(help.text, /^  maka activate /m);
-    assert.match(help.text, /^  maka eval /m);
-    assert.match(help.text, /^  maka update --target /m);
-    assert.match(
-      help.text,
-      /^  maka --acp      Serve ACP v1 over stdio \(initialize, session\/new, session\/list\)$/m,
-    );
-    assert.match(help.text, /^  maka runtime-host serve /m);
+    assert.match(help.text, /^ {2}maka run /m);
+    assert.match(help.text, /^ {2}maka activate /m);
+    assert.match(help.text, /^ {2}maka eval /m);
+    assert.match(help.text, /^ {2}maka update /m);
+    assert.match(help.text, /^ {2}maka --acp {2,}Serve ACP v1 over stdio /m);
+    // Runtime Host owns its own help; the root lists it once and points there.
+    assert.match(help.text, /^ {2}maka runtime-host \.\.\. {2,}Serve and manage a Runtime Host$/m);
+    assert.doesNotMatch(help.text, /^ {2}maka runtime-host (?:serve|service|access) /m);
+    assert.ok(help.text.split('\n').length < 30, 'the root help stays a single screen');
     assert.doesNotMatch(help.text, /cli:dev/);
   });
 
@@ -118,18 +118,27 @@ describe('Maka CLI args', () => {
     assert.equal(help.kind, 'help');
     if (help.kind === 'help') {
       assert.match(help.text, /^Usage: npm run cli:dev --$/m);
-      assert.match(
-        help.text,
-        /^  npm run cli:dev -- runtime-host access issue --principal <id> --preset /m,
-      );
-      assert.match(help.text, /^  npm run cli:dev -- runtime-host project list /m);
-      assert.match(
-        help.text,
-        /^  npm run cli:dev -- runtime-host profile set .*--ssh-destination /m,
-      );
-      assert.match(help.text, /^  npm run cli:dev -- runtime-host profile set .*--plaintext-url /m);
-      assert.doesNotMatch(help.text, /^  maka runtime-host /m);
+      assert.match(help.text, /^ {2}npm run cli:dev -- runtime-host \.\.\. /m);
+      assert.doesNotMatch(help.text, /^ {2}maka runtime-host /m);
       assert.doesNotMatch(help.text, /maka-agent/);
+    }
+    // The launcher name has to survive every layer, not just the root.
+    const hostHelp = parseMakaCliArgs(['runtime-host', '--help'], '0.1.0', 'npm run cli:dev --');
+    assert.equal(hostHelp.kind, 'help');
+    if (hostHelp.kind === 'help') {
+      assert.match(hostHelp.text, /^Usage: npm run cli:dev -- runtime-host <command>/m);
+    }
+    const accessHelp = parseMakaCliArgs(
+      ['runtime-host', 'access', '--help'],
+      '0.1.0',
+      'npm run cli:dev --',
+    );
+    assert.equal(accessHelp.kind, 'help');
+    if (accessHelp.kind === 'help') {
+      assert.match(
+        accessHelp.text,
+        /^ {2}npm run cli:dev -- runtime-host access issue --principal <id> --preset /m,
+      );
     }
     await assert.rejects(
       runMakaCli(['--version'], {
@@ -366,3 +375,74 @@ async function readClientInstanceId(path: string): Promise<string> {
   }
   return document.clientInstanceId;
 }
+
+describe('layered help coverage', () => {
+  const screens = (launcher = 'maka') => {
+    const texts: string[] = [];
+    const grab = (argv: string[]) => {
+      const command = parseMakaCliArgs(argv, '0.1.0', launcher);
+      if (command.kind === 'help') texts.push(command.text);
+    };
+    grab(['--help']);
+    grab(['update', '--help']);
+    grab(['session-export', '--help']);
+    grab(['session-import', '--help']);
+    grab(['runtime-host', '--help']);
+    for (const topic of [
+      'activate',
+      'serve',
+      'setup',
+      'service',
+      'access',
+      'project',
+      'plugin',
+      'profile',
+      'capability-provider',
+    ]) {
+      grab(['runtime-host', topic, '--help']);
+    }
+    return texts.join('\n');
+  };
+
+  test('every command the parser accepts has a help screen', () => {
+    const all = screens();
+    for (const command of [
+      'runtime-host activate',
+      'runtime-host serve',
+      'runtime-host setup',
+      'runtime-host service',
+      'runtime-host access',
+      'runtime-host project',
+      'runtime-host plugin',
+      'runtime-host profile',
+      'runtime-host capability-provider',
+      'session-export',
+      'session-import',
+      'update',
+    ]) {
+      assert.ok(all.includes(`maka ${command}`), `${command} is unreachable from any help screen`);
+    }
+  });
+
+  test('the credential environment variable stays documented', () => {
+    // Its only other home was the root screen, which the layering shrank.
+    assert.match(screens(), /MAKA_RUNTIME_HOST_ACCESS_CREDENTIAL/);
+  });
+
+  test('every summary in the root screen shares one column', () => {
+    const help = parseMakaCliArgs(['--help'], '0.1.0');
+    assert.equal(help.kind, 'help');
+    if (help.kind !== 'help') return;
+    const summaryColumns = help.text
+      .split('\n')
+      .filter((line) => /^ {2}maka\b/.test(line))
+      .map((line) => line.search(/(?<= {2})\S(?!.*\s{2}\S)/u))
+      .filter((column) => column > 0);
+    assert.ok(summaryColumns.length > 5, 'the root screen should list several commands');
+    assert.equal(
+      new Set(summaryColumns).size,
+      1,
+      `summaries start at ${[...new Set(summaryColumns)].join(', ')}`,
+    );
+  });
+});

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -30,6 +30,7 @@ import {
   parseRuntimeHostInstalledUpdateCommand,
   type RuntimeHostCliCommand,
 } from './runtime-host-cli.js';
+import { sessionBundleHelpText } from './runtime-host-help.js';
 import { resolveCliUiLocale } from './cli-ui-locale.js';
 
 export type MakaCliCommand =
@@ -85,11 +86,14 @@ export function parseMakaCliArgs(
   if (first?.startsWith('--')) return parseTuiArgs(argv);
   if (first === 'run' || first === '-p') return { kind: 'run', args: argv.slice(1) };
   if (first === 'activate') return { kind: 'activate', args: argv.slice(1) };
-  if (first === 'session-export') return { kind: 'session-export', args: argv.slice(1) };
-  if (first === 'session-import') return { kind: 'session-import', args: argv.slice(1) };
+  if (first === 'session-export' || first === 'session-import') {
+    return argv[1] === '--help' || argv[1] === '-h'
+      ? { kind: 'help', text: sessionBundleHelpText(cliCommand, first) }
+      : { kind: first, args: argv.slice(1) };
+  }
   if (first === 'eval') return { kind: 'eval', args: argv.slice(1) };
-  if (first === 'update') return parseRuntimeHostInstalledUpdateCommand(argv.slice(1));
-  if (first === 'runtime-host') return parseRuntimeHostCommand(argv.slice(1));
+  if (first === 'update') return parseRuntimeHostInstalledUpdateCommand(argv.slice(1), cliCommand);
+  if (first === 'runtime-host') return parseRuntimeHostCommand(argv.slice(1), cliCommand);
   return {
     kind: 'error',
     message: `Unexpected argument: ${first ?? ''}`,
@@ -136,48 +140,27 @@ function helpText(cliCommand: string): string {
     'Launches the Maka terminal UI in the current working directory.',
     '',
     'Commands:',
-    `  ${cliCommand}              Start the TUI`,
-    `  ${cliCommand} --acp      Serve ACP v1 over stdio (initialize, session/new, session/list)`,
-    `  ${cliCommand} run ...      Run one non-interactive model turn`,
-    `  ${cliCommand} activate ... Run one Cloud Session activation and emit JSONL`,
-    `  ${cliCommand} session-export --workspace-root <dir> --session <id> --out <file.maka-session>`,
-    `  ${cliCommand} session-import --workspace-root <dir> --bundle <file.maka-session>`,
-    `  ${cliCommand} -p ...       Alias for ${cliCommand} run`,
-    `  ${cliCommand} eval ...     Run one declarative multi-arm experiment`,
-    `  ${cliCommand} update --target <latest|next|version>  Update this npm-global CLI and its local Runtime Host`,
-    `  ${cliCommand} runtime-host serve [options]  Run a Runtime Host service`,
-    `  ${cliCommand} runtime-host activate --framed --root-id <id>`,
-    `  ${cliCommand} runtime-host setup --principal <id> --preset <desktop-client|terminal-client> [options]`,
-    `  ${cliCommand} runtime-host service install [options]`,
-    `  ${cliCommand} runtime-host service configure (--project-root <label>=<path> ... | --no-project-roots) --expected-config-fingerprint <sha256:...> --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
-    `  ${cliCommand} runtime-host service status|start|stop|restart|logs [--json]`,
-    `  ${cliCommand} runtime-host service uninstall --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
-    `  ${cliCommand} runtime-host service peer enable|disable|status|rotate|descriptor [options]`,
-    `  ${cliCommand} runtime-host service mesh status|create|invite|join|remove|leave|close|reconcile [options]`,
-    `  ${cliCommand} runtime-host service retire --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
-    `  ${cliCommand} runtime-host service check-update --target <latest|next|version> [--json]`,
-    `  ${cliCommand} runtime-host service update [--target <latest|next|version>] --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
-    `  ${cliCommand} runtime-host service update-policy [--target <manual|latest|next|version>] [--json]`,
-    `  ${cliCommand} runtime-host service reconcile-update [--json]`,
-    `  ${cliCommand} runtime-host access issue --principal <id> --grant <operation>`,
-    `  ${cliCommand} runtime-host access issue --principal <id> --preset <desktop-client|terminal-client>`,
-    `  ${cliCommand} runtime-host access connection-code [--name <name>] [--root <path>]`,
-    `  ${cliCommand} runtime-host access list`,
-    `  ${cliCommand} runtime-host access issue --kind capability-provider --principal <id>`,
-    `  ${cliCommand} runtime-host access revoke --credential <id>`,
-    `  ${cliCommand} runtime-host project list [--root <path>]`,
-    `  ${cliCommand} runtime-host project add <path> [--prefer] [--root <path>]`,
-    `  ${cliCommand} runtime-host plugin status|list|inspect|failures [--root <path>]`,
-    `  ${cliCommand} runtime-host plugin install|uninstall|reload <target> [--root <path>]`,
-    `  ${cliCommand} runtime-host plugin export <extension-id> <bundle-path> [--root <path>]`,
-    `  ${cliCommand} runtime-host plugin apply <operations.json> [--root <path>]`,
-    `  ${cliCommand} runtime-host plugin reconcile [--root <path>]`,
-    `  ${cliCommand} runtime-host profile list`,
-    `  ${cliCommand} runtime-host profile set --id <id> --name <name> --tls-url <wss-url> --expected-root <root-id> [--credential-env <name>]`,
-    `  ${cliCommand} runtime-host profile set --id <id> --name <name> --ssh-destination <user@host> --ssh-remote-port <port> --expected-root <root-id> [--ssh-port <port>] [--credential-env <name>]`,
-    `  ${cliCommand} runtime-host profile set --id <id> --name <name> --plaintext-url <ws-url> --acknowledge-plaintext --expected-root <root-id> [--credential-env <name>]`,
-    `  ${cliCommand} runtime-host profile remove --id <id>`,
-    `  ${cliCommand} runtime-host capability-provider serve --url <ws-url> --mcp-config <path> --expected-root <root-id>`,
+    ...(
+      [
+        ['', 'Start the TUI'],
+        ['--acp', 'Serve ACP v1 over stdio (initialize, session/new, session/list)'],
+        ['run ...', 'Run one non-interactive model turn'],
+        ['-p ...', `Alias for ${cliCommand} run`],
+        ['activate ...', 'Run one Cloud Session activation and emit JSONL'],
+        ['eval ...', 'Run one declarative multi-arm experiment'],
+        ['session-export ...', 'Write a Session bundle to a file'],
+        ['session-import ...', 'Read a Session bundle back into a workspace'],
+        ['update ...', 'Update this npm-global CLI and its local Runtime Host'],
+        ['runtime-host ...', 'Serve and manage a Runtime Host'],
+      ] as const
+    ).map(([name, summary], _index, entries) => {
+      // A custom launcher ("npm run cli:dev --") is far wider than `maka`, so the
+      // column is measured, never assumed.
+      const width = Math.max(
+        ...entries.map(([other]) => `${cliCommand} ${other}`.trimEnd().length),
+      );
+      return `  ${`${cliCommand} ${name}`.trimEnd().padEnd(width + 2)}${summary}`;
+    }),
     '',
     'Options:',
     '  -h, --help        Show help',
@@ -186,70 +169,8 @@ function helpText(cliCommand: string): string {
     '  --resume <id> --cwd <path>  Reopen a session after its directory moved',
     '  --host <profile-id>     Connect the TUI to a saved Runtime Host profile',
     '  --project <project-id>  Select an existing Project on a remote Host',
-    '  MAKA_RUNTIME_HOST_ACCESS_CREDENTIAL  Access credential used by runtime-host profile set',
     '',
-    'Runtime Host serve options:',
-    '  --root <path>                 Select the canonical data root',
-    '  --project-root <label>=<path> Publish an absolute project directory root (repeatable)',
-    '  --no-project-roots            Disable remote project browsing and registration',
-    '  --websocket-port <port>       Enable an authenticated WebSocket listener',
-    '  --websocket-host <host>       Bind host (default: 127.0.0.1)',
-    '  --websocket-path <path>       Upgrade path (default: /runtime-host)',
-    '  --tls-certificate <path>      TLS certificate for WSS',
-    '  --tls-private-key <path>      TLS private key for WSS',
-    '  --allow-insecure-remote       Allow plaintext WebSocket access beyond loopback',
-    '  --allow-origin <origin>       Allow one browser Origin (repeatable)',
-    '  --peer-native-path <path>     Load the experimental direct-peer native module',
-    '  --peer-key <path>             Persist the direct-peer transport identity',
-    '  --peer-id <id>                Require an existing direct-peer transport identity',
-    '  --peer-listen <multiaddr>     Listen on a direct-peer address (repeatable)',
-    '  --peer-coordination-relay <multiaddr>  Use a DCUtR coordination relay (repeatable)',
-    '  --json                        Emit one machine-readable ready event',
-    '',
-    'Managed Runtime Host service install options (Linux or macOS):',
-    '  --root <path>                 Select the canonical data root',
-    '  --project-root <label>=<path> Publish an absolute directory root (repeatable)',
-    '  --no-project-roots            Disable remote project browsing and registration',
-    '  --websocket-port <port>       Persist a loopback port (chosen automatically by default)',
-    '  --websocket-path <path>       Persist the upgrade path (default: /runtime-host)',
-    '  --json                        Emit a machine-readable result',
-    '',
-    'Managed Runtime Host setup options (Linux or macOS):',
-    '  --principal <id>              Stable Client pairing identity',
-    '  --preset <name>               Pair a desktop-client or terminal-client',
-    '  --root <path>                 Select the canonical data root',
-    '  --project-root <label>=<path> Publish an absolute directory root (repeatable)',
-    '  --no-project-roots            Disable remote project browsing and registration',
-    '  --websocket-port <port>       Persist a loopback port (chosen automatically by default)',
-    '  --websocket-path <path>       Persist the upgrade path (default: /runtime-host)',
-    '  --json                        Emit framed machine-readable progress and result records',
-    '',
-    'Managed Runtime Host direct-peer options:',
-    '  --listen <multiaddr>          Persist a listener address (repeatable)',
-    '  --coordination-relay <addr>   Prefer a Circuit Relay v2 address (repeatable)',
-    '  --clear-coordination-relays   Remove every manually configured relay',
-    '  --automatic-relay-discovery   Enable best-effort public relay discovery',
-    '  --no-automatic-relay-discovery  Disable public discovery and retain manual relays',
-    '  --default-public-stun          Use the packaged best-effort public STUN policy',
-    '  --no-public-stun               Disable public STUN and keep host candidates only',
-    '  --webrtc-stun <stun-url>       Use a custom STUN endpoint (repeatable)',
-    '',
-    'Runtime Host access issue options:',
-    '  --root <path>                 Select the canonical data root',
-    '  --kind <kind>                 remote-owner or capability-provider',
-    '  --principal <id>              Name the authenticated Client principal',
-    '  --grant <operation>           Grant one exact operation (repeatable)',
-    '  --preset <name>               Grant the desktop-client or terminal-client operation set',
-    '  --publish-client-capabilities Allow Client Capability publication',
-    '  --allow-host-paths            Allow operations that submit Host paths',
-    '  --capability-owner-credential <id>  Bind a provider to one Client-bound owner credential',
-    '',
-    'Runtime Host capability provider options:',
-    '  --url <ws-url>                Connect to an authenticated Runtime Host WebSocket',
-    '  --mcp-config <path>           Publish tools from an MCP configuration file',
-    '  --expected-root <root-id>     Pin the canonical Runtime Host root identity',
-    '  --credential-env <name>       Read the access credential from this environment variable',
-    '  --client-identity <path>      Persist the provider Client instance identity here',
+    `Run \`${cliCommand} <command> --help\` for a command's own options.`,
   ].join('\n');
 }
 

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -40,8 +40,15 @@ import {
 import type { RuntimeHostManagedServiceTarget } from './runtime-host-service-manager.js';
 import { hasEphemeralRuntimeHostPeerPort } from './runtime-host-peer-artifact.js';
 import type { RuntimeHostInstalledUpdateExpectedSource } from './runtime-host-installed-update-coordinator.js';
+import {
+  installedUpdateHelpText,
+  isRuntimeHostHelpTopic,
+  runtimeHostCommandHelpText,
+  runtimeHostHelpText,
+} from './runtime-host-help.js';
 
 type RuntimeHostCliError = { kind: 'error'; message: string; exitCode: number };
+type RuntimeHostCliHelp = { kind: 'help'; text: string };
 
 export type RuntimeHostUpdateSelector =
   | { readonly kind: 'channel'; readonly channel: 'latest' | 'next' }
@@ -378,9 +385,19 @@ export type RuntimeHostCliCommand =
       expectedRootId: string;
     }
   | { kind: 'runtime-host-profile-remove'; id: string }
+  | RuntimeHostCliHelp
   | RuntimeHostCliError;
 
-export function parseRuntimeHostCommand(argv: string[]): RuntimeHostCliCommand {
+export function parseRuntimeHostCommand(
+  argv: string[],
+  cliCommand = 'maka',
+): RuntimeHostCliCommand {
+  if (!argv[0] || argv[0] === '--help' || argv[0] === '-h') {
+    return { kind: 'help', text: runtimeHostHelpText(cliCommand) };
+  }
+  if ((argv[1] === '--help' || argv[1] === '-h') && isRuntimeHostHelpTopic(argv[0])) {
+    return { kind: 'help', text: runtimeHostCommandHelpText(cliCommand, argv[0]) };
+  }
   if (argv[0] === 'activate' || argv[0] === 'connect') {
     return parseManagedRootFramedCommand(argv[0], argv.slice(1));
   }
@@ -397,11 +414,7 @@ export function parseRuntimeHostCommand(argv: string[]): RuntimeHostCliCommand {
     return parseCapabilityProviderCommand(argv.slice(1));
   }
   if (argv[0] === 'profile') return parseProfileCommand(argv.slice(1));
-  return error(
-    argv[0]
-      ? `Unexpected runtime-host command: ${argv[0]}`
-      : 'runtime-host requires the activate, connect, serve, setup, service, access, project, plugin, profile, or capability-provider command',
-  );
+  return error(`Unexpected runtime-host command: ${argv[0]}`);
 }
 
 function parseManagedRootFramedCommand(
@@ -444,7 +457,13 @@ function parseManagedRootFramedCommand(
   };
 }
 
-export function parseRuntimeHostInstalledUpdateCommand(argv: string[]): RuntimeHostCliCommand {
+export function parseRuntimeHostInstalledUpdateCommand(
+  argv: string[],
+  cliCommand = 'maka',
+): RuntimeHostCliCommand {
+  if (argv[0] === '--help' || argv[0] === '-h') {
+    return { kind: 'help', text: installedUpdateHelpText(cliCommand) };
+  }
   let target: string | undefined;
   let allowInterruptActiveTasks = false;
   for (let index = 0; index < argv.length; index += 1) {

--- a/packages/cli/src/runtime-host-help.ts
+++ b/packages/cli/src/runtime-host-help.ts
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const SUBCOMMANDS = {
+  activate: {
+    summary: 'Run one framed activation against a managed root',
+    lines: (cliCommand: string) => [
+      `  ${cliCommand} runtime-host activate --framed --root-id <id>`,
+      `  ${cliCommand} runtime-host connect --framed --root-id <id>`,
+      '',
+      'Managed root options:',
+      '  --framed                      Frame stdio for a supervising parent',
+      '  --root-id <id>                Pin the canonical Runtime Host root identity',
+      '  --repair-root-after-remount   Repair the root after its volume was remounted',
+    ],
+  },
+  serve: {
+    summary: 'Run a Runtime Host service',
+    lines: (cliCommand: string) => [
+      `  ${cliCommand} runtime-host serve [options]  Run a Runtime Host service`,
+      '',
+      'Options:',
+      '  --root <path>                 Select the canonical data root',
+      '  --project-root <label>=<path> Publish an absolute project directory root (repeatable)',
+      '  --no-project-roots            Disable remote project browsing and registration',
+      '  --websocket-port <port>       Enable an authenticated WebSocket listener',
+      '  --websocket-host <host>       Bind host (default: 127.0.0.1)',
+      '  --websocket-path <path>       Upgrade path (default: /runtime-host)',
+      '  --tls-certificate <path>      TLS certificate for WSS',
+      '  --tls-private-key <path>      TLS private key for WSS',
+      '  --allow-insecure-remote       Allow plaintext WebSocket access beyond loopback',
+      '  --allow-origin <origin>       Allow one browser Origin (repeatable)',
+      '  --peer-native-path <path>     Load the experimental direct-peer native module',
+      '  --peer-key <path>             Persist the direct-peer transport identity',
+      '  --peer-id <id>                Require an existing direct-peer transport identity',
+      '  --peer-listen <multiaddr>     Listen on a direct-peer address (repeatable)',
+      '  --peer-coordination-relay <multiaddr>  Use a DCUtR coordination relay (repeatable)',
+      '  --json                        Emit one machine-readable ready event',
+      '',
+    ],
+  },
+  setup: {
+    summary: 'Provision a managed Runtime Host',
+    lines: (cliCommand: string) => [
+      `  ${cliCommand} runtime-host setup --principal <id> --preset <desktop-client|terminal-client> [options]`,
+      '',
+      'Options (Linux or macOS):',
+      '  --principal <id>              Stable Client pairing identity',
+      '  --preset <name>               Pair a desktop-client or terminal-client',
+      '  --root <path>                 Select the canonical data root',
+      '  --project-root <label>=<path> Publish an absolute directory root (repeatable)',
+      '  --no-project-roots            Disable remote project browsing and registration',
+      '  --websocket-port <port>       Persist a loopback port (chosen automatically by default)',
+      '  --websocket-path <path>       Persist the upgrade path (default: /runtime-host)',
+      '  --json                        Emit framed machine-readable progress and result records',
+      '',
+    ],
+  },
+  service: {
+    summary: 'Install and operate the managed service',
+    lines: (cliCommand: string) => [
+      `  ${cliCommand} runtime-host service install [options]`,
+      `  ${cliCommand} runtime-host service configure (--project-root <label>=<path> ... | --no-project-roots) --expected-config-fingerprint <sha256:...> --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
+      `  ${cliCommand} runtime-host service status|start|stop|restart|logs [--json]`,
+      `  ${cliCommand} runtime-host service uninstall --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
+      `  ${cliCommand} runtime-host service peer enable|disable|status|rotate|descriptor [options]`,
+      `  ${cliCommand} runtime-host service mesh status|create|invite|join|remove|leave|close|reconcile [options]`,
+      `  ${cliCommand} runtime-host service retire --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
+      `  ${cliCommand} runtime-host service check-update --target <latest|next|version> [--json]`,
+      `  ${cliCommand} runtime-host service update [--target <latest|next|version>] --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
+      `  ${cliCommand} runtime-host service update-policy [--target <manual|latest|next|version>] [--json]`,
+      `  ${cliCommand} runtime-host service reconcile-update [--json]`,
+      '',
+      'Install options (Linux or macOS):',
+      '  --root <path>                 Select the canonical data root',
+      '  --project-root <label>=<path> Publish an absolute directory root (repeatable)',
+      '  --no-project-roots            Disable remote project browsing and registration',
+      '  --websocket-port <port>       Persist a loopback port (chosen automatically by default)',
+      '  --websocket-path <path>       Persist the upgrade path (default: /runtime-host)',
+      '  --json                        Emit a machine-readable result',
+      '',
+      '',
+      'Direct-peer options:',
+      '  --listen <multiaddr>          Persist a listener address (repeatable)',
+      '  --coordination-relay <addr>   Prefer a Circuit Relay v2 address (repeatable)',
+      '  --clear-coordination-relays   Remove every manually configured relay',
+      '  --automatic-relay-discovery   Enable best-effort public relay discovery',
+      '  --no-automatic-relay-discovery  Disable public discovery and retain manual relays',
+      '  --default-public-stun          Use the packaged best-effort public STUN policy',
+      '  --no-public-stun               Disable public STUN and keep host candidates only',
+      '  --webrtc-stun <stun-url>       Use a custom STUN endpoint (repeatable)',
+      '',
+    ],
+  },
+  access: {
+    summary: 'Issue and revoke access credentials',
+    lines: (cliCommand: string) => [
+      `  ${cliCommand} runtime-host access issue --principal <id> --grant <operation>`,
+      `  ${cliCommand} runtime-host access issue --principal <id> --preset <desktop-client|terminal-client>`,
+      `  ${cliCommand} runtime-host access connection-code [--name <name>] [--root <path>]`,
+      `  ${cliCommand} runtime-host access list`,
+      `  ${cliCommand} runtime-host access issue --kind capability-provider --principal <id>`,
+      `  ${cliCommand} runtime-host access revoke --credential <id>`,
+      '',
+      'Issue options:',
+      '  --root <path>                 Select the canonical data root',
+      '  --kind <kind>                 remote-owner or capability-provider',
+      '  --principal <id>              Name the authenticated Client principal',
+      '  --grant <operation>           Grant one exact operation (repeatable)',
+      '  --preset <name>               Grant the desktop-client or terminal-client operation set',
+      '  --publish-client-capabilities Allow Client Capability publication',
+      '  --allow-host-paths            Allow operations that submit Host paths',
+      '  --capability-owner-credential <id>  Bind a provider to one Client-bound owner credential',
+      '',
+    ],
+  },
+  project: {
+    summary: 'Register project directory roots',
+    lines: (cliCommand: string) => [
+      `  ${cliCommand} runtime-host project list [--root <path>]`,
+      `  ${cliCommand} runtime-host project add <path> [--prefer] [--root <path>]`,
+    ],
+  },
+  plugin: {
+    summary: 'Install and inspect plugins',
+    lines: (cliCommand: string) => [
+      `  ${cliCommand} runtime-host plugin status|list|inspect|failures [--root <path>]`,
+      `  ${cliCommand} runtime-host plugin install|uninstall|reload <target> [--root <path>]`,
+      `  ${cliCommand} runtime-host plugin export <extension-id> <bundle-path> [--root <path>]`,
+      `  ${cliCommand} runtime-host plugin apply <operations.json> [--root <path>]`,
+      `  ${cliCommand} runtime-host plugin reconcile [--root <path>]`,
+    ],
+  },
+  profile: {
+    summary: 'Save and select remote Host profiles',
+    lines: (cliCommand: string) => [
+      `  ${cliCommand} runtime-host profile list`,
+      `  ${cliCommand} runtime-host profile set --id <id> --name <name> --tls-url <wss-url> --expected-root <root-id> [--credential-env <name>]`,
+      `  ${cliCommand} runtime-host profile set --id <id> --name <name> --ssh-destination <user@host> --ssh-remote-port <port> --expected-root <root-id> [--ssh-port <port>] [--credential-env <name>]`,
+      `  ${cliCommand} runtime-host profile set --id <id> --name <name> --plaintext-url <ws-url> --acknowledge-plaintext --expected-root <root-id> [--credential-env <name>]`,
+      `  ${cliCommand} runtime-host profile remove --id <id>`,
+      '',
+      'Environment:',
+      '  MAKA_RUNTIME_HOST_ACCESS_CREDENTIAL  Access credential used when --credential-env is omitted',
+    ],
+  },
+  'capability-provider': {
+    summary: 'Publish MCP tools to a Host',
+    lines: (cliCommand: string) => [
+      `  ${cliCommand} runtime-host capability-provider serve --url <ws-url> --mcp-config <path> --expected-root <root-id>`,
+      '',
+      'Options:',
+      '  --url <ws-url>                Connect to an authenticated Runtime Host WebSocket',
+      '  --mcp-config <path>           Publish tools from an MCP configuration file',
+      '  --expected-root <root-id>     Pin the canonical Runtime Host root identity',
+      '  --credential-env <name>       Read the access credential from this environment variable',
+      '  --client-identity <path>      Persist the provider Client instance identity here',
+    ],
+  },
+} as const;
+
+export type RuntimeHostHelpTopic = keyof typeof SUBCOMMANDS;
+
+export function isRuntimeHostHelpTopic(value: string): value is RuntimeHostHelpTopic {
+  return Object.hasOwn(SUBCOMMANDS, value);
+}
+
+/** Overview of the Runtime Host commands, one line each. */
+export function runtimeHostHelpText(cliCommand: string): string {
+  return [
+    `Usage: ${cliCommand} runtime-host <command> [options]`,
+    '',
+    'Serves and manages a Runtime Host: the background service that runs Sessions.',
+    '',
+    'Commands:',
+    ...Object.entries(SUBCOMMANDS).map(([name, topic]) => `  ${name.padEnd(20)}${topic.summary}`),
+    '',
+    `Run \`${cliCommand} runtime-host <command> --help\` for its own options.`,
+  ].join('\n');
+}
+
+/** A lone command line that only repeats the Usage grammar adds nothing to its screen. */
+function withoutRedundantUsage(lines: readonly string[], usage: string): readonly string[] {
+  const rest = lines[0]?.trim().startsWith(usage) ? lines.slice(1) : lines;
+  const body = rest[0]?.trim() === '' ? rest.slice(1) : rest;
+  // A screen that still opens on command lines needs the heading its option
+  // sections already carry.
+  return body[0]?.startsWith('  ') && !body[0].trim().startsWith('-')
+    ? ['Commands:', ...body]
+    : body;
+}
+
+/** Every command line and option belonging to one Runtime Host command. */
+export function runtimeHostCommandHelpText(
+  cliCommand: string,
+  topic: RuntimeHostHelpTopic,
+): string {
+  return [
+    `Usage: ${cliCommand} runtime-host ${topic} [options]`,
+    '',
+    ...withoutRedundantUsage(
+      SUBCOMMANDS[topic].lines(cliCommand),
+      `${cliCommand} runtime-host ${topic} [options]`,
+    ),
+  ].join('\n');
+}
+
+/** `maka update` manages the npm-global CLI, so it sits outside the Host topics. */
+export function installedUpdateHelpText(cliCommand: string): string {
+  return [
+    `Usage: ${cliCommand} update [options]`,
+    '',
+    'Updates this npm-global CLI and the Runtime Host it manages locally.',
+    '',
+    'Options:',
+    '  --target <latest|next|version>  Select the release to install',
+    '  --allow-interrupt-active-tasks  Update even while the Host has running work',
+  ].join('\n');
+}
+
+/** Session bundles move a Session between workspaces; neither side takes flags beyond these. */
+export function sessionBundleHelpText(
+  cliCommand: string,
+  command: 'session-export' | 'session-import',
+): string {
+  return command === 'session-export'
+    ? [
+        `Usage: ${cliCommand} session-export --workspace-root <dir> --session <id> --out <file.maka-session>`,
+        '',
+        'Writes one Session and its transcript to a portable bundle.',
+        '',
+        'Options:',
+        '  --workspace-root <dir>   Workspace holding the Session',
+        '  --session <id>           Session to export',
+        '  --out <file>             Bundle path to write',
+      ].join('\n')
+    : [
+        `Usage: ${cliCommand} session-import --workspace-root <dir> --bundle <file.maka-session>`,
+        '',
+        'Reads a Session bundle back into a workspace.',
+        '',
+        'Options:',
+        '  --workspace-root <dir>   Workspace to import into',
+        '  --bundle <file>          Bundle path to read',
+      ].join('\n');
+}


### PR DESCRIPTION
## Summary

`maka --help` printed 110 lines. Sixty-two of them were the Runtime Host surface — `service`, `access`, `plugin`, `profile` and their six option sections — which only an operator installing a background service needs. Someone running the tool for the first time met a wall of administration syntax before finding out what it does, and the root screen carried section titles like `Managed Runtime Host direct-peer options (Linux or macOS)`, which is a structure leaking through its own help.

Help is now layered the way `run` and `activate` already were:

```
maka --help                        25 lines: top-level commands and the TUI options
maka runtime-host --help           the nine Runtime Host commands, one line each
maka runtime-host serve --help     that command's own options
maka update --help                 a screen it never had
maka session-export --help         likewise
```

Every screen has the same shape — `Usage:`, then `Commands:` where there is
more than one, then `Options:`. The section titles shed the qualifiers they
needed only while six of them shared the root screen: `Managed Runtime Host
service install options (Linux or macOS)` is just `Install options (Linux or
macOS)` once `Usage: maka runtime-host service` sits above it.

`maka update --help`, `session-export --help` and `session-import --help` previously answered `Unexpected argument` or exited 1 with a usage line on stderr. They are real screens now, which matters because the root no longer spells their flags out.

Column widths are measured from the entries rather than fixed, so a development launcher (`npm run cli:dev --`) aligns like the packaged `maka` does. The previous hardcoded width broke on the longer name — `-- --acpServe ACP v1…` — which the existing test caught.

Refs #2672

## Verification

```
packages/cli dist suite         937 pass / 0 fail
packages/cli tsc --noEmit       0 errors
check-tui-copy                  ok (18 files)
check-locale-hygiene            passed
npm run format:check            clean
```

Before and after, root help:

```
$ maka --help | wc -l
110

$ maka --help | wc -l
25
```

Two existing assertions changed, both because they pinned the old shape rather than a behavior: one matched an exact column width (`/^  maka {14}Start the TUI$/`), the other required `runtime-host serve` to appear in the *root* screen. They now assert the layering — that the root names `runtime-host` once and points at it, that it stays under 30 lines, that every summary starts in one column whatever the launcher name costs, and that the launcher name survives into the second and third level.

Three new assertions guard the move itself, because the new module was
generated by a script that lifted the old text and regrouped it — which is
exactly where content gets dropped or mis-filed. One walks every command the
parser accepts and fails if it appears on no screen; removing `activate` from
the topic table fails it with `runtime-host activate is unreachable from any
help screen`. That test found nothing when written, because it was written
after a review caught what it would have caught:

- `runtime-host activate` was dropped outright — the generator's topic list
  omitted `activate` and `connect`, so a command the parser still accepts
  appeared on no screen and answered `Unexpected runtime-host activate option`.
- `MAKA_RUNTIME_HOST_ACCESS_CREDENTIAL` was lost with the root `Options`
  rewrite. It is the credential `profile set` reads when `--credential-env` is
  omitted, so the advertised default invocation had no documented way to supply
  one. It now sits under `runtime-host profile --help`.
- `session-export` / `session-import` lost their grammar to `...` in the root
  screen while neither had a `--help` to move it to.

## Review focus

This replaces what this PR held before — a decision to record the English-only help as a contract. That framing was wrong on two counts, and the second one is the reason for this rewrite:

- The argument for it was that help gets pasted and searched, so one language keeps it quotable. That holds for error messages, not for help text, which is read once in a terminal.
- The follow-up argument — that too little of the file is translatable prose to bother — does not survive counting: 57 of 58 option lines carry a description, and about two thirds of the non-blank lines contain translatable text, not the small fraction it looks like at a glance.

So the honest position is that the root help was never *decided* to be English; it was never localized, and it was also too long to be useful in any language. This PR fixes the length and the structure. Localizing the now-25-line root screen is a separate, much smaller change, and nothing here forecloses it.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: **Claude Code** — restructured the help, wired the per-command dispatch, updated the tests, and wrote this description. A second model (Codex) argued against the previous framing of this PR and supplied the line counts that overturned it. The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — `maka --help` no longer lists the Runtime Host subcommands; they moved to `maka runtime-host --help`
- [ ] No

