### PR TITLE
ci: install only the headless Chromium shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,9 +424,11 @@ jobs:
         if: steps.plan.outputs.e2e == 'true'
         run: xvfb-run -a node scripts/audit-alignment.mjs
 
+      # The smoke only launches headless; the full Chrome build was downloaded
+      # and never opened. The headed consumer (perf/storybook.mjs) self-installs.
       - name: Install Playwright Chromium
         if: steps.plan.outputs.storybook == 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps --only-shell chromium
 
       - name: Build Storybook
         if: steps.plan.outputs.storybook == 'true'


### PR DESCRIPTION
## Summary

The Storybook smoke always launches headless, and Playwright picks its executable
by headedness, so `playwright install chromium` downloaded the full Chrome build
on every Storybook-selected run and never opened it. `--only-shell` installs only
the build the smoke uses.

No behavior change — the smoke was already launching `chromium-headless-shell`.
`SMOKE_HEADED=1` stops working on a runner; it was only ever meaningful locally,
where developers install their own browsers.

## Verification

Download per Storybook-selected run:

```
before   184.3 MiB full Chrome + 114.7 MiB headless shell + 2.3 MiB FFmpeg = 301.3 MiB, 18s
after                           114.7 MiB headless shell + 2.3 MiB FFmpeg = 117.0 MiB, 13s
```

Before from job 102913386594 on `main`, after from this PR's own run. The install after the change, and the
smoke's exact launch call against it:

```
$ npx playwright install --only-shell chromium && ls "$PLAYWRIGHT_BROWSERS_PATH"
chromium_headless_shell-1234
ffmpeg-1011

$ node -e "chromium.launch({headless:true})..."
LAUNCH OK: ok

$ node -e "chromium.launch({headless:false})..."
browserType.launch: Executable doesn't exist at .../chromium-1234/...
```

Ran locally: `npm run format:check`, `node --test scripts/ci-workflow-policy.test.mjs`
(43 pass). Editing `ci.yml` selects every surface, so this PR's own `test` run
exercises the changed step.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code found the unused download while profiling CI step
timings, wrote the change and ran the verification above. Codex (gpt-5.6-sol) and
a second independent Claude session reviewed the diff. Review below is human.

## Checklist

- [ ] Tests cover the change and fail without it — no test covers a workflow
      install flag; a wrong flag fails the Storybook smoke outright
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

