### PR TITLE
fix(scheduled-task): preserve snoozed occurrence on edits

### DIFF
--- a/packages/core/src/__tests__/scheduled-task.test.ts
+++ b/packages/core/src/__tests__/scheduled-task.test.ts
@@ -62,7 +62,7 @@ describe('scheduled-task catalog', () => {
     assert.equal(next.fireCount, 1);
   });
 
-  it('pause and resume restore nextFireAt', () => {
+  it('pause and resume preserve a pending occurrence', () => {
     const now = Date.UTC(2026, 0, 5, 8, 0, 0);
     const next = computeNextFireAt({ kind: 'interval', everySeconds: 3600, startAt: now }, now);
     assert.ok(next);
@@ -87,12 +87,41 @@ describe('scheduled-task catalog', () => {
     assert.equal(isScheduledTaskDue(task, next), true);
     const paused = pauseScheduledTask(task, now + 1);
     assert.equal(paused.status, 'paused');
-    assert.equal(paused.nextFireAt, null);
+    assert.equal(paused.nextFireAt, next);
+    assert.equal(isScheduledTaskDue(paused, next), false);
     const resumed = resumeScheduledTask(paused, now + 2);
     assert.ok(!('error' in resumed));
     if ('error' in resumed) return;
     assert.equal(resumed.status, 'active');
-    assert.ok(typeof resumed.nextFireAt === 'number');
+    assert.equal(resumed.nextFireAt, next);
+  });
+
+  it('resume recomputes an occurrence that elapsed while paused', () => {
+    const now = Date.UTC(2026, 0, 5, 8, 0, 0);
+    const pending = now + 10 * 60_000;
+    const task: ScheduledTask = {
+      id: 'snoozed-daily',
+      title: 'Daily',
+      intent: { kind: 'text', body: 'tick' },
+      schedule: { kind: 'calendar', recurrence: 'daily', anchorAt: now },
+      effect: { kind: 'notify', channel: 'local' },
+      status: 'paused',
+      nextFireAt: pending,
+      lastFireAt: null,
+      fireCount: 0,
+      maxFires: null,
+      expiresAt: null,
+      createdBy: { kind: 'user' },
+      createdAt: now,
+      updatedAt: now,
+      runs: [],
+      lastError: null,
+    };
+
+    const resumed = resumeScheduledTask(task, pending + 1);
+    assert.ok(!('error' in resumed));
+    if ('error' in resumed) return;
+    assert.equal(resumed.nextFireAt, computeNextFireAt(task.schedule, pending + 1));
   });
 
   it('does not resume a task whose fire budget is already spent', () => {

--- a/packages/core/src/scheduled-task.ts
+++ b/packages/core/src/scheduled-task.ts
@@ -321,7 +321,6 @@ export function pauseScheduledTask(task: ScheduledTask, now: number): ScheduledT
   return {
     ...task,
     status: 'paused',
-    nextFireAt: null,
     updatedAt: now,
   };
 }
@@ -345,7 +344,10 @@ export function resumeScheduledTask(
       updatedAt: now,
     };
   }
-  const nextFireAt = computeNextFireAt(task.schedule, now);
+  const nextFireAt =
+    task.nextFireAt !== null && task.nextFireAt > now
+      ? task.nextFireAt
+      : computeNextFireAt(task.schedule, now);
   if (nextFireAt === null) {
     return { error: 'Schedule has no remaining fire' };
   }

--- a/packages/storage/src/__tests__/scheduled-task-row-operations.test.ts
+++ b/packages/storage/src/__tests__/scheduled-task-row-operations.test.ts
@@ -272,6 +272,50 @@ test('ScheduledTask metadata updates keep schedule and expired-trigger semantics
   });
 });
 
+test('ScheduledTask metadata updates preserve a future snoozed occurrence', async (t) => {
+  await withStore(t, async ({ store }) => {
+    const anchorAt = NOW + 60_000;
+    const task = await store.create(
+      {
+        ...notifyInput('Daily reminder'),
+        schedule: { kind: 'calendar', recurrence: 'daily', anchorAt },
+      },
+      NOW,
+    );
+    const snoozed = await store.snooze(task.id, 10_000, NOW + 1);
+    const renamed = await store.update(task.id, { title: 'Renamed reminder' }, NOW + 2);
+
+    assert.equal(renamed.title, 'Renamed reminder');
+    assert.deepEqual(renamed.schedule, task.schedule);
+    assert.equal(renamed.nextFireAt, snoozed.nextFireAt);
+
+    const editedAnchorAt = NOW + 90_000;
+    const rescheduled = await store.update(
+      task.id,
+      {
+        schedule: { kind: 'calendar', recurrence: 'weekly', anchorAt: editedAnchorAt },
+      },
+      NOW + 3,
+    );
+    assert.deepEqual(rescheduled.schedule, {
+      kind: 'calendar',
+      recurrence: 'weekly',
+      anchorAt: editedAnchorAt,
+    });
+    assert.equal(rescheduled.nextFireAt, editedAnchorAt);
+
+    const intervalTask = await store.create(notifyInput('Interval reminder'), NOW);
+    const snoozedInterval = await store.snooze(intervalTask.id, 10_000, NOW + 4);
+    const renamedInterval = await store.update(
+      intervalTask.id,
+      { title: 'Renamed interval reminder' },
+      NOW + 5,
+    );
+    assert.deepEqual(renamedInterval.schedule, intervalTask.schedule);
+    assert.equal(renamedInterval.nextFireAt, snoozedInterval.nextFireAt);
+  });
+});
+
 test('ScheduledTask due discovery rejects a damaged task identity before changing another task', async (t) => {
   await withStore(t, async ({ store, probe }) => {
     const expiring = await store.create(

--- a/packages/storage/src/__tests__/scheduled-task-row-operations.test.ts
+++ b/packages/storage/src/__tests__/scheduled-task-row-operations.test.ts
@@ -289,13 +289,26 @@ test('ScheduledTask metadata updates preserve a future snoozed occurrence', asyn
     assert.deepEqual(renamed.schedule, task.schedule);
     assert.equal(renamed.nextFireAt, snoozed.nextFireAt);
 
+    const paused = await store.pause(task.id, NOW + 3);
+    assert.equal(paused.status, 'paused');
+    assert.equal(paused.nextFireAt, snoozed.nextFireAt);
+    const renamedWhilePaused = await store.update(
+      task.id,
+      { title: 'Renamed while paused' },
+      NOW + 4,
+    );
+    assert.equal(renamedWhilePaused.nextFireAt, snoozed.nextFireAt);
+    const resumed = await store.resume(task.id, NOW + 5);
+    assert.equal(resumed.status, 'active');
+    assert.equal(resumed.nextFireAt, snoozed.nextFireAt);
+
     const editedAnchorAt = NOW + 90_000;
     const rescheduled = await store.update(
       task.id,
       {
         schedule: { kind: 'calendar', recurrence: 'weekly', anchorAt: editedAnchorAt },
       },
-      NOW + 3,
+      NOW + 6,
     );
     assert.deepEqual(rescheduled.schedule, {
       kind: 'calendar',
@@ -305,11 +318,11 @@ test('ScheduledTask metadata updates preserve a future snoozed occurrence', asyn
     assert.equal(rescheduled.nextFireAt, editedAnchorAt);
 
     const intervalTask = await store.create(notifyInput('Interval reminder'), NOW);
-    const snoozedInterval = await store.snooze(intervalTask.id, 10_000, NOW + 4);
+    const snoozedInterval = await store.snooze(intervalTask.id, 10_000, NOW + 7);
     const renamedInterval = await store.update(
       intervalTask.id,
       { title: 'Renamed interval reminder' },
-      NOW + 5,
+      NOW + 8,
     );
     assert.deepEqual(renamedInterval.schedule, intervalTask.schedule);
     assert.equal(renamedInterval.nextFireAt, snoozedInterval.nextFireAt);

--- a/packages/storage/src/scheduled-task-store.ts
+++ b/packages/storage/src/scheduled-task-store.ts
@@ -289,11 +289,10 @@ class SqliteScheduledTaskStore implements ScheduledTaskStore {
         normalized.value.schedule === undefined &&
         task.nextFireAt !== null &&
         task.nextFireAt > now;
-      const nextFireAt =
-        task.status === 'active'
-          ? keepsPendingFire
-            ? task.nextFireAt
-            : computeRequiredNext(schedule, now)
+      const nextFireAt = keepsPendingFire
+        ? task.nextFireAt
+        : task.status === 'active'
+          ? computeRequiredNext(schedule, now)
           : null;
       const effect = normalized.value.effect ?? task.effect;
       const intentBody = normalized.value.intentBody ?? task.intent.body;

--- a/packages/storage/src/scheduled-task-store.ts
+++ b/packages/storage/src/scheduled-task-store.ts
@@ -285,7 +285,16 @@ class SqliteScheduledTaskStore implements ScheduledTaskStore {
         throw storeError('operation_conflict', 'Cannot update a terminal scheduled task');
       }
       const schedule = normalized.value.schedule ?? task.schedule;
-      const nextFireAt = task.status === 'active' ? computeRequiredNext(schedule, now) : null;
+      const keepsPendingFire =
+        normalized.value.schedule === undefined &&
+        task.nextFireAt !== null &&
+        task.nextFireAt > now;
+      const nextFireAt =
+        task.status === 'active'
+          ? keepsPendingFire
+            ? task.nextFireAt
+            : computeRequiredNext(schedule, now)
+          : null;
       const effect = normalized.value.effect ?? task.effect;
       const intentBody = normalized.value.intentBody ?? task.intent.body;
       const expiresAt = Object.prototype.hasOwnProperty.call(normalized.value, 'expiresAt')

--- a/packages/ui/src/__tests__/scheduled-task-form-schedule.test.ts
+++ b/packages/ui/src/__tests__/scheduled-task-form-schedule.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ScheduledTask } from '@maka/core/scheduled-task';
+import {
+  scheduledTaskEditSeed,
+  scheduledTaskScheduleFromForm,
+  toScheduledTaskLocalDateTimeValue,
+} from '../scheduled-task-helpers.js';
+
+const recurrenceAnchor = new Date(2026, 8, 13, 9, 0).getTime();
+const snoozedNextFire = new Date(2026, 8, 13, 9, 10).getTime();
+
+const snoozedDailyTask: ScheduledTask = {
+  id: 'daily-reminder',
+  title: 'Daily reminder',
+  intent: { kind: 'text', body: '' },
+  schedule: { kind: 'calendar', recurrence: 'daily', anchorAt: recurrenceAnchor },
+  effect: { kind: 'notify', channel: 'local' },
+  status: 'active',
+  nextFireAt: snoozedNextFire,
+  lastFireAt: null,
+  fireCount: 0,
+  maxFires: null,
+  expiresAt: null,
+  createdBy: { kind: 'user' },
+  createdAt: recurrenceAnchor - 1_000,
+  updatedAt: recurrenceAnchor - 1_000,
+  runs: [],
+  lastError: null,
+};
+
+const snoozedIntervalTask: ScheduledTask = {
+  ...snoozedDailyTask,
+  id: 'interval-reminder',
+  schedule: { kind: 'interval', everySeconds: 3_600, startAt: recurrenceAnchor },
+};
+
+test('preserves a snoozed daily anchor when schedule fields are unchanged', () => {
+  const seed = scheduledTaskEditSeed(snoozedDailyTask);
+
+  assert.equal(seed.runAtLocal, toScheduledTaskLocalDateTimeValue(snoozedNextFire));
+  assert.equal(scheduledTaskScheduleFromForm(seed, {
+    runAtLocal: seed.runAtLocal,
+    parsedRunAt: Date.parse(seed.runAtLocal),
+    recurrence: seed.recurrence,
+    cronExpression: seed.cronExpression,
+  }), undefined);
+});
+
+test('omits an unchanged interval schedule after snoozing', () => {
+  const seed = scheduledTaskEditSeed(snoozedIntervalTask);
+
+  assert.equal(seed.recurrence, 'interval');
+  assert.equal(scheduledTaskScheduleFromForm(seed, {
+    runAtLocal: seed.runAtLocal,
+    parsedRunAt: Date.parse(seed.runAtLocal),
+    recurrence: seed.recurrence,
+    cronExpression: seed.cronExpression,
+  }), undefined);
+});
+
+test('uses an explicitly edited time as the new daily anchor', () => {
+  const seed = scheduledTaskEditSeed(snoozedDailyTask);
+  const editedAnchor = new Date(2026, 8, 13, 9, 30).getTime();
+
+  assert.deepEqual(scheduledTaskScheduleFromForm(seed, {
+    runAtLocal: toScheduledTaskLocalDateTimeValue(editedAnchor),
+    parsedRunAt: editedAnchor,
+    recurrence: seed.recurrence,
+    cronExpression: seed.cronExpression,
+  }), { kind: 'calendar', recurrence: 'daily', anchorAt: editedAnchor });
+});
+
+test('uses an explicitly edited recurrence with the displayed next-run time', () => {
+  const seed = scheduledTaskEditSeed(snoozedDailyTask);
+
+  assert.deepEqual(scheduledTaskScheduleFromForm(seed, {
+    runAtLocal: seed.runAtLocal,
+    parsedRunAt: snoozedNextFire,
+    recurrence: 'weekly',
+    cronExpression: seed.cronExpression,
+  }), { kind: 'calendar', recurrence: 'weekly', anchorAt: snoozedNextFire });
+});

--- a/packages/ui/src/scheduled-task-form-dialog.tsx
+++ b/packages/ui/src/scheduled-task-form-dialog.tsx
@@ -38,7 +38,7 @@ import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
 import { BotBrandLogo } from './bot-brand-logo.js';
 import type { BotProvider } from '@maka/core/bot-chat-settings';
-import type { ScheduledTask, ScheduledTaskSchedule } from '@maka/core/scheduled-task';
+import type { ScheduledTask } from '@maka/core/scheduled-task';
 import { BOT_DELIVERY_PROVIDERS } from '@maka/core/bot-chat-settings';
 import { botDisplayLabel } from '@maka/core/bot-events';
 import {
@@ -46,6 +46,7 @@ import {
   formatScheduledTaskDeliveryProviderList,
   scheduledTaskFormValidation,
   scheduledTaskPresetRunAt,
+  scheduledTaskScheduleFromForm,
   scheduledTaskTemplateSeed,
   toScheduledTaskLocalDateTimeValue,
 } from './scheduled-task-helpers.js';
@@ -179,22 +180,18 @@ export function ScheduledTaskFormDialog(props: {
     event.preventDefault();
     if (submitDisabled || submitPendingRef.current) return;
     if (!effect) return;
-    let schedule: ScheduledTaskSchedule;
-    if (recurrence === 'interval') {
-      if (!props.seed.lockedSchedule) return;
-      schedule = props.seed.lockedSchedule;
-    } else if (recurrence === 'none') {
-      schedule = { kind: 'once', runAt: parsedRunAt };
-    } else if (recurrence === 'cron') {
-      schedule = { kind: 'cron', expression: cronExpression.trim(), startAt: parsedRunAt };
-    } else {
-      schedule = { kind: 'calendar', recurrence, anchorAt: parsedRunAt };
-    }
+    const schedule = scheduledTaskScheduleFromForm(props.seed, {
+      runAtLocal,
+      parsedRunAt,
+      recurrence,
+      cronExpression,
+    });
+    if (schedule === null) return;
     submitPendingRef.current = true;
     const baseInput = {
       title: title.trim(),
       intentBody: note.trim(),
-      schedule,
+      ...(schedule ? { schedule } : {}),
     };
     // Preserve a pre-#3927 slug-only target without resubmitting it as a new
     // effect; title, intent, and schedule remain editable.
@@ -209,7 +206,9 @@ export function ScheduledTaskFormDialog(props: {
             editingId,
             preservesLegacyEffect ? baseInput : { ...baseInput, effect },
           )
-        : await props.onCreate?.({ ...baseInput, effect });
+        : schedule
+          ? await props.onCreate?.({ ...baseInput, schedule, effect })
+          : false;
       if (result !== false && scheduledTaskMountedRef.current) {
         resetForm();
         props.onOpenChange(false);

--- a/packages/ui/src/scheduled-task-helpers.ts
+++ b/packages/ui/src/scheduled-task-helpers.ts
@@ -284,10 +284,34 @@ export interface ScheduledTaskFormSeed {
   deliveryMethod: ScheduledTaskDeliveryMethod;
   deliveryPlatform: BotProvider;
   deliveryChatId: string;
+  /** Preserve the persisted schedule when an edit changes only non-schedule fields. */
+  originalSchedule?: ScheduledTaskSchedule;
   /** UI does not expose interval cadence editing; preserve it instead of coercing to once. */
   lockedSchedule?: Extract<ScheduledTaskSchedule, { kind: 'interval' }>;
   /** Agent execution is frozen at creation and must never be rewritten as notification delivery. */
   lockedEffect?: Exclude<ScheduledTaskEffect, { kind: 'notify' }>;
+}
+
+export function scheduledTaskScheduleFromForm(seed: ScheduledTaskFormSeed, input: {
+  runAtLocal: string;
+  parsedRunAt: number;
+  recurrence: ScheduledTaskRecurrence;
+  cronExpression: string;
+}): ScheduledTaskSchedule | null | undefined {
+  if (
+    seed.editingId !== null &&
+    seed.originalSchedule !== undefined &&
+    input.runAtLocal === seed.runAtLocal &&
+    input.recurrence === seed.recurrence &&
+    (input.recurrence !== 'cron' || input.cronExpression.trim() === seed.cronExpression.trim())
+  ) return undefined;
+
+  if (input.recurrence === 'interval') return seed.lockedSchedule ?? null;
+  if (input.recurrence === 'none') return { kind: 'once', runAt: input.parsedRunAt };
+  if (input.recurrence === 'cron') {
+    return { kind: 'cron', expression: input.cronExpression.trim(), startAt: input.parsedRunAt };
+  }
+  return { kind: 'calendar', recurrence: input.recurrence, anchorAt: input.parsedRunAt };
 }
 
 /**
@@ -354,6 +378,7 @@ function scheduledTaskFormSeedFromTask(task: ScheduledTask): ScheduledTaskFormSe
     recurrence: scheduledTaskRecurrenceValue(task),
     cronExpression: task.schedule.kind === 'cron' ? task.schedule.expression : '0 9 * * 1-5',
     deliveryMethod: task.effect.kind === 'notify' ? task.effect.channel : 'agent_run',
+    originalSchedule: task.schedule,
     ...(task.effect.kind === 'notify' && task.effect.channel === 'bot'
       ? { deliveryPlatform: task.effect.platform, deliveryChatId: task.effect.chatId }
       : { deliveryPlatform: 'telegram' as BotProvider, deliveryChatId: '' }),


### PR DESCRIPTION
## Summary

Keep schedule edits distinct from metadata-only edits so renaming a snoozed recurring task preserves both its recurrence anchor and its pending snoozed occurrence.

The edit form now omits the schedule patch when its schedule fields are unchanged. Storage preserves a future pending occurrence for metadata-only updates, while explicit schedule changes and overdue occurrences continue to recompute normally.

Fixes #5221

## Verification

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/storage run typecheck`
- `npm --workspace @maka/ui run typecheck`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/ui run build`
- Scheduled-task storage regression suite: 13/13 passed
- UI scheduled-task regression tests: 4/4 passed
- Cleanly compiled UI suite: 422/422 passed

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the schedule-update fix and added the targeted regression coverage.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
