### PR TITLE
docs(runtime): document subpath-only public API and shared composition entry

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -40,7 +40,7 @@ The main integration points are:
 - `buildBuiltinTools()` and the workspace executor interfaces for tool composition.
 - `RuntimeKernel`, runtime events, projections, and recovery helpers for execution lifecycle.
 
-Shared execution composition — where `BackendRegistry` and `SessionManager` are constructed — lives in the Runtime Host at [`packages/runtime-host/src/server/execution-composition.ts`](../../packages/runtime-host/src/server/execution-composition.ts). Clients, including Desktop, execute Maka through Runtime Host rather than composing Runtime directly.
+Shared execution composition — where `BackendRegistry` and `SessionManager` are constructed — lives in the Runtime Host at [`packages/runtime-host/src/server/execution-composition.ts`](../runtime-host/src/server/execution-composition.ts). Clients, including Desktop, execute Maka through Runtime Host rather than composing Runtime directly.
 
 ## Extension rules
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -23,7 +23,15 @@
 
 ## Public seam
 
-The package root barrel and the subpaths declared in `package.json` are supported public APIs. Do not import undeclared internal source paths from another package. The main integration points are:
+The supported public API is the set of subpaths declared in the `exports` map of `package.json`. The package root is not exported: `import('@maka/runtime')` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Do not import undeclared internal source paths from another package. For example:
+
+```ts
+import { SessionManager, BackendRegistry } from '@maka/runtime/session-manager';
+import { AiSdkBackend } from '@maka/runtime/ai-sdk-backend';
+import { buildBuiltinTools } from '@maka/runtime/builtin-tools';
+```
+
+The main integration points are:
 
 - `SessionManager` for session and turn orchestration.
 - `BackendRegistry` and `AgentBackend` for backend selection.
@@ -32,14 +40,14 @@ The package root barrel and the subpaths declared in `package.json` are supporte
 - `buildBuiltinTools()` and the workspace executor interfaces for tool composition.
 - `RuntimeKernel`, runtime events, projections, and recovery helpers for execution lifecycle.
 
-Desktop composition lives in `apps/desktop/src/main/main.ts`. Other clients execute Maka through Runtime Host rather than composing Runtime directly.
+Shared execution composition — where `BackendRegistry` and `SessionManager` are constructed — lives in the Runtime Host at [`packages/runtime-host/src/server/execution-composition.ts`](../../packages/runtime-host/src/server/execution-composition.ts). Clients, including Desktop, execute Maka through Runtime Host rather than composing Runtime directly.
 
 ## Extension rules
 
 - Add backend behavior behind `AgentBackend` and register it through the existing registry.
 - Add tools through the builtin/tool composition seams; keep filesystem and shell effects behind `WorkspaceExecutor`.
 - Put shared pure contracts in `packages/core` and interactive Runtime state in the SQLite control plane owned by `packages/storage`.
-- Expose supported package APIs through the root barrel or a declared `package.json` subpath rather than importing internal files from another package.
+- Expose supported package APIs through a declared `package.json` `exports` subpath rather than importing internal files from another package.
 - Keep provider credentials and Electron IPC outside this package. The product shell resolves credentials and passes only the dependencies required for execution.
 
 For the system-level model and code-reading map, start with the root `ARCHITECTURE.md`. Sandbox-specific contracts live in `src/sandbox/README.md`.


### PR DESCRIPTION
## Summary

`packages/runtime/README.md` advertised two things that no longer hold on `main`:

1. The package root as a supported public API — but `packages/runtime/package.json` exports only named subpaths, so `import('@maka/runtime')` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
2. `apps/desktop/src/main/main.ts` as the place where Runtime is composed — but the shared execution composition now lives in the Runtime Host.

## Changes

- **Public seam**: state that the supported public API is the set of subpaths declared in the `package.json` `exports` map, say explicitly that the package root is not exported, and add concrete subpath import examples (`SessionManager`, `BackendRegistry`, `AiSdkBackend`, `buildBuiltinTools` — the same subpaths the shared composition imports).
- **Composition pointer**: point contributors to [`packages/runtime-host/src/server/execution-composition.ts`](../../runtime-host/src/server/execution-composition.ts) — where `BackendRegistry` and `SessionManager` are constructed — via a relative link, following the cross-package README convention (`packages/eval`, `packages/computer-use`).
- **Extension rules**: replace "through the root barrel or a declared `package.json` subpath" with the subpath-only rule.

## Verification

- Reproduced on `main` from `packages/runtime`:
  `node --input-type=module -e "import('@maka/runtime')"` → `ERR_PACKAGE_PATH_NOT_EXPORTED` ("No exports main defined").
- Verified each example import resolves to a declared subpath whose source module actually exports the named symbol (`session-manager.ts`, `ai-sdk-backend.ts`, `builtin-tools.ts`), matching how `execution-composition.ts` consumes the package.
- Adversarial diff review before submission caught a broken relative link (missing `packages/` segment) — fixed and re-verified on disk.
- Checked the rest of the repo for the same stale claims: remaining "package root"/"root barrel" hits are only in historical material (`docs/archive/`, versioned design docs), untouched here.

Fixes #5141
