### PR TITLE
fix(storage): reject non-directory paths in project add

### DIFF
--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -83,6 +83,43 @@ function sessionInput(cwd: string, projectId: string) {
   };
 }
 
+test('a regular file is rejected as a project location', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-file-'));
+  try {
+    const outsideFile = join(base, 'README.md');
+    await writeFile(outsideFile, 'not a project\n');
+    await assert.rejects(
+      () => resolveProjectLocation({ path: outsideFile }),
+      (error) =>
+        error instanceof TypeError &&
+        String(error.message).includes('Project path is not a directory'),
+    );
+
+    const repository = join(base, 'repository');
+    await mkdir(repository);
+    await execFileAsync('git', ['init', '--quiet'], { cwd: repository });
+    const insideFile = join(repository, 'README.md');
+    await writeFile(insideFile, 'not a project\n');
+    await assert.rejects(
+      () => resolveProjectLocation({ path: insideFile }),
+      (error) =>
+        error instanceof TypeError &&
+        String(error.message).includes('Project path is not a directory'),
+    );
+
+    const catalog = createProjectCatalog(join(base, 'storage'));
+    await assert.rejects(
+      () => catalog.register(insideFile),
+      (error) =>
+        error instanceof TypeError &&
+        String(error.message).includes('Project path is not a directory'),
+    );
+    assert.deepEqual(await catalog.list(), []);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test('a plain folder resolves without requiring the Git executable', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-project-folder-no-git-'));
   try {

--- a/packages/storage/src/project-catalog.ts
+++ b/packages/storage/src/project-catalog.ts
@@ -861,6 +861,12 @@ export async function resolveProjectLocation(input: {
   path: string;
 }): Promise<ResolvedProjectLocation> {
   const canonicalPath = normalize(await realpath(resolve(input.path)));
+  // Regular files are not valid projects. Without this check, a file inside a
+  // Git worktree reaches `git -C <file> rev-parse ...`, whose numeric failure
+  // is not treated as an invalid path by the Host coordinator and drains it.
+  if (!(await stat(canonicalPath)).isDirectory()) {
+    throw new TypeError(`Project path is not a directory: ${canonicalPath}`);
+  }
   if (!(await hasEnclosingGitEntry(canonicalPath))) {
     return {
       canonicalPath,


### PR DESCRIPTION
## Summary

`runtime-host project add` did not validate that the supplied path is a directory. A regular file inside a Git repository returned `Project catalog mutation outcome is unknown` and drained the Host; outside Git the same file was accepted as an unavailable folder project.

`resolveProjectLocation` already realpath'd the input but never checked `stat().isDirectory()` before repository discovery. Inside a Git worktree that reached `git -C <file> rev-parse ...`, whose numeric failure is not an invalid-path errno, so the coordinator called `requestDrain()`. Reject non-directories with `TypeError` so register/add treat them as invalid input and the Host stays up.

Fixes #5220

## Verification

```sh
export PATH="/home/box/.local/node-v22.19.0/bin:$PATH"
npm ci --ignore-scripts
node scripts/apply-dependency-patches.mjs
npm --workspace @maka/core run build
npm --workspace @maka/storage run build
cd packages/storage && node --test dist/__tests__/project-catalog.test.js
```

Result: 23/23 pass, including new test `a regular file is rejected as a project location` (file outside Git, file inside a Git repo, and `catalog.register` of that file).

Did not run full workspace `npm test` or the CLI Host reproduction from the issue (build surface limited to `@maka/core` + `@maka/storage`).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Cursor / Grok assisted the surgical `resolveProjectLocation` check and the unit test; commit author/committer is riba2534 only.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No