### PR TITLE
feat(desktop): offer safe resume after user stop

### DIFF
--- a/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
+++ b/apps/desktop/src/main/__tests__/interrupted-resume.test.ts
@@ -23,6 +23,35 @@ import { materializeTurns } from '@maka/ui';
 import { latestInterruptedResumeTurnId } from '../../renderer/interrupted-resume.js';
 
 describe('latest interrupted resume candidate', () => {
+  it('recognizes the latest turn interrupted by the Desktop Stop button', () => {
+    assert.equal(
+      latestInterruptedResumeTurnId([
+        { turnId: 'turn-1', status: 'completed' },
+        {
+          turnId: 'turn-2',
+          status: 'aborted',
+          abortSource: 'renderer.stop_button',
+        },
+      ]),
+      'turn-2',
+    );
+  });
+
+  it('does not treat other aborted turns as a Desktop Stop resume candidate', () => {
+    for (const abortSource of [undefined, 'runtime_host.shutdown', 'user_stop']) {
+      assert.equal(
+        latestInterruptedResumeTurnId([
+          {
+            turnId: 'turn-1',
+            status: 'aborted',
+            ...(abortSource ? { abortSource } : {}),
+          },
+        ]),
+        undefined,
+      );
+    }
+  });
+
   it('recognizes a timeout after a completed tool result', () => {
     assert.equal(
       latestInterruptedResumeTurnId([

--- a/apps/desktop/src/renderer/interrupted-resume.ts
+++ b/apps/desktop/src/renderer/interrupted-resume.ts
@@ -21,6 +21,7 @@ export interface InterruptedResumeTurn {
   turnId: string;
   status: string;
   errorClass?: string;
+  abortSource?: string;
   /** Tool activity already has a durable result in the rendered Turn. */
   tools?: readonly { status: string }[];
 }
@@ -29,6 +30,12 @@ export function latestInterruptedResumeTurnId(
   turns: readonly InterruptedResumeTurn[],
 ): string | undefined {
   const latestTurn = turns.at(-1);
+  if (
+    latestTurn?.status === 'aborted' &&
+    latestTurn.abortSource === 'renderer.stop_button'
+  ) {
+    return latestTurn.turnId;
+  }
   if (latestTurn?.status !== 'failed') return undefined;
   const errorClass = latestTurn.errorClass?.toLowerCase();
   if (errorClass === 'app_restarted') return latestTurn.turnId;

--- a/apps/desktop/src/renderer/use-shell-resume.ts
+++ b/apps/desktop/src/renderer/use-shell-resume.ts
@@ -34,12 +34,13 @@ type ToastApi = {
 
 /**
  * Owns the #1223 safe-boundary resume cluster: the in-flight `resumePendingSessionId`
- * guard and the per-session parked-diagnostic descriptions surfaced on the
- * interrupted-turn banner, plus the `resumeInterruptedSession` handler that drives
+ * guard and the per-session parked-diagnostic descriptions surfaced on eligible
+ * failure banners, plus the `resumeInterruptedSession` handler shared by those
+ * banners and the user-Stop status notice. The handler drives
  * `sessions.resumeLatest`. `activeId` is injected (the handler snapshots it as
  * `sessionId` so a session switch mid-resume settles the ORIGINAL session's pending
  * flag) alongside `toastApi` / `shellCopy` / `uiLocale`. The two state values are
- * returned raw so AppShell's banner JSX keeps its exact `resumePendingSessionId ===
+ * returned raw so AppShell's action wiring keeps its exact `resumePendingSessionId ===
  * activeId` / `resumeParkDescriptionBySession[activeId]` reads; the wiring
  * (`safeResumeAction=` element) stays in AppShell. Pure move — zero behavior change.
  */

--- a/docs/architecture/runtime-resume-phase1-safe-boundary-contract.md
+++ b/docs/architecture/runtime-resume-phase1-safe-boundary-contract.md
@@ -144,7 +144,8 @@ plan captures these facts in a safety snapshot and execution revalidates them.
 
 ## Host entry points and observability
 
-- desktop interrupted-turn banner action: **Safe resume**;
+- desktop interrupted-turn presentation: **Safe resume** on an eligible failure
+  banner or user-Stop status notice;
 - desktop main IPC: `sessions:resumeLatest`;
 - CLI TUI command: `/resume`;
 - startup recovery: repairs and reconstructs already admitted continuations but

--- a/packages/ui/src/__tests__/chat-turn-answer-identity.test.tsx
+++ b/packages/ui/src/__tests__/chat-turn-answer-identity.test.tsx
@@ -87,11 +87,16 @@ function renderTurn(
   root: ReturnType<typeof createRoot>,
   turn: TurnViewModel,
   liveStreaming?: { onStreamingSettled?: (messageId?: string) => void },
+  safeResumeAction?: { pending: boolean; onResume(): void },
 ): Promise<void> {
   return act(() => {
     root.render(
       <LocaleProvider locale="en">
-        <TurnView turn={turn} liveStreaming={liveStreaming} />
+        <TurnView
+          turn={turn}
+          liveStreaming={liveStreaming}
+          safeResumeAction={safeResumeAction}
+        />
       </LocaleProvider>,
     );
   }) as unknown as Promise<void>;
@@ -135,6 +140,28 @@ test('places the aborted turn outcome after its timeline content', async () => {
   const outcome = container.querySelector('.astryx-chat-system-message[role="status"]');
   assert.ok(answer && assistantMessage && outcome);
   assert.equal(assistantMessage.nextElementSibling?.isSameNode(outcome), true);
+});
+
+test('offers Safe resume in the Desktop Stop outcome notice', async () => {
+  const { container, root } = domRoot();
+  let resumeCalls = 0;
+  await renderTurn(
+    root,
+    {
+      ...turnWith([{ ...ANSWER, live: false }]),
+      status: 'aborted',
+      abortSource: 'renderer.stop_button',
+    },
+    undefined,
+    { pending: false, onResume: () => resumeCalls++ },
+  );
+
+  const outcome = container.querySelector('.astryx-chat-system-message[role="status"]');
+  const button = outcome?.querySelector('button');
+  assert.ok(button, 'the action stays attached to the Stop outcome it continues');
+  assert.equal(button.textContent, 'Continue this turn');
+  await act(() => button.click());
+  assert.equal(resumeCalls, 1);
 });
 
 /**

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -776,10 +776,23 @@ export const TurnView = memo(function TurnView(props: {
             </LocalizedChatMessage>
             {/* An abort is a short, settled status change rather than sender
                 content or a recovery error. Keep Astryx's system notice as a
-                sibling of the assistant message, after the work it closes. */}
+                sibling of the assistant message, after the work it closes;
+                the Desktop continuation action remains attached to that same
+                outcome while the Host retains final safety authority. */}
             {ownsTurnChrome && turn.status === 'aborted' && (
               <ChatSystemMessage icon={<Ban size={ICON_SIZE.meta} aria-hidden="true" />}>
                 {turnAbortStatusLabel(turn.abortSource, locale)}
+                {props.safeResumeAction && (
+                  <UiButton
+                    variant="ghost"
+                    size="sm"
+                    isDisabled={props.safeResumeAction.pending}
+                    onClick={props.safeResumeAction.onResume}
+                    label={
+                      props.safeResumeAction.pending ? copy.safeResumePending : copy.safeResume
+                    }
+                  />
+                )}
               </ChatSystemMessage>
             )}
           </Fragment>


### PR DESCRIPTION
## Summary

Offer the existing `Continue this turn` action directly on the Desktop status
notice produced by the renderer Stop button.

Desktop now treats an aborted Turn as an explicit resume candidate only when
its abort source is `renderer.stop_button`. Other cancellation sources remain
ineligible for this presentation path.

The button reuses the existing Desktop resume controller and
`sessions:resumeLatest` IPC operation. It does not pre-authorize continuation:
the Runtime Host planner still decides whether the stopped Run is safe and
returns the existing refusal reasons when it is not.

This PR is stacked on the explicit-resume policy PR.

Closes #5205

## Verification

- `npm run rebuild`
- `npm --workspace @maka/ui run test:dist`
- `npm --workspace @maka/desktop run test:dist`
  - Desktop: 2494 passed, 0 failed
- Focused Desktop selector and UI interaction coverage: 22 passed, 0 failed
- `npm run check:renderer-architecture -- --base cb3af4b2f24a3ace8d9574ca60396ffc1cc97219`
  - architecture fixtures: 103 passed, 0 failed
- `npm run lint`
- `npm run format:check`
- `npm run check:asf-headers`
- `npm run check:stale`
- `git diff --check`

A packaged Desktop visual smoke test was not run. The button visibility and
click behavior are covered by the DOM interaction regression; the final
placement still needs human UX review.

Hosted CI has not run yet.

## Review focus

Please verify that the Stop outcome is the correct place for this action and
that matching `renderer.stop_button` is sufficiently narrow. The Runtime Host,
rather than the renderer selector, must remain the safety authority.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex traced the Desktop Stop projection and existing
resume controller, implemented the affordance and regressions, updated the
architecture documentation, and performed adversarial pre-PR review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
