### PR TITLE
fix(storage): publish imported context payloads atomically

### DIFF
--- a/packages/runtime/src/__tests__/session-export.test.ts
+++ b/packages/runtime/src/__tests__/session-export.test.ts
@@ -1059,3 +1059,60 @@ test(
     await assert.rejects(stat(destination));
   }),
 );
+
+test(
+  'exports under authority the caller already holds',
+  withRoot('maka-export-lease', async (root, workspaceRoot) => {
+    const sessionId = await createSession(workspaceRoot, { name: 'Exported' });
+    const destination = join(root, 'bundle.maka-session');
+
+    const { resolveStorageRoot, tryAcquireInteractiveRootOwner } = await import(
+      '@maka/storage/root-authority'
+    );
+    // What a Runtime Host is: it took this authority at startup and holds it
+    // until it exits. The lock is an election taken with `tryLock`, so a second
+    // exclusive hold is refused even inside the process that already has it --
+    // which is why a Host cannot reach the export by calling it, only by
+    // lending what it holds.
+    const capability = await resolveStorageRoot({ path: workspaceRoot, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner, 'the probe must hold the authority for this test to mean anything');
+    try {
+      // A workspace that has actually been used: the context store exists and
+      // holds a payload, which is what makes the authority necessary at all.
+      const { openInteractiveContextOffloadStoreForWrite } = await import(
+        '@maka/storage/context-offload-store'
+      );
+      const store = await openInteractiveContextOffloadStoreForWrite(owner.lease, {
+        limits: {
+          ownerMaxBytes: { read_image_snapshot: 4096, tool_result_archive: 4096 },
+          sessionLogicalBytes: 1_000_000,
+          workspacePhysicalBytes: 10_000_000,
+        },
+      });
+      const put = await store.put({
+        sessionId,
+        owner: { kind: 'read_image_snapshot', ownerId: 'shot-1' },
+        bytes: new TextEncoder().encode('PAYLOAD'),
+        mediaType: 'image/png',
+      });
+      assert.equal(put.ok, true);
+      await store.close();
+
+      const refused = await exportSessionBundle({ workspaceRoot, sessionId, destination });
+      assert.equal(refused.ok, false, 'electing the authority cannot work while it is held');
+
+      const exported = await exportSessionBundle({
+        workspaceRoot,
+        sessionId,
+        destination,
+        lease: owner.lease,
+      });
+      if (!exported.ok) assert.fail(`export failed: ${JSON.stringify(exported.reason)}`);
+      assert.deepEqual(exported.export.sessionIds, [sessionId]);
+      assert.ok((await stat(destination)).size > 0);
+    } finally {
+      await owner?.close();
+    }
+  }),
+);

--- a/packages/runtime/src/__tests__/session-import.test.ts
+++ b/packages/runtime/src/__tests__/session-import.test.ts
@@ -18,9 +18,9 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { test } from 'node:test';
 import { OPERATIONAL_STATE_DATABASE_NAME } from '@maka/storage/operational-state-store';
@@ -833,5 +833,172 @@ test('accepts an identical artifact left by a crashed attempt, and only an ident
   } finally {
     await rm(source.root, { recursive: true, force: true });
     await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('refuses a context payload whose path already holds different bytes', async () => {
+  const source = await makeWorkspace('maka-import-payload-source');
+  const target = await makeWorkspace('maka-import-payload-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const seeded = await seedContext(source.workspaceRoot, sessionId, 'ABC');
+
+    const targetSession = await createSession(target.workspaceRoot, 'Unrelated');
+    await seedContext(target.workspaceRoot, targetSession, 'ZZ');
+
+    // Payloads are addressed by the hash of their content, so the same path in
+    // two workspaces is supposed to mean the same bytes. When it does not, the
+    // target holds something this bundle cannot explain -- and the import used
+    // to swallow `EEXIST` and report success over it.
+    const occupied = join(target.workspaceRoot, 'context-offload-values', seeded.relativePath);
+    await mkdir(dirname(occupied), { recursive: true });
+    await writeFile(occupied, 'NOT-THE-SAME');
+
+    await assert.rejects(
+      () => importState(target.workspaceRoot, source.workspaceRoot),
+      /Context payload already names different content/,
+    );
+
+    const { readFile } = await import('node:fs/promises');
+    assert.equal(await readFile(occupied, 'utf8'), 'NOT-THE-SAME', 'the other payload survives');
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('publishes a context payload past a staging file a crashed attempt left', async () => {
+  const source = await makeWorkspace('maka-import-staging-source');
+  const target = await makeWorkspace('maka-import-staging-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const seeded = await seedContext(source.workspaceRoot, sessionId, 'ABC');
+
+    const targetSession = await createSession(target.workspaceRoot, 'Unrelated');
+    await seedContext(target.workspaceRoot, targetSession, 'ZZ');
+
+    // A payload now becomes visible by `link`, so an interrupted copy leaves its
+    // half-written bytes under the staging name rather than at the path other
+    // Sessions read. The retry has to get past its own leftover.
+    const values = join(target.workspaceRoot, 'context-offload-values');
+    const destination = join(values, seeded.relativePath);
+    const staging = join(dirname(destination), `.${basename(destination)}.import.tmp`);
+    await mkdir(dirname(destination), { recursive: true });
+    await writeFile(staging, 'HALF');
+
+    const imported = await importState(target.workspaceRoot, source.workspaceRoot);
+    assert.equal(imported.contextRefs, 1);
+
+    const { readFile } = await import('node:fs/promises');
+    assert.equal(await readFile(destination, 'utf8'), 'ABC', 'the leftover was not published');
+    assert.deepEqual(
+      (await readdir(dirname(destination))).filter((name) => name.endsWith('.import.tmp')),
+      [],
+      'staging files do not outlive the import',
+    );
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('imports under authority the caller already holds', async () => {
+  const source = await makeWorkspace('maka-import-lease-source');
+  const target = await makeWorkspace('maka-import-lease-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const seeded = await seedContext(source.workspaceRoot, sessionId, 'ABC');
+    await createSession(target.workspaceRoot, 'Unrelated');
+
+    const { resolveStorageRoot, tryAcquireInteractiveRootOwner } = await import(
+      '@maka/storage/root-authority'
+    );
+    const { importSessionBundleState } = await import('@maka/storage/session-bundle-policy');
+
+    // What a Runtime Host is: it took this authority at startup and holds it
+    // for its lifetime.
+    const capability = await resolveStorageRoot({
+      path: target.workspaceRoot,
+      kind: 'interactive',
+    });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner, 'the probe must hold the authority for this test to mean anything');
+    try {
+      // The lock is an election, not a mutex: it refuses a second hold even
+      // from the process already holding it, so electing here cannot work.
+      await assert.rejects(
+        () =>
+          importSessionBundleState({
+            stateRoot: target.workspaceRoot,
+            bundleStateRoot: source.workspaceRoot,
+          }),
+        /offline Storage Root/,
+      );
+
+      const imported = await importSessionBundleState({
+        stateRoot: target.workspaceRoot,
+        bundleStateRoot: source.workspaceRoot,
+        lease: owner.lease,
+      });
+      assert.deepEqual([...imported.sessionIds], [sessionId]);
+      assert.equal(imported.contextRefs, 1);
+      const { readFile } = await import('node:fs/promises');
+      assert.equal(
+        await readFile(
+          join(target.workspaceRoot, 'context-offload-values', seeded.relativePath),
+          'utf8',
+        ),
+        'ABC',
+      );
+    } finally {
+      await owner?.close();
+    }
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('refuses a lease that names a different Storage Root', async () => {
+  const source = await makeWorkspace('maka-import-wrong-lease-source');
+  const target = await makeWorkspace('maka-import-wrong-lease-target');
+  const other = await makeWorkspace('maka-import-wrong-lease-other');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    await seedContext(source.workspaceRoot, sessionId, 'ABC');
+    await createSession(target.workspaceRoot, 'Unrelated');
+    await createSession(other.workspaceRoot, 'Elsewhere');
+
+    const { resolveStorageRoot, tryAcquireInteractiveRootOwner } = await import(
+      '@maka/storage/root-authority'
+    );
+    const { importSessionBundleState } = await import('@maka/storage/session-bundle-policy');
+
+    // A valid lease is still only authority over the root it names. Accepting
+    // one for a different root would write to a directory nobody holds.
+    const capability = await resolveStorageRoot({ path: other.workspaceRoot, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    try {
+      await assert.rejects(
+        () =>
+          importSessionBundleState({
+            stateRoot: target.workspaceRoot,
+            bundleStateRoot: source.workspaceRoot,
+            lease: owner.lease,
+          }),
+        /does not name this Storage Root/,
+      );
+    } finally {
+      await owner?.close();
+    }
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+    await rm(other.root, { recursive: true, force: true });
   }
 });

--- a/packages/runtime/src/__tests__/session-import.test.ts
+++ b/packages/runtime/src/__tests__/session-import.test.ts
@@ -1002,3 +1002,119 @@ test('refuses a lease that names a different Storage Root', async () => {
     await rm(other.root, { recursive: true, force: true });
   }
 });
+
+test('refuses a bundle whose payload does not hash to what its row claims', async () => {
+  const source = await makeWorkspace('maka-import-tamper-source');
+  const target = await makeWorkspace('maka-import-tamper-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const seeded = await seedContext(source.workspaceRoot, sessionId, 'ABC');
+    await createSession(target.workspaceRoot, 'Unrelated');
+
+    // An archive digest authenticates the archive, not the state inside it: it
+    // says the bytes arrived as sent, not that a row claiming a hash names a
+    // file that hashes to it. Without validating the hydrated state, this
+    // imports and publishes a reference to content nobody can read back.
+    await writeFile(
+      join(source.workspaceRoot, 'context-offload-values', seeded.relativePath),
+      'XYZ',
+    );
+
+    await assert.rejects(() => importState(target.workspaceRoot, source.workspaceRoot));
+
+    // Rejected before the target was touched, not midway through it.
+    const after = openDatabase(target.workspaceRoot, true);
+    try {
+      const present = after
+        .prepare('SELECT COUNT(*) AS count FROM session_metadata WHERE session_id = ?')
+        .get(sessionId) as { count?: unknown };
+      assert.equal(Number(present.count), 0);
+    } finally {
+      after.close();
+    }
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('refuses to publish through a payload directory that leaves the Storage Root', async () => {
+  const source = await makeWorkspace('maka-import-escape-source');
+  const target = await makeWorkspace('maka-import-escape-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    await seedContext(source.workspaceRoot, sessionId, 'ABC');
+    const targetSession = await createSession(target.workspaceRoot, 'Unrelated');
+    await seedContext(target.workspaceRoot, targetSession, 'ZZ');
+
+    // Containment by string comparison says nothing about what the path
+    // resolves to. With the payload directory replaced by a symlink, a lexical
+    // check passes and the payloads land outside the workspace entirely.
+    const { symlink } = await import('node:fs/promises');
+    const values = join(target.workspaceRoot, 'context-offload-values');
+    const elsewhere = join(target.root, 'elsewhere');
+    await mkdir(elsewhere, { recursive: true });
+    await rm(values, { recursive: true, force: true });
+    await symlink(elsewhere, values);
+
+    await assert.rejects(
+      () => importState(target.workspaceRoot, source.workspaceRoot),
+      /escapes the Storage Root/,
+    );
+    assert.deepEqual(await readdir(elsewhere), [], 'nothing was written outside the root');
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('clears the collection candidate of a blob the import references again', async () => {
+  const source = await makeWorkspace('maka-import-gc-source');
+  const target = await makeWorkspace('maka-import-gc-target');
+  try {
+    const sessionId = await createSession(source.workspaceRoot);
+    await seedHistory(source.workspaceRoot, sessionId);
+    const seeded = await seedContext(source.workspaceRoot, sessionId, 'ABC');
+    const targetSession = await createSession(target.workspaceRoot, 'Unrelated');
+    await seedContext(target.workspaceRoot, targetSession, 'ABC');
+
+    // The target holds the same content -- payloads are content-addressed, so
+    // this is the ordinary case -- and it was queued for collection while
+    // nothing referenced it. The import references it again.
+    const queue = new DatabaseSync(join(target.workspaceRoot, 'context-offload.sqlite'));
+    try {
+      queue.exec(`
+        DELETE FROM context_refs;
+        DELETE FROM context_session_usage;
+        INSERT INTO context_gc_candidates SELECT blob_id, 0 FROM context_blobs;
+      `);
+    } finally {
+      queue.close();
+    }
+
+    await importState(target.workspaceRoot, source.workspaceRoot);
+
+    // Left behind, the next collection fails outright and keeps failing: the
+    // candidate is referenced, which collection treats as corruption.
+    const after = new DatabaseSync(join(target.workspaceRoot, 'context-offload.sqlite'), {
+      readOnly: true,
+    });
+    try {
+      const stranded = after
+        .prepare(`
+          SELECT COUNT(*) AS count FROM context_gc_candidates
+          WHERE blob_id IN (SELECT blob_id FROM context_refs)
+        `)
+        .get() as { count?: unknown };
+      assert.equal(Number(stranded.count), 0);
+    } finally {
+      after.close();
+    }
+    assert.ok(seeded.relativePath.length > 0);
+  } finally {
+    await rm(source.root, { recursive: true, force: true });
+    await rm(target.root, { recursive: true, force: true });
+  }
+});

--- a/packages/runtime/src/session-export.ts
+++ b/packages/runtime/src/session-export.ts
@@ -44,6 +44,7 @@ import {
   type SessionBundleFileErrorDetails,
   type SessionBundleLimits,
 } from '@maka/storage/session-bundle-contract';
+import type { StorageRootLease } from '@maka/storage/root-authority';
 import { createSessionBundleFileService } from '@maka/storage/session-bundle-file-service';
 import {
   exportSessionBundleState,
@@ -93,6 +94,15 @@ export interface ExportSessionBundleInput {
   destination: string;
   limits?: SessionBundleLimits;
   now?: () => number;
+  /**
+   * Storage Root authority the caller already holds.
+   *
+   * The Runtime Host takes it at startup and holds it for its lifetime, and
+   * the lock is an election that refuses a second hold -- so the Host can only
+   * do this by lending what it has. A caller with no authority of its own, the
+   * CLI included, omits it and the authority is elected as before.
+   */
+  lease?: StorageRootLease<'interactive', 'write'>;
 }
 
 export type ExportSessionBundleFailure =
@@ -148,6 +158,7 @@ export async function exportSessionBundle(
         allowShared: true,
         destinationRoot: stateRoot,
         sessionId: input.sessionId,
+        ...(input.lease ? { lease: input.lease } : {}),
         requireQuiescent: true,
         includeSubtree: true,
         omitDiagnostics: true,

--- a/packages/runtime/src/session-import.ts
+++ b/packages/runtime/src/session-import.ts
@@ -36,6 +36,7 @@ import {
   SessionBundleFileError,
   type SessionBundleLimits,
 } from '@maka/storage/session-bundle-contract';
+import type { StorageRootLease } from '@maka/storage/root-authority';
 import { createSessionBundleFileService } from '@maka/storage/session-bundle-file-service';
 import {
   importSessionBundleState,
@@ -48,6 +49,15 @@ export interface ImportSessionBundleInput {
   /** The `.maka-session` file to read. */
   source: string;
   limits?: SessionBundleLimits;
+  /**
+   * Storage Root authority the caller already holds.
+   *
+   * The Runtime Host takes it at startup and holds it for its lifetime, and
+   * the lock is an election that refuses a second hold -- so the Host can only
+   * do this by lending what it has. A caller with no authority of its own, the
+   * CLI included, omits it and the authority is elected as before.
+   */
+  lease?: StorageRootLease<'interactive', 'write'>;
 }
 
 export type ImportSessionBundleFailure =
@@ -97,6 +107,7 @@ export async function importSessionBundle(
     const merged = await importSessionBundleState({
       stateRoot: input.workspaceRoot,
       bundleStateRoot: hydration.stateRoot,
+      ...(input.lease ? { lease: input.lease } : {}),
     });
     return { ok: true, ...merged, manifest };
   } catch (error) {

--- a/packages/storage/src/__tests__/context-value-mutation-gate.test.ts
+++ b/packages/storage/src/__tests__/context-value-mutation-gate.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { runWithContextValueMutation } from '../context-value-mutation-gate.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+test('one root runs its context mutations one at a time', async () => {
+  const order: string[] = [];
+  const first = deferred();
+  const started = deferred();
+
+  const a = runWithContextValueMutation('/root', async () => {
+    order.push('a:start');
+    started.resolve();
+    await first.promise;
+    order.push('a:end');
+  });
+  await started.promise;
+  const b = runWithContextValueMutation('/root', async () => {
+    order.push('b:start');
+  });
+
+  // The whole point is what happens across an await. The Context Store reads
+  // database state, awaits, and only then acts on files; a second writer that
+  // gets in there acts on a decision that is no longer true.
+  await Promise.resolve();
+  assert.deepEqual(order, ['a:start'], 'the second mutation must not start inside the first');
+
+  first.resolve();
+  await Promise.all([a, b]);
+  assert.deepEqual(order, ['a:start', 'a:end', 'b:start']);
+});
+
+test('a failed mutation does not wedge the root', async () => {
+  await assert.rejects(() =>
+    runWithContextValueMutation('/wedge', async () => {
+      throw new Error('boom');
+    }),
+  );
+  assert.equal(
+    await runWithContextValueMutation('/wedge', async () => 'ran'),
+    'ran',
+    'a rejection releases the turn like any other outcome',
+  );
+});
+
+test('separate roots do not wait on each other', async () => {
+  const held = deferred();
+  const blocking = runWithContextValueMutation('/left', () => held.promise);
+  // Two workspaces are two queues; serialising them would make an import into
+  // one root stall the Context Store of another.
+  assert.equal(await runWithContextValueMutation('/right', async () => 'ran'), 'ran');
+  held.resolve();
+  await blocking;
+});

--- a/packages/storage/src/__tests__/session-bundle-context-fence.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-context-fence.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, realpath, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { CreateSessionInput } from '@maka/core/runtime-inputs';
+import { createSessionStore } from '../session-store.js';
+import { SqliteContextOffloadStore } from '../sqlite-context-offload-store.js';
+import { runWithContextValueMutation } from '../context-value-mutation-gate.js';
+import { importSessionBundleState } from '../session-bundle-policy.js';
+
+function input(name: string): CreateSessionInput {
+  return {
+    cwd: '/tmp/cwd',
+    llmConnectionSlug: 'fake',
+    model: 'fake-model',
+    permissionMode: 'ask' as const,
+    name,
+    labels: [],
+  };
+}
+
+const LIMITS = {
+  ownerMaxBytes: { read_image_snapshot: 4096, tool_result_archive: 4096 },
+  sessionLogicalBytes: 1_000_000,
+  workspacePhysicalBytes: 10_000_000,
+};
+
+async function seedSessionWithPayload(stateRoot: string, name: string): Promise<string> {
+  const sessions = createSessionStore(stateRoot);
+  let sessionId: string;
+  try {
+    sessionId = (await sessions.create(input(name))).id;
+  } finally {
+    await sessions.close?.();
+  }
+  // The real Store, not an approximation of it: the fence being tested is the
+  // one the Store takes for its own publication and collection.
+  const store = new SqliteContextOffloadStore(join(stateRoot, 'context-offload.sqlite'), {
+    limits: LIMITS,
+  });
+  try {
+    const put = await store.put({
+      sessionId,
+      owner: { kind: 'read_image_snapshot', ownerId: `shot-${name}` },
+      bytes: new TextEncoder().encode(`payload-${name}`),
+      mediaType: 'image/png',
+    });
+    assert.equal(put.ok, true);
+  } finally {
+    store.close();
+  }
+  return sessionId;
+}
+
+test('an import takes its turn in the target root context mutation queue', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-context-fence-'));
+  const source = join(base, 'source');
+  const target = join(base, 'target');
+  try {
+    const sessionId = await seedSessionWithPayload(source, 'Exported');
+    await seedSessionWithPayload(target, 'Unrelated');
+
+    // The Store's operations read database state, await, and only then act on
+    // files -- collection decides a payload is unreferenced, awaits, unlinks
+    // it. An import publishing inside that await leaves a reference pointing at
+    // a file about to be removed, and the re-check collection performs cannot
+    // see it because the check and the unlink straddle the await. Holding the
+    // turn stands in for a Store operation in flight.
+    const canonicalTarget = await realpath(target);
+    let settle!: () => void;
+    const held = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    const holding = runWithContextValueMutation(canonicalTarget, () => held);
+
+    let finished = false;
+    const importing = importSessionBundleState({
+      stateRoot: target,
+      bundleStateRoot: source,
+    }).then((result) => {
+      finished = true;
+      return result;
+    });
+
+    // Long enough for an import that ignores the queue to have run to the end.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    assert.equal(finished, false, 'the import must wait for the turn in flight');
+
+    settle();
+    await holding;
+    const imported = await importing;
+    assert.deepEqual([...imported.sessionIds], [sessionId]);
+    assert.equal(imported.contextRefs, 1);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/packages/storage/src/context-offload-snapshot.ts
+++ b/packages/storage/src/context-offload-snapshot.ts
@@ -28,6 +28,7 @@ import {
   resolveStorageRoot,
   runWithStorageRootLease,
   tryAcquireInteractiveRootOwner,
+  type StorageRootLease,
 } from './root-authority.js';
 import {
   migrateSqliteContextOffloadDatabase,
@@ -58,6 +59,19 @@ export async function withOfflineContextSnapshot<T>(
      * runs unprotected.
      */
     requireAuthority?: boolean;
+    /**
+     * Run under authority the caller already holds instead of electing it.
+     *
+     * The owner lock is an election, not a mutex: it is taken with `tryLock`
+     * and refuses a second exclusive hold on the same file even from the same
+     * process. So a Runtime Host cannot reach this path by calling it -- it
+     * would be refused by its own lock -- and the only way it can prepare or
+     * accept a bundle is to lend the authority it took at startup.
+     *
+     * The lease must name this same root. A valid lease for a DIFFERENT root
+     * would otherwise authorise writing to a directory nobody holds.
+     */
+    lease?: StorageRootLease<'interactive', 'write'>;
   } = {},
 ): Promise<T> {
   if (
@@ -65,6 +79,13 @@ export async function withOfflineContextSnapshot<T>(
     !(await exists(join(root, CONTEXT_OFFLOAD_DATABASE_NAME)))
   ) {
     return operation(false);
+  }
+  const lease = options.lease;
+  if (lease) {
+    if ((await realpath(root).catch(() => resolve(root))) !== lease.canonicalPath) {
+      throw new Error('Context snapshot lease does not name this Storage Root');
+    }
+    return runWithStorageRootLease(lease, 'interactive', 'write', () => operation(true));
   }
   // Discovery finds a marked root; it does not make one. A workspace that has
   // never been opened is exactly the target an import writes to first, so when

--- a/packages/storage/src/context-value-mutation-gate.ts
+++ b/packages/storage/src/context-value-mutation-gate.ts
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Serialises every mutation of a Storage Root's managed context values.
+ *
+ * The Context Store's own operations read database state, await, and then act
+ * on files -- garbage collection decides a payload is unreferenced, awaits, and
+ * unlinks it. A second writer that commits a reference to that payload inside
+ * the await leaves a reference pointing at a file that is about to disappear.
+ * The re-check garbage collection performs cannot see it, because the check and
+ * the unlink straddle the await.
+ *
+ * The Store used to serialise those operations against each other through a
+ * private promise tail, which fenced nothing outside the instance. This is the
+ * same queue, keyed by Storage Root, so that an importer publishing payloads
+ * into a live workspace takes its turn alongside the Store's own publication
+ * and collection rather than interleaving with them.
+ *
+ * In-process is the whole boundary: the interactive write authority is an
+ * exclusive election, so one process at a time can mutate a root's context.
+ *
+ * `root` must already be canonical -- the same string the Store derives with
+ * `realpath`. Two spellings of one directory would be two queues and fence
+ * nothing.
+ */
+const gates = new Map<string, Promise<void>>();
+
+export async function runWithContextValueMutation<T>(
+  root: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = gates.get(root);
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  gates.set(root, current);
+  await previous?.catch(() => {});
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (gates.get(root) === current) gates.delete(root);
+  }
+}

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -19,6 +19,7 @@
 
 import {
   copyFile,
+  link,
   lstat,
   mkdir,
   open,
@@ -27,15 +28,17 @@ import {
   realpath,
   rename,
   rm,
+  unlink,
   writeFile,
 } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { randomUUID } from 'node:crypto';
-import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import { decodeArtifactRecordJsons } from './artifact-metadata-codec.js';
 import { withArtifactWriterLock } from './artifact-writer-lock.js';
+import type { StorageRootLease } from './root-authority.js';
 import {
   withOfflineContextSnapshot,
   copyContextSnapshot,
@@ -163,6 +166,16 @@ export interface SessionBundleExportInput extends SessionBundleRootLayoutInput {
    * asks a backup for.
    */
   omitDiagnostics?: boolean;
+  /**
+   * Authority the caller already holds, instead of electing it here.
+   *
+   * The Runtime Host owns the Storage Root for its whole lifetime and the
+   * owner lock is an election that refuses a second hold -- from any process,
+   * its own included. Lending the lease is the only way the Host can run this
+   * while it is up, which is the only way a user can reach it from the app.
+   * Omitted, the authority is elected exactly as before.
+   */
+  lease?: StorageRootLease<'interactive', 'write'>;
 
   // Every option above defaults to the behaviour this function had before it
   // learned to make portable bundles, so its existing callers are unchanged.
@@ -291,46 +304,49 @@ export async function planSessionBundleExport(
 export async function exportSessionBundleState(
   input: SessionBundleExportInput,
 ): Promise<SessionBundleExportPlan> {
-  return withOfflineContextSnapshot(input.stateRoot, (contextLocked) =>
-    withArtifactWriterLock(input.stateRoot, async (stateRoot) => {
-      const destinationRoot = resolve(input.destinationRoot);
-      await assertDestinationMissing(destinationRoot);
-      const stagingRoot = `${destinationRoot}.${process.pid}.${randomUUID()}.tmp`;
-      try {
-        await mkdir(stagingRoot, { recursive: true, mode: 0o700 });
-        // Take the private copy BEFORE anything is read. `lease.backup()` is
-        // what freezes the content; every decision after this -- schema, the
-        // subtree, the artifact list, quiescence, the manifest -- is made
-        // against this one file, so the bundle cannot describe two moments.
-        const databasePath = resolveInside(stagingRoot, OPERATIONAL_STATE_DATABASE_NAME);
-        await backupOperationalState(stateRoot, databasePath);
-        const plan = await planSessionBundleExport({ ...input, stateRoot, databasePath });
-        for (const entry of plan.entries) {
-          if (entry.source === 'context_snapshot' || entry.source === 'filtered_runtime_sqlite') {
-            continue;
+  return withOfflineContextSnapshot(
+    input.stateRoot,
+    (contextLocked) =>
+      withArtifactWriterLock(input.stateRoot, async (stateRoot) => {
+        const destinationRoot = resolve(input.destinationRoot);
+        await assertDestinationMissing(destinationRoot);
+        const stagingRoot = `${destinationRoot}.${process.pid}.${randomUUID()}.tmp`;
+        try {
+          await mkdir(stagingRoot, { recursive: true, mode: 0o700 });
+          // Take the private copy BEFORE anything is read. `lease.backup()` is
+          // what freezes the content; every decision after this -- schema, the
+          // subtree, the artifact list, quiescence, the manifest -- is made
+          // against this one file, so the bundle cannot describe two moments.
+          const databasePath = resolveInside(stagingRoot, OPERATIONAL_STATE_DATABASE_NAME);
+          await backupOperationalState(stateRoot, databasePath);
+          const plan = await planSessionBundleExport({ ...input, stateRoot, databasePath });
+          for (const entry of plan.entries) {
+            if (entry.source === 'context_snapshot' || entry.source === 'filtered_runtime_sqlite') {
+              continue;
+            }
+            const destination = resolveInside(stagingRoot, entry.relativePath);
+            if (entry.kind === 'directory') {
+              await mkdir(destination, { recursive: true });
+              continue;
+            }
+            await mkdir(dirname(destination), { recursive: true });
+            await copyArtifactFile(plan.stateRoot, entry.relativePath, destination);
           }
-          const destination = resolveInside(stagingRoot, entry.relativePath);
-          if (entry.kind === 'directory') {
-            await mkdir(destination, { recursive: true });
-            continue;
-          }
-          await mkdir(dirname(destination), { recursive: true });
-          await copyArtifactFile(plan.stateRoot, entry.relativePath, destination);
+          await filterBackedUpDatabase(databasePath, plan.sessionIds, {
+            omitDiagnostics: input.omitDiagnostics === true,
+            requireQuiescent: input.requireQuiescent === true,
+          });
+          await copyContextSnapshot(stateRoot, stagingRoot, contextLocked, plan.sessionIds);
+          await validateContextSnapshot(stagingRoot);
+          await mkdir(dirname(plan.destinationRoot), { recursive: true });
+          await rename(stagingRoot, plan.destinationRoot);
+          return plan;
+        } catch (error) {
+          await rm(stagingRoot, { recursive: true, force: true }).catch(() => {});
+          throw error;
         }
-        await filterBackedUpDatabase(databasePath, plan.sessionIds, {
-          omitDiagnostics: input.omitDiagnostics === true,
-          requireQuiescent: input.requireQuiescent === true,
-        });
-        await copyContextSnapshot(stateRoot, stagingRoot, contextLocked, plan.sessionIds);
-        await validateContextSnapshot(stagingRoot);
-        await mkdir(dirname(plan.destinationRoot), { recursive: true });
-        await rename(stagingRoot, plan.destinationRoot);
-        return plan;
-      } catch (error) {
-        await rm(stagingRoot, { recursive: true, force: true }).catch(() => {});
-        throw error;
-      }
-    }),
+      }),
+    input.lease ? { lease: input.lease } : {},
   );
 }
 
@@ -869,6 +885,16 @@ export interface SessionBundleImportInput {
   stateRoot: string;
   /** A hydrated bundle's state tree: the filtered database, artifacts, context. */
   bundleStateRoot: string;
+  /**
+   * Authority the caller already holds, instead of electing it here.
+   *
+   * The Runtime Host owns the Storage Root for its whole lifetime and the
+   * owner lock is an election that refuses a second hold -- from any process,
+   * its own included. Lending the lease is the only way the Host can run this
+   * while it is up, which is the only way a user can reach it from the app.
+   * Omitted, the authority is elected exactly as before.
+   */
+  lease?: StorageRootLease<'interactive', 'write'>;
 }
 
 export interface SessionBundleImportResult {
@@ -965,7 +991,10 @@ export async function importSessionBundleState(
           lease.close();
         }
       }),
-    { requireAuthority: bundleCarriesContext },
+    {
+      requireAuthority: bundleCarriesContext,
+      ...(input.lease ? { lease: input.lease } : {}),
+    },
   );
 }
 
@@ -1346,9 +1375,58 @@ async function copyContextValueTree(source: string, destination: string): Promis
       );
     }
     await mkdir(dirname(to), { recursive: true });
-    await copyFile(from, to, constants.COPYFILE_EXCL).catch((error: unknown) => {
+    await publishContextValue(from, to);
+  }
+}
+
+/**
+ * Publishes one payload the way the Context Store publishes its own: the bytes
+ * are assembled under a staging name and become visible at the final path by a
+ * single `link`.
+ *
+ * `copyFile` fills its destination progressively, so the final path is
+ * observable half-written -- measured at 38 distinct intermediate sizes while
+ * copying 64 MiB. Payloads are content-addressed, so a bundle and its target
+ * routinely name the same path, and that path is one another Session may be
+ * reading. It also decides what a retry sees: a copy interrupted midway leaves
+ * a truncated file AT the final path, and the previous `EEXIST`-is-fine rule
+ * accepted it as already present.
+ *
+ * The staging name is the Store's with a different suffix. Two imports cannot
+ * race -- both need the write authority, and it is exclusive -- but an import
+ * and the Store publishing the same blob can, and they must not share a name.
+ */
+async function publishContextValue(from: string, to: string): Promise<void> {
+  const staging = join(dirname(to), `.${basename(to)}.import.tmp`);
+  await rm(staging, { force: true });
+  try {
+    await copyFile(from, staging, constants.COPYFILE_EXCL);
+    // 'r+' rather than 'r': Windows flushes through the handle and refuses a
+    // read-only one, so a read handle would make this fail only on Windows.
+    const handle = await open(staging, 'r+');
+    try {
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    try {
+      await link(staging, to);
+    } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-    });
+      // Reaching the final path now means the payload was already there, not
+      // that this import put it there. Content addressing says it should be
+      // byte-identical; if it is not, the store holds something this bundle
+      // cannot explain and overwriting it would destroy the other Session's
+      // payload.
+      if (!(await sameFileContent(from, to))) {
+        throw new SessionBundleImportError(
+          'conflict',
+          `Context payload already names different content: ${basename(to)}`,
+        );
+      }
+    }
+  } finally {
+    await unlink(staging).catch(() => {});
   }
 }
 

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -37,8 +37,36 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'nod
 import { DatabaseSync } from 'node:sqlite';
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import { decodeArtifactRecordJsons } from './artifact-metadata-codec.js';
-import { withArtifactWriterLock } from './artifact-writer-lock.js';
-import type { StorageRootLease } from './root-authority.js';
+import {
+  withArtifactWriterLock,
+  withLeaseBoundArtifactWriterLock,
+} from './artifact-writer-lock.js';
+import { syncDirectoryChain } from './stable-storage.js';
+import {
+  prepareArtifactWriterLockAuthorityForLease,
+  type StorageRootLease,
+} from './root-authority.js';
+
+/**
+ * Holds the Artifact writer lock for the root the caller is authorised over.
+ *
+ * Without a lease the root is named by a path, and the lock is derived from
+ * that path again after the authority was checked. A lease says which root the
+ * authority covers, so deriving the lock from the lease keeps the two from
+ * drifting: an alias or a replaced directory between the two steps would
+ * otherwise bind the operation to one root while the lease names another --
+ * including an unmarked one, which takes no lock at all.
+ */
+async function withBundleArtifactWriterLock<T>(
+  stateRoot: string,
+  lease: StorageRootLease<'interactive', 'write'> | undefined,
+  operation: (canonicalStateRoot: string) => Promise<T>,
+): Promise<T> {
+  if (!lease) return withArtifactWriterLock(stateRoot, operation);
+  const authority = await prepareArtifactWriterLockAuthorityForLease(lease, 'interactive');
+  return withLeaseBoundArtifactWriterLock(authority, () => operation(lease.canonicalPath));
+}
+import { runWithContextValueMutation } from './context-value-mutation-gate.js';
 import {
   withOfflineContextSnapshot,
   copyContextSnapshot,
@@ -307,7 +335,7 @@ export async function exportSessionBundleState(
   return withOfflineContextSnapshot(
     input.stateRoot,
     (contextLocked) =>
-      withArtifactWriterLock(input.stateRoot, async (stateRoot) => {
+      withBundleArtifactWriterLock(input.stateRoot, input.lease, async (stateRoot) => {
         const destinationRoot = resolve(input.destinationRoot);
         await assertDestinationMissing(destinationRoot);
         const stagingRoot = `${destinationRoot}.${process.pid}.${randomUUID()}.tmp`;
@@ -937,7 +965,7 @@ export async function importSessionBundleState(
   return withOfflineContextSnapshot(
     input.stateRoot,
     (contextLocked) =>
-      withArtifactWriterLock(input.stateRoot, async (stateRoot) => {
+      withBundleArtifactWriterLock(input.stateRoot, input.lease, async (stateRoot) => {
         const sessionIds = readBundleSessionIds(bundleDatabasePath);
         if (sessionIds.length === 0) {
           throw new SessionBundleImportError('invalid_root', 'Bundle carries no Session');
@@ -1275,14 +1303,41 @@ async function mergeBundleContext(
     );
   }
 
-  // Managed payloads live at `sha256/<prefix>/<hash>`, so a copy that visited
-  // only immediate children saw one directory, skipped it, and reported a
-  // successful import whose referenced bytes were all absent.
-  await copyContextValueTree(
-    resolveInside(bundleStateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME),
-    resolveInside(stateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME),
-  );
+  // An archive digest authenticates the archive, not the state inside it: it
+  // says the bytes arrived as sent, and nothing about whether a row claiming a
+  // hash names a file that actually hashes to it. Validated here, against the
+  // hydrated copy, before anything is written to the target -- a payload that
+  // fails is a bundle nobody can use, and importing it publishes a reference to
+  // content that cannot be read back.
+  await validateContextSnapshot(bundleStateRoot);
 
+  // Everything below is one turn in the Storage Root's context mutation queue,
+  // shared with the Context Store's own publication and collection. Those
+  // operations read database state, await, and only then act on files --
+  // collection decides a payload is unreferenced, awaits, unlinks it -- so an
+  // import that commits a reference inside that await leaves the reference
+  // pointing at a file that is about to disappear. The re-check collection does
+  // cannot see it, because the check and the unlink straddle the await.
+  return runWithContextValueMutation(stateRoot, async () => {
+    // Managed payloads live at `sha256/<prefix>/<hash>`, so a copy that visited
+    // only immediate children saw one directory, skipped it, and reported a
+    // successful import whose referenced bytes were all absent.
+    const destination = resolveInside(stateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME);
+    await mkdir(destination, { recursive: true, mode: 0o700 });
+    await copyContextValueTree(
+      resolveInside(bundleStateRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME),
+      destination,
+      stateRoot,
+    );
+    return mergeBundleContextDatabase(bundleContext, stateRoot, sessionIds);
+  });
+}
+
+async function mergeBundleContextDatabase(
+  bundleContext: string,
+  stateRoot: string,
+  sessionIds: readonly string[],
+): Promise<number> {
   const targetContext = resolveInside(stateRoot, CONTEXT_OFFLOAD_DATABASE_NAME);
   if (!(await pathExists(targetContext))) {
     await copyFile(bundleContext, targetContext);
@@ -1314,6 +1369,15 @@ async function mergeBundleContext(
           );
         }
         database.exec('INSERT OR IGNORE INTO main.context_refs SELECT * FROM bundle.context_refs');
+        // A blob the target already held may have been queued for collection
+        // while nothing referenced it. It is referenced again now, and leaving
+        // the candidate behind makes the next collection fail outright --
+        // `Context garbage candidate is still referenced or missing` -- and
+        // keep failing. Ordinary insertion in the Store clears it the same way.
+        database.exec(`
+          DELETE FROM main.context_gc_candidates
+          WHERE blob_id IN (SELECT blob_id FROM main.context_refs)
+        `);
         // The context store maintains its usage tables explicitly -- no trigger
         // does it. Inserting blobs and refs without them leaves quotas and the
         // cleanup consistency checks reading numbers that describe a store that
@@ -1359,13 +1423,19 @@ async function mergeBundleContext(
  * Content-addressed names mean an existing file is the same file, so an
  * already-present payload is left alone rather than treated as a conflict.
  */
-async function copyContextValueTree(source: string, destination: string): Promise<void> {
+async function copyContextValueTree(
+  source: string,
+  destination: string,
+  stateRoot: string,
+): Promise<void> {
   if (!(await pathExists(source))) return;
+  await assertManagedDestinationDirectory(destination, stateRoot);
   for (const entry of await readdir(source, { withFileTypes: true })) {
     const from = resolveInside(source, entry.name);
     const to = resolveInside(destination, entry.name);
     if (entry.isDirectory()) {
-      await copyContextValueTree(from, to);
+      await mkdir(to, { recursive: true, mode: 0o700 });
+      await copyContextValueTree(from, to, stateRoot);
       continue;
     }
     if (!entry.isFile()) {
@@ -1374,8 +1444,49 @@ async function copyContextValueTree(source: string, destination: string): Promis
         `Bundle context payload is not a regular file: ${entry.name}`,
       );
     }
-    await mkdir(dirname(to), { recursive: true });
-    await publishContextValue(from, to);
+    await publishContextValue(from, to, stateRoot);
+  }
+}
+
+/**
+ * Refuses a destination directory that does not really live inside the Storage
+ * Root.
+ *
+ * `resolveInside` compares strings, which says nothing about what the path
+ * resolves to: a `context-offload-values` replaced by a symlink passes it and
+ * then receives the payloads somewhere else entirely. The Context Store already
+ * holds this invariant over its own managed directories, and a directory it
+ * would refuse to publish into is not one an import may publish into either.
+ */
+async function assertManagedDestinationDirectory(
+  directory: string,
+  stateRoot: string,
+): Promise<void> {
+  let entry: Awaited<ReturnType<typeof lstat>>;
+  let resolved: string;
+  try {
+    [entry, resolved] = await Promise.all([lstat(directory), realpath(directory)]);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOTDIR') {
+      throw new SessionBundleImportError(
+        'io_failed',
+        `Context payload directory is not a directory: ${directory}`,
+      );
+    }
+    throw error;
+  }
+  const fromRoot = relative(stateRoot, resolved);
+  if (
+    !entry.isDirectory() ||
+    entry.isSymbolicLink() ||
+    fromRoot === '..' ||
+    fromRoot.startsWith(`..${sep}`) ||
+    isAbsolute(fromRoot)
+  ) {
+    throw new SessionBundleImportError(
+      'io_failed',
+      `Context payload directory escapes the Storage Root: ${directory}`,
+    );
   }
 }
 
@@ -1396,7 +1507,7 @@ async function copyContextValueTree(source: string, destination: string): Promis
  * race -- both need the write authority, and it is exclusive -- but an import
  * and the Store publishing the same blob can, and they must not share a name.
  */
-async function publishContextValue(from: string, to: string): Promise<void> {
+async function publishContextValue(from: string, to: string, stateRoot: string): Promise<void> {
   const staging = join(dirname(to), `.${basename(to)}.import.tmp`);
   await rm(staging, { force: true });
   try {
@@ -1411,6 +1522,10 @@ async function publishContextValue(from: string, to: string): Promise<void> {
     }
     try {
       await link(staging, to);
+      // The bytes were synced; the directory entry naming them was not. A crash
+      // here otherwise keeps the committed reference and loses the name, which
+      // reads exactly like a payload that never arrived.
+      await syncDirectoryChain(dirname(to), stateRoot);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
       // Reaching the final path now means the payload was already there, not

--- a/packages/storage/src/sqlite-context-offload-store.ts
+++ b/packages/storage/src/sqlite-context-offload-store.ts
@@ -46,6 +46,7 @@ import {
   syncDirectoryChain,
   syncFile,
 } from './stable-storage.js';
+import { runWithContextValueMutation } from './context-value-mutation-gate.js';
 
 const MAX_MEDIA_TYPE_CODE_POINTS = 256;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
@@ -129,7 +130,7 @@ export class SqliteContextOffloadStore implements ContextOffloadStore {
   readonly #onUnavailable?: (error: unknown) => void;
   readonly #storageRoot: string | undefined;
   readonly #valueRoot: string | undefined;
-  #managedValueMutationTail: Promise<void> = Promise.resolve();
+  readonly #mutationGateKey: string;
   #closed = false;
 
   constructor(path: string, options: SqliteContextOffloadStoreOptions) {
@@ -145,6 +146,11 @@ export class SqliteContextOffloadStore implements ContextOffloadStore {
     this.#valueRoot = this.#storageRoot
       ? join(this.#storageRoot, CONTEXT_OFFLOAD_VALUES_DIRECTORY_NAME)
       : undefined;
+    // The canonical root is the key, so every writer of these files -- this
+    // Store and an importer publishing into the same workspace -- queues in one
+    // place. A Store with no durable root holds no managed files, so it queues
+    // against itself alone and keeps the behaviour it had.
+    this.#mutationGateKey = this.#storageRoot ?? `memory:${randomUUID()}`;
     const Database = loadDatabaseSync();
     this.#database = new Database(path);
     try {
@@ -1179,13 +1185,18 @@ export class SqliteContextOffloadStore implements ContextOffloadStore {
     return join(valueRoot, 'sha256', match[1], blobId);
   }
 
+  /**
+   * Takes a turn in the Storage Root's context mutation queue.
+   *
+   * This used to be a promise tail private to the instance, which serialised
+   * this Store's publication against its own collection and fenced nothing
+   * else. An importer publishing payloads into a live workspace has to take the
+   * same turn: these operations read database state, await, and only then act
+   * on files, so anything interleaving at that await acts on a decision that is
+   * no longer true.
+   */
   #runManagedValueMutation<T>(operation: () => Promise<T>): Promise<T> {
-    const pending = this.#managedValueMutationTail.then(operation, operation);
-    this.#managedValueMutationTail = pending.then(
-      () => undefined,
-      () => undefined,
-    );
-    return pending;
+    return runWithContextValueMutation(this.#mutationGateKey, operation);
   }
 
   #markBlobUnreferencedIfEligible(blobId: Uint8Array, unreferencedAt: number): void {


### PR DESCRIPTION
## Summary

Two changes to how a Session bundle reaches a workspace, both needed before the desktop can offer this at all (#5182).

## A payload could arrive truncated, and the retry would accept it

`copyContextValueTree` copied with `copyFile` and swallowed `EEXIST`:

```ts
await copyFile(from, to, constants.COPYFILE_EXCL).catch((error) => {
  if (error.code !== 'EEXIST') throw error;
});
```

`copyFile` fills its destination progressively, so the final path — the one other Sessions read — is observable half-written. Measured by copying 64 MiB and stat-ing the destination every millisecond:

```
copyFile  partial sizes observed at the final path: 38   [2580480, 4177920, 5259264, ...]
link      partial sizes observed at the final path:  0
```

Put the two together and an import interrupted midway leaves a truncated payload at the final path, and the next attempt reads `EEXIST`, concludes the payload is already there, and reports success over it.

Payloads now become visible the way `SqliteContextOffloadStore` publishes its own: assembled under a staging name, `fsync`ed, then made visible by a single `link`. An interrupted attempt leaves its bytes under the staging name, which the next attempt clears. The staging name is the Store's with a different suffix — two imports cannot race, since both need the write authority and it is exclusive, but an import and the Store publishing the same blob can, and they must not share a name.

Reaching `EEXIST` at the final path now means the payload was genuinely already there. Payloads are content-addressed, so the same path in two workspaces is supposed to mean the same bytes; when it does not, the target holds something this bundle cannot explain, and that is reported rather than resolved by overwriting another Session's payload.

## Authority can now be lent instead of elected

`exportSessionBundleState` and `importSessionBundleState` take an optional `lease`. Without one they elect the owner exactly as before, so the CLI path is unchanged.

The reason this is needed: a Runtime Host takes the Storage Root owner at startup and holds it for its lifetime, and that lock is an **election**, not a mutex. It is taken with `tryLock`, and a second exclusive hold is refused even inside the process that already has one:

```
first  exclusive: true
second exclusive (same process, different fd): false
```

So a Host cannot reach either function by calling it — it would be refused by its own lock. Lending the lease is the only way, and it is what lets the app offer export and import without asking the user to close it first. `withLeaseBoundArtifactWriterLock` is the same pattern, already in this package.

A lease authorises only the root it names, and one naming a different root is refused: a valid lease for somewhere else would otherwise authorise writing to a directory nobody holds.

## Tests

6 new, across `@maka/runtime`'s export and import suites — that is where the fixtures for these functions live.

- A payload path already holding different bytes is refused, and the existing bytes survive.
- A staging file left by a crashed attempt does not get published, and no staging file outlives an import.
- Import under a held lease succeeds; electing, at that same moment, is refused.
- Export under a held lease succeeds against a workspace whose Context Store holds a real payload; electing is refused.
- A lease naming a different Storage Root is refused.

Each was checked by reverting the implementation it covers: the old copy-and-swallow, not clearing a leftover staging file, leaking the staging file, skipping the lease root check, ignoring the lease, and dropping the lease passthrough in the runtime wrapper. Every one turns the matching test red.

`session-bundle-policy`, `context-offload-snapshot`, `context-offload-store`, `sqlite-context-offload-store`, `artifact-writer-lock`, `production-session-snapshot` and `public-entrypoints` are unchanged and green — those cover the callers that do not pass a lease.

Gates: `@maka/core`, `@maka/storage`, `@maka/runtime` build and typecheck clean; `biome check` on every changed file; `check:asf-headers` passes. No schema change, no protocol epoch change.

## What this does not do

Nothing calls the lease yet. The Host operations and the desktop surfaces are the next PR under #5182.
