### PR TITLE
fix(runtime-host): respect transcript continuation boundaries

### DIFF
--- a/packages/runtime-host/src/__tests__/fixtures/session-transcript-reader.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/session-transcript-reader.ts
@@ -25,25 +25,26 @@ import type { SessionTranscriptReader } from '../../server/session-transcript-re
 export function transcriptReader(
   durable: readonly StoredMessage[],
   overlay: readonly StoredMessage[] = [],
+  sequenceStride = 1,
 ): SessionTranscriptReader {
+  const durableRecords = () =>
+    durable.map((message, index) => ({ sequence: index * sequenceStride, message }));
+  const durableHighWater = () =>
+    durable.length === 0 ? null : (durable.length - 1) * sequenceStride + sequenceStride - 1;
   return {
-    readDurableHighWater: async () => (durable.length === 0 ? null : durable.length - 1),
+    readDurableHighWater: async () => durableHighWater(),
     readDurablePage: async (_sessionId, request) => {
       const throughSequence =
-        request.throughSequence === undefined
-          ? durable.length === 0
-            ? null
-            : durable.length - 1
-          : request.throughSequence;
+        request.throughSequence === undefined ? durableHighWater() : request.throughSequence;
       if (throughSequence === null) {
         return { throughSequence: null, fragments: [], rawBytes: 0, next: null };
       }
       const position = request.position ?? (request.direction === 'older' ? throughSequence : 0);
-      const candidates = durable
-        .map((message, sequence) => {
-          const data = Buffer.from(JSON.stringify(message), 'utf8');
-          return { sequence, data };
-        })
+      const candidates = durableRecords()
+        .map(({ sequence, message }) => ({
+          sequence,
+          data: Buffer.from(JSON.stringify(message), 'utf8'),
+        }))
         .filter(
           ({ sequence }) =>
             sequence <= throughSequence &&
@@ -97,7 +98,7 @@ export function transcriptReader(
       }
       if (next === null && fragments.length > 0 && fragments.length < candidates.length) {
         next = {
-          position: fragments.at(-1)!.sequence + (request.direction === 'older' ? -1 : 1),
+          position: candidates[fragments.length]!.sequence,
           byteOffset: null,
         };
       }
@@ -105,17 +106,12 @@ export function transcriptReader(
     },
     readDurableRecords: async (_sessionId, request) => {
       const throughSequence =
-        request.throughSequence === undefined
-          ? durable.length === 0
-            ? null
-            : durable.length - 1
-          : request.throughSequence;
+        request.throughSequence === undefined ? durableHighWater() : request.throughSequence;
       if (throughSequence === null) {
         return { throughSequence: null, records: [], nextPosition: null };
       }
       const position = request.position ?? (request.direction === 'older' ? throughSequence : 0);
-      const candidates = durable
-        .map((message, sequence) => ({ sequence, message }))
+      const candidates = durableRecords()
         .filter(
           ({ sequence }) =>
             sequence <= throughSequence &&
@@ -126,23 +122,27 @@ export function transcriptReader(
             ? right.sequence - left.sequence
             : left.sequence - right.sequence,
         );
-      const records = candidates.slice(0, request.maxMessages);
-      const last = records.at(-1);
+      const records: ReturnType<typeof durableRecords> = [];
+      let storedBytes = 0;
+      for (const candidate of candidates) {
+        if (records.length >= request.maxMessages || storedBytes >= request.maxStoredBytes) break;
+        records.push(candidate);
+        storedBytes += Buffer.byteLength(JSON.stringify(candidate.message), 'utf8');
+      }
       return {
         throughSequence,
         records,
         nextPosition:
-          last && records.length < candidates.length
-            ? last.sequence + (request.direction === 'older' ? -1 : 1)
-            : null,
+          records.length < candidates.length ? candidates[records.length]!.sequence : null,
       };
     },
     readDurableMessagesById: async (_sessionId, request) =>
       request.throughSequence === null
         ? []
-        : durable.filter(
-            (message, sequence) =>
-              sequence <= request.throughSequence! && request.messageIds.includes(message.id),
+        : durableRecords().flatMap(({ sequence, message }) =>
+            sequence <= request.throughSequence! && request.messageIds.includes(message.id)
+              ? [message]
+              : [],
           ),
     readDurableTurnContributions: async (
       _sessionId,
@@ -150,11 +150,11 @@ export function transcriptReader(
       position,
       maxContributions,
     ) => {
-      const watermark = throughSequence ?? (durable.length === 0 ? null : durable.length - 1);
+      const watermark = throughSequence ?? durableHighWater();
       if (watermark === null)
         return { throughSequence: null, contributions: [], nextPosition: null };
       const folded = new Map<string, SessionTurnContribution>();
-      for (const [sequence, message] of durable.entries()) {
+      for (const { sequence, message } of durableRecords()) {
         const turnId = message.turnId;
         if (turnId === undefined || sequence < position || sequence > watermark) continue;
         if (!folded.has(turnId) && folded.size >= maxContributions) {
@@ -173,11 +173,11 @@ export function transcriptReader(
       };
     },
     readDurableTurnLandmarks: async (_sessionId, maxLandmarks) => {
-      const watermark = durable.length === 0 ? null : durable.length - 1;
+      const watermark = durableHighWater();
       if (watermark === null) return { throughSequence: null, landmarks: [] };
       const seen = new Set<string>();
       const landmarks: SessionTurnLandmark[] = [];
-      for (const [sequence, message] of durable.entries()) {
+      for (const { sequence, message } of durableRecords()) {
         if (landmarks.length >= maxLandmarks) break;
         const turnId = message.turnId;
         if (message.type !== 'user' || turnId === undefined || seen.has(turnId)) continue;

--- a/packages/runtime-host/src/__tests__/session-transcript-pager.test.ts
+++ b/packages/runtime-host/src/__tests__/session-transcript-pager.test.ts
@@ -416,6 +416,86 @@ test('opens the complete latest Turn when bootstrap starts inside its assistant'
   assert.equal(decoded.nextCursor, null);
 });
 
+test('keeps sparse adjacent Turns in separate client ranges while paging in either direction', async () => {
+  const durable: StoredMessage[] = [
+    ...Array.from({ length: 161 }, (_, index) => ({
+      ...assistantMessage(index),
+      turnId: 'turn-older',
+      text: 'x'.repeat(1_600),
+    })),
+    ...Array.from({ length: 134 }, (_, index) => ({
+      ...assistantMessage(index + 161),
+      turnId: 'turn-newer',
+      text: 'x'.repeat(1_600),
+    })),
+  ];
+
+  for (const direction of ['older', 'newer'] as const) {
+    for (const projection of ['owner', 'shared'] as const) {
+      const ranges = await decodeSparseTranscriptRanges(durable, direction, projection);
+      const expected = direction === 'older' ? [134, 161] : [161, 134];
+
+      assert.deepEqual(
+        ranges.map((range) => range.length),
+        expected,
+        `${projection} ${direction}`,
+      );
+      assert.equal(
+        new Set(ranges.flat().map(({ identity }) => identity)).size,
+        durable.length,
+        `${projection} ${direction}`,
+      );
+    }
+  }
+});
+
+test('admits a sparse Turn exactly at the client range message bound', async () => {
+  const durable: StoredMessage[] = [
+    ...Array.from({ length: 256 }, (_, index) => ({
+      ...assistantMessage(index),
+      turnId: 'turn-at-bound',
+      text: 'x'.repeat(1_600),
+    })),
+    ...Array.from({ length: 20 }, (_, index) => ({
+      ...assistantMessage(index + 256),
+      turnId: 'turn-after',
+      text: 'x'.repeat(1_600),
+    })),
+  ];
+
+  for (const projection of ['owner', 'shared'] as const) {
+    const ranges = await decodeSparseTranscriptRanges(durable, 'newer', projection);
+    assert.deepEqual(
+      ranges.map((range) => range.length),
+      [256, 20],
+      projection,
+    );
+  }
+});
+
+test('restarts a partial first row deferred past a sparse range boundary', async () => {
+  const durable: StoredMessage[] = [
+    ...Array.from({ length: 161 }, (_, index) => ({
+      ...assistantMessage(index),
+      turnId: 'turn-older',
+      text: index === 160 ? 'y'.repeat(600 * 1024) : 'x'.repeat(1_600),
+    })),
+    ...Array.from({ length: 134 }, (_, index) => ({
+      ...assistantMessage(index + 161),
+      turnId: 'turn-newer',
+      text: 'x'.repeat(1_600),
+    })),
+  ];
+
+  const ranges = await decodeSparseTranscriptRanges(durable, 'older', 'owner');
+  assert.deepEqual(
+    ranges.map((range) => range.length),
+    [134, 161],
+  );
+  assert.equal(new Set(ranges.flat().map(({ identity }) => identity)).size, durable.length);
+  assert.deepEqual(ranges[1]?.find(({ identity }) => identity === 160 * 8)?.message, durable[160]);
+});
+
 test('pages through a terminal Turn that exceeds the Host range message bound', async () => {
   const durable: StoredMessage[] = Array.from({ length: 286 }, (_, index) => ({
     ...assistantMessage(index),
@@ -985,6 +1065,75 @@ function decodeBootstrap(
   return page.fragments.map((fragment) =>
     JSON.parse(Buffer.from(fragment.data, 'base64').toString('utf8')),
   );
+}
+
+async function decodeSparseTranscriptRanges(
+  durable: readonly StoredMessage[],
+  direction: 'older' | 'newer',
+  projection: 'owner' | 'shared',
+): Promise<Array<readonly { identity: number; message: StoredMessage }[]>> {
+  const reader = transcriptReader(durable, [], 8);
+  const throughSequence = (durable.length - 1) * 8 + 7;
+  const subscriptionId = `subscription-${projection}-${direction}`;
+  const { bootstrap, state } = await createSessionTranscriptBootstrap({
+    reader,
+    sessionId: 'session-1',
+    subscriptionId,
+    throughSequence,
+    rootTurn: null,
+    activeAssistantStreams: [],
+    maxBytes: 16 * 1024,
+    projection,
+  });
+  const subscription = new ClientSessionSubscription(
+    {
+      hostEpoch: 'host-1',
+      subscriptionId,
+      nextSequence: 1,
+      activeAssistantStreams: [],
+      transcript: bootstrap,
+      snapshot: {
+        schemaVersion: SESSION_CONTINUITY_SCHEMA_VERSION,
+        session: {
+          sessionId: 'session-1',
+          metadataRevision: 1,
+          status: 'active',
+          createdAt: 1,
+          isArchived: false,
+        },
+        projectionRevision: 1,
+        rootTurn: null,
+        goal: null,
+        queue: { hostEpoch: 'host-1', queueRevision: 1, steering: [], followup: [] },
+        interactions: { pending: [] },
+      },
+    },
+    async () => undefined,
+    (request) => readSessionTranscriptPage({ reader, state, request }),
+  );
+  const decodeStoredMessage = (value: unknown): StoredMessage =>
+    decodePersistedStoredMessage(markPersisted<StoredMessage>(value));
+  const ranges: Array<readonly { identity: number; message: StoredMessage }[]> = [];
+  let cursor: string | null = null;
+  do {
+    const page = await readSessionTranscriptPage({
+      reader,
+      state,
+      request: {
+        subscriptionId,
+        source: 'durable',
+        direction,
+        throughSequence,
+        cursor,
+        anchorSequence: null,
+        maxBytes: 128 * 1024,
+      },
+    });
+    const decoded = await subscription.decodeTranscriptPage(page, decodeStoredMessage);
+    ranges.push(decoded.messages);
+    cursor = decoded.nextCursor;
+  } while (cursor !== null);
+  return ranges;
 }
 
 test('shared transcript preserves admitted action identity alongside its physical Turn', () => {

--- a/packages/runtime-host/src/server/session-transcript-pager.ts
+++ b/packages/runtime-host/src/server/session-transcript-pager.ts
@@ -246,7 +246,11 @@ export async function readSessionTranscriptPage(input: {
           position.rangeBoundarySequence,
         )
       : await input.reader.readDurablePage(state.sessionId, durableRequest);
-  const selected = storageSelection(storage);
+  const selected = selectionThroughRangeBoundary(
+    storageSelection(storage),
+    request.direction,
+    position.rangeBoundarySequence,
+  );
   const rangeEdges = await readRangeEdges({
     reader: input.reader,
     state,
@@ -640,6 +644,37 @@ function storageSelection(
     })),
     rawBytes: storage.rawBytes,
     next: storage.next,
+  };
+}
+
+function selectionThroughRangeBoundary(
+  selected: SelectedFragments,
+  direction: SessionTranscriptPageDirection,
+  rangeBoundarySequence: number | null,
+): SelectedFragments {
+  if (rangeBoundarySequence === null) return selected;
+  // RuntimeEvent-backed message sequences are sparse, so a continuation's
+  // message limit cannot infer how many records remain from sequence distance.
+  const firstOmittedIndex = selected.fragments.findIndex(
+    (fragment) =>
+      fragment.kind === 'durable' &&
+      (direction === 'older'
+        ? fragment.sequence < rangeBoundarySequence
+        : fragment.sequence > rangeBoundarySequence),
+  );
+  if (firstOmittedIndex === -1) return selected;
+  const firstOmitted = selected.fragments[firstOmittedIndex]!;
+  if (firstOmitted.kind !== 'durable') {
+    throw new Error('Session transcript durable range contained an overlay fragment');
+  }
+  const fragments = selected.fragments.slice(0, firstOmittedIndex);
+  return {
+    fragments,
+    rawBytes: fragments.reduce(
+      (sum, fragment) => sum + Buffer.from(fragment.data, 'base64').byteLength,
+      0,
+    ),
+    next: { position: firstOmitted.sequence, byteOffset: null },
   };
 }
 


### PR DESCRIPTION
## Summary

Keep durable transcript continuations within the Turn boundary encoded in their cursor. Durable message sequences are sparse, so their numeric distance can overestimate the remaining message count and let a continuation pull in the next Turn, exceeding the client's 256-message range limit.

Clip the continuation at its original boundary and resume the next page at the first deferred message. Preserve fragmented-message continuation, normal Turn protection, and the existing protocol limits and wire format.

Fixes #5183

## Verification

- Added real pager/client regressions for adjacent 161/134-message Turns in both directions and owner/shared projections, a Turn exactly at 256 messages, and a partially read message deferred to the next range.
- Pager suite: 23 tests passed. The adjacent-Turn and exact-cap regressions fail with the reported RangeError without the fix.
- Runtime Host suite: 1849 passed, 12 skipped.
- `npm run lint`, `npm run format:check`, `npm run build`, and `npm run typecheck` passed.
- `npx knip --workspace apps/desktop` and `npx knip --workspace packages/ui` passed.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex — diagnosis, implementation, regression tests, validation, and PR text.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
