### PR TITLE
refactor(desktop): register Goals and WorkHub controller owners

### DIFF
--- a/apps/desktop/renderer-architecture.json
+++ b/apps/desktop/renderer-architecture.json
@@ -289,6 +289,13 @@
       "count": 1
     },
     {
+      "implementation": "src/renderer/features/goals/controller/use-goal-controller.ts",
+      "symbol": "useGoalController",
+      "owner": "src/renderer/features/goals/ui/goal-provider.tsx",
+      "ownerSymbol": "GoalProvider",
+      "count": 1
+    },
+    {
       "implementation": "src/renderer/features/module-hub/controller/use-module-hub-controller.ts",
       "symbol": "useModuleHubController",
       "owner": "src/renderer/features/module-hub/ui/module-hub-provider.tsx",
@@ -300,6 +307,13 @@
       "symbol": "useTaskEntryController",
       "owner": "src/renderer/features/task-entry/ui/task-entry-provider.tsx",
       "ownerSymbol": "TaskEntryRoot",
+      "count": 1
+    },
+    {
+      "implementation": "src/renderer/features/workhub/controller/use-workhub-controller.ts",
+      "symbol": "useWorkHubController",
+      "owner": "src/renderer/features/workhub/ui/workhub-root.tsx",
+      "ownerSymbol": "WorkHubRoot",
       "count": 1
     }
   ],

--- a/apps/desktop/src/main/__tests__/workhub-surface-switch.test.ts
+++ b/apps/desktop/src/main/__tests__/workhub-surface-switch.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { act, createElement, useEffect } from 'react';
+import { useToast, useUiLocale } from '@maka/ui';
+import type { UiLocale } from '@maka/core/ui-locale';
+import {
+  WorkHubServicesProvider,
+  WorkHubSurfaceSwitch,
+  type WorkHubServices,
+} from '../../renderer/features/workhub/index.js';
+import { cleanupFakeDom, installReactRenderer } from './fake-dom.js';
+
+afterEach(cleanupFakeDom);
+
+test('the main surface does not mount WorkHub or start its lifecycle', async () => {
+  const { root, container } = installReactRenderer();
+  const services = { surface: 'main' } as WorkHubServices;
+  function UnexpectedWorkHub() {
+    return assert.fail('WorkHub must not mount in the main surface');
+  }
+  try {
+    await act(async () => root.render(createElement(WorkHubServicesProvider, {
+      services,
+      children: createElement(WorkHubSurfaceSwitch, {
+        main: createElement('div', null, 'main'),
+        workhub: createElement(UnexpectedWorkHub),
+      }),
+    })));
+    assert.equal(container.textContent, 'main');
+  } finally {
+    await act(async () => root.unmount());
+  }
+});
+
+test('the WorkHub slot retains its providers and mount across locale updates', async () => {
+  const { root } = installReactRenderer();
+  let emitLocale!: (locale: UiLocale) => void;
+  let latestLocale: UiLocale | undefined;
+  let mounts = 0;
+  let unmounts = 0;
+  let subscriptions = 0;
+  let unsubscribes = 0;
+  let readyCalls = 0;
+  const services = {
+    surface: 'workhub',
+    initialLocale: 'en',
+    subscribeAppearance: (handler: (locale: UiLocale) => void) => {
+      subscriptions += 1;
+      emitLocale = handler;
+      return () => { unsubscribes += 1; };
+    },
+    presentation: { ready: async () => { readyCalls += 1; } },
+  } as WorkHubServices;
+  function WorkHubProbe() {
+    latestLocale = useUiLocale();
+    assert.equal(typeof useToast().toast, 'function');
+    useEffect(() => {
+      mounts += 1;
+      return () => { unmounts += 1; };
+    }, []);
+    return null;
+  }
+  function UnexpectedMain() {
+    return assert.fail('the main shell must not mount in the WorkHub surface');
+  }
+  try {
+    await act(async () => root.render(createElement(WorkHubServicesProvider, {
+      services,
+      children: createElement(WorkHubSurfaceSwitch, {
+        main: createElement(UnexpectedMain),
+        workhub: createElement(WorkHubProbe),
+      }),
+    })));
+    assert.equal(latestLocale, 'en');
+    await act(async () => emitLocale('zh-CN'));
+    assert.equal(latestLocale, 'zh-CN');
+    assert.deepEqual({ mounts, unmounts, subscriptions, readyCalls }, {
+      mounts: 1, unmounts: 0, subscriptions: 1, readyCalls: 1,
+    });
+  } finally {
+    await act(async () => root.unmount());
+  }
+  assert.equal(unmounts, 1);
+  assert.equal(unsubscribes, 1);
+});

--- a/apps/desktop/src/renderer/composition/legacy-desktop-region.tsx
+++ b/apps/desktop/src/renderer/composition/legacy-desktop-region.tsx
@@ -19,7 +19,7 @@
 
 import type { ComponentProps } from 'react';
 import { AppShell as LegacyAppShell } from '../app-shell';
-import { WorkHubSurfaceSwitch } from '../features/workhub';
+import { WorkHubRoot, WorkHubSurfaceSwitch } from '../features/workhub';
 export function AppShell(props: ComponentProps<typeof LegacyAppShell>) {
-  return <WorkHubSurfaceSwitch main={<LegacyAppShell {...props} />} />;
+  return <WorkHubSurfaceSwitch main={<LegacyAppShell {...props} />} workhub={<WorkHubRoot />} />;
 }

--- a/apps/desktop/src/renderer/features/workhub/ui/workhub-surface-switch.tsx
+++ b/apps/desktop/src/renderer/features/workhub/ui/workhub-surface-switch.tsx
@@ -20,16 +20,15 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { AstryxLocaleProvider, LocaleProvider, ToastProvider } from '@maka/ui';
 import { useWorkHubServices } from '../services.js';
-import { WorkHubRoot } from './workhub-root.js';
 
-export function WorkHubSurfaceSwitch({ main }: { main: ReactNode }) {
+export function WorkHubSurfaceSwitch({ main, workhub }: { main: ReactNode; workhub: ReactNode }) {
   const services = useWorkHubServices();
-  return services.surface === 'workhub' ? <WorkHubApplication /> : main;
+  return services.surface === 'workhub' ? <WorkHubApplication>{workhub}</WorkHubApplication> : main;
 }
-function WorkHubApplication() {
+function WorkHubApplication({ children }: { children: ReactNode }) {
   const services = useWorkHubServices();
   const [locale, setLocale] = useState(services.initialLocale);
   useEffect(() => services.subscribeAppearance(setLocale), [services]);
   useEffect(() => { void services.presentation.ready(); }, [services]);
-  return <LocaleProvider locale={locale}><AstryxLocaleProvider><ToastProvider><WorkHubRoot /></ToastProvider></AstryxLocaleProvider></LocaleProvider>;
+  return <LocaleProvider locale={locale}><AstryxLocaleProvider><ToastProvider>{children}</ToastProvider></AstryxLocaleProvider></LocaleProvider>;
 }


### PR DESCRIPTION
## Summary

Goals and WorkHub already call their controllers below AppShell, but neither call site is registered in `controllerOwners`. Register `useGoalController` with `GoalProvider` and `useWorkHubController` with `WorkHubRoot`, each with one production call, so the existing architecture gate rejects additional callers, public controller exports, and removal of the ownership contract.

WorkHub's surface switch currently imports `WorkHubRoot` privately, which the owner contract rejects. Composition now supplies `<WorkHubRoot />` through the public feature entry as the switch's WorkHub slot. Surface selection and the existing locale/Toast providers, appearance subscription, and ready notification retain their mount boundaries. The checker implementation and debt measurements are unchanged.

Refs #4582

## Verification

- Fresh `npm ci` with Node 24.19.0 and npm 11.19.0; build, typecheck, lint, format, and Desktop/UI Knip passed.
- Architecture fixtures: 103/103. Architecture check against `upstream/main` passed; AppShell hook gate remains 40 hooks / 65 call sites.
- Desktop suite: 2,498/2,498. The two new surface tests verify exclusive mounting, locale propagation without remounting, Toast context, one ready notification, and subscription cleanup. Removing the Toast provider makes the new test fail.
- Temporary copies of the real source: for each controller, a second production caller and public export pass without registration and fail with it; removing either registration fails against the registered base (6/6 rejection checks). Restored source passes.
- Windows test inventory, ASF headers, Astryx inventory, and `git diff --check` passed.
- Rebased onto `main` `96f8e3f93`; the upstream change touches only Runtime session trace projection. Its rebuilt tests, the focused Goals/WorkHub tests, and the architecture base check passed after rebase; `range-diff` is unchanged and `merge-tree` is clean.
- Electron E2E was not run locally; hosted CI runs it.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the registrations and composition adjustment, wrote tests, ran validation, and performed automated self-review. The commit carries a `Generated-by: Codex` trailer. Automated review is not independent human approval.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — the architecture gate now enforces the two existing controller owners; runtime product behavior is preserved.
- [ ] No
