### PR TITLE
feat(runtime-host): enable explicit safe resume by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Workspace data lives under Electron `userData` by default:
 - API keys and similar secrets are a local plaintext file (`credential-vault.json`), readable only by your OS account. The renderer never sees them.
 - Tools that write files or run a shell must pass the sandbox boundary first.
 - `runtime.sqlite` is the live record. Older JSONL transcripts and Electron `safeStorage` credential files are not imported; an upgraded workspace can show empty threads, and those credentials must be entered again.
-- Resuming an interrupted turn is off by default. Set `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` only if you want Desktop **Safe resume**, CLI `/resume`, and startup auto-resume — those calls hit the model and use tokens.
+- Explicit interrupted-turn resume is available by default in Desktop and through CLI/TUI `/resume`; a successful continuation calls the model and uses tokens. Set `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=0` to disable new resume planning, or `=1` to additionally allow model-driven WorkHub resume. Startup recovery repairs already admitted continuations but does not automatically select an ordinary failed or cancelled turn.
 
 Details: [SECURITY.md](./SECURITY.md), [privacy](./docs/workspace-privacy-context.md), [resume](./docs/architecture/runtime-resume-architecture.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -196,7 +196,7 @@ Workspace 数据默认放在 Electron `userData` 下：
 - API key 一类的机密存在本地明文文件（`credential-vault.json`），只有你的系统账号能读。界面进程拿不到明文。
 - 写文件、跑 Shell 的工具必须先过沙箱边界。
 - `runtime.sqlite` 是当前生效的那份记录。更早的 JSONL transcript 和 Electron `safeStorage` 凭据不会导入；升级后会话可能是空的，那些凭据需要重新填写。
-- 中断回合的续跑默认关闭。只有设置 `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` 才会打开 Desktop **安全恢复**、CLI `/resume` 和启动时自动续跑——这些路径会真的请求模型、消耗 token。
+- Desktop 与 CLI/TUI `/resume` 默认可以显式恢复中断回合；成功续跑会请求模型并消耗 token。设置 `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=0` 可关闭新的 resume planning；设置 `=1` 会额外开启 WorkHub 模型驱动 resume。启动恢复只修复已经 admission 的 continuation，不会自动选择普通的 failed 或 cancelled Turn。
 
 细节见 [SECURITY.md](./SECURITY.md)、[隐私](./docs/workspace-privacy-context.md)、[续跑](./docs/architecture/runtime-resume-architecture.zh-CN.md)。
 

--- a/docs/architecture/runtime-resume-architecture.md
+++ b/docs/architecture/runtime-resume-architecture.md
@@ -489,7 +489,9 @@ sequenceDiagram
   end
 ```
 
-CLI/TUI `/resume` uses the same `SessionManager` plan/execute seam. Desktop startup auto-resume also reuses it.
+CLI/TUI `/resume` uses the same `SessionManager` plan/execute seam. Startup
+recovery can reconstruct an already admitted continuation through that seam,
+but it does not automatically select an ordinary failed or cancelled Run.
 
 ### Current parked-reason boundary
 
@@ -829,9 +831,15 @@ Start with production-shaped red tests, then land core contract, storage constra
 
 ## Feature flags, migration, and rollback
 
-| Flag | Purpose | Rollback meaning |
+| Setting | Purpose | Rollback meaning |
 |---|---|---|
-| `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` | Enable Desktop manual/auto resume and CLI `/resume` | May disable visible continuation; does not delete durable facts |
+| unset | Enable explicit Desktop and CLI/TUI resume; keep model-driven WorkHub resume disabled | Default product behavior |
+| `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` | Also enable model-driven WorkHub resume | Preserves the previous full opt-in behavior |
+| `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=0` | Disable explicit and model-driven resume planning | May park reconstruction; does not delete durable facts |
+
+Unknown non-empty values fail closed like `0`. Every enabled entry point still
+uses the same authoritative planner; the policy only controls whether a new
+resume attempt may reach it.
 
 RuntimeEvent migration is unconditional on the first write. Downgrading to a
 reader that does not understand the new schema requires explicit, verified

--- a/docs/architecture/runtime-resume-architecture.zh-CN.md
+++ b/docs/architecture/runtime-resume-architecture.zh-CN.md
@@ -497,7 +497,8 @@ sequenceDiagram
   end
 ```
 
-CLI/TUI 的 `/resume` 走同一个 `SessionManager` plan/execute seam。Desktop startup auto-resume 也复用同一 planner 和 execution path，不维护第三套恢复逻辑。
+CLI/TUI 的 `/resume` 走同一个 `SessionManager` plan/execute seam。启动恢复也会通过这条
+seam 重建已经 admission 的 continuation，但不会自动选择普通的 failed 或 cancelled Run。
 
 ### 当前的 parked 原因边界
 
@@ -861,9 +862,14 @@ flowchart TD
 
 RuntimeEvent 迁移不再由开关控制；首次写入必然迁移。当前恢复行为开关如下：
 
-| 开关 | 作用 | 回滚含义 |
+| 设置 | 作用 | 回滚含义 |
 |---|---|---|
-| `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` | 开启 Desktop 手动/自动 resume 与 CLI `/resume` | 可关闭用户可见 continuation，但不会删除或改写 durable facts |
+| 未设置 | 开启 Desktop 与 CLI/TUI 的显式 resume；保持 WorkHub 模型驱动 resume 关闭 | 默认产品行为 |
+| `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` | 额外开启 WorkHub 模型驱动 resume | 保留此前完整 opt-in 行为 |
+| `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=0` | 关闭显式和模型驱动 resume planning | 可能 park reconstruction，但不会删除 durable facts |
+
+未知的非空值与 `0` 一样 fail closed。所有已开启的入口仍使用同一个权威 planner；策略只决定
+新的 resume 尝试能否到达 planner。
 
 真正降级到不理解新 schema 的旧版本前，必须显式 export 并验证。Migration 失败不能删除 legacy JSONL；数据库版本比当前程序新时必须 fail closed。
 

--- a/docs/architecture/runtime-resume-phase1-safe-boundary-contract.md
+++ b/docs/architecture/runtime-resume-phase1-safe-boundary-contract.md
@@ -24,12 +24,13 @@ Phase 1 adds an explicit, fail-closed continuation path on top of the Phase 0
 when the committed source boundary is complete and the host supplies every
 required external safety fact.
 
-Planning and execution remain separate operations. Hosts expose them only when
-`MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1`: desktop provides a **Safe resume** action
-on the interrupted-turn banner, CLI/TUI provide `/resume`, and desktop may
-automatically continue an eligible interrupted session after its startup repair
-pass. With the flag absent, normal turns do not run continuation safety
-inspection and preserve the pre-Phase-1 happy path.
+Planning and execution remain separate operations. Desktop and CLI/TUI expose
+explicit resume by default; every attempt still passes through the authoritative
+safety planner. `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=0` disables new explicit and
+model-driven resume planning. `=1` additionally permits model-driven WorkHub
+resume, preserving the previous full opt-in behavior. Startup recovery may
+reconstruct an already admitted continuation, but it does not automatically
+select an ordinary failed or cancelled Run.
 
 ## Continuation unit
 
@@ -146,8 +147,8 @@ plan captures these facts in a safety snapshot and execution revalidates them.
 - desktop interrupted-turn banner action: **Safe resume**;
 - desktop main IPC: `sessions:resumeLatest`;
 - CLI TUI command: `/resume`;
-- desktop startup auto-continuation: enabled only by the same feature flag and
-  only after interrupted-run repair;
+- startup recovery: repairs and reconstructs already admitted continuations but
+  does not select ordinary failed or cancelled Runs;
 - structured operational events: `plan_approved`, `plan_parked`,
   `execution_started`, `execution_completed`, and `execution_failed`.
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -7703,7 +7703,7 @@ Slug openai-work<cursor>
       terminal.input('\r');
       await waitFor(() =>
         plainTerminalOutput(terminal.output()).includes(
-          'Safe-boundary resume is not enabled on this runtime',
+          'Safe-boundary resume is disabled by this runtime policy',
         ),
       );
       assert.equal(driver.resumeCalls, 1);

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -354,7 +354,7 @@ export function safeBoundaryResumeParkedCopy(reason: TurnResumeParkReason): {
     case 'resume_feature_disabled':
       return {
         level: 'info',
-        text: 'Safe-boundary resume is not enabled on this runtime (set MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1 to enable).',
+        text: 'Safe-boundary resume is disabled by this runtime policy.',
       };
     case 'resume_candidate_missing':
       return {

--- a/packages/runtime-host/src/__tests__/execution-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-composition.test.ts
@@ -963,6 +963,90 @@ test('production composition commits automatic titles through Host-owned Session
   });
 });
 
+test('production composition enables an explicit resume after user Stop by default', async () => {
+  await withCompositionRoot(async ({ root, owner }) => {
+    const { composition, manager } = await createCapturedExecutionComposition(owner);
+    const context = {
+      hostEpoch: 'execution-composition-test',
+      connectionId: 'default-interactive-resume-client',
+      principal: 'local_os_user' as const,
+      acquireResidency: () => ({ release() {} }),
+    };
+    try {
+      const session = await manager.createSession({
+        cwd: root,
+        llmConnectionId: FAKE_CONNECTION_ID,
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        permissionMode: 'ask',
+      });
+      const started = await composition.handlers['turn.start'](
+        {
+          sessionId: session.id,
+          turnId: 'turn-default-interactive-resume',
+          content: { text: FAKE_HOLD_OPEN_PROMPT },
+        },
+        context,
+      );
+      assert.equal(started.ok, true);
+      if (!started.ok || started.result.kind !== 'started') return;
+      const stopped = await composition.handlers['turn.stop'](
+        {
+          sessionId: session.id,
+          turnId: started.result.turn.turnId,
+          runId: started.result.turn.runId,
+        },
+        context,
+      );
+      assert.equal(stopped.ok, true);
+
+      const plan = await composition.handlers['turn.resume.query'](
+        { sessionId: session.id },
+        context,
+      );
+      assert.equal(plan.ok, true);
+      if (plan.ok) assert.equal(plan.result.disposition, 'ready');
+    } finally {
+      await composition.close();
+    }
+  });
+});
+
+test('production composition preserves an explicit interactive resume kill switch', async () => {
+  await withCompositionRoot(async ({ root, owner }) => {
+    const { composition, manager } = await createCapturedExecutionComposition(owner, {
+      safeBoundaryResume: false,
+    });
+    const context = {
+      hostEpoch: 'execution-composition-test',
+      connectionId: 'disabled-interactive-resume-client',
+      principal: 'local_os_user' as const,
+      acquireResidency: () => ({ release() {} }),
+    };
+    try {
+      const session = await manager.createSession({
+        cwd: root,
+        llmConnectionId: FAKE_CONNECTION_ID,
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        permissionMode: 'ask',
+      });
+      const plan = await composition.handlers['turn.resume.query'](
+        { sessionId: session.id },
+        context,
+      );
+      assert.equal(plan.ok, true);
+      assert.deepEqual(plan.ok && plan.result, {
+        sessionId: session.id,
+        disposition: 'parked',
+        reason: 'resume_feature_disabled',
+      });
+    } finally {
+      await composition.close();
+    }
+  });
+});
+
 test('WorkHub creates new work through the production assignment composition', async () => {
   await withCompositionRoot(async ({ root, owner }) => {
     const connectionId = await configureFakeDefaultTarget(owner);
@@ -1284,12 +1368,10 @@ test('WorkHub Resume and Stop follow logical lineage across repeated physical ha
   });
 });
 
-test('WorkHub does not record resume while safe-boundary resume is disabled', async () => {
+test('WorkHub does not record resume when only interactive resume is enabled by default', async () => {
   await withCompositionRoot(async ({ root, owner }) => {
     const connectionId = await configureFakeDefaultTarget(owner);
-    const { composition, manager } = await createCapturedExecutionComposition(owner, {
-      safeBoundaryResume: false,
-    });
+    const { composition, manager } = await createCapturedExecutionComposition(owner);
     const context = {
       hostEpoch: 'execution-composition-test',
       connectionId: 'workhub-disabled-resume-client',
@@ -2641,7 +2723,7 @@ async function createCapturedExecutionComposition(
   };
   try {
     if (options.safeBoundaryResume === true) process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME = '1';
-    if (options.safeBoundaryResume === false) delete process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME;
+    if (options.safeBoundaryResume === false) process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME = '0';
     // The production composition no longer registers a test backend of its
     // own; the deterministic one arrives through the same `primaryBackendFactory`
     // seam the Desktop E2E run uses.

--- a/packages/runtime-host/src/__tests__/execution-host-continuation.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host-continuation.test.ts
@@ -346,7 +346,7 @@ test('startup parks a pre-claim continuation whose Client Capability is absent',
   });
 });
 
-test('Runtime Host keeps safe-boundary continuation opt-in', async () => {
+test('Runtime Host honors the explicit safe-boundary continuation opt-out', async () => {
   await withExecutionRoot(async (fixture) => {
     const source = await fixture.seedSafeBoundaryContinuationSource();
     const targetTurnId = 'turn-disabled-safe-boundary-continuation';

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
@@ -1289,7 +1289,7 @@ export class ExecutionFixture {
   ): ChildProcess {
     const env = { ...process.env };
     if (safeBoundaryResumeEnabled) env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME = '1';
-    else delete env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME;
+    else env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME = '0';
     const child = fork(
       new URL('./execution-host.js', import.meta.url),
       [

--- a/packages/runtime-host/src/__tests__/safe-boundary-resume-policy.test.ts
+++ b/packages/runtime-host/src/__tests__/safe-boundary-resume-policy.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { resolveSafeBoundaryResumePolicy } from '../server/safe-boundary-resume-policy.js';
+
+test('enables interactive resume by default without enabling automated resume', () => {
+  assert.deepEqual(resolveSafeBoundaryResumePolicy(undefined), {
+    interactive: true,
+    automated: false,
+  });
+  assert.deepEqual(resolveSafeBoundaryResumePolicy(''), {
+    interactive: true,
+    automated: false,
+  });
+});
+
+test('preserves the existing explicit full opt-in', () => {
+  for (const value of ['1', 'true']) {
+    assert.deepEqual(resolveSafeBoundaryResumePolicy(value), {
+      interactive: true,
+      automated: true,
+    });
+  }
+});
+
+test('explicit disable and invalid values fail closed', () => {
+  for (const value of ['0', 'false', 'unexpected']) {
+    assert.deepEqual(resolveSafeBoundaryResumePolicy(value), {
+      interactive: false,
+      automated: false,
+    });
+  }
+});

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -201,6 +201,7 @@ import { HostPluginPlatformCoordinator } from './plugin-platform-coordinator.js'
 import { HostPluginPlatform } from './plugin-platform.js';
 import { RootAdmissionOwner } from './root-admission-owner.js';
 import { RootTurnCoordinator } from './root-turn-coordinator.js';
+import { resolveSafeBoundaryResumePolicy } from './safe-boundary-resume-policy.js';
 import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
 import { notifySandboxBoundaryGraphWake } from './sandbox-boundary-graph-wake.js';
 import { HostRuntimePolicyCoordinator } from './runtime-policy-coordinator.js';
@@ -1279,6 +1280,9 @@ export async function createExecutionRuntimeHostComposition(
           (connection) => connection.slug === slug,
         ) ?? null,
     });
+    const safeBoundaryResumePolicy = resolveSafeBoundaryResumePolicy(
+      process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME,
+    );
     manager = new SessionManager({
       store: stores.sessionStore,
       runStore: stores.agentRunStore,
@@ -1288,7 +1292,7 @@ export async function createExecutionRuntimeHostComposition(
       subagentCatalog,
       newId: randomUUID,
       now: Date.now,
-      safeBoundaryResumeEnabled: process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME === '1',
+      safeBoundaryResumeEnabled: safeBoundaryResumePolicy.interactive,
       inspectContinuationSafety: createLocalContinuationSafetyInspector({
         readSessionCwd: async (sessionId) =>
           (await stores.sessionStore.readHeaderSnapshot(sessionId)).cwd,
@@ -1960,6 +1964,12 @@ export async function createExecutionRuntimeHostComposition(
               );
             }
             return { outcome: 'resume_started' as const, targetTurnId };
+          }
+          if (!safeBoundaryResumePolicy.automated) {
+            throw new WorkHubActionEffectFailure(
+              'operation_unavailable',
+              'Safe-boundary resume is disabled for this Runtime Host',
+            );
           }
           await validateFreshTarget();
           const disposition = await messages.readMessageExecutionDisposition(

--- a/packages/runtime-host/src/server/safe-boundary-resume-policy.ts
+++ b/packages/runtime-host/src/server/safe-boundary-resume-policy.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface SafeBoundaryResumePolicy {
+  /** User-invoked TUI and Desktop continuation requests. */
+  readonly interactive: boolean;
+  /** Model-driven or otherwise automatic continuation requests. */
+  readonly automated: boolean;
+}
+
+export function resolveSafeBoundaryResumePolicy(
+  value: string | undefined,
+): SafeBoundaryResumePolicy {
+  if (value === undefined || value === '') {
+    return { interactive: true, automated: false };
+  }
+  if (value === '1' || value === 'true') {
+    return { interactive: true, automated: true };
+  }
+  return { interactive: false, automated: false };
+}


### PR DESCRIPTION
## Summary

Make explicit safe-boundary resume available to TUI and Desktop when
`MAKA_RUNTIME_SAFE_BOUNDARY_RESUME` is unset, while keeping model-driven
WorkHub resume delegation disabled by default.

A single policy resolver now separates the two authorization boundaries:

- unset: explicit interactive resume enabled; automated delegation disabled
- `1` or `true`: both enabled
- `0`, `false`, or an unrecognized value: both disabled

The existing Runtime Host planner remains the final safety authority. The
policy only controls whether a caller may request planning; it does not turn a
stopped Run into an automatically resumable Run.

This also updates the TUI copy and the English/Chinese architecture and product
documentation. The startup documentation now distinguishes repair of an
already admitted continuation from selection of an ordinary stopped Run.

Refs #5205

## Verification

- `npm run rebuild`
- Runtime Host suite: 1859 passed, 0 failed, 12 skipped
- Focused production-composition coverage:
  - explicit resume after user Stop is available with no environment variable
  - `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=0` disables explicit resume
  - WorkHub resume delegation remains disabled when the variable is unset
- TUI parked-resume presentation tests
- `npm run lint`
- `npm run format:check`
- `npm run check:asf-headers`
- `npm run check:stale`
- `git diff --check`

Hosted CI has not run yet.

## Review focus

This changes the default behavior of an operation that may continue spending
tokens. Please review the separation between explicit user authorization and
model-driven WorkHub authorization, including the handling of an existing
durable WorkHub admission.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex traced the resume authorization paths, designed
and implemented the policy boundary, added tests and documentation, and
performed adversarial pre-PR review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
