### PR TITLE
fix(desktop): align rail hover fills and put model config before the enable switch

### DIFF
--- a/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
@@ -31,18 +31,30 @@ if (!sidebarCssUrl) throw new Error('Could not locate renderer/styles/sidebar.cs
 const sidebarCss = readFileSync(sidebarCssUrl, 'utf8');
 
 describe('project-grouped session hierarchy', () => {
-  it('aligns session titles with the project name', () => {
+  it('shares the project row left edge with its sessions', () => {
     const projectChildrenRule = sidebarCss.match(
       /\.maka-project-row\s*>\s*div\s*>\s*\[role=["']group["']\]\s*>\s*div\s*\{([^}]*)\}/,
     );
 
     assert.ok(projectChildrenRule, 'project children must have an explicit hierarchy rule');
-    // Product contract: 8px nest so session titles share the project title's x.
-    // SideNav's default spacing-6 is a fixed child inset, not that alignment.
+    // Product contract: session rows sit on the project row's left edge, so
+    // the two hover/selected fills start on the same x rather than the 8px
+    // nest that used to offset only the session rows. SideNav's default
+    // spacing-6 is a fixed child inset, not that alignment.
     assert.match(
       projectChildrenRule[1] ?? '',
-      /padding-inline-start:\s*var\(--spacing-2\)\s*!important;/,
-      'project sessions must keep an 8px hierarchical nest',
+      /padding-inline-start:\s*0\s*!important;/,
+      'project sessions must not be inset from the project row',
+    );
+
+    // The gutter that replaces the nest: the same 1rem box as the project
+    // folder icon, so titles still share one x.
+    const signalRule = sidebarCss.match(/\.maka-session-row-signal\s*\{([^}]*)\}/);
+    assert.ok(signalRule, 'the session status gutter must be declared');
+    assert.match(
+      signalRule[1] ?? '',
+      /width:\s*1rem;/,
+      'the session status gutter must match the project folder icon width',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
@@ -41,6 +41,13 @@ describe('project-grouped session hierarchy', () => {
     // the two hover/selected fills start on the same x rather than the 8px
     // nest that used to offset only the session rows. SideNav's default
     // spacing-6 is a fixed child inset, not that alignment.
+    //
+    // These pin the declarations, not the geometry they serve: a StyleX
+    // default, a later equal-or-higher-specificity rule, or a renamed wrapper
+    // class would leave this green while the rail drifts apart. The rendered
+    // half is owned by the ProjectGroups play in
+    // packages/ui/stories/session-list-panel.stories.tsx (session inset within
+    // 1px, title x within 2px).
     assert.match(
       projectChildrenRule[1] ?? '',
       /padding-inline-start:\s*0\s*!important;/,

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -780,7 +780,7 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
                 value={facts}
                 actionLabel={copy.declareCapabilities}
                 actionAriaLabel={copy.declareCapabilitiesAria(label)}
-                beforeAction={modelEnableSwitch(id, label)}
+                afterAction={modelEnableSwitch(id, label)}
                 isEditing={editingModelId === id}
                 isDisabled={allActionsBusy}
                 canSave={hasRelayProfileChanges}

--- a/apps/desktop/src/renderer/settings/settings-expandable-row.tsx
+++ b/apps/desktop/src/renderer/settings/settings-expandable-row.tsx
@@ -72,11 +72,12 @@ export function SettingsExpandableRow(props: {
    */
   end?: ReactNode;
   /**
-   * Content that sits beside the built-in trigger while collapsed — a model
-   * row's enable switch, say. Unlike `end`, this keeps the trigger and the
-   * focus return that goes with it.
+   * Content that sits beside the built-in trigger while collapsed, after it —
+   * a model row's enable switch, say, which reads as the row's last control.
+   * Unlike `end`, this keeps the trigger and the focus return that goes with
+   * it.
    */
-  beforeAction?: ReactNode;
+  afterAction?: ReactNode;
   isEditing: boolean;
   isDisabled?: boolean;
   /** Save stays disabled until the draft actually differs from the value. */
@@ -125,7 +126,6 @@ export function SettingsExpandableRow(props: {
         align="start"
         end={props.end ?? (
           <>
-            {props.beforeAction}
             <Button
               ref={triggerRef}
               data-maka-assistant-target={props.assistantTarget ? `${props.assistantTarget}.edit` : undefined}
@@ -136,6 +136,7 @@ export function SettingsExpandableRow(props: {
               label={props.actionLabel ?? ''}
               aria-label={props.actionAriaLabel}
             />
+            {props.afterAction}
           </>
         )}
       />

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -239,20 +239,19 @@
 }
 
 /*
- * Project groups are a parent-child hierarchy. SideNav always nests children
- * by spacing-6; that is a fixed inset, not a title-alignment rule. Project
- * rows lead with a 16px folder, session rows with an 8px StatusDot, so the
- * default 24px inset puts session titles 16px right of the project name.
- * Product intent: keep an 8px hierarchical inset (spacing-2) so titles share
- * one x. The whole session button, including hover/selected fill, moves with
- * that inset; the right edge stays on the rail. Pin the value because StyleX
+ * Project groups are a parent-child hierarchy, and SideNav indents children by
+ * spacing-6 by default. That inset shifted the whole session button — its
+ * hover/selected fill included — 24px right of the project row, so the two
+ * fills began on different x. Zero it: session rows sit on the project row's
+ * left edge, and the leading status gutter below is the same 1rem as the
+ * project folder, so titles still share one x. Pin the value because StyleX
  * owns the unlayered default. Child combinator only — do not use a descendant
  * selector that would indent deeper nest levels twice if any appear later.
  * DOM: .maka-project-row > SideNavItem root > [role=group] > childrenInner
  */
 .maka-project-row > div > [role="group"] > div {
   /* !important: StyleX childrenInner paddingInlineStart is unlayered. */
-  padding-inline-start: var(--spacing-2) !important;
+  padding-inline-start: 0 !important;
 }
 
 /*
@@ -368,15 +367,19 @@
 /*
  * Slot 1: the leading status gutter.
  *
- * Astryx's StatusDot is a fixed 8px box (StatusDot.tsx), so only the empty case
- * needs declaring: a row with no dot must still hold the column, or titles would
- * start at a different x depending on whether the task has a state. The dot is
- * present or absent; the gutter is not.
+ * A fixed box every row pays for, whether or not it has a dot, so state reads
+ * as one column down the rail instead of a mark that drifts with each title's
+ * length. 1rem, the same box Astryx gives the project row's `size="sm"` folder
+ * icon: with the group inset zeroed above, the equal gutters are what keep
+ * session titles on the project name's x, and the session hover/selected fill
+ * on the project row's left edge.
  */
-.maka-session-row .maka-session-row-signal-empty {
-  display: block;
-  width: 8px;
-  height: 8px;
+.maka-session-row-signal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
   flex: none;
 }
 

--- a/apps/desktop/stories/settings/provider-settings.stories.tsx
+++ b/apps/desktop/stories/settings/provider-settings.stories.tsx
@@ -804,6 +804,21 @@ export const StaticCatalogConnectionDetail: Story = {
       autoOpen="detail-static"
     />
   ),
+  // The row carries two controls; they read 配置参数 then 开启. The editor
+  // trigger comes first and the enable switch is the row's trailing edge.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const configure = await canvas.findByRole('button', {
+      name: detailCopy.declareCapabilitiesAria('deepseek-v4-pro-beta'),
+    });
+    const end = configure.closest('.settingsRowEnd');
+    if (!end) throw new Error('model row end slot is missing');
+    const enable = end.querySelector<HTMLElement>('[role="switch"]');
+    if (!enable) throw new Error('model enable switch is missing');
+    expect(configure.getBoundingClientRect().right).toBeLessThanOrEqual(
+      enable.getBoundingClientRect().left,
+    );
+  },
 };
 
 // Real path: 设置 → 模型 → click a custom relay — several enabled models, each

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -799,17 +799,17 @@ const SessionNavRow = memo(function SessionNavRow(props: {
         // whether or not it has a dot, so state reads as one column down the
         // rail instead of a mark that drifts with each title's length.
         icon={
-          signal ? (
-            <StatusDot
-              variant={signal.variant}
-              label={signal.label}
-              isPulsing={signal.isPulsing}
-              tooltip={signal.tooltip}
-              data-session-status={props.session.status}
-            />
-          ) : (
-            <span className="maka-session-row-signal-empty" aria-hidden="true" />
-          )
+          <span className="maka-session-row-signal">
+            {signal ? (
+              <StatusDot
+                variant={signal.variant}
+                label={signal.label}
+                isPulsing={signal.isPulsing}
+                tooltip={signal.tooltip}
+                data-session-status={props.session.status}
+              />
+            ) : null}
+          </span>
         }
         onClick={(event) => {
           // Shift- and ⌘-clicks are answered by the list, which has already

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -519,8 +519,9 @@ export const PinnedAndRecentSections: Story = {
   ),
 };
 
-// Real path: group-by-project — collapsible project rows, sessions nested 8px
-// under the project so titles share one x, worktree mark + project actions.
+// Real path: group-by-project — collapsible project rows, sessions on the
+// project row's left edge so both titles and hover fills share one x, worktree
+// mark + project actions.
 export const ProjectGroups: Story = {
   render: () => {
     const maka = makeProject({
@@ -642,9 +643,11 @@ export const ProjectGroups: Story = {
     expect(projectRow.querySelectorAll('button button')).toHaveLength(0);
     const projectBox = navigation.getBoundingClientRect();
     const taskBox = taskControl.getBoundingClientRect();
+    // The task row sits on the project row's left edge, so the two
+    // hover/selected fills start on the same x — not the 8px nest that used to
+    // offset only the task rows.
     const sessionInset = taskBox.x - projectBox.x;
-    expect(sessionInset).toBeGreaterThanOrEqual(6);
-    expect(sessionInset).toBeLessThan(16);
+    expect(Math.abs(sessionInset)).toBeLessThanOrEqual(1);
     expect(Math.abs(
       projectTitle.getBoundingClientRect().x - taskTitle.getBoundingClientRect().x,
     )).toBeLessThanOrEqual(2);


### PR DESCRIPTION
## Summary

Two defects reported from the running app, one on the model page and one in the session rail.

**Model rows: 配置参数 and 开启 were reversed.** Each model row rendered its enable `Switch` before the 配置参数 trigger, so the toggle read as the leading control and the editor trigger as the trailing one. `SettingsExpandableRow` now renders the trigger first and its `afterAction` slot (the switch) last, so the enable toggle is the row's trailing control.

**Session rail: project and task hover fills were not left-aligned.** SideNav indents a group's children by 24px by default; the rail overrode that to an 8px nest so task titles line up with the project name. That 8px moved the whole task button — its hover/selected fill included — so the project fill started at x=8 and the task fill at x=16. The nest is now zeroed and the leading status gutter is 1rem, the same box the project row's folder icon occupies: titles still share one x, and both fills now start on the project row's left edge.

## Verification

Measured in the built Storybook with Playwright, `main` before vs this branch after:

- Rail (`Product/Sidebar Session List / ProjectGroups`): task row x − project row x was `8`, now `0`; both fills start at `x=8`; project and task titles stay at `x=40`.
- Model rows (`Product/Settings/Providers / StaticCatalogConnectionDetail`): the row was `[switch 986-1018][配置参数 1026-1106]`, now `[配置参数 986-1066][switch 1074-1106]`.

Checks run:

- `node --test dist/main/__tests__/session-project-hierarchy-contract.test.js` (updated) — pass
- `node --test dist/**/session-history-*.test.js` (`@maka/ui`) — pass
- `npm --workspace @maka/desktop run typecheck` and `typecheck:stories` — pass
- `npm run format`, `npm run lint` — clean

The updated contract test and both story play assertions fail on `main` and pass here.

The images below are the two stories rendered from `main`'s and this branch's `storybook-static` at the same viewport, light/dark, BEFORE left and AFTER right. The provider capture expands the page's internal scroller so the whole page is in frame.

![Session rail — light](https://github.com/user-attachments/assets/6a699503-6cd9-4822-964a-fff8042cadcc)
![Session rail — dark](https://github.com/user-attachments/assets/c4d35d5f-c934-4ae5-9853-b81da948e469)
![Model rows — light](https://github.com/user-attachments/assets/ce944757-7263-488b-93b5-e2eeda677d4d)
![Model rows — dark](https://github.com/user-attachments/assets/e6f02910-4c64-470e-a62a-7abe1ab66b2c)

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka wrote the code changes, the test/story assertions, and the verification; the commits carry `Generated-by: Maka` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
